### PR TITLE
Apply Rites of War from Blood Angels to all Legions that aren't Dark Angels

### DIFF
--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -9244,7 +9244,7 @@ Limitations
         </selectionEntry>
         <selectionEntry id="a621-2c8c-3df0-89d3" name="Underworld Assault^" publicationId="a716-c1c4-7b26-8424" page="100" hidden="false" collective="false" import="true" type="upgrade">
           <rules>
-            <rule id="bc0e-857d-6ab6-7aa8" name="Underworld Aaasult^" publicationId="a716-c1c4-7b26-8424" page="100" hidden="false">
+            <rule id="bc0e-857d-6ab6-7aa8" name="Underworld Assault^" publicationId="a716-c1c4-7b26-8424" page="100" hidden="false">
               <description>Effects
 • All units in this Detachment eligible to take a Legion Rhino Transport as a Dedicated Transport may instead select a Legion Termite Assault Drill as a Dedicated Transport.
 • Legion Termite Assault Drills may be selected as Fast Attack choices and Heavy Support choices in a Detachment with this Rite of War.

--- a/2022 - LA - Alpha Legion.cat
+++ b/2022 - LA - Alpha Legion.cat
@@ -6,8 +6,7 @@
       </constraints>
     </categoryEntry>
   </categoryEntries>
-  <entryLinks>
-    <entryLink id="e317-e9d1-4af8-8de5" name=" XX: Alpha Legion" hidden="false" collective="false" import="true" targetId="c0df-c1fa-5ddc-9ee5" type="selectionEntry">
+  <entryLinks><entryLink id="e317-e9d1-4af8-8de5" name=" XX: Alpha Legion" hidden="false" collective="false" import="true" targetId="c0df-c1fa-5ddc-9ee5" type="selectionEntry">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f412-57a4-c87f-5081" type="min" />
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a338-2298-5f62-d6d0" type="max" />
@@ -1207,937 +1206,1689 @@
         <categoryLink id="7618-a59b-753f-2ff8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="9e61-f556-1d53-d498" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="30c6-07bb-66e2-7586" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="dbad-f03d-2374-d4fe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <entryLink id="9e61-f556-1d53-d498" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="dd65-9d73-41ca-96bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6d4-581f-4746-bec3</comment></categoryLink>
+        <categoryLink id="8f07-256b-48db-a923" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_2489-ee2a-45dd-b384</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
-    <entryLink id="b606-853d-d4d2-f65c" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6ae1-591c-b00d-41ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f291-ca6c-f515-b766" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
-    <entryLink id="c7fd-2e08-2272-d83f" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink><entryLink id="b606-853d-d4d2-f65c" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b02f-e65f-4a88-a175</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_b87b-bf35-4238-b7c6</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1aff-27af-435e-8102</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_fdf9-4906-4180-a39d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f98f-f9ef-94fe-28b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="48a4-d400-2275-20e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3f76-a329-e3cf-fb10" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="39d8-6f42-493f-9da2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8378-ede4-476d-b657</comment></categoryLink>
+        <categoryLink id="5226-92f8-4d38-a3c3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_d64f-ad19-426c-adf7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
-    <entryLink id="ba5e-59d7-8e8d-4b06" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink><entryLink id="c7fd-2e08-2272-d83f" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_7fd1-8ce8-4d10-82e7</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_eaae-8c43-4d30-898c</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7b83-b262-dea6-9101" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="48ba-bc38-5e44-7893" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6553-6f18-eb65-92bc" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
-    <entryLink id="fb8d-6314-050f-ca29" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="89d5-edca-9a9f-f11d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="de55-8a31-476c-f9fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d75f-9534-fdae-1ec1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="35cc-ad2e-7808-03f4" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup" />
-        <entryLink id="9c83-c217-aeb9-b37b" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
-    <entryLink id="ea7b-3257-1195-c916" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="cab2-c502-6f7b-2c72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="94fb-f54b-5100-c67a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="bb45-ca2b-c893-43dd" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="4c7f-801b-9b25-2ffb" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup" />
-        <entryLink id="c1b6-16f6-5c19-359a" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
-    <entryLink id="2656-d573-fed9-0490" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="90ef-1989-c7c5-e945" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="512b-2135-2521-6f18" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="2012-9645-f680-f750" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="6a6c-812f-ce8f-e826" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup" />
-        <entryLink id="b495-ad40-bec7-7f4d" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
-    <entryLink id="2f88-d6b1-dd8a-ecc0" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3b2c-8463-91f4-3403" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="8d0e-9409-6060-6057" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
-    <entryLink id="0879-5810-e96b-da21" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="98be-e25b-29d6-2166" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="09af-4e67-1395-20c2" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
-    <entryLink id="b51f-90bc-e5ba-2a3c" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3e37-d797-92a9-9210" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6acb-a40f-164d-71df" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
-    <entryLink id="c07f-7c57-bdbe-2daa" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="be1a-f2e2-1c45-b41b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7083-52ed-4eeb-2105" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
-    <entryLink id="2c8a-e224-a5f0-2354" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5083-72be-b0a6-dd03" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="35c4-22cf-690d-9395" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
-    <entryLink id="7170-8817-0f9e-2ee0" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="465a-0540-9d96-9b21" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="f188-747b-4d2b-bdd1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
-    <entryLink id="c1b8-9a38-3805-4421" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0a90-70a1-3166-86f8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="bb6c-c837-2689-7e9f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
-    <entryLink id="01e8-be04-bdd2-6a50" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_f67d-8cf3-424f-b491</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_b949-6414-4f3d-b268</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="61d3-ddc7-c916-1ae4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="82f3-384e-8329-43de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f4be-7c04-7777-25a9" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="291c-80cd-49a8-863a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_ac26-e639-4d53-9b8b</comment></categoryLink>
+        <categoryLink id="b18c-5d6f-47d1-bb41" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_49af-0d08-4c7e-8ce6</comment></categoryLink>
+        <categoryLink id="f32e-7991-437d-b342" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_b606-de16-4659-95cd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
-    <entryLink id="25b3-fc01-564d-396b" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0062-2a58-add1-457a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6a03-8e61-9177-20df" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
-    <entryLink id="f846-8f5f-89b9-3158" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="true" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="cef2-18eb-734e-6d0d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="0010-2076-4f3e-165e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
-    <entryLink id="f799-0fc7-f087-844e" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2389-24f4-9d13-9a44" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="5503-3e99-e4b4-df79" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
-    <entryLink id="3906-77b6-552a-adc4" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="565c-e27f-51f5-4b95" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="1914-e8b5-82ae-864b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
-    <entryLink id="f4bf-f90d-88b7-0c56" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="25c3-58f6-2ac5-b0d2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6d2e-63c1-dd57-5d95" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
-    <entryLink id="ec25-d672-37be-8d78" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5406-c9ce-e2c9-a4d1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="f030-3b2c-6218-0c72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
-    <entryLink id="c0f4-4dc2-9fdd-be0c" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink><entryLink id="ba5e-59d7-8e8d-4b06" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_27a3-1e4c-4b76-a594</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_d59a-dcd0-44fd-b866</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_0c8b-2b92-49ed-98c7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_bafe-f799-41d9-ac85</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_6369-288c-4fec-a640</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_fe53-8858-41dc-8ec4</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="463e-597a-62f8-3dd8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="011a-fe41-77e1-9713" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ff4b-8e71-4a9e-97f1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_3a22-caae-4eea-9bc5</comment></categoryLink>
+        <categoryLink id="17ce-4ee3-4f48-aaad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f759-f33e-4698-9f8a</comment></categoryLink>
+        <categoryLink id="d32c-ea83-4a51-8617" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_c624-3ae0-46c0-9b06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
-    <entryLink id="bf8c-f11e-272f-5a3b" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink><entryLink id="fb8d-6314-050f-ca29" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry"><categoryLinks>
+        <categoryLink id="7c04-1450-4e22-a122" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_2599-24e3-44e5-9568</comment></categoryLink>
+        <categoryLink id="ce5f-7cef-4cff-a572" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_285f-6e56-473b-b2fe</comment></categoryLink>
+        <categoryLink id="501c-ed5d-4de8-b130" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_685e-022f-4e2f-a568</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="e2a7-0d6a-44ba-bffb" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup"><comment>    template_id_2a38-6544-4267-b584    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="8dd6-83b7-42c0-977b" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_8287-16ff-46ba-9838</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_81c1-fca9-44dc-ba4c</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_6e59-4592-47ef-b76d    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink><entryLink id="ea7b-3257-1195-c916" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ad5d-3c79-4239-9116</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_60b1-049b-4a5f-85c2</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dfe8-f215-a5a1-5502" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ec59-ec06-f3e0-122a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="8caa-ec08-4828-aa35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bd6a-0cda-4e0f-80ae</comment></categoryLink>
+        <categoryLink id="dff6-3290-43b6-b790" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_ae75-7cca-4701-9d56</comment></categoryLink>
+        <categoryLink id="de92-9ae1-4978-9ea2" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_e517-62d4-48f7-8174</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
-    <entryLink id="bade-7656-b138-1ad9" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
+      <entryLinks>
+        <entryLink id="7b87-13b5-4dff-8337" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup"><comment>    template_id_fafb-6414-474a-8a09    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="f60a-15d3-4b28-ab26" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_1e43-c980-4508-8ec2</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_4140-36a7-4203-b5e9</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_a6a6-9bc7-4d4e-86a7    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink><entryLink id="2656-d573-fed9-0490" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry"><categoryLinks>
+        <categoryLink id="7a67-133d-4d9e-94c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fc9d-03d1-4bbd-a1c4</comment></categoryLink>
+        <categoryLink id="2c25-22f0-4770-9195" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_f51c-73d7-4f29-be1c</comment></categoryLink>
+        <categoryLink id="ee00-8be7-41bd-ab32" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_257d-78c0-4bab-ba65</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="efa7-b5de-428e-9cc9" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup"><comment>    template_id_ac26-33db-40a7-bdba    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="3f45-23f4-49a6-82af" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_189b-db75-4db6-9fe9</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_cbdb-2500-4e13-876a</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_dc8e-2801-46d6-84f8    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink><entryLink id="2f88-d6b1-dd8a-ecc0" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b43b-547f-472e-9076</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8ff9-0498-4540-8552</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fbfe-931a-489b-a589</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f4c3-5aa6-4caa-abf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_17f8-f055-4c9c-b757</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="62c8-1c02-cf9c-c31c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="b174-b39d-dab5-b04f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7004-0a0e-41de-8931" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f1c8-27fd-4f98-8527</comment></categoryLink>
+        <categoryLink id="056a-4c0d-47ef-a90a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2b20-1a8b-4753-b657</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
-    <entryLink id="9c9a-5c7e-99df-2aba" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="93fd-9a6c-6906-78ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2a60-b1d0-a3b1-4c44" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink><entryLink id="0879-5810-e96b-da21" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry"><categoryLinks>
+        <categoryLink id="10ad-5649-4d41-a7b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4207-8d8f-4b1a-836b</comment></categoryLink>
+        <categoryLink id="2aba-b6bf-4981-8577" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_2b34-077f-4279-86fb</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
-    <entryLink id="42d2-513c-74dd-efb8" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="cf62-bc25-35a0-6e72" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="de55-ea76-e8af-a098" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
-    <entryLink id="7cde-5dcf-8b78-63c2" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e9ef-0cfe-e8d9-cb5b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5dc3-f5f5-f3e3-8ac9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
-    <entryLink id="417c-8df9-7f24-faee" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b1e2-4b8f-3743-a601" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d457-866f-9d4e-8f2f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
-    <entryLink id="f73f-75e7-1202-83ad" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink><entryLink id="b51f-90bc-e5ba-2a3c" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="05a4-a87f-6666-6ec4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="59fc-d9a7-a8d0-7ac3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="e8ee-b856-4e5c-83f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6577-e0fb-4fda-834e</comment></categoryLink>
+        <categoryLink id="52ac-2db5-4d9f-9f7f" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_5d59-09bf-4566-b7e1</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
-    <entryLink id="e833-3c0d-564a-ae07" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink><entryLink id="c07f-7c57-bdbe-2daa" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"><categoryLinks>
+        <categoryLink id="ca47-d0a1-41d1-b02d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_aa93-057d-42f6-82d7</comment></categoryLink>
+        <categoryLink id="148e-4b11-4409-97c5" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_403c-4e9c-4af5-84ec</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink><entryLink id="2c8a-e224-a5f0-2354" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_23fa-06dd-49f9-a7db</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5b26-059e-40b3-9d93</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f7bf-3a1c-4103-aed8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="ba81-942b-bbf9-4f78" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="4d24-ccb8-1b76-b671" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="88a0-8557-4f48-9e1c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dd44-e0a8-42a8-bdcc</comment></categoryLink>
+        <categoryLink id="bf38-2dd3-44c2-88ef" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_c5b0-f9ae-468d-924a</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
-    <entryLink id="cbe2-ac9a-15e5-3fbc" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink><entryLink id="7170-8817-0f9e-2ee0" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8396-e51c-4e2b-bada</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_13bb-9fb5-4580-92cf</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_bfb8-8125-4548-92f5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25e3-b8f5-4448-a7c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="b88a-4279-b0ec-5a87" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="cc12-9fd8-6d7f-0da2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="f0dd-4ac2-439b-a2b2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_f926-27fd-4a92-97a1</comment></categoryLink>
+        <categoryLink id="76d0-2ece-4b5c-b8fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_82e3-36e1-4e85-8fcb</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
-    <entryLink id="368b-85cb-1202-69f6" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink><entryLink id="c1b8-9a38-3805-4421" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_658f-b1ad-4347-a998</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_12bc-3db2-4d28-abce</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_9d83-7691-41d6-8dad</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_add7-ba48-46d4-8a02</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_1fb0-2421-40a4-9e49</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="41b2-fac6-4f73-a263" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7004-b00d-481f-b740</comment></categoryLink>
+        <categoryLink id="9343-c6fc-49d4-9dc7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4f88-2fc3-491c-bfb7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink><entryLink id="01e8-be04-bdd2-6a50" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_8ed4-376d-4030-9439</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8a11-c2a0-4335-99ef</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_fa8e-1af7-4d41-ac8c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_94bd-c771-4a85-8581</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="30b0-c2c3-4700-9569" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_361e-fb90-4b0e-ac3d</comment></categoryLink>
+        <categoryLink id="b7dd-57c3-40ed-96b0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d4ef-1074-45a9-959e</comment></categoryLink>
+        <categoryLink id="3889-01ab-43cc-805b" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_febb-f536-4d25-a8ab</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink><entryLink id="25b3-fc01-564d-396b" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="7955-d9c4-46ac-a748" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_473b-e812-4158-9416</comment></categoryLink>
+        <categoryLink id="e9dc-2281-454b-8dbb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_00a2-63ff-4698-a35b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink><entryLink id="f846-8f5f-89b9-3158" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7cf3-8a72-4f82-8cdc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_228c-5681-4ce8-b726</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_01bb-8abd-4253-9a4d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="bf0c-eb03-43bb-af46" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2a08-4432-42ad-bfdb</comment></categoryLink>
+        <categoryLink id="13ae-1f22-40f7-b5ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_422e-0808-4897-8630</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink><entryLink id="f799-0fc7-f087-844e" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1af8-4459-4717-8e3b</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_06b4-92b9-438c-b1a5</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6c8d-8b28-417b-9a7c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_715d-8186-4aa6-b40c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_390e-358c-4f8e-ade8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cfbb-8b59-4e55-9d8e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f4c0-4396-4f39-a34f</comment></categoryLink>
+        <categoryLink id="5173-1b2c-4066-8847" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1301-8415-490e-8f06</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink><entryLink id="3906-77b6-552a-adc4" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d0c9-9a26-4324-b030</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4e9e-a61d-42f2-bacb</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ed9e-b634-4bec-9eb0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4614-ad0f-4fba-adaf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_8d08-24f6-41be-8931</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6a95-de6b-4210-8792" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_caf6-5548-4b89-8102</comment></categoryLink>
+        <categoryLink id="7534-c598-4943-82d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_63a3-be61-428d-ab29</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink><entryLink id="f4bf-f90d-88b7-0c56" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f318-4b03-4767-8c7f</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b8ef-7245-4df8-a8c4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_6bce-ec44-48cb-873a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="16bc-aefa-46f2-9c6a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0678-4fdd-48e6-8f61</comment></categoryLink>
+        <categoryLink id="3009-d072-4d11-bb21" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0d82-10a9-4de2-8ad7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink><entryLink id="ec25-d672-37be-8d78" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ada1-1e18-4cbc-9598</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b1d1-ac44-47dd-9159</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5d64-f00c-4464-891b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25f0-f825-4a83-8f0d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_64b1-9e36-44da-b36a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6cc6-e627-4a99-a3b0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_d53e-113f-4a40-a3d5</comment></categoryLink>
+        <categoryLink id="a6a8-47c0-43c2-972c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1939-76b5-4279-9f8c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink><entryLink id="c0f4-4dc2-9fdd-be0c" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d765-3bb2-4b48-bd12</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_0ca1-cfb4-4a56-ab3b</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e410-1ff4-4aac-aa9d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e6f7-a6ca-4825-bfc5</comment></categoryLink>
+        <categoryLink id="72fd-ea7d-4dde-a973" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dbec-e027-4ec1-8514</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink><entryLink id="bf8c-f11e-272f-5a3b" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d8ee-81ed-45f9-8b79</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_8f4e-e8cb-4ac9-a415</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="62ae-24eb-48a3-befe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_cefb-cfd7-4dc8-99c4</comment></categoryLink>
+        <categoryLink id="90fe-68d3-4553-a7ea" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a9fd-9d16-4a5e-855c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink><entryLink id="bade-7656-b138-1ad9" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e76b-46ca-4ab8-a93d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8035-75b8-43bb-97c9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_71a4-31e7-4927-a0ab</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="98eb-4153-4ff5-ba4d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_a56d-347b-4b09-a918</comment></categoryLink>
+        <categoryLink id="f6a2-7107-48bf-87b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_96e5-4531-4213-903e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink><entryLink id="9c9a-5c7e-99df-2aba" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1fb5-2375-4c22-b41e</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7d7c-255d-49b6-96b9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5321-254b-4890-9bf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ddf8-b8b7-4afb-b6dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="aef1-7c82-4b16-884e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9441-d79b-4720-9667</comment></categoryLink>
+        <categoryLink id="30bf-fcc6-4f9d-bd44" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7d7e-32d3-4692-b401</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink><entryLink id="42d2-513c-74dd-efb8" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ae67-ef52-4cac-958c</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fc61-7306-4d99-acde</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1be0-67e7-45a1-bdbb</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_42a8-7fda-4e05-af0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="28a4-1d6d-4d81-b09d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_565a-1592-491f-8b9b</comment></categoryLink>
+        <categoryLink id="4077-1d17-436b-b5f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_81d5-c14a-42ab-bdde</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink><entryLink id="7cde-5dcf-8b78-63c2" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1ae7-c41b-4818-be71</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_08a5-b1bb-4ba1-ba42</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d677-b5ad-4838-8746</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_537f-bc1f-4aaa-b0dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e814-7ce4-4679-86e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bc67-ce1f-4004-aeb7</comment></categoryLink>
+        <categoryLink id="e715-f122-4594-ba5d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_9a45-9699-4475-aeef</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink><entryLink id="417c-8df9-7f24-faee" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_c28f-4109-44c4-ab64</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fdc1-a894-48bc-9e7c</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_4936-a68c-4524-9088</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb37-ac0c-49ae-9d6f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9264-18b2-4239-9909" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3afe-cfc0-4da6-a985</comment></categoryLink>
+        <categoryLink id="a1d4-1cfd-4aff-8908" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_04a8-6aae-45ae-bd4c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink><entryLink id="f73f-75e7-1202-83ad" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_773a-1ea4-41a0-b766</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_9d4d-6fb8-4131-a5a3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e3bc-02f8-4ece-a5ea</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c371-76d9-4a4d-bc00</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b4c6-d4ba-4b2e-9b99</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e827-31ba-49a2-940a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6ea9-a7e5-437d-9e35</comment></categoryLink>
+        <categoryLink id="71f1-23b0-40f9-80b8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_3cec-f053-42ab-a6eb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink><entryLink id="e833-3c0d-564a-ae07" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1e60-42ba-4c8b-9077</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9860-f593-425e-b89b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_c842-10e8-4509-8eda</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ea52-ff41-40f6-8cf3</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_51e6-c5e1-4003-96bc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8738-db14-4b13-a2c5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4d7c-201f-4c99-b89a</comment></categoryLink>
+        <categoryLink id="4ee1-4f38-4640-b617" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_10f9-4718-4e07-bb32</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink><entryLink id="cbe2-ac9a-15e5-3fbc" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry"><categoryLinks>
+        <categoryLink id="6cf8-ab23-4976-91e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6140-2404-46f9-bd42</comment></categoryLink>
+        <categoryLink id="4798-3935-4057-a29e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_1c86-fad8-46ec-a0b0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink><entryLink id="368b-85cb-1202-69f6" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4dce-8632-4f7c-813e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_8a71-3995-4155-ac33</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d206-f2ce-41b8-945a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan">
+                  <comment>    node_id_2e02-cf1c-4a71-861c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ec81-bd33-45a8-8550</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_3344-743c-45d3-b930</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="418d-a2cf-fefa-58ed" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="8d76-374a-f14b-3c4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e6fc-6a0f-4825-9f9f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4272-9b9d-4c59-95f0</comment></categoryLink>
+        <categoryLink id="11f7-444e-4ba8-8527" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_d85b-1ae7-40d5-9341</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
-    <entryLink id="19d9-6b41-7e99-c834" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="30b4-436f-db36-16fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d54f-37d1-d1e0-ca74" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink><entryLink id="19d9-6b41-7e99-c834" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry"><categoryLinks>
+        <categoryLink id="0991-5236-4969-99ae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ff9f-01cb-41b9-800e</comment></categoryLink>
+        <categoryLink id="a4da-54f1-4849-a4fa" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_1315-6051-4a46-b070</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
-    <entryLink id="1024-5940-3bbc-2737" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d45f-0474-619c-5755" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="5d7e-a9d1-64bd-3af8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="f5d0-5bc0-9608-900b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink><entryLink id="1024-5940-3bbc-2737" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry"><categoryLinks>
+        <categoryLink id="7b2f-09ab-4029-b9d7" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_b084-df23-4f99-812f</comment></categoryLink>
+        <categoryLink id="581e-8eaf-4990-8109" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_84fc-9304-4e9e-ab78</comment></categoryLink>
+        <categoryLink id="1958-c968-42da-a00d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d06a-7939-4691-9aed</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="a14e-0eae-a869-3ba7" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup" />
-        <entryLink id="cfff-e969-ba76-1e0e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup" />
+        <entryLink id="42ab-3005-492f-9018" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup"><comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+        <entryLink id="7b33-057d-4e6e-be34" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup"><comment>    template_id_741d-8c09-4211-ada6    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
-    <entryLink id="9ad7-2903-7a24-9b9f" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink><entryLink id="9ad7-2903-7a24-9b9f" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_54a4-6ec8-4c61-9c3e</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_f7fd-2d16-4603-a065</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4ae2-042e-0977-17cc" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="9eb2-8e4f-15e4-1c91" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0c4c-579f-4964-a6fa" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="9f5b-552a-4dd8-892f" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_c0ac-4b8c-421c-a21b</comment></categoryLink>
+        <categoryLink id="dd08-6080-4b08-be85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8db9-079e-4482-b200</comment></categoryLink>
+        <categoryLink id="5dec-5089-4cd9-9687" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_413c-9273-4308-b546</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="3774-8d62-b6ab-4d25" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup" />
-        <entryLink id="0633-a2f6-c828-ca22" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup" />
+        <entryLink id="1b20-e466-4f1b-9ed4" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup"><comment>    template_id_bbc4-33fc-4664-a18e    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="7ca2-2e61-4f1f-a997" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup"><comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
-    <entryLink id="2124-5d7a-a791-dfc7" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d3a8-7307-482e-da17" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="d57c-104d-b963-01bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8377-fe6f-b1c6-7d2b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink><entryLink id="2124-5d7a-a791-dfc7" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry"><categoryLinks>
+        <categoryLink id="47a3-bca8-47a6-83b9" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_4c8d-96f6-48f9-9590</comment></categoryLink>
+        <categoryLink id="2337-7d4d-430c-8846" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_049c-0fa5-4575-8fa8</comment></categoryLink>
+        <categoryLink id="5bce-f862-4cb3-8772" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_7358-52d7-4aae-8e07</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="30fe-646d-5b3c-7e60" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup" />
-        <entryLink id="7ee3-e682-662c-82f8" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup" />
+        <entryLink id="4095-41ef-46c5-b9f5" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup"><comment>    template_id_4784-b370-444b-93ae    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="3a53-3fc3-4f0d-adf5" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup"><comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
-    <entryLink id="210d-22c6-de87-d587" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink><entryLink id="210d-22c6-de87-d587" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_3c03-a823-4466-9bd6</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8bbb-f95b-413f-b6f4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_41b0-6b0a-482a-919e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e1f7-3cc6-4794-8b6d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="a940-a06c-63b1-f384" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="293c-ba1d-2f84-b33a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="3159-b9ee-4300-8dfd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_05ce-cc31-40ad-9320</comment></categoryLink>
+        <categoryLink id="a055-039d-4a3a-ab1d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f13c-f8e1-4a50-bfe3</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
-    <entryLink id="ed73-562e-50f0-0b3f" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9521-8f2e-41d3-b746" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1b94-afca-35f8-fb40" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink><entryLink id="ed73-562e-50f0-0b3f" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry"><categoryLinks>
+        <categoryLink id="7e49-1f15-47ec-bb24" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_75a7-dc06-445b-b2dc</comment></categoryLink>
+        <categoryLink id="d6b0-768f-4711-8f68" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_e21a-c03b-4885-ac46</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
-    <entryLink id="33a8-d329-4912-7b67" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink><entryLink id="33a8-d329-4912-7b67" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9a08-5fe6-4010-bbc3</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_72cf-cfce-4e02-b379</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7f39-d948-329e-89ad" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="fdb3-afd6-08b7-576b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8ac5-b487-4889-8504" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_f55b-7555-444b-beee</comment></categoryLink>
+        <categoryLink id="9cfe-69e0-46eb-b1bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3386-c9ad-4d74-9474</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
-    <entryLink id="e447-df88-7247-6ef4" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink><entryLink id="e447-df88-7247-6ef4" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry"><modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_a0f6-9606-4b75-a2f8</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_94b3-1331-474b-885b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0fcf-f9f5-f15f-f44b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="d824-4a0a-aa45-88b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4dc5-b1be-4e81-a759" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_79fa-3370-4ae0-9e12</comment></categoryLink>
+        <categoryLink id="a674-e8d0-41ac-9ba8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bb53-4e65-4fb6-9dd7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
-    <entryLink id="5ec4-4c52-fc33-13d8" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="bd70-27e2-264f-5912" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="8ada-0642-92c4-0bdb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
-    <entryLink id="65a7-b67f-1ad4-655d" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="170b-331c-f45a-9b7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7194-4978-1fac-7c2b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
-    <entryLink id="d8cb-af69-e634-2557" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink><entryLink id="5ec4-4c52-fc33-13d8" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f8cc-833a-4ac1-bf89</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+              <comment>    node_id_5988-c012-4dad-9a66</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1095-0d3e-b6fc-a106" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="2f0b-d447-91d9-6ed6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="93b3-d3b3-4e5c-bfb4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_8d82-3279-4481-84bb</comment></categoryLink>
+        <categoryLink id="8ef1-19ac-44c2-abcd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e25c-925e-4b96-8bb3</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
-    <entryLink id="bea4-21f1-cac1-c329" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="fb2c-f0cf-414c-25fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d7dc-1fd8-fb0a-13da" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
-    <entryLink id="a5e2-cebd-957f-cc8e" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c350-5999-1988-4489" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1f7d-23a6-7263-0f8a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
-    <entryLink id="8eb9-e280-6a73-9f74" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="237a-bba3-bee8-24ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="04cc-6610-9b41-bda9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
-    <entryLink id="3d4a-042b-056e-b8fb" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a410-7441-6ec1-e9d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1e01-fbaa-7bb9-f59e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
-    <entryLink id="38b9-be65-0f8f-c5e5" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="cf26-daa7-1824-ee30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6e5b-2b5c-fb44-50f4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
-    <entryLink id="3fb8-86a4-5eaa-c5da" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="575b-37ac-96f7-baa5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7b85-f61f-f655-a7ab" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
-    <entryLink id="460d-e79c-d3a8-c8b0" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8b56-6736-d08c-43fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d4e9-3255-2b78-fac0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
-    <entryLink id="2225-0ca4-1702-8fdb" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="74eb-b246-f3f8-a5b5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="c7bf-2362-70b8-7583" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
-    <entryLink id="e713-408d-a46b-1944" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="900f-1539-5d72-2a13" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="9730-fda0-ef8c-8700" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
-    <entryLink id="de2d-9a98-f9d0-8376" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink><entryLink id="65a7-b67f-1ad4-655d" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6b73-b21c-4e2b-9d14</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_a7fe-cc62-4a6f-a781</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5be1-1937-4964-a455</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_da1d-b2bc-4117-82a4</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2d22-6ee1-51da-5d7b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b175-46b8-4bfe-5d1a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="e11e-b343-b63e-6b5a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="1489-21a2-4d07-bd0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7010-be56-4709-b058</comment></categoryLink>
+        <categoryLink id="4f8a-f4d5-4f7e-b114" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7379-a740-47ba-a054</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
-    <entryLink id="8e6c-c80b-e372-ab3c" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink><entryLink id="d8cb-af69-e634-2557" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_dd34-83cf-47d7-b557</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_be88-afef-49b3-bd1e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="c112-b274-210c-69ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f466-404e-9ff0-a46a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="a71a-bed7-4494-844c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_944f-7420-4982-8ea9</comment></categoryLink>
+        <categoryLink id="a50c-6437-4f7c-86c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ea80-0efe-457d-a450</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
-    <entryLink id="4d04-02d7-a275-24ec" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink><entryLink id="bea4-21f1-cac1-c329" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><categoryLinks>
+        <categoryLink id="f191-6c74-4606-bee9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9a36-f261-43cc-9bd1</comment></categoryLink>
+        <categoryLink id="75fd-3c54-4cdf-a950" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a648-8396-442a-af59</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink><entryLink id="a5e2-cebd-957f-cc8e" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_cb81-0303-4b88-ae53</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9648-31e3-43aa-8cf3</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_0507-da81-4023-bfcf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0e84-54ff-488d-b066</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="86ad-98f4-0273-9d13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="84c4-3f67-9f73-18c4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="6b5b-3f75-4d08-b2aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6ff-0977-4c92-bb28</comment></categoryLink>
+        <categoryLink id="14ed-e797-4583-ba9e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f555-7d39-458f-84c9</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
-    <entryLink id="3c27-70ed-3739-9f09" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink><entryLink id="8eb9-e280-6a73-9f74" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8203-5b00-497b-b939</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_40ee-3e71-4978-b1e4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f6a8-f660-46dc-b3c5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_d988-3af6-48bf-b0a8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c6c3-7560-453e-8f6f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_39e5-eda5-45d1-a643</comment></categoryLink>
+        <categoryLink id="68dc-bfac-4a4a-88ba" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_6416-21bb-4df4-9de8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink><entryLink id="3d4a-042b-056e-b8fb" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b03e-5d91-4be3-8adc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_0443-29c0-46e9-ad1d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f2c9-7356-4c27-a22f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0e9-4a9e-4b2b-a9d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c4a0-7b0c-4952-99a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5528-2dac-4be5-900c</comment></categoryLink>
+        <categoryLink id="4cb8-2645-4b9b-bd4e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_dc8f-d888-4585-991d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink><entryLink id="38b9-be65-0f8f-c5e5" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1d3c-8e17-489f-9002</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5725-8bee-4bcc-878d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_be47-0d6f-49f2-9f4b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_863c-f3a4-4802-b80c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="aa4c-e3b2-4c67-83a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_899e-b052-4d5b-8c18</comment></categoryLink>
+        <categoryLink id="dffe-6b16-4e1f-939a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f5e9-cff6-41d2-a016</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink><entryLink id="3fb8-86a4-5eaa-c5da" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_72da-1513-4e02-b595</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7a48-a3b0-4a26-849b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e232-25f3-4cb7-8ab2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_9aa4-5660-4697-8ab2</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cf6c-e7ea-414f-a98e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_09cd-2176-40af-bba6</comment></categoryLink>
+        <categoryLink id="3a38-d6e8-4301-9675" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_05e6-7c63-4a35-9ba0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink><entryLink id="460d-e79c-d3a8-c8b0" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d029-44b7-45af-99df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0dfa-4004-4751-8022</comment></categoryLink>
+        <categoryLink id="70fb-763f-4c6b-878a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a669-0f5d-4fd3-811b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink><entryLink id="2225-0ca4-1702-8fdb" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_09b5-4e3b-4c84-a574</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_32e5-ebba-41fb-9ff2</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_838e-0ccf-4d3a-aabd</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_dfef-0ec2-49fb-a534</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5d9a-0b03-4847-a322" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4f60-472b-45a9-ab9e</comment></categoryLink>
+        <categoryLink id="3b14-a126-4512-8db7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e2e3-af36-45a6-a955</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink><entryLink id="e713-408d-a46b-1944" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_a743-0cc2-45ae-a7eb</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2721-e88d-41f7-bedc</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_e10f-1390-4b33-8fcc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6aa2-28ce-4637-b897" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2008-f1c4-4285-a14f</comment></categoryLink>
+        <categoryLink id="280a-430d-4f29-8b1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e88b-a95a-4647-af3b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink><entryLink id="de2d-9a98-f9d0-8376" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_25d8-330b-4574-b515</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7836-6878-47a8-8827</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_5ea9-46dd-4a11-9410</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_ab5d-961b-4924-a705</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="bd87-7eb9-44cb-bbfd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9189-836c-475d-a52e</comment></categoryLink>
+        <categoryLink id="31e3-9699-4212-9052" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_e1fa-b7d8-47b0-a88a</comment></categoryLink>
+        <categoryLink id="28b2-f834-4f65-84fa" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_a137-e3c0-4d63-a48c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink><entryLink id="8e6c-c80b-e372-ab3c" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry"><categoryLinks>
+        <categoryLink id="7fce-6dc4-44f8-a830" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b1d5-fd75-4f17-bbf4</comment></categoryLink>
+        <categoryLink id="edfc-a1ad-4598-b5d5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_f221-bf81-4045-849b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink><entryLink id="4d04-02d7-a275-24ec" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry"><categoryLinks>
+        <categoryLink id="c92f-0ac2-4469-b637" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_51af-a137-4a1c-97a4</comment></categoryLink>
+        <categoryLink id="b78e-d286-4c5c-8468" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ec1f-c326-40a8-9d1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink><entryLink id="3c27-70ed-3739-9f09" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_c111-feb0-4012-98cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_63d7-8427-431d-9ae6</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="19e1-cf1a-de5a-3a75" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="8817-aa93-54a1-bbd8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1934-b921-4584-9156" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_e707-fde1-457f-91c4</comment></categoryLink>
+        <categoryLink id="065e-83f3-4508-901b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ec67-8573-4460-89db</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
-    <entryLink id="3e12-cfe5-d35d-2867" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9a1a-b5ea-a356-1928" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="ca5e-2cb8-913e-76fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink><entryLink id="3e12-cfe5-d35d-2867" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry"><categoryLinks>
+        <categoryLink id="7ffb-aa68-4a39-9e23" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ac1c-b3bf-4011-918a</comment></categoryLink>
+        <categoryLink id="d45e-df6b-4cd9-830e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_589c-1d0e-4b7d-be6b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
-    <entryLink id="a563-4ed7-87d2-1d4f" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3e96-2675-f739-a789" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="c4ba-fcb8-eba6-a607" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
-    <entryLink id="90af-930f-182e-8518" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b16d-4e2f-0edb-62fe" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="907b-8694-3c99-f1cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
-    <entryLink id="87a8-6884-e508-2395" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d3cc-3bd1-6336-ae9e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5a84-2565-3576-94de" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
-        <categoryLink id="41e6-6306-de04-05ac" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
-    <entryLink id="5b3f-b375-7375-5f7a" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8608-d602-5574-25b3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="28fe-18b0-6b49-0aed" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
-    <entryLink id="a710-8b26-1b87-f522" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8391-fd83-9f10-4dbe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d274-15a1-80d4-3013" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
-    <entryLink id="8481-56ed-57c9-49bb" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink><entryLink id="a563-4ed7-87d2-1d4f" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6087-a5e5-4d3c-9ebd</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c7e1-5f42-4528-bf07</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1950-08dc-4544-ab01</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_daf3-31ed-42c0-85dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="80fc-1ac5-7236-2065" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="864c-2f86-9c9e-69e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="54a2-be22-4670-a709" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_7d4f-547c-43ed-a520</comment></categoryLink>
+        <categoryLink id="60de-22e0-4f83-9151" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f04e-04e8-4891-9b1f</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
-    <entryLink id="f06a-1330-a62d-8fe4" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink><entryLink id="90af-930f-182e-8518" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d512-fd07-4a29-863a</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_55c6-a35f-485a-9f0d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d89e-cf1f-4ceb-b3de</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e2c9-0d01-403c-900e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_a7b8-c835-4cb2-b3d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8381-c5f9-8f07-4351" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="c080-5197-cd1f-2bc1" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="869f-d28c-4320-b5ac" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_e22a-c5f8-4825-a45f</comment></categoryLink>
+        <categoryLink id="b00b-2e9b-4244-bbfc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03fc-6a7f-45a5-bcb8</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
-    <entryLink id="c048-6aed-e0c9-05a9" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink><entryLink id="87a8-6884-e508-2395" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry"><categoryLinks>
+        <categoryLink id="7692-594b-4e14-b1fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0aff-4f6e-4b03-a23c</comment></categoryLink>
+        <categoryLink id="f27c-d454-447b-99d8" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"><comment>    template_id_7d5a-62e7-43ee-b79b</comment></categoryLink>
+        <categoryLink id="6940-944b-49d2-b4e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_4986-9157-49f2-b670</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink><entryLink id="5b3f-b375-7375-5f7a" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_319e-90d4-44a3-8e83</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_28db-d943-4099-9abd</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1a45-a592-49df-9465</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb31-d0b2-4677-928e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="59c9-a29a-0ca3-7ebb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="2a27-bdef-2071-7405" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2b78-a63c-4ce1-99b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1b86-0977-4a8b-adac</comment></categoryLink>
+        <categoryLink id="299b-90f0-4b8b-97db" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_b449-403a-4e42-9239</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
-    <entryLink id="175a-9e0a-68ab-35c8" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink><entryLink id="a710-8b26-1b87-f522" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_fbfa-8d78-4d6d-8a05</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_21f2-0916-46bf-b75a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_4fbd-633b-4dd6-9fdd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cad3-b602-4a23-982b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4f71-446f-4cff-afda</comment></categoryLink>
+        <categoryLink id="8c30-97d8-4256-bbd8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_3f44-8647-43a4-ac22</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink><entryLink id="8481-56ed-57c9-49bb" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7583-6fa0-4089-a19e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_0e5c-99ab-41d3-a42e</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c296-e8e8-4a7a-989a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_8868-5bcb-4604-ba8e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d18a-b406-423f-8896" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a009-a597-4b51-b228</comment></categoryLink>
+        <categoryLink id="fff6-fe0e-424f-ae57" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_24f4-9145-4016-80d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink><entryLink id="f06a-1330-a62d-8fe4" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_e732-7499-47bf-9748</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_81a5-a959-46b7-baa4</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7ec3-447a-4644-b012</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_71e2-c430-4c99-a559</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_df7b-3fb9-4f65-9165</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="674e-e8a9-4f35-8fca" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c165-3906-463a-9c73</comment></categoryLink>
+        <categoryLink id="d245-4fe9-4949-9dc2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6d1-d14c-473f-be09</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink><entryLink id="c048-6aed-e0c9-05a9" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_13b3-ce1e-4f9d-8319</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d681-9d81-4abd-b11b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a57-e48b-4534-bca5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_1859-5641-4674-9097</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="99e0-f1a4-408e-b33d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_251a-df5b-4bfd-ad63</comment></categoryLink>
+        <categoryLink id="7838-5c39-4a76-bc76" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4644-98ab-4e3f-b1fd</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink><entryLink id="175a-9e0a-68ab-35c8" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_591d-d028-4663-918d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_0482-c5f9-4c95-9597</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_75a7-971d-4978-a83f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_a7d5-2bfe-4621-ac0c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9f13-b460-4f27-b0cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_31fc-e265-45a7-bb5b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5fc7-b62d-530e-4892" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="f400-1820-e157-cc75" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e835-9b85-4453-b0f4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_67c2-df43-44fc-92d1</comment></categoryLink>
+        <categoryLink id="ddf1-701b-41d2-a4b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4136-bb4e-4dd4-99f9</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
-    <entryLink id="3067-6d02-c8ea-a03b" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink><entryLink id="3067-6d02-c8ea-a03b" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e315-bff8-bbf6-6c8c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="3b5c-963d-23c0-3aea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
-    <entryLink id="aba4-6878-0788-a3dc" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="90a6-9ae7-d542-1774" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="4225-b067-c405-4143" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
-    <entryLink id="f5d9-bece-f973-158f" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0541-6ca5-0619-0ed5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="4129-8f1e-5ca4-31fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
-    <entryLink id="ba21-eab2-432a-2475" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="254f-c967-42b0-45ad" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="d73e-276b-60b5-0787" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
-    <entryLink id="b161-b776-8ce7-6245" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="23f2-c4e6-5cf2-3fc0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="4b72-f7ff-0f3a-6ed0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
-    <entryLink id="fe82-5cc4-9adc-9d46" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3bda-05ee-2b53-f1d7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="3c3f-d108-39ee-63a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
-    <entryLink id="f283-1bce-0b7c-4e43" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="2b7f-5afd-9554-f3cf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="3861-7db7-fef3-8a64" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
-    <entryLink id="7124-6c5b-745f-5685" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="17bc-1559-6f1b-7cc6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="e6cf-e961-ca5a-3d22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
-    <entryLink id="54c9-619a-115d-6477" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="c62d-e194-4ecd-f184" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="c4b6-a051-631e-785e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
-    <entryLink id="603b-327b-e62d-67a6" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="5208-ba63-5fcd-d472" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="6446-51bb-9f89-8e52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
-    <entryLink id="35aa-70ad-086e-39f0" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e4df-7194-e569-cc65" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="9b1a-4f40-03fe-2954" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
-    <entryLink id="c5a2-61b9-4bcc-db25" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="942a-1229-6cb6-c01d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="470c-9306-46e2-6c8b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
-    <entryLink id="51bb-8682-066b-c838" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_99fc-5fe7-4b37-a62f</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_25f4-f6b8-4b44-8350</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_81f7-2311-4cce-95bc</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_09aa-af2a-4012-91d1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_00ae-fad3-4df6-9cb9</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4a6d-548d-97eb-697d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="9aa6-dbd3-a5d7-c7e3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c255-88c9-4314-9911" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f65b-8958-49b3-92a5</comment></categoryLink>
+        <categoryLink id="1def-511a-439e-9447" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0451-1929-4942-8c3f</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
-    <entryLink id="ff4d-e160-221f-1192" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink><entryLink id="aba4-6878-0788-a3dc" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="351d-d206-1388-c6d5" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="d821-9cca-24a9-8751" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
-    <entryLink id="eb83-2fa9-c320-7e5b" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="5ea5-a7a2-97c0-3f76" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="9b52-68af-91d0-3bd9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
-    <entryLink id="8ce3-53d4-e96a-e2de" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7d32-2e6b-d728-b40d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="68b9-cfa2-d75c-8c87" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
-    <entryLink id="c012-84f2-bde7-42b5" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_edc4-4915-40ba-bbf0</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_105f-ba26-4146-bc54</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7a2c-a76c-421c-a8a2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_05c9-0543-47ee-ba81</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e6ad-f0d7-4627-921b</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0b4a-48da-4242-988e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c6a8-22a8-4d41-b969</comment></categoryLink>
+        <categoryLink id="3f35-61ca-45f1-a80c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03ca-12cc-4e0a-b628</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink><entryLink id="f5d9-bece-f973-158f" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ae19-30c0-43c5-920e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_6ebe-1bf3-4d78-9dd0</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1887-152d-48b7-b13f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_a7c4-ee6a-4f0b-8ab0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bd85-fa90-47ff-9f84</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_7bd6-9043-4d7e-ba37</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="bbf9-de75-4e7c-8a7b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3610-c975-4d55-bdfe</comment></categoryLink>
+        <categoryLink id="7b1b-95bc-4a67-a6c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2fc2-f636-4c80-9608</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink><entryLink id="ba21-eab2-432a-2475" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_85c5-d4d9-4b23-9e4d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_80e8-d50b-4906-8153</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_b93b-d4f1-45eb-8a69</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e183-f183-4db7-83b5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0f39-204a-4217-b896</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_eee9-7bfd-4fea-a1bd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="29d8-4893-4769-8f26" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f81d-9435-4f11-99c1</comment></categoryLink>
+        <categoryLink id="a8f0-3f36-4a58-830a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9568-6142-4fdd-be3a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink><entryLink id="b161-b776-8ce7-6245" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_005e-6607-4e2c-8dd2</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_7745-260c-4c36-b719</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_ba25-a4b2-4ba9-b023</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ddeb-f4c8-4091-9153</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4904-fd2f-429f-9cf7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_faea-b21b-43c5-b918</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cd8e-d681-413e-8d04" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_b24f-3ae0-4cbb-b016</comment></categoryLink>
+        <categoryLink id="5365-9e60-417d-bcbb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fd26-8e6b-4521-92b9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink><entryLink id="fe82-5cc4-9adc-9d46" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6ecb-28e2-43ed-a6a0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_c067-1118-4d96-b28b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_250e-23c0-4e43-bf74</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1553-a6e6-4291-853f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_aab6-797b-427a-9fd8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ab1e-5821-460f-87b1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c77f-0819-473b-a8a2</comment></categoryLink>
+        <categoryLink id="a202-7bd7-48f9-858a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_89fb-c924-4daf-923d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink><entryLink id="f283-1bce-0b7c-4e43" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d72c-519a-451f-81b6</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_3d16-444c-42c9-aad1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_f4b2-6371-494b-863a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_797f-a84b-42f6-8e66</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0d78-fe38-4829-9b12</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b26b-fa98-4b3f-997c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0397-c837-4fea-a527</comment></categoryLink>
+        <categoryLink id="6fbe-0a96-4e78-b359" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_060b-bccb-4776-bd83</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink><entryLink id="7124-6c5b-745f-5685" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3c84-6d74-4c42-b38d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_5b15-7aa4-4897-aaf1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_3326-31ed-4151-9b37</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6a0e-1b65-4057-ba5d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f8c7-abc9-45ec-955f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_2538-8dc5-446c-8344</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5ea9-1909-4746-b2ea" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_c1cf-cea4-4278-8f27</comment></categoryLink>
+        <categoryLink id="54e5-6d49-4ade-8f8f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5f51-2734-4a46-9f72</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink><entryLink id="54c9-619a-115d-6477" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af71-f3ff-49b1-83e9</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_1c9e-b3bf-4e88-a43f</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_6d0d-1b1d-4065-89cf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d0b7-8686-491e-9d33</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_7db8-0874-487a-be6f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1034-29a0-44b1-a85f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5605-d1e3-4f4e-afc9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_0c16-6841-42b2-b02d</comment></categoryLink>
+        <categoryLink id="e802-d9d8-411f-be0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_602d-2d2d-4ff4-a82a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink><entryLink id="603b-327b-e62d-67a6" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_22bd-baae-45f9-b366</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_52bd-55de-4d53-ba55</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_df1b-7476-4ab8-8d2f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_49fa-0dcf-4a61-a5b1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0ea-1443-4993-86e7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2a8-3fbe-448c-9902</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6e6b-e874-4f68-9e92" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3632-0b5d-4622-ae33</comment></categoryLink>
+        <categoryLink id="4160-1fc4-4ec5-ad56" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_da44-7815-4fdd-981c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink><entryLink id="35aa-70ad-086e-39f0" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2bfa-b203-47e2-a828</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a39b-8a3c-49cf-bf62</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2a05-07b3-49c5-8145</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f730-87fb-44bd-b68e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_2d0e-6c49-4493-a022</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2e2-50c1-40c3-b4dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="31fa-c2be-4b3a-8d1b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_5ad5-8701-42cd-b2b6</comment></categoryLink>
+        <categoryLink id="1de7-8105-44a3-bda1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_20a4-4346-4a3b-a7d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink><entryLink id="c5a2-61b9-4bcc-db25" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f837-6db8-4fae-9fca" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4e52-ad1b-48d4-8eed</comment></categoryLink>
+        <categoryLink id="4557-2293-442f-a99b" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_6979-1ed3-4f1f-a025</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink><entryLink id="51bb-8682-066b-c838" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4729-bc86-456b-b73d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_cf0f-e3f4-4fb4-989d</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1cc8-5611-4d9a-9218</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_2e32-ca02-48f0-a8dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7fc4-0309-47eb-b285" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_0af1-d052-4bd7-aab6</comment></categoryLink>
+        <categoryLink id="310a-c51f-4f4c-9928" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_45ce-e338-43c9-b63e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink><entryLink id="ff4d-e160-221f-1192" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_db78-4d49-42ab-954a</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_f14d-9943-47b6-866c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a95-938f-4a07-9727</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_7775-78e1-44cc-87c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5089-2257-4ee6-8f60" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_b822-3417-4613-be37</comment></categoryLink>
+        <categoryLink id="bcb9-2aa0-4819-b54e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_25db-b03f-4881-b310</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink><entryLink id="eb83-2fa9-c320-7e5b" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_936f-1ef7-472e-840e</comment>
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+              <comment>    node_id_d73d-d52e-4c75-8ac0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2f40-598e-431e-aefe" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_7a55-ecb4-4e5d-b955</comment></categoryLink>
+        <categoryLink id="4b2b-c811-44bb-a167" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f28c-710e-4ff8-9810</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink><entryLink id="8ce3-53d4-e96a-e2de" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_b743-7a00-43e4-beb8</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d12f-2c98-4e62-a716</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d4d7-ba67-47aa-962f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+                  <comment>    node_id_1637-edee-457a-bb0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b25-6068-44a2-ba92" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_f203-bc26-421f-b79e</comment></categoryLink>
+        <categoryLink id="d472-dbb0-417a-bbe0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_a53e-59d9-4ac2-a21f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink><entryLink id="c012-84f2-bde7-42b5" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3348-16e4-4a9a-a549</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_bea4-c4a8-4843-b9fe</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2970-17ff-4be1-91e5</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_503a-46e7-40e7-bd07</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_4555-15e1-43ff-80a0</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f2f7-4c19-87c9-a916" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="94cb-c54d-d366-cc58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="777c-a916-40a0-8ca7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_fce3-801c-49c8-85d4</comment></categoryLink>
+        <categoryLink id="46ce-a6ee-4757-8c88" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0c2d-2349-44b6-9831</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
-    <entryLink id="2e0a-2e35-22a8-b267" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink><entryLink id="2e0a-2e35-22a8-b267" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="19bf-1708-cb3a-397a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="5feb-05fd-1326-5f6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
-    <entryLink id="abfd-f2ba-0684-9352" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2f46-a0b6-48a5-a0ee</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_636f-0f8a-43f1-910b</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c883-39c8-4a74-aeaa</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_0796-e467-4438-89b3</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="912a-f456-b8cb-ce2d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="65be-35ba-4e9c-9f4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="49b8-177a-478f-bb9c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_5a04-9847-4c91-a49a</comment></categoryLink>
+        <categoryLink id="d58e-a7f9-4e9d-8b5b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b4b4-daeb-483c-a306</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
-    <entryLink id="8d5c-2b26-28f7-a6b4" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink><entryLink id="abfd-f2ba-0684-9352" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_dfdc-f6f6-49d2-a7b3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_354c-c71f-472f-b268</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1127-c974-4663-874d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_0843-bef2-4767-8307</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ac91-ff61-4c5b-9d17" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_28e0-91e7-4ada-9fac</comment></categoryLink>
+        <categoryLink id="dc1e-4f94-460b-ad9b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4448-a712-4dd7-bf6d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink><entryLink id="8d5c-2b26-28f7-a6b4" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafa-470f-4c2c-8be3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_e2ba-a855-4de2-9f46</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_0171-b30d-44ee-9389</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fdfb-119b-4774-934a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_3891-9a00-4f8f-b95f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="483c-8c7e-438d-82e6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e5df-17d4-4521-9d5b</comment></categoryLink>
+        <categoryLink id="2d63-0652-4307-b366" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"><comment>    template_id_0ecd-4873-4d3a-b28b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink><entryLink id="29b7-efb2-b00c-31b5" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af15-2c71-4f8b-833e</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_d95a-80b9-4463-af55</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="118c-b263-a228-d93d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="1061-00eb-1be3-3844" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f350-1bcc-441e-94c6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6b1-886e-4194-8bcd</comment></categoryLink>
+        <categoryLink id="35b2-f26b-443a-bee5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_51b5-f9c1-4587-8fc7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
-    <entryLink id="29b7-efb2-b00c-31b5" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9458-1032-5c85-0b99" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3e95-ab10-bf35-f965" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
-    <entryLink id="57fa-669d-8a9b-96fd" name="Numerologist Cabal" hidden="true" collective="false" import="false" targetId="ca26-b6e2-0bef-85a5" type="selectionEntry">
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink><entryLink id="57fa-669d-8a9b-96fd" name="Numerologist Cabal" hidden="true" collective="false" import="false" targetId="ca26-b6e2-0bef-85a5" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -2188,8 +2939,269 @@
         <categoryLink id="b16c-d76c-4ffc-2668" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-  </entryLinks>
-  <sharedSelectionEntries>
+  <entryLink id="16fc-932b-4534-ad02" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
+    <entryLink id="75b2-723b-48fd-a2ab" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
+    <entryLink id="51a6-b786-4eb9-8b2e" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
+    <entryLink id="174f-46c2-4693-aaca" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <entryLink id="24d0-b77c-4b1e-a8ba" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3531-57d1-4081-882d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_f233-2361-4177-8ba7</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b932-667a-4b43-8331</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <entryLink id="0b90-3598-42e3-b090" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <entryLink id="a264-dc07-4ac0-ac76" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3129-6f59-4365-906b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2bcb-0af1-4aea-9191" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <entryLink id="637f-8fbf-4635-9b5f" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ede2-d453-4e34-8cda</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2907-3215-4b01-96ff</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_c90c-959f-40fb-a4cb</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ba2d-50ad-45f1-91c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0e88-485e-43c2-8bef" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <entryLink id="0e73-fdf5-45e1-b3ae" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_409c-0a5d-4ef8-a871</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7078-c1c7-4af2-b43d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_9a69-0fdc-4957-8982</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1a4c-69b5-4219-8502" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fba0-3ea7-4eaf-b33a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <entryLink id="bcf5-0a28-4245-a457" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
+    <entryLink id="4285-56d5-4db0-b7af" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
+    <entryLink id="a16d-4209-40a9-b75d" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
+    <entryLink id="4f64-f878-448f-832e" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+  </entryLinks><sharedSelectionEntries>
     <selectionEntry id="6161-d387-f086-0958" name="Lernaean Terminator Squad" publicationId="09c5-eeae-f398-b653" page="338" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="e2f0-815b-eec3-19e0" name="Hydran Exemplars" publicationId="09c5-eeae-f398-b653" page="338" hidden="false">

--- a/2022 - LA - Alpha Legion.cat
+++ b/2022 - LA - Alpha Legion.cat
@@ -3689,7 +3689,7 @@
       <entryLinks>
         <entryLink id="60d9-0256-0936-703a" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_7dee-602c-4b47-be09</comment></selectionEntryGroup>
     <selectionEntryGroup id="09f9-933c-a88e-6e38" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ac58-c1d8-56cb-9f48" type="max" />
@@ -3707,7 +3707,7 @@
           </modifiers>
         </entryLink>
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_be38-a066-4f8e-ae54</comment></selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
     <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />

--- a/2022 - LA - Alpha Legion.cat
+++ b/2022 - LA - Alpha Legion.cat
@@ -1,35 +1,34 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9c06-1c61-d01d-8445" name="LA - XX: Alpha Legion" revision="28" battleScribeVersion="2.03" authorName="Alphalas" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="29" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="9c06-1c61-d01d-8445" name="LA - XX: Alpha Legion" revision="28" battleScribeVersion="2.03" authorName="Alphalas" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="29">
   <categoryEntries>
     <categoryEntry id="2275-5253-2421-7383" name="Rewards of Trechery" hidden="false">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2807-51e3-d25f-a9ec" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2807-51e3-d25f-a9ec" type="max" />
       </constraints>
     </categoryEntry>
   </categoryEntries>
   <entryLinks>
     <entryLink id="e317-e9d1-4af8-8de5" name=" XX: Alpha Legion" hidden="false" collective="false" import="true" targetId="c0df-c1fa-5ddc-9ee5" type="selectionEntry">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f412-57a4-c87f-5081" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a338-2298-5f62-d6d0" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f412-57a4-c87f-5081" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a338-2298-5f62-d6d0" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="e87e-6482-7fb1-d401" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="e87e-6482-7fb1-d401" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4468-6b05-89df-92c9" name="Rewards of Treachery" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a55-15b9-4ff6-e4cf" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="400c-4f11-d6ab-a665" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a55-15b9-4ff6-e4cf" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="400c-4f11-d6ab-a665" type="min" />
           </constraints>
           <categoryLinks>
-            <categoryLink id="fb80-a015-c2da-9d72" name="New CategoryLink" hidden="false" targetId="2275-5253-2421-7383" primary="true"/>
+            <categoryLink id="fb80-a015-c2da-9d72" name="New CategoryLink" hidden="false" targetId="2275-5253-2421-7383" primary="true" />
           </categoryLinks>
           <entryLinks>
-            <entryLink id="b935-123f-ef5d-3bc1" name="Legion" hidden="false" collective="false" import="true" targetId="4a48-4935-246d-0c2e" type="selectionEntryGroup"/>
+            <entryLink id="b935-123f-ef5d-3bc1" name="Legion" hidden="false" collective="false" import="true" targetId="4a48-4935-246d-0c2e" type="selectionEntryGroup" />
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -40,138 +39,138 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="296e-301e-3ce1-1c15" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="296e-301e-3ce1-1c15" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="007a-4705-5f7a-695b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="69ff-87ed-3c34-3742" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="c597-72fd-c1c9-39ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="007a-4705-5f7a-695b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="69ff-87ed-3c34-3742" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="c597-72fd-c1c9-39ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="8bd1-2ebe-9806-2c7a" name="Alpharius" hidden="false" collective="false" import="false" targetId="e56e-40d5-e362-0e1c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3a48-ebd5-979a-ab0e" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
-        <categoryLink id="b56c-b87b-07a2-6437" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3a48-ebd5-979a-ab0e" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true" />
+        <categoryLink id="b56c-b87b-07a2-6437" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="d7e9-6d99-675b-0a20" name="Armillus Dynat" hidden="false" collective="false" import="false" targetId="42af-ab98-e733-dc01" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="dd12-09e4-7e98-1293" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="3732-e871-9e0b-7235" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="b2da-e306-a467-d325" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="dd12-09e4-7e98-1293" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="3732-e871-9e0b-7235" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="b2da-e306-a467-d325" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="9515-498a-82b3-893b" name="Exodus" hidden="false" collective="false" import="false" targetId="f912-9416-39ea-b3fc" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2c9a-c549-943f-5cd4" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="9b6f-0ee4-663a-93da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2c9a-c549-943f-5cd4" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="9b6f-0ee4-663a-93da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="886e-415e-5ab8-3190" name="Headhunter Kill Team" hidden="false" collective="false" import="false" targetId="70e6-ace3-8feb-1ddc" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8616-35c3-c887-a64c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="c995-fa87-2f17-b073" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8616-35c3-c887-a64c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="c995-fa87-2f17-b073" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="d20f-c0b6-43bd-93a0" name="Lernaean Terminator Squad" hidden="false" collective="false" import="false" targetId="6161-d387-f086-0958" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="46d2-e42c-5804-d2d4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="1a05-3dc3-65de-89f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="46d2-e42c-5804-d2d4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="1a05-3dc3-65de-89f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="3249-0974-fb92-4e6b" name="Contemptor-Incaendius Dreadnought" hidden="true" collective="false" import="false" targetId="090c-5656-0180-16c8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="296e-301e-3ce1-1c15" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="296e-301e-3ce1-1c15" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c05e-35d3-2f58-ee87" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="85bf-5c39-d77e-de7e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="0322-dc48-e060-7882" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c05e-35d3-2f58-ee87" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="85bf-5c39-d77e-de7e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="0322-dc48-e060-7882" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="fef9-8f33-d164-6c07" name="Dawnbreaker Cohort" hidden="true" collective="false" import="false" targetId="3c67-35da-d64a-f22b" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="296e-301e-3ce1-1c15" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="296e-301e-3ce1-1c15" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a8ff-df82-9b34-d336" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="2a5f-6671-1cd0-8824" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="7f2a-7de5-1140-d4c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a8ff-df82-9b34-d336" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="2a5f-6671-1cd0-8824" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="7f2a-7de5-1140-d4c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="5a11-ffcb-138c-07af" name="The Angel&apos;s Tears" hidden="true" collective="false" import="false" targetId="dda1-0fcf-0245-6c10" type="selectionEntry">
+    <entryLink id="5a11-ffcb-138c-07af" name="The Angel's Tears" hidden="true" collective="false" import="false" targetId="dda1-0fcf-0245-6c10" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="296e-301e-3ce1-1c15" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="296e-301e-3ce1-1c15" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="04c0-2b59-6737-2841" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="4cb8-a680-b384-2e82" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="209d-5586-1f70-fda7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="04c0-2b59-6737-2841" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4cb8-a680-b384-2e82" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="209d-5586-1f70-fda7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="4ebf-55c4-fb59-569d" name="Dreadwing Interemptor Squad" hidden="true" collective="false" import="false" targetId="3008-e8ed-9e97-71c9" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b3ad-92e7-3dcd-b644" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="ea34-926e-6a09-afe1" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="ae94-21c7-e1d1-a2fc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b3ad-92e7-3dcd-b644" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="ea34-926e-6a09-afe1" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="ae94-21c7-e1d1-a2fc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="4d98-c46c-40f7-b5f4" name="Firewing Enigmatus Cabal" hidden="true" collective="false" import="false" targetId="3731-e0df-bd0c-a33e" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="46a9-0c8d-202d-f470" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="1cb0-db62-d7b8-96fb" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="4bac-0e00-a20e-b1bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="46a9-0c8d-202d-f470" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="1cb0-db62-d7b8-96fb" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="4bac-0e00-a20e-b1bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="948c-2c74-497e-47e8" name="Excindio Battle-automata" hidden="true" collective="false" import="false" targetId="cf23-fd3a-15a0-7347" type="selectionEntry">
@@ -180,21 +179,21 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6141-22f3-bbe6-e74f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="1aa8-88aa-6181-ff4c" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="e183-a5aa-1334-af65" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6141-22f3-bbe6-e74f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="1aa8-88aa-6181-ff4c" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="e183-a5aa-1334-af65" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="3d59-14ba-095f-f402" name="Inner Circle Knights Cenobium" hidden="true" collective="false" import="false" targetId="9946-61c0-3656-36dd" type="selectionEntry">
@@ -203,21 +202,21 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="10d9-0cba-6158-32a9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="f31f-785e-2f52-2ebc" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="ecd5-a8eb-ac46-efaa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="10d9-0cba-6158-32a9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="f31f-785e-2f52-2ebc" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="ecd5-a8eb-ac46-efaa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="853d-6ff7-293a-3474" name="Inner Circle Knights Cenobium - Order of the Broken Claws" hidden="true" collective="false" import="false" targetId="b9ad-ab3e-437e-c373" type="selectionEntry">
@@ -226,35 +225,35 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="41da-54c7-c6c3-4991" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="b730-a050-02af-16d5" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="6522-92fe-75aa-77a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="41da-54c7-c6c3-4991" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="b730-a050-02af-16d5" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="6522-92fe-75aa-77a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="1193-4e5a-ab65-f739" name="Mortus Poisoner Squad" hidden="true" collective="false" import="false" targetId="dd7b-fe21-cf53-0ebc" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b9f4-db55-fe6d-94b2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="2c47-5afd-2dc9-7b56" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="3cca-372c-6f4e-a10e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b9f4-db55-fe6d-94b2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="2c47-5afd-2dc9-7b56" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="3cca-372c-6f4e-a10e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="241d-6c1a-dfe4-5b69" name="Grave Warden Terminator Squad" hidden="true" collective="false" import="false" targetId="be32-77c9-fe55-7dc0" type="selectionEntry">
@@ -263,21 +262,21 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="16e5-e6f3-635f-6251" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="c1e3-bbfd-225e-5ab3" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="60eb-e7a6-75c2-be95" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="16e5-e6f3-635f-6251" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="c1e3-bbfd-225e-5ab3" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="60eb-e7a6-75c2-be95" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="26ab-aed8-c986-17d5" name="Kakophoni Squad" hidden="true" collective="false" import="false" targetId="8359-c463-9cde-4f21" type="selectionEntry">
@@ -286,90 +285,90 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e90b-c3e4-96a6-40d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cba5-d0a7-9735-c282" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="a921-1b20-3242-bd7a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="e90b-c3e4-96a6-40d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cba5-d0a7-9735-c282" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="a921-1b20-3242-bd7a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="027a-256b-f351-75f5" name="Palatine Blade Squad" hidden="true" collective="false" import="false" targetId="fa86-f7a5-0062-a205" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="980f-cfcf-c294-e804" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a7f9-b7c1-8756-f9ea" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="0df2-e5ac-30c0-562a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="980f-cfcf-c294-e804" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a7f9-b7c1-8756-f9ea" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="0df2-e5ac-30c0-562a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="c326-cb15-c3dd-3f9c" name="Phoenix Terminator Squad" hidden="true" collective="false" import="false" targetId="5b08-65c1-cc45-1b91" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a77e-592b-fe68-b614" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3e22-e8a9-32e5-c9ca" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="e8d2-9f63-b325-32c0" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="a77e-592b-fe68-b614" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3e22-e8a9-32e5-c9ca" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="e8d2-9f63-b325-32c0" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="4dbb-34a4-fdd2-0cbf" name="Sun Killer Squad" hidden="true" collective="false" import="false" targetId="cce2-fd03-ac17-88e4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="731f-fd34-3855-df4a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9f80-c46b-5b87-06fc" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="731f-fd34-3855-df4a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9f80-c46b-5b87-06fc" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="0830-4929-8091-746a" name="Huscarl Squad" hidden="true" collective="false" import="false" targetId="4420-5ce0-beb7-cb5e" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6c1e-4c9e-e3bd-1ed1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="85c5-b06d-1d39-aad0" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="b485-56bf-6221-dd06" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6c1e-4c9e-e3bd-1ed1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="85c5-b06d-1d39-aad0" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="b485-56bf-6221-dd06" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="0457-3563-1aab-ece5" name="Templar Brethren" hidden="true" collective="false" import="false" targetId="6f69-665c-3199-77aa" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bae3-e5c1-dfc6-dc12" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="274f-7764-d62a-c30a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="7001-3855-b64e-05b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bae3-e5c1-dfc6-dc12" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="274f-7764-d62a-c30a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="7001-3855-b64e-05b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="e31e-95d0-222e-589c" name="Phalanx Warder Squad" hidden="true" collective="false" import="false" targetId="19ce-b8dc-dd40-fee9" type="selectionEntry">
@@ -378,21 +377,21 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="08d9-f6ed-b8dd-e10c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="a4fa-28fa-2625-6b6e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="94ac-87ca-a047-7f37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="08d9-f6ed-b8dd-e10c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="a4fa-28fa-2625-6b6e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="94ac-87ca-a047-7f37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="c427-5adb-5425-5ab9" name="Gorgon Terminator Squad" hidden="true" collective="false" import="false" targetId="ea50-6315-7a52-f560" type="selectionEntry">
@@ -401,21 +400,21 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e9fb-2b4f-655a-82db" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="90cd-cd1d-07cb-c23b" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="4e70-99fb-415a-a938" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e9fb-2b4f-655a-82db" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="90cd-cd1d-07cb-c23b" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="4e70-99fb-415a-a938" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="dac8-a583-c05d-6c22" name="Medusan Immortal Squad" hidden="true" collective="false" import="false" targetId="f9e4-0da2-5049-df81" type="selectionEntry">
@@ -424,21 +423,21 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ae0e-4cf9-c6f7-c1a2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="a82b-8ee2-5f4e-826f" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="1461-85ec-945e-5e31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ae0e-4cf9-c6f7-c1a2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="a82b-8ee2-5f4e-826f" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="1461-85ec-945e-5e31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="84af-f180-93a9-b4e6" name="Iron Circle Maniple" hidden="true" collective="false" import="false" targetId="a6e3-baab-45b9-7fea" type="selectionEntry">
@@ -447,21 +446,21 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="475a-4d51-e6b1-b353" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="9758-f439-2d9f-f6c0" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="443f-534b-ca5c-39ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="475a-4d51-e6b1-b353" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="9758-f439-2d9f-f6c0" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="443f-534b-ca5c-39ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="21ea-86f3-aab1-a0cc" name="Tyrant Siege Terminator Squad" hidden="true" collective="false" import="false" targetId="795a-5698-a1bc-6ec6" type="selectionEntry">
@@ -470,35 +469,35 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8d21-c340-4539-6209" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="8daf-d124-9b5c-e0c1" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="c6fd-e694-7395-20f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8d21-c340-4539-6209" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="8daf-d124-9b5c-e0c1" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="c6fd-e694-7395-20f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="f48c-ea6c-0fbc-598a" name="Dominator Cohort" hidden="true" collective="false" import="false" targetId="1bfa-2413-beb9-5f32" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f056-f0c1-ad40-6834" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="54f4-39a6-c4fc-c33e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="fe1a-584c-173e-87f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f056-f0c1-ad40-6834" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="54f4-39a6-c4fc-c33e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="fe1a-584c-173e-87f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="c4d9-2b32-325e-9c4f" name="Iron Havocs" hidden="true" collective="false" import="false" targetId="d355-5488-1277-fabf" type="selectionEntry">
@@ -507,119 +506,119 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6eb4-905f-5c57-cf57" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="68dc-de7f-8ab8-838d" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="3166-a82f-5b57-1c5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6eb4-905f-5c57-cf57" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="68dc-de7f-8ab8-838d" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="3166-a82f-5b57-1c5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="3291-aa2f-0e9e-017f" name="Atramentar Squad" hidden="true" collective="false" import="false" targetId="12d3-9df0-4118-997f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b28b-71f7-e4f4-8f9c" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b28b-71f7-e4f4-8f9c" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c435-91dd-cb19-23ed" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="cdf9-f163-9e6d-1243" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="4ee3-79a9-4706-6791" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c435-91dd-cb19-23ed" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="cdf9-f163-9e6d-1243" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="4ee3-79a9-4706-6791" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="30e5-1996-ad7f-1cb8" name="Terror Squad" hidden="true" collective="false" import="false" targetId="53ce-6dc9-aa69-fbaa" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b28b-71f7-e4f4-8f9c" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b28b-71f7-e4f4-8f9c" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1f0a-5ac7-30de-45e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="ae02-dcb6-4b6e-f03e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="127b-1f7c-f850-d939" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1f0a-5ac7-30de-45e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="ae02-dcb6-4b6e-f03e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="127b-1f7c-f850-d939" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="0303-9efb-a46c-9e35" name="Night Raptor Squad" hidden="true" collective="false" import="false" targetId="9bb8-8fe4-11c1-9e50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b28b-71f7-e4f4-8f9c" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b28b-71f7-e4f4-8f9c" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a09d-624d-b66c-4f59" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="1175-0a3e-b135-13f0" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="aebc-435f-a0b7-79c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a09d-624d-b66c-4f59" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="1175-0a3e-b135-13f0" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="aebc-435f-a0b7-79c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="522b-84dd-0422-1ca5" name="Contekar Terminator Squad" hidden="true" collective="false" import="false" targetId="837e-c3ca-437e-dfbf" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b28b-71f7-e4f4-8f9c" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b28b-71f7-e4f4-8f9c" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="57a2-7099-cbed-ecc4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="d02b-01a8-c88c-266f" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="aa49-0b17-af19-2871" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="57a2-7099-cbed-ecc4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="d02b-01a8-c88c-266f" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="aa49-0b17-af19-2871" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="3449-42bd-723e-8f58" name="Dark Furies" hidden="true" collective="false" import="false" targetId="58f4-3d8d-f243-6e5d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="97b1-3f08-d172-8a15" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="90c2-8531-b18d-b9b9" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="a1a6-0507-e958-2599" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="97b1-3f08-d172-8a15" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="90c2-8531-b18d-b9b9" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="a1a6-0507-e958-2599" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="61aa-3233-8f98-7243" name="Mor Deythan Squad" hidden="true" collective="false" import="false" targetId="c268-08ac-5b90-d034" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0d35-e913-d462-7066" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="6267-16c3-3f0c-d3ce" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="af87-08f0-109f-d6c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0d35-e913-d462-7066" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="6267-16c3-3f0c-d3ce" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="af87-08f0-109f-d6c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="2563-d825-3a1f-556a" name="Deliverers Squad" hidden="true" collective="false" import="false" targetId="5d1d-8348-ed95-d366" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="95ea-2552-bc04-8f45" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="8610-0a32-a51b-1666" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="e8ef-534c-a9ca-b1e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="95ea-2552-bc04-8f45" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="8610-0a32-a51b-1666" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="e8ef-534c-a9ca-b1e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="9c8e-6562-6c4b-5687" name="Firedrake Terminator Squad" hidden="true" collective="false" import="false" targetId="6775-8379-8d6b-9614" type="selectionEntry">
@@ -628,35 +627,35 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5fe0-ce32-6415-3d27" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="b2d4-8fb2-d07a-d9d1" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="2b5a-3212-0e2c-4b35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5fe0-ce32-6415-3d27" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="b2d4-8fb2-d07a-d9d1" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="2b5a-3212-0e2c-4b35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="2982-0553-c877-9b8c" name="Pyroclast Squad" hidden="true" collective="false" import="false" targetId="71fe-d3bc-b7f9-75ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fe9d-d416-66cc-3840" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="5bbd-91c1-a792-d250" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="5dcd-cef6-8861-fba9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fe9d-d416-66cc-3840" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="5bbd-91c1-a792-d250" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="5dcd-cef6-8861-fba9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="e30f-252c-9d00-eb3a" name="Deathsworn Pack" hidden="true" collective="false" import="false" targetId="3fa0-d6ed-981b-e361" type="selectionEntry">
@@ -665,21 +664,21 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ab26-ddb6-3918-328e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="6b1d-a72a-6eae-d530" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="ad6f-009a-e3fd-03f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ab26-ddb6-3918-328e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="6b1d-a72a-6eae-d530" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="ad6f-009a-e3fd-03f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="1d61-9489-044c-4d84" name="Chieftain Squad" hidden="true" collective="false" import="false" targetId="0c73-9141-d1b4-6a40" type="selectionEntry">
@@ -688,21 +687,21 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01b4-57c7-bf61-2abf" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01b4-57c7-bf61-2abf" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="aa05-6f88-816e-bfda" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="387c-5bef-8480-79fa" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="e42f-2919-31ba-66ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="aa05-6f88-816e-bfda" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="387c-5bef-8480-79fa" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="e42f-2919-31ba-66ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="3762-6cfd-39ef-1a13" name="Justaerin Terminator Squad" hidden="true" collective="false" import="false" targetId="c45d-ade3-6b28-68a2" type="selectionEntry">
@@ -711,49 +710,49 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01b4-57c7-bf61-2abf" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01b4-57c7-bf61-2abf" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a321-0fd1-53f5-1756" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="75fd-7486-ed31-b419" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="d328-4b4c-55b5-63bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a321-0fd1-53f5-1756" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="75fd-7486-ed31-b419" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="d328-4b4c-55b5-63bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="38cc-adf2-fed4-85be" name="Reaver Agressor Squad" hidden="true" collective="false" import="false" targetId="af3a-334f-152f-d55f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01b4-57c7-bf61-2abf" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01b4-57c7-bf61-2abf" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e5a7-c6bf-98d1-b1f7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="5f5b-f5e8-7f86-eb96" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="441b-6620-46c3-d0b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e5a7-c6bf-98d1-b1f7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="5f5b-f5e8-7f86-eb96" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="441b-6620-46c3-d0b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="4ed2-aeff-41a0-466f" name="Reaver Attack Squad" hidden="true" collective="false" import="false" targetId="8b29-bf2a-a814-5642" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01b4-57c7-bf61-2abf" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01b4-57c7-bf61-2abf" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6400-720a-7c91-b8c6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="dcf6-53ba-4274-e748" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="6da8-2162-e41c-9dbb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6400-720a-7c91-b8c6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="dcf6-53ba-4274-e748" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="6da8-2162-e41c-9dbb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="7666-52aa-d0d6-05f9" name="Varagyr Wolf Guard Terminator Squad" hidden="true" collective="false" import="false" targetId="9359-61a5-fcdb-c28e" type="selectionEntry">
@@ -762,126 +761,126 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="13ca-19e6-fa4c-59a3" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="226f-9aa6-780b-aac9" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="98c7-72db-c50a-e9e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="13ca-19e6-fa4c-59a3" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="226f-9aa6-780b-aac9" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="98c7-72db-c50a-e9e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="d7de-2fe2-d8a3-0134" name="Grey Slayer Pack" hidden="true" collective="false" import="false" targetId="4bbf-f3df-7b18-4a49" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="greaterThan" />
           </conditions>
         </modifier>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6792-3273-84df-2c16" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="ae24-f3cc-26f6-f8ed" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="c36d-5646-132d-cfde" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="6792-3273-84df-2c16" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="ae24-f3cc-26f6-f8ed" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="c36d-5646-132d-cfde" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="76d1-b4cc-e1c4-f8d0" name="Grey Stalker Pack" hidden="true" collective="false" import="false" targetId="4dbc-6266-853a-5114" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="greaterThan" />
           </conditions>
         </modifier>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dc7c-154a-28ef-62cc" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="9e6c-a4a4-973d-f93f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="90e3-ff3c-3b76-d42c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
-        <categoryLink id="26c4-7af8-ab43-8177" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="dc7c-154a-28ef-62cc" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="9e6c-a4a4-973d-f93f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="90e3-ff3c-3b76-d42c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="26c4-7af8-ab43-8177" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="d7db-4065-219f-32fe" name="Jorlund Hunter Pack" hidden="true" collective="false" import="false" targetId="fcc8-bc3c-e443-eb3f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8fc2-00bd-c7a6-0cca" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="c1c1-f2a0-d7a8-8a2f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="73b5-a699-f247-c096" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8fc2-00bd-c7a6-0cca" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="c1c1-f2a0-d7a8-8a2f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="73b5-a699-f247-c096" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="59b0-23da-b88c-698b" name="Ammitara Occult Intercession Cabal" hidden="true" collective="false" import="false" targetId="d3ad-275c-e22b-a28f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8cce-74a0-825f-76b2" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="fcea-6b0f-9886-453f" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="0f28-156d-4624-4fb8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8cce-74a0-825f-76b2" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="fcea-6b0f-9886-453f" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="0f28-156d-4624-4fb8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="87d8-139a-0e23-da54" name="Castellax-Achea Automata" hidden="true" collective="false" import="false" targetId="95cb-9366-295e-f10d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="10b6-efe8-eb05-1122" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="8493-2d60-abcf-0341" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="b10b-27e3-45a1-93c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="10b6-efe8-eb05-1122" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="8493-2d60-abcf-0341" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="b10b-27e3-45a1-93c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="6cc5-b7ae-1d59-c024" name="Khenetai Occult Cabal" hidden="true" collective="false" import="false" targetId="faa7-27d5-2ee2-5d58" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="43b6-e5db-d065-4c3d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="3e9e-aa2d-e31b-82b4" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="985b-042a-6c7f-3d8b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="43b6-e5db-d065-4c3d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="3e9e-aa2d-e31b-82b4" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="985b-042a-6c7f-3d8b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="7471-4aa8-40a3-ba58" name="Sekhmet Terminator Cabal" hidden="true" collective="false" import="false" targetId="dda2-bdd0-3ced-b427" type="selectionEntry">
@@ -890,21 +889,21 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e9db-b17f-ef90-49c9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="9881-969b-bd71-6e33" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="b75b-ced4-7c8c-82ee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e9db-b17f-ef90-49c9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="9881-969b-bd71-6e33" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="b75b-ced4-7c8c-82ee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="9e0a-dda3-e372-0548" name="Fulmentarus Terminator Squad" hidden="true" collective="false" import="false" targetId="7fb0-6302-d46f-029d" type="selectionEntry">
@@ -913,21 +912,21 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4b53-0b13-f50e-bd04" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="4e61-2ef8-09c5-342f" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="6ef7-3e18-5801-0c99" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4b53-0b13-f50e-bd04" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4e61-2ef8-09c5-342f" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="6ef7-3e18-5801-0c99" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="ffee-e152-1467-4bed" name="Invictarus Suzerain Squad" hidden="true" collective="false" import="false" targetId="ed63-e872-9410-a4b5" type="selectionEntry">
@@ -936,49 +935,49 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6081-3aef-69a9-0723" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="46a6-2a49-b309-965a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="6a44-ef13-acf2-cef6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6081-3aef-69a9-0723" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="46a6-2a49-b309-965a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="6a44-ef13-acf2-cef6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="f900-3681-c641-0842" name="Locutarus Storm Squad" hidden="true" collective="false" import="false" targetId="314d-f363-fb52-743a" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="10ca-0f92-db85-de6f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="4582-1241-6135-f55c" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="3be9-a405-a78b-a1d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="10ca-0f92-db85-de6f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="4582-1241-6135-f55c" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="3be9-a405-a78b-a1d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="35c9-cc7b-a14e-a4c7" name="Nemesis Destroyer Squad" hidden="true" collective="false" import="false" targetId="32d1-29a6-9023-142c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8576-3c18-b764-3bf9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="b291-e267-0c5b-6b07" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="ecf9-b782-cdec-0f89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8576-3c18-b764-3bf9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="b291-e267-0c5b-6b07" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="ecf9-b782-cdec-0f89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="dbed-4afc-faad-50c6" name="Praetorian Breacher Squad" hidden="true" collective="false" import="false" targetId="7587-35cc-01f6-b5d2" type="selectionEntry">
@@ -987,21 +986,21 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b90f-7fe3-220d-b301" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="2601-513b-bf12-ee56" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="3d0a-44a8-dd1c-1167" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b90f-7fe3-220d-b301" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="2601-513b-bf12-ee56" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="3d0a-44a8-dd1c-1167" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="ab1f-ce36-7a3a-e274" name="Golden Keshig Squadron" hidden="true" collective="false" import="false" targetId="1d55-faa7-caa5-a132" type="selectionEntry">
@@ -1010,35 +1009,35 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2abe-d220-2c83-214a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="8957-dd47-1e4a-f19e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="101d-e6ef-d933-ef24" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2abe-d220-2c83-214a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="8957-dd47-1e4a-f19e" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="101d-e6ef-d933-ef24" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="7aa6-6013-0a0a-ea52" name="Ebon Keshig Cohort" hidden="true" collective="false" import="false" targetId="eb44-e977-2ce5-b239" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="99d9-1f22-45d6-01e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2d51-411b-c502-acaf" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="375c-755b-17a9-1232" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="99d9-1f22-45d6-01e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2d51-411b-c502-acaf" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="375c-755b-17a9-1232" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="336e-3223-67ce-912c" name="Kyzagan Assault Speeder Squadron" hidden="true" collective="false" import="false" targetId="e37e-09ea-50c6-2daa" type="selectionEntry">
@@ -1047,49 +1046,49 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3e18-b878-223f-289e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="1538-9081-32fa-c24b" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="6de1-d44e-3b0c-d4b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3e18-b878-223f-289e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="1538-9081-32fa-c24b" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="6de1-d44e-3b0c-d4b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="034d-cae7-d430-71a5" name="Dark Sons of Death" hidden="true" collective="false" import="false" targetId="4372-ad51-04a6-97ce" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="806e-73fd-00f3-b1ca" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="55ad-798d-1f21-7563" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="1c7f-0bda-93a9-fd09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="806e-73fd-00f3-b1ca" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="55ad-798d-1f21-7563" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="1c7f-0bda-93a9-fd09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="00c2-d209-94ce-05ad" name="Falcon&apos;s Claws" hidden="true" collective="false" import="false" targetId="c598-7fda-13d0-7523" type="selectionEntry">
+    <entryLink id="00c2-d209-94ce-05ad" name="Falcon's Claws" hidden="true" collective="false" import="false" targetId="c598-7fda-13d0-7523" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="89aa-08cc-1ad3-9073" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="6cef-29a8-2dba-b29a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="c6fd-0435-662e-908d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="89aa-08cc-1ad3-9073" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="6cef-29a8-2dba-b29a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="c6fd-0435-662e-908d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="b16e-245e-993e-37a4" name="Ashen Circle" hidden="true" collective="false" import="false" targetId="f4e7-a798-a322-dc10" type="selectionEntry">
@@ -1098,63 +1097,63 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9dbf-0760-d7ae-f125" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9dbf-0760-d7ae-f125" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b1a0-b911-73a6-3f52" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="399f-5ed8-9211-f7be" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="9503-23d5-fc66-cea2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b1a0-b911-73a6-3f52" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="399f-5ed8-9211-f7be" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="9503-23d5-fc66-cea2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="54d0-9a88-bfb3-dce5" name="Mhara Gal Dreadnought" hidden="true" collective="false" import="false" targetId="5254-5c76-10d4-c909" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9dbf-0760-d7ae-f125" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9dbf-0760-d7ae-f125" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="581b-17a1-da13-5fea" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="7f2e-7d15-717b-90a6" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="99e6-38c3-c771-151d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="581b-17a1-da13-5fea" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="7f2e-7d15-717b-90a6" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="99e6-38c3-c771-151d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="1ffe-18a3-a1e0-fae5" name="Gal Vorbak Squad" hidden="true" collective="false" import="false" targetId="be3a-5acc-b4bd-8621" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9dbf-0760-d7ae-f125" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9dbf-0760-d7ae-f125" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6af3-1969-4705-0fb1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="91af-e352-f10a-b59a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="c519-c47d-546b-3000" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6af3-1969-4705-0fb1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="91af-e352-f10a-b59a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="c519-c47d-546b-3000" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="e2e9-3770-5b79-8838" name="Rampager Squad" hidden="true" collective="false" import="false" targetId="2fb9-74a8-43b0-dd00" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d168-2562-e83e-8e9b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="2eb1-2e57-dbbc-957b" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="ce2b-fc21-8058-7388" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d168-2562-e83e-8e9b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="2eb1-2e57-dbbc-957b" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="ce2b-fc21-8058-7388" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="62ad-e646-2deb-0a06" name="Red Butchers" hidden="true" collective="false" import="false" targetId="1987-2aa5-929b-979e" type="selectionEntry">
@@ -1163,993 +1162,993 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bab1-bf37-f813-87b0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="7d89-c6b5-084b-5ed7" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="dc77-206a-860a-db65" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bab1-bf37-f813-87b0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="7d89-c6b5-084b-5ed7" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="dc77-206a-860a-db65" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="5613-923b-06e3-3d91" name="Red Hand Destroyer Assault Squad" hidden="true" collective="false" import="false" targetId="7a04-bc44-70bb-cb98" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6601-3a00-9ee4-d330" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="822c-7e6e-04bd-e562" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="ca87-f80f-b302-cabb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6601-3a00-9ee4-d330" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="822c-7e6e-04bd-e562" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="ca87-f80f-b302-cabb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="f1f4-2076-9174-8149" name="Contemptor-Osiron Dreadnought Talon" hidden="true" collective="false" import="false" targetId="eef1-0f91-a59f-b3e2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="87af-6bfa-d646-4441" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="b0ef-c961-5f21-627a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
-        <categoryLink id="7618-a59b-753f-2ff8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="87af-6bfa-d646-4441" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="b0ef-c961-5f21-627a" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
+        <categoryLink id="7618-a59b-753f-2ff8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="9e61-f556-1d53-d498" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="30c6-07bb-66e2-7586" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dbad-f03d-2374-d4fe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="30c6-07bb-66e2-7586" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="dbad-f03d-2374-d4fe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
     <entryLink id="b606-853d-d4d2-f65c" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6ae1-591c-b00d-41ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f291-ca6c-f515-b766" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6ae1-591c-b00d-41ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f291-ca6c-f515-b766" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
     <entryLink id="c7fd-2e08-2272-d83f" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f98f-f9ef-94fe-28b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="48a4-d400-2275-20e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3f76-a329-e3cf-fb10" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="f98f-f9ef-94fe-28b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="48a4-d400-2275-20e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3f76-a329-e3cf-fb10" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="ba5e-59d7-8e8d-4b06" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7b83-b262-dea6-9101" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="48ba-bc38-5e44-7893" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6553-6f18-eb65-92bc" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="7b83-b262-dea6-9101" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="48ba-bc38-5e44-7893" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6553-6f18-eb65-92bc" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
     <entryLink id="fb8d-6314-050f-ca29" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="89d5-edca-9a9f-f11d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="de55-8a31-476c-f9fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d75f-9534-fdae-1ec1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="89d5-edca-9a9f-f11d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="de55-8a31-476c-f9fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d75f-9534-fdae-1ec1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="35cc-ad2e-7808-03f4" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup"/>
+        <entryLink id="35cc-ad2e-7808-03f4" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup" />
         <entryLink id="9c83-c217-aeb9-b37b" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
     <entryLink id="ea7b-3257-1195-c916" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cab2-c502-6f7b-2c72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="94fb-f54b-5100-c67a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="bb45-ca2b-c893-43dd" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="cab2-c502-6f7b-2c72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="94fb-f54b-5100-c67a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="bb45-ca2b-c893-43dd" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="4c7f-801b-9b25-2ffb" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup"/>
+        <entryLink id="4c7f-801b-9b25-2ffb" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup" />
         <entryLink id="c1b6-16f6-5c19-359a" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
     <entryLink id="2656-d573-fed9-0490" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="90ef-1989-c7c5-e945" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="512b-2135-2521-6f18" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="2012-9645-f680-f750" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="90ef-1989-c7c5-e945" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="512b-2135-2521-6f18" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="2012-9645-f680-f750" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="6a6c-812f-ce8f-e826" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup"/>
+        <entryLink id="6a6c-812f-ce8f-e826" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup" />
         <entryLink id="b495-ad40-bec7-7f4d" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
     <entryLink id="2f88-d6b1-dd8a-ecc0" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3b2c-8463-91f4-3403" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="8d0e-9409-6060-6057" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3b2c-8463-91f4-3403" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="8d0e-9409-6060-6057" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
     <entryLink id="0879-5810-e96b-da21" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="98be-e25b-29d6-2166" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="09af-4e67-1395-20c2" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="98be-e25b-29d6-2166" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="09af-4e67-1395-20c2" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
     <entryLink id="b51f-90bc-e5ba-2a3c" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3e37-d797-92a9-9210" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6acb-a40f-164d-71df" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="3e37-d797-92a9-9210" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6acb-a40f-164d-71df" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
     <entryLink id="c07f-7c57-bdbe-2daa" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="be1a-f2e2-1c45-b41b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7083-52ed-4eeb-2105" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="be1a-f2e2-1c45-b41b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7083-52ed-4eeb-2105" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
     <entryLink id="2c8a-e224-a5f0-2354" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5083-72be-b0a6-dd03" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="35c4-22cf-690d-9395" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="5083-72be-b0a6-dd03" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="35c4-22cf-690d-9395" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
     <entryLink id="7170-8817-0f9e-2ee0" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="465a-0540-9d96-9b21" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="f188-747b-4d2b-bdd1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="465a-0540-9d96-9b21" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="f188-747b-4d2b-bdd1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
     <entryLink id="c1b8-9a38-3805-4421" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0a90-70a1-3166-86f8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bb6c-c837-2689-7e9f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="0a90-70a1-3166-86f8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bb6c-c837-2689-7e9f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
     <entryLink id="01e8-be04-bdd2-6a50" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="61d3-ddc7-c916-1ae4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="82f3-384e-8329-43de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f4be-7c04-7777-25a9" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="61d3-ddc7-c916-1ae4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="82f3-384e-8329-43de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f4be-7c04-7777-25a9" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="25b3-fc01-564d-396b" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0062-2a58-add1-457a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6a03-8e61-9177-20df" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="0062-2a58-add1-457a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6a03-8e61-9177-20df" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="f846-8f5f-89b9-3158" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="true" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="cef2-18eb-734e-6d0d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="0010-2076-4f3e-165e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="cef2-18eb-734e-6d0d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="0010-2076-4f3e-165e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
     <entryLink id="f799-0fc7-f087-844e" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2389-24f4-9d13-9a44" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="5503-3e99-e4b4-df79" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2389-24f4-9d13-9a44" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="5503-3e99-e4b4-df79" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
     <entryLink id="3906-77b6-552a-adc4" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="565c-e27f-51f5-4b95" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="1914-e8b5-82ae-864b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="565c-e27f-51f5-4b95" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="1914-e8b5-82ae-864b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
     <entryLink id="f4bf-f90d-88b7-0c56" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="25c3-58f6-2ac5-b0d2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6d2e-63c1-dd57-5d95" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="25c3-58f6-2ac5-b0d2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6d2e-63c1-dd57-5d95" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
     <entryLink id="ec25-d672-37be-8d78" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5406-c9ce-e2c9-a4d1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="f030-3b2c-6218-0c72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5406-c9ce-e2c9-a4d1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="f030-3b2c-6218-0c72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
     <entryLink id="c0f4-4dc2-9fdd-be0c" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="463e-597a-62f8-3dd8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="011a-fe41-77e1-9713" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="463e-597a-62f8-3dd8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="011a-fe41-77e1-9713" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
     <entryLink id="bf8c-f11e-272f-5a3b" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dfe8-f215-a5a1-5502" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ec59-ec06-f3e0-122a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="dfe8-f215-a5a1-5502" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ec59-ec06-f3e0-122a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
     <entryLink id="bade-7656-b138-1ad9" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="62c8-1c02-cf9c-c31c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="b174-b39d-dab5-b04f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="62c8-1c02-cf9c-c31c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="b174-b39d-dab5-b04f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
     <entryLink id="9c9a-5c7e-99df-2aba" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="93fd-9a6c-6906-78ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2a60-b1d0-a3b1-4c44" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="93fd-9a6c-6906-78ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2a60-b1d0-a3b1-4c44" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="42d2-513c-74dd-efb8" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="cf62-bc25-35a0-6e72" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="de55-ea76-e8af-a098" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="cf62-bc25-35a0-6e72" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="de55-ea76-e8af-a098" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
     <entryLink id="7cde-5dcf-8b78-63c2" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e9ef-0cfe-e8d9-cb5b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5dc3-f5f5-f3e3-8ac9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="e9ef-0cfe-e8d9-cb5b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5dc3-f5f5-f3e3-8ac9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
     <entryLink id="417c-8df9-7f24-faee" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b1e2-4b8f-3743-a601" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d457-866f-9d4e-8f2f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="b1e2-4b8f-3743-a601" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d457-866f-9d4e-8f2f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
     <entryLink id="f73f-75e7-1202-83ad" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="05a4-a87f-6666-6ec4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="59fc-d9a7-a8d0-7ac3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="05a4-a87f-6666-6ec4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="59fc-d9a7-a8d0-7ac3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
     <entryLink id="e833-3c0d-564a-ae07" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ba81-942b-bbf9-4f78" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="4d24-ccb8-1b76-b671" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ba81-942b-bbf9-4f78" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="4d24-ccb8-1b76-b671" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
     <entryLink id="cbe2-ac9a-15e5-3fbc" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b88a-4279-b0ec-5a87" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cc12-9fd8-6d7f-0da2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="b88a-4279-b0ec-5a87" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cc12-9fd8-6d7f-0da2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="368b-85cb-1202-69f6" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="418d-a2cf-fefa-58ed" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="8d76-374a-f14b-3c4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="418d-a2cf-fefa-58ed" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="8d76-374a-f14b-3c4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="19d9-6b41-7e99-c834" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="30b4-436f-db36-16fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d54f-37d1-d1e0-ca74" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="30b4-436f-db36-16fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d54f-37d1-d1e0-ca74" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="1024-5940-3bbc-2737" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d45f-0474-619c-5755" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="5d7e-a9d1-64bd-3af8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="f5d0-5bc0-9608-900b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d45f-0474-619c-5755" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="5d7e-a9d1-64bd-3af8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="f5d0-5bc0-9608-900b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="a14e-0eae-a869-3ba7" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup"/>
-        <entryLink id="cfff-e969-ba76-1e0e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup"/>
+        <entryLink id="a14e-0eae-a869-3ba7" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup" />
+        <entryLink id="cfff-e969-ba76-1e0e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
     <entryLink id="9ad7-2903-7a24-9b9f" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4ae2-042e-0977-17cc" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="9eb2-8e4f-15e4-1c91" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0c4c-579f-4964-a6fa" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="4ae2-042e-0977-17cc" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="9eb2-8e4f-15e4-1c91" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0c4c-579f-4964-a6fa" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="3774-8d62-b6ab-4d25" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup"/>
-        <entryLink id="0633-a2f6-c828-ca22" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup"/>
+        <entryLink id="3774-8d62-b6ab-4d25" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup" />
+        <entryLink id="0633-a2f6-c828-ca22" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
     <entryLink id="2124-5d7a-a791-dfc7" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d3a8-7307-482e-da17" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="d57c-104d-b963-01bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8377-fe6f-b1c6-7d2b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="d3a8-7307-482e-da17" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d57c-104d-b963-01bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8377-fe6f-b1c6-7d2b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="30fe-646d-5b3c-7e60" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup"/>
-        <entryLink id="7ee3-e682-662c-82f8" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup"/>
+        <entryLink id="30fe-646d-5b3c-7e60" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="a1f6-6ccd-6b3e-aba2" type="selectionEntryGroup" />
+        <entryLink id="7ee3-e682-662c-82f8" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
     <entryLink id="210d-22c6-de87-d587" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a940-a06c-63b1-f384" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="293c-ba1d-2f84-b33a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="a940-a06c-63b1-f384" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="293c-ba1d-2f84-b33a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="ed73-562e-50f0-0b3f" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9521-8f2e-41d3-b746" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1b94-afca-35f8-fb40" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="9521-8f2e-41d3-b746" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1b94-afca-35f8-fb40" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="33a8-d329-4912-7b67" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7f39-d948-329e-89ad" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="fdb3-afd6-08b7-576b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7f39-d948-329e-89ad" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="fdb3-afd6-08b7-576b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
     <entryLink id="e447-df88-7247-6ef4" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0fcf-f9f5-f15f-f44b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="d824-4a0a-aa45-88b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0fcf-f9f5-f15f-f44b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="d824-4a0a-aa45-88b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
     <entryLink id="5ec4-4c52-fc33-13d8" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="bd70-27e2-264f-5912" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="8ada-0642-92c4-0bdb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bd70-27e2-264f-5912" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="8ada-0642-92c4-0bdb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
     <entryLink id="65a7-b67f-1ad4-655d" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="170b-331c-f45a-9b7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7194-4978-1fac-7c2b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="170b-331c-f45a-9b7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7194-4978-1fac-7c2b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
     <entryLink id="d8cb-af69-e634-2557" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1095-0d3e-b6fc-a106" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="2f0b-d447-91d9-6ed6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1095-0d3e-b6fc-a106" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2f0b-d447-91d9-6ed6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
     <entryLink id="bea4-21f1-cac1-c329" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fb2c-f0cf-414c-25fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d7dc-1fd8-fb0a-13da" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="fb2c-f0cf-414c-25fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d7dc-1fd8-fb0a-13da" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
     <entryLink id="a5e2-cebd-957f-cc8e" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c350-5999-1988-4489" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1f7d-23a6-7263-0f8a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="c350-5999-1988-4489" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1f7d-23a6-7263-0f8a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
     <entryLink id="8eb9-e280-6a73-9f74" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="237a-bba3-bee8-24ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="04cc-6610-9b41-bda9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="237a-bba3-bee8-24ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="04cc-6610-9b41-bda9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
     <entryLink id="3d4a-042b-056e-b8fb" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a410-7441-6ec1-e9d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1e01-fbaa-7bb9-f59e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="a410-7441-6ec1-e9d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1e01-fbaa-7bb9-f59e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
     <entryLink id="38b9-be65-0f8f-c5e5" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="cf26-daa7-1824-ee30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6e5b-2b5c-fb44-50f4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="cf26-daa7-1824-ee30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6e5b-2b5c-fb44-50f4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="3fb8-86a4-5eaa-c5da" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="575b-37ac-96f7-baa5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7b85-f61f-f655-a7ab" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="575b-37ac-96f7-baa5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7b85-f61f-f655-a7ab" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
     <entryLink id="460d-e79c-d3a8-c8b0" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8b56-6736-d08c-43fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d4e9-3255-2b78-fac0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="8b56-6736-d08c-43fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d4e9-3255-2b78-fac0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="2225-0ca4-1702-8fdb" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="74eb-b246-f3f8-a5b5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c7bf-2362-70b8-7583" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="74eb-b246-f3f8-a5b5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="c7bf-2362-70b8-7583" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
     <entryLink id="e713-408d-a46b-1944" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="900f-1539-5d72-2a13" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="9730-fda0-ef8c-8700" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="900f-1539-5d72-2a13" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="9730-fda0-ef8c-8700" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
     <entryLink id="de2d-9a98-f9d0-8376" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2d22-6ee1-51da-5d7b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b175-46b8-4bfe-5d1a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="e11e-b343-b63e-6b5a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="2d22-6ee1-51da-5d7b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b175-46b8-4bfe-5d1a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="e11e-b343-b63e-6b5a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="8e6c-c80b-e372-ab3c" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c112-b274-210c-69ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f466-404e-9ff0-a46a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="c112-b274-210c-69ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f466-404e-9ff0-a46a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
     <entryLink id="4d04-02d7-a275-24ec" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="86ad-98f4-0273-9d13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="84c4-3f67-9f73-18c4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="86ad-98f4-0273-9d13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="84c4-3f67-9f73-18c4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
     <entryLink id="3c27-70ed-3739-9f09" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="19e1-cf1a-de5a-3a75" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="8817-aa93-54a1-bbd8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="19e1-cf1a-de5a-3a75" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="8817-aa93-54a1-bbd8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="3e12-cfe5-d35d-2867" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9a1a-b5ea-a356-1928" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="ca5e-2cb8-913e-76fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9a1a-b5ea-a356-1928" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="ca5e-2cb8-913e-76fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="a563-4ed7-87d2-1d4f" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3e96-2675-f739-a789" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c4ba-fcb8-eba6-a607" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3e96-2675-f739-a789" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="c4ba-fcb8-eba6-a607" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
     <entryLink id="90af-930f-182e-8518" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b16d-4e2f-0edb-62fe" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="907b-8694-3c99-f1cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b16d-4e2f-0edb-62fe" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="907b-8694-3c99-f1cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
     <entryLink id="87a8-6884-e508-2395" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d3cc-3bd1-6336-ae9e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5a84-2565-3576-94de" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="41e6-6306-de04-05ac" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="d3cc-3bd1-6336-ae9e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5a84-2565-3576-94de" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
+        <categoryLink id="41e6-6306-de04-05ac" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="5b3f-b375-7375-5f7a" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8608-d602-5574-25b3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="28fe-18b0-6b49-0aed" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="8608-d602-5574-25b3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="28fe-18b0-6b49-0aed" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
     <entryLink id="a710-8b26-1b87-f522" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8391-fd83-9f10-4dbe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d274-15a1-80d4-3013" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="8391-fd83-9f10-4dbe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d274-15a1-80d4-3013" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
     <entryLink id="8481-56ed-57c9-49bb" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="80fc-1ac5-7236-2065" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="864c-2f86-9c9e-69e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="80fc-1ac5-7236-2065" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="864c-2f86-9c9e-69e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
     <entryLink id="f06a-1330-a62d-8fe4" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8381-c5f9-8f07-4351" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="c080-5197-cd1f-2bc1" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="8381-c5f9-8f07-4351" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="c080-5197-cd1f-2bc1" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
     <entryLink id="c048-6aed-e0c9-05a9" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="59c9-a29a-0ca3-7ebb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="2a27-bdef-2071-7405" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="59c9-a29a-0ca3-7ebb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="2a27-bdef-2071-7405" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
     <entryLink id="175a-9e0a-68ab-35c8" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5fc7-b62d-530e-4892" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="f400-1820-e157-cc75" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5fc7-b62d-530e-4892" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="f400-1820-e157-cc75" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
     <entryLink id="3067-6d02-c8ea-a03b" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e315-bff8-bbf6-6c8c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="3b5c-963d-23c0-3aea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e315-bff8-bbf6-6c8c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="3b5c-963d-23c0-3aea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
     <entryLink id="aba4-6878-0788-a3dc" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="90a6-9ae7-d542-1774" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="4225-b067-c405-4143" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="90a6-9ae7-d542-1774" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="4225-b067-c405-4143" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
     <entryLink id="f5d9-bece-f973-158f" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0541-6ca5-0619-0ed5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="4129-8f1e-5ca4-31fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0541-6ca5-0619-0ed5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="4129-8f1e-5ca4-31fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
     <entryLink id="ba21-eab2-432a-2475" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="254f-c967-42b0-45ad" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="d73e-276b-60b5-0787" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="254f-c967-42b0-45ad" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="d73e-276b-60b5-0787" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
     <entryLink id="b161-b776-8ce7-6245" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="23f2-c4e6-5cf2-3fc0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="4b72-f7ff-0f3a-6ed0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="23f2-c4e6-5cf2-3fc0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="4b72-f7ff-0f3a-6ed0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
     <entryLink id="fe82-5cc4-9adc-9d46" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3bda-05ee-2b53-f1d7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="3c3f-d108-39ee-63a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3bda-05ee-2b53-f1d7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="3c3f-d108-39ee-63a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
     <entryLink id="f283-1bce-0b7c-4e43" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2b7f-5afd-9554-f3cf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="3861-7db7-fef3-8a64" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2b7f-5afd-9554-f3cf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="3861-7db7-fef3-8a64" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
     <entryLink id="7124-6c5b-745f-5685" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="17bc-1559-6f1b-7cc6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="e6cf-e961-ca5a-3d22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="17bc-1559-6f1b-7cc6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="e6cf-e961-ca5a-3d22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
     <entryLink id="54c9-619a-115d-6477" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c62d-e194-4ecd-f184" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c4b6-a051-631e-785e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c62d-e194-4ecd-f184" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="c4b6-a051-631e-785e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
     <entryLink id="603b-327b-e62d-67a6" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5208-ba63-5fcd-d472" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="6446-51bb-9f89-8e52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5208-ba63-5fcd-d472" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="6446-51bb-9f89-8e52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
     <entryLink id="35aa-70ad-086e-39f0" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e4df-7194-e569-cc65" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="9b1a-4f40-03fe-2954" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e4df-7194-e569-cc65" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="9b1a-4f40-03fe-2954" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
     <entryLink id="c5a2-61b9-4bcc-db25" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="942a-1229-6cb6-c01d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="470c-9306-46e2-6c8b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="942a-1229-6cb6-c01d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="470c-9306-46e2-6c8b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
     <entryLink id="51bb-8682-066b-c838" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4a6d-548d-97eb-697d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="9aa6-dbd3-a5d7-c7e3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4a6d-548d-97eb-697d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="9aa6-dbd3-a5d7-c7e3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
     <entryLink id="ff4d-e160-221f-1192" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="351d-d206-1388-c6d5" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="d821-9cca-24a9-8751" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="351d-d206-1388-c6d5" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="d821-9cca-24a9-8751" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
     <entryLink id="eb83-2fa9-c320-7e5b" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5ea5-a7a2-97c0-3f76" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="9b52-68af-91d0-3bd9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5ea5-a7a2-97c0-3f76" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="9b52-68af-91d0-3bd9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
     <entryLink id="8ce3-53d4-e96a-e2de" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7d32-2e6b-d728-b40d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="68b9-cfa2-d75c-8c87" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7d32-2e6b-d728-b40d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="68b9-cfa2-d75c-8c87" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
     <entryLink id="c012-84f2-bde7-42b5" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f2f7-4c19-87c9-a916" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="94cb-c54d-d366-cc58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f2f7-4c19-87c9-a916" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="94cb-c54d-d366-cc58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
     <entryLink id="2e0a-2e35-22a8-b267" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="19bf-1708-cb3a-397a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="5feb-05fd-1326-5f6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="19bf-1708-cb3a-397a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="5feb-05fd-1326-5f6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
     <entryLink id="abfd-f2ba-0684-9352" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="912a-f456-b8cb-ce2d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="65be-35ba-4e9c-9f4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="912a-f456-b8cb-ce2d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="65be-35ba-4e9c-9f4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
     <entryLink id="8d5c-2b26-28f7-a6b4" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="118c-b263-a228-d93d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="1061-00eb-1be3-3844" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="118c-b263-a228-d93d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="1061-00eb-1be3-3844" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
     <entryLink id="29b7-efb2-b00c-31b5" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9458-1032-5c85-0b99" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3e95-ab10-bf35-f965" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9458-1032-5c85-0b99" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3e95-ab10-bf35-f965" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
     <entryLink id="57fa-669d-8a9b-96fd" name="Numerologist Cabal" hidden="true" collective="false" import="false" targetId="ca26-b6e2-0bef-85a5" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b5c7-eef2-083e-e476" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="36a5-9aa2-c707-37c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6e85-f36f-314a-039b" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false"/>
+        <categoryLink id="b5c7-eef2-083e-e476" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="36a5-9aa2-c707-37c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6e85-f36f-314a-039b" name="Rewards of Trechery" hidden="false" targetId="2275-5253-2421-7383" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="f09e-404b-0014-15ea" name="Autilon Skorr" hidden="true" collective="false" import="false" targetId="b470-1f0d-f0b5-ceeb" type="selectionEntry">
@@ -2158,17 +2157,17 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9100-0528-4fb3-498f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="d60c-df86-9cb1-55cd" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="92d0-76a4-36ac-6286" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9100-0528-4fb3-498f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d60c-df86-9cb1-55cd" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="92d0-76a4-36ac-6286" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="8a9f-409e-713e-0699" name="Palatine Blade Aquilae Squad" hidden="true" collective="false" import="false" targetId="1d83-4f3d-4a9b-dc39" type="selectionEntry">
@@ -2177,16 +2176,16 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3178-b0d7-a0fa-b4cc" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="b16c-d76c-4ffc-2668" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3178-b0d7-a0fa-b4cc" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="b16c-d76c-4ffc-2668" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -2198,37 +2197,37 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="776b-f753-adcf-aa20" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule"/>
-        <infoLink id="8e3f-2fb5-90c4-5778" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="776b-f753-adcf-aa20" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule" />
+        <infoLink id="8e3f-2fb5-90c4-5778" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="cde4-eeae-81c7-39bb" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="It Will Not Die (5+)"/>
+            <modifier type="set" field="name" value="It Will Not Die (5+)" />
           </modifiers>
         </infoLink>
         <infoLink id="7649-4cee-62cf-cd7f" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="fc9c-7a9f-0979-474a" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="fc9c-7a9f-0979-474a" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="86bf-d7af-033d-7bc5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="38f4-15f0-cef1-6eed" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="d9d8-ed91-7e24-1a00" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="9c8d-bff7-f814-f674" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="86bf-d7af-033d-7bc5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="38f4-15f0-cef1-6eed" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="d9d8-ed91-7e24-1a00" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="9c8d-bff7-f814-f674" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="215d-b8b6-0c32-188b" name="Harrower" publicationId="09c5-eeae-f398-b653" page="338" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b22-6f7e-bbcc-5448" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d245-f4db-5399-b121" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b22-6f7e-bbcc-5448" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d245-f4db-5399-b121" type="max" />
           </constraints>
           <profiles>
             <profile id="9225-f3f5-86ab-a342" name="Harrower" publicationId="09c5-eeae-f398-b653" page="338" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Line, Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2242,24 +2241,24 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="d584-40d1-2dbf-3d6f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="d584-40d1-2dbf-3d6f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="e762-1d80-a5ba-2417" name="CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="acfe-034f-af46-0f75">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18d9-6272-4ca0-be9e" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba7e-179d-b0ed-2a94" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18d9-6272-4ca0-be9e" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba7e-179d-b0ed-2a94" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="acfe-034f-af46-0f75" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
+                <entryLink id="acfe-034f-af46-0f75" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
                 <entryLink id="b4a8-4a3c-77f6-1abc" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="dc75-65cd-1f77-a1a1" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -2268,27 +2267,27 @@
           <entryLinks>
             <entryLink id="0159-e46c-4c00-1ea6" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82d7-349f-d38c-cdb2" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69a9-8b82-9d69-59e1" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82d7-349f-d38c-cdb2" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69a9-8b82-9d69-59e1" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="5513-2ae0-02b4-259c" name="Venom Spheres" hidden="false" collective="false" import="true" targetId="82f5-cca1-51a0-31dd" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee1c-9459-2d33-e14e" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3d7-8be1-f267-4bed" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee1c-9459-2d33-e14e" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3d7-8be1-f267-4bed" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="0a64-dfaf-70e2-83b8" name=" Lernaean" hidden="false" collective="false" import="true" defaultSelectionEntryId="ee69-d749-7ec4-a20e">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="433d-227c-0b0c-e710" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8b3-20f9-6cd1-c51d" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="433d-227c-0b0c-e710" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8b3-20f9-6cd1-c51d" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="4876-8b25-e96c-1c14" name="Lernaean w/Chainfist" publicationId="09c5-eeae-f398-b653" page="338" hidden="false" collective="false" import="true" type="model">
@@ -2312,31 +2311,31 @@
               <entryLinks>
                 <entryLink id="b6cd-91c1-bba5-5b08" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="5c82-c306-9c5c-5908" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcd0-962e-b7a6-120d" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4947-ea25-7e12-4cda" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcd0-962e-b7a6-120d" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4947-ea25-7e12-4cda" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="5e0d-1040-6de7-7a88" name="Chainfist" hidden="false" collective="false" import="true" targetId="1b03-1224-cd1a-6d3e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5ac-b6eb-113d-c476" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe02-44ed-7bcd-829f" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5ac-b6eb-113d-c476" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe02-44ed-7bcd-829f" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="b604-cadf-ca1e-33e1" name="Lernaean w/Heavy Weapon " publicationId="09c5-eeae-f398-b653" page="338" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="set" field="de19-32c5-68a6-318f" value="2.0">
                   <conditions>
-                    <condition field="selections" scope="6161-d387-f086-0958" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast"/>
+                    <condition field="selections" scope="6161-d387-f086-0958" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de19-32c5-68a6-318f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de19-32c5-68a6-318f" type="max" />
               </constraints>
               <profiles>
                 <profile id="7128-a135-2eaa-1ccd" name="Lernaean" publicationId="09c5-eeae-f398-b653" page="338" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2358,54 +2357,54 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="1500-076d-83b9-4faf" name="CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="8677-a1f9-3337-77d8">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea46-ef7b-bb33-59e2" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="caa3-2382-0af1-04d9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea46-ef7b-bb33-59e2" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="caa3-2382-0af1-04d9" type="min" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="8677-a1f9-3337-77d8" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
+                    <entryLink id="8677-a1f9-3337-77d8" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
                     <entryLink id="0b63-e143-0745-5200" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="93d9-c6ca-8260-8fee" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="d3f4-7a16-b1d6-2661" name="HW" hidden="false" collective="false" import="true" defaultSelectionEntryId="6efe-195f-ef27-ac43">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2045-a28b-469c-16c9" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ecd-6fcf-0132-1834" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2045-a28b-469c-16c9" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ecd-6fcf-0132-1834" type="min" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="6efe-195f-ef27-ac43" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="c6d5-33af-0597-3ff6" name="Conversion Beam Cannon" hidden="false" collective="false" import="true" targetId="5775-0d94-8e13-8c1f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="5928-f3e5-2528-63b5" name="Plasma Blaster" hidden="false" collective="false" import="true" targetId="cd52-e9e8-3ab1-995c" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="db81-7237-b42d-6cce" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="170d-44e0-455c-8207" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="65fe-767b-3b47-ef53" name="Lernaean w/Power Fist" publicationId="09c5-eeae-f398-b653" page="338" hidden="false" collective="false" import="true" type="model">
@@ -2429,19 +2428,19 @@
               <entryLinks>
                 <entryLink id="c633-5dd3-1e97-7be9" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="5c82-c306-9c5c-5908" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d46-9b5b-858a-713a" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cb3-8f2a-1a00-e0dc" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d46-9b5b-858a-713a" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cb3-8f2a-1a00-e0dc" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="8b70-77a5-02cd-c1c6" name="Power Fist" hidden="false" collective="false" import="true" targetId="a472-3ded-51a3-44a0" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07d8-f0fa-65fe-3933" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cdb-a825-fb1e-400f" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07d8-f0fa-65fe-3933" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cdb-a825-fb1e-400f" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="ee69-d749-7ec4-a20e" name=" Lernaean w/Power Axe" publicationId="09c5-eeae-f398-b653" page="338" hidden="false" collective="false" import="true" type="model">
@@ -2465,43 +2464,43 @@
               <entryLinks>
                 <entryLink id="fe9c-5f30-bf8c-8c33" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="5c82-c306-9c5c-5908" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4634-ed4b-6b54-fb2f" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d78a-62fc-5635-0711" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4634-ed4b-6b54-fb2f" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d78a-62fc-5635-0711" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="eaf4-3bea-7854-003f" name="Power Axe" hidden="false" collective="false" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00a7-2c44-aaa0-8846" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76d8-6f9c-eae4-17cc" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00a7-2c44-aaa0-8846" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76d8-6f9c-eae4-17cc" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="db18-5e36-0893-59e4" name="Dedicated Transport" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e801-7ff5-332a-2f21" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e801-7ff5-332a-2f21" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="7ba6-9796-bed5-a987" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="6161-d387-f086-0958" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="selections" scope="6161-d387-f086-0958" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="36a9-8860-e162-61a2" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"/>
+            <entryLink id="36a9-8860-e162-61a2" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry" />
             <entryLink id="ac82-56e8-f3fd-e625" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="true" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="6161-d387-f086-0958" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="selections" scope="6161-d387-f086-0958" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -2512,13 +2511,13 @@
       <entryLinks>
         <entryLink id="2828-152c-be3c-1932" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b0e-d0eb-4008-1279" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e69-0453-b1b9-b6ac" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b0e-d0eb-4008-1279" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e69-0453-b1b9-b6ac" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="f912-9416-39ea-b3fc" name="Exodus" publicationId="09c5-eeae-f398-b653" page="340" hidden="false" collective="false" import="true" type="unit">
@@ -2526,7 +2525,7 @@
         <profile id="28c0-5b02-c7a6-4ea1" name="Exodus" publicationId="09c5-eeae-f398-b653" page="340" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Light)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">6</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2540,43 +2539,43 @@
         </profile>
       </profiles>
       <rules>
-        <rule id="e892-ac82-5a17-5627" name="Assassin&apos;s Eye" publicationId="09c5-eeae-f398-b653" page="341" hidden="false">
+        <rule id="e892-ac82-5a17-5627" name="Assassin's Eye" publicationId="09c5-eeae-f398-b653" page="341" hidden="false">
           <description>When Exodus makes any attacks as part of a Shooting Attack, the range of any Weapons is not restricted or affected by the Night Fight rules, Shroud bombs or any other special rule. In addition, Exodus never suffers any penalty to his Ballistic Skill from Night Fight or any other special rules, always makes To Hit rolls using his full Ballistic Skill (including Snap Shots) and no model may make Shrouded rolls to negate Wounds inflicted by their attacks.</description>
         </rule>
         <rule id="b184-c6bf-4ef7-9ff6" name="Lone Killer" publicationId="09c5-eeae-f398-b653" page="340" hidden="false">
-          <description>Exodus may not be taken as a compulsory HQ choice, only as an non-Compulsory HQ choice. He may never be an army’s Warlord, and may not join other units except Legion Reconnaissance squads or Alpha Legion Headhunter Kill Teams.</description>
+          <description>Exodus may not be taken as a compulsory HQ choice, only as an non-Compulsory HQ choice. He may never be an army&#8217;s Warlord, and may not join other units except Legion Reconnaissance squads or Alpha Legion Headhunter Kill Teams.</description>
         </rule>
         <rule id="4589-afa6-c49c-571c" name="The Hidden Hand" publicationId="09c5-eeae-f398-b653" page="340" hidden="false">
-          <description>When deploying Exodus onto the battlefield at the start of the battle, the controlling player may place him in any position on the battlefield, as long as Exodus is within Area Terrain, or at least 9&quot; from any enemy model if Exodus is not within Area Terrain, regardless of the Line of Sight or Proximity of enemy models. If Exodus is deployed from Reserve after the start of the first turn, then he may enter play from any point on the battlefield’s edge, chosen by the controlling player. If Exodus joins a unit during deployment or whilst in Reserves and is deployed as part of that unit, he may not use any of the benefits of this special rule, but instead gains the Scout and Infiltrate special rules only if the unit he has joined also possesses those special rules.</description>
+          <description>When deploying Exodus onto the battlefield at the start of the battle, the controlling player may place him in any position on the battlefield, as long as Exodus is within Area Terrain, or at least 9" from any enemy model if Exodus is not within Area Terrain, regardless of the Line of Sight or Proximity of enemy models. If Exodus is deployed from Reserve after the start of the first turn, then he may enter play from any point on the battlefield&#8217;s edge, chosen by the controlling player. If Exodus joins a unit during deployment or whilst in Reserves and is deployed as part of that unit, he may not use any of the benefits of this special rule, but instead gains the Scout and Infiltrate special rules only if the unit he has joined also possesses those special rules.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="aff0-13fe-9650-6cb5" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule"/>
-        <infoLink id="973e-9805-6efd-b477" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule"/>
-        <infoLink id="6cb7-3445-0cce-ac65" name="Pathfinder" hidden="false" targetId="ec97-7aa8-49f5-b298" type="rule"/>
-        <infoLink id="6ce5-5601-6fe3-99d6" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="aff0-13fe-9650-6cb5" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule" />
+        <infoLink id="973e-9805-6efd-b477" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule" />
+        <infoLink id="6cb7-3445-0cce-ac65" name="Pathfinder" hidden="false" targetId="ec97-7aa8-49f5-b298" type="rule" />
+        <infoLink id="6ce5-5601-6fe3-99d6" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="9c92-3407-d5dc-8195" name="Shrouded (X)" hidden="false" targetId="10c3-fdb0-089f-ca65" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Shrouded (5+)"/>
+            <modifier type="set" field="name" value="Shrouded (5+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="53f7-5d61-294f-9b80" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="bb2c-c74f-2106-5acc" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="f843-2674-b0ea-6b16" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="fd9e-233c-7003-2c13" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="53f7-5d61-294f-9b80" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="bb2c-c74f-2106-5acc" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="f843-2674-b0ea-6b16" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="fd9e-233c-7003-2c13" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="fc1f-0089-4c16-d538" name="The Instrument" publicationId="09c5-eeae-f398-b653" page="341" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9899-c024-66b5-3e42" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2310-0d96-0d91-922a" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9899-c024-66b5-3e42" type="min" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2310-0d96-0d91-922a" type="max" />
           </constraints>
           <profiles>
             <profile id="0b92-0b1a-ea84-065b" name="The Instrument - Rapid Shot" publicationId="09c5-eeae-f398-b653" page="341" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">24"</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 3, Sundering, Pinning</characteristic>
@@ -2584,7 +2583,7 @@
             </profile>
             <profile id="6ae6-7e9f-f3ad-29a7" name="The Instrument - Execution Shot" publicationId="09c5-eeae-f398-b653" page="341" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">72&quot;</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">72"</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Sniper, Sunder, Pinning, Deadly Aim</characteristic>
@@ -2602,108 +2601,108 @@
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="ac5e-bf62-aab2-a450" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
-            <infoLink id="0631-ce7d-1df7-8ccc" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
-            <infoLink id="d60e-ad7f-c1ae-7c61" name="Sniper" hidden="false" targetId="9cd8-e726-5dbe-b106" type="rule"/>
-            <infoLink id="4518-5a8a-9813-e7d0" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
+            <infoLink id="ac5e-bf62-aab2-a450" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule" />
+            <infoLink id="0631-ce7d-1df7-8ccc" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule" />
+            <infoLink id="d60e-ad7f-c1ae-7c61" name="Sniper" hidden="false" targetId="9cd8-e726-5dbe-b106" type="rule" />
+            <infoLink id="4518-5a8a-9813-e7d0" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule" />
             <infoLink id="d69d-9a25-b522-5906" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Brutal (2)"/>
+                <modifier type="set" field="name" value="Brutal (2)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="3ef9-8376-5293-8268" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eccf-02fa-7de0-814f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d0e-a10e-a2dd-15af" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eccf-02fa-7de0-814f" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d0e-a10e-a2dd-15af" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="cd55-4ed3-3aed-aae8" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce42-89b1-d6c1-cd72" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f45-757a-0c4b-38b4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce42-89b1-d6c1-cd72" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f45-757a-0c4b-38b4" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="35a3-69c2-d077-2ea6" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6a4-2db1-16cd-0904" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9567-6fa3-99cf-9a57" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6a4-2db1-16cd-0904" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9567-6fa3-99cf-9a57" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="a96b-5d43-dd47-fa71" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af8c-c54d-0604-5766" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bca8-38e3-62eb-46b8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af8c-c54d-0604-5766" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bca8-38e3-62eb-46b8" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="bb17-066d-3818-5bd7" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9342-26c7-e828-ce26" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c811-c669-4041-22fa" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9342-26c7-e828-ce26" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c811-c669-4041-22fa" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="89aa-a209-dab1-dc8b" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80ba-18c1-111d-6f0c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c21c-6fe1-437f-55e1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80ba-18c1-111d-6f0c" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c21c-6fe1-437f-55e1" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="d2a3-159f-a3b8-4e2f" name="Power Dagger" hidden="false" collective="false" import="true" targetId="8157-b77c-0dd3-85b2" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4536-b333-b80a-0632" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eeaa-03a6-3f9e-1bca" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4536-b333-b80a-0632" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eeaa-03a6-3f9e-1bca" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="92f9-ce09-95fa-0574" name="Venom Spheres" hidden="false" collective="false" import="true" targetId="82f5-cca1-51a0-31dd" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3af5-273b-8284-80b8" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8088-8bf4-1b13-bd48" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3af5-273b-8284-80b8" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8088-8bf4-1b13-bd48" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="4677-36e3-f144-a5ce" name="Shroud Bombs" hidden="false" collective="false" import="true" targetId="5d4d-36b7-6bf5-fc92" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b736-c374-bd26-23e9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="899e-1b74-9230-e5a9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b736-c374-bd26-23e9" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="899e-1b74-9230-e5a9" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="165.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="165.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="70e6-ace3-8feb-1ddc" name="Headhunter Kill Team" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="6008-9c60-adbe-3383" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule"/>
-        <infoLink id="cfa3-7d8c-89e4-de03" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="6008-9c60-adbe-3383" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule" />
+        <infoLink id="cfa3-7d8c-89e4-de03" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="c5b2-2fbc-25bf-587d" name="Precision Shots (X)" hidden="false" targetId="4b71-81ee-31f4-fa09" type="rule">
           <modifiers>
-            <modifier type="append" field="name" value="(4+)"/>
+            <modifier type="append" field="name" value="(4+)" />
           </modifiers>
         </infoLink>
         <infoLink id="ee8a-501e-d4eb-6c81" name="Preferred Enemy (X)" hidden="false" targetId="37ab-d4db-891a-de8c" type="rule">
           <modifiers>
-            <modifier type="append" field="name" value="(Independant Character)"/>
+            <modifier type="append" field="name" value="(Independant Character)" />
           </modifiers>
         </infoLink>
-        <infoLink id="b7d7-4e01-2e3e-6478" name="Infiltrate" hidden="false" targetId="0e32-5b92-a95a-8464" type="rule"/>
-        <infoLink id="4ec2-a1a0-d7a2-73cd" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
+        <infoLink id="b7d7-4e01-2e3e-6478" name="Infiltrate" hidden="false" targetId="0e32-5b92-a95a-8464" type="rule" />
+        <infoLink id="4ec2-a1a0-d7a2-73cd" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="a10b-7811-b811-52e6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="0374-00b9-d878-2d9b" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
-        <categoryLink id="924c-38c1-a729-0f0b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="a10b-7811-b811-52e6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="0374-00b9-d878-2d9b" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false" />
+        <categoryLink id="924c-38c1-a729-0f0b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e0e7-2496-e912-61f5" name="Headhunter Prime" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68ad-725d-9732-b634" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="724d-c04c-6225-5e4f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68ad-725d-9732-b634" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="724d-c04c-6225-5e4f" type="min" />
           </constraints>
           <profiles>
             <profile id="6609-b7ae-1081-f304" name="Headhunter Prime" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2723,22 +2722,22 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="579c-b98b-7d1e-9128" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-            <categoryLink id="2832-eaa8-d1e5-3410" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
-            <categoryLink id="cc85-e37a-ac25-6e25" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="579c-b98b-7d1e-9128" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+            <categoryLink id="2832-eaa8-d1e5-3410" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false" />
+            <categoryLink id="cc85-e37a-ac25-6e25" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="1ffe-3d45-d4e3-7721" name="1) Bolt Pistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="5fea-c95e-e400-821c">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94a8-7807-9f66-56c4" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f41d-5183-a76b-10bc" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94a8-7807-9f66-56c4" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f41d-5183-a76b-10bc" type="min" />
               </constraints>
               <selectionEntries>
                 <selectionEntry id="b135-381e-1c84-412d" name="Inferno Pistol" hidden="false" collective="false" import="true" type="upgrade">
                   <profiles>
                     <profile id="70ed-5fab-abed-5030" name="Inferno Pistol " hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                       <characteristics>
-                        <characteristic name="Range" typeId="95ba-cda7-b831-6066">6&quot;</characteristic>
+                        <characteristic name="Range" typeId="95ba-cda7-b831-6066">6"</characteristic>
                         <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
                         <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
                         <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 1, Armourbane (Melta)</characteristic>
@@ -2748,135 +2747,135 @@
                   <infoLinks>
                     <infoLink id="18a1-b3e9-a05f-9922" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
                       <modifiers>
-                        <modifier type="set" field="name" value="Armourbane (Melta)"/>
+                        <modifier type="set" field="name" value="Armourbane (Melta)" />
                       </modifiers>
                     </infoLink>
                   </infoLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
                 <entryLink id="5fea-c95e-e400-821c" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7edb-58da-f100-9803" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7edb-58da-f100-9803" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="4ae9-0e7f-f524-b548" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad32-ff18-b8d3-b3ac" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad32-ff18-b8d3-b3ac" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="2640-2f49-543b-8229" name="2) May take:" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60d2-ab97-0e66-b156" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60d2-ab97-0e66-b156" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="34b8-aba0-f6eb-e9e6" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="7d3c-8acb-2f0c-62ef" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="b440-3316-5fbe-cfe2" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="398f-bece-59c7-69bd" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="9e77-1e02-aa22-d100" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="76ea-4912-4339-4c4a" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="53c4-cf82-2d21-dbd9" name="3) Armor choice:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f52c-2f09-cd9f-b0e1">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40f7-fed0-1233-6a25" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab49-6d83-5b3f-1eef" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40f7-fed0-1233-6a25" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab49-6d83-5b3f-1eef" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="f52c-2f09-cd9f-b0e1" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry"/>
+                <entryLink id="f52c-2f09-cd9f-b0e1" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry" />
                 <entryLink id="08f5-ddde-c695-d8fa" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="22e6-6a90-1a76-01de" name="2) Combi-bolter" hidden="false" collective="false" import="true" defaultSelectionEntryId="e896-f437-9159-572b">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a3b-2315-8fd7-d509" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28fa-c838-2bfa-e9b7" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a3b-2315-8fd7-d509" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28fa-c838-2bfa-e9b7" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="e896-f437-9159-572b" name="Banestrike Combi-Bolter" hidden="false" collective="false" import="true" targetId="d3eb-73ae-7b59-c348" type="selectionEntry"/>
+                <entryLink id="e896-f437-9159-572b" name="Banestrike Combi-Bolter" hidden="false" collective="false" import="true" targetId="d3eb-73ae-7b59-c348" type="selectionEntry" />
                 <entryLink id="145a-15a5-943e-2ac3" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="33f0-6234-45e4-3f45" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="3d11-dd1a-f5bd-c6d2" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry"/>
-                <entryLink id="dc28-826a-8b4f-f999" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry"/>
-                <entryLink id="15e0-4316-4abb-64c6" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry"/>
+                <entryLink id="3d11-dd1a-f5bd-c6d2" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry" />
+                <entryLink id="dc28-826a-8b4f-f999" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry" />
+                <entryLink id="15e0-4316-4abb-64c6" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
             <entryLink id="6b51-6584-8e75-2cd5" name="Power Dagger" hidden="false" collective="false" import="true" targetId="8157-b77c-0dd3-85b2" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87f7-fc7c-1c79-b9c8" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b382-5e7b-3dc0-2cc3" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87f7-fc7c-1c79-b9c8" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b382-5e7b-3dc0-2cc3" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="9d34-9c9c-456d-6ba7" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07c8-8f3e-1bc4-3d18" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9de-7748-43a1-0286" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07c8-8f3e-1bc4-3d18" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9de-7748-43a1-0286" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="0b78-3187-96f5-7da5" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d47-0fb2-2d4e-9dab" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ac8-8feb-72e2-db86" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d47-0fb2-2d4e-9dab" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ac8-8feb-72e2-db86" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="a2a4-51b3-1858-f8c3" name="1) Headhunters " hidden="false" collective="false" import="true" defaultSelectionEntryId="c051-b8a4-fb93-8ef1">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0b2-0948-60c1-fbef" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a612-9970-a4da-7a27" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0b2-0948-60c1-fbef" type="min" />
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a612-9970-a4da-7a27" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="bc51-dcfd-5f18-cb7e" name="Headhunter w/Combi-weapon" hidden="false" collective="false" import="true" type="upgrade">
@@ -2900,60 +2899,60 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="2eb8-287b-5a5a-0737" name="Ranged:" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a80-21e0-00c0-1f31" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f18-b014-dcea-aa40" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a80-21e0-00c0-1f31" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f18-b014-dcea-aa40" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="b804-b9a0-1bd1-c76c" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="0d1c-227e-a3f8-cd63" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="66fc-992d-6a22-da52" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="cc98-8596-c713-516c" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
-                    <entryLink id="0697-673b-05d4-e096" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="34c4-db99-db36-0f2a" type="selectionEntry"/>
-                    <entryLink id="76ab-b237-d49e-9927" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="aa3c-f5a5-9ce9-1497" type="selectionEntry"/>
-                    <entryLink id="0cd9-c0f7-cd54-fabf" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="7e5c-3d25-5c88-32e0" type="selectionEntry"/>
+                    <entryLink id="0697-673b-05d4-e096" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="34c4-db99-db36-0f2a" type="selectionEntry" />
+                    <entryLink id="76ab-b237-d49e-9927" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="aa3c-f5a5-9ce9-1497" type="selectionEntry" />
+                    <entryLink id="0cd9-c0f7-cd54-fabf" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="7e5c-3d25-5c88-32e0" type="selectionEntry" />
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
                 <entryLink id="a0be-13ae-3445-64f2" name="Power Dagger" hidden="false" collective="false" import="true" targetId="8157-b77c-0dd3-85b2" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e9a-da56-703a-f6fb" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9739-b314-4706-d734" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e9a-da56-703a-f6fb" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9739-b314-4706-d734" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="2c51-b7fd-c325-6e86" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04de-3dde-5b2e-806b" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2c8-e504-e744-a5ea" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04de-3dde-5b2e-806b" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2c8-e504-e744-a5ea" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="a612-310e-2164-68f9" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="571c-dda4-e24a-44b9" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8778-3e66-e601-daa0" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="571c-dda4-e24a-44b9" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8778-3e66-e601-daa0" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="e2a2-bd17-7fa1-d69f" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80b7-62b8-d79c-a4a0" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b324-cc87-c9a0-1a75" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80b7-62b8-d79c-a4a0" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b324-cc87-c9a0-1a75" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="97bc-e34e-2201-3f7a" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09c8-f41e-fb22-ec33" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5377-81a3-627e-0d60" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09c8-f41e-fb22-ec33" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5377-81a3-627e-0d60" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="c051-b8a4-fb93-8ef1" name="Headhunter" hidden="false" collective="false" import="true" type="upgrade">
@@ -2977,48 +2976,48 @@
               <entryLinks>
                 <entryLink id="a002-d627-6b9a-af75" name="Power Dagger" hidden="false" collective="false" import="true" targetId="47b3-acd0-e43e-cd63" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="521c-b6ca-7043-afbe" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="764e-5d82-46f0-aaba" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="521c-b6ca-7043-afbe" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="764e-5d82-46f0-aaba" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="8b0e-6a56-eaab-793e" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6e1-62bb-b4c3-d397" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8753-5c62-7174-28f3" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6e1-62bb-b4c3-d397" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8753-5c62-7174-28f3" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="470f-9c05-2c21-4bc0" name="Power Armour" hidden="false" collective="false" import="true" targetId="486f-a33c-7da5-c580" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b7e-5812-717a-685d" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c93-9782-764e-e7be" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b7e-5812-717a-685d" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c93-9782-764e-e7be" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="dd00-1ced-7c29-5787" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="4fd8-9e1f-ae28-3004" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1065-5ab5-0d84-bbf7" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e11-87d7-e299-88fe" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1065-5ab5-0d84-bbf7" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e11-87d7-e299-88fe" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="b461-6328-d1bd-1668" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="3739-1019-344e-761d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5850-e563-8339-9a31" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="792e-c6ed-64bf-6342" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5850-e563-8339-9a31" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="792e-c6ed-64bf-6342" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="c7b3-e725-6953-7599" name="Banestrike Combi-Bolter" hidden="false" collective="false" import="true" targetId="1b2e-7f13-38fd-e5c6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5217-f3c6-2e49-52e0" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d11a-54da-c34c-ed3d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5217-f3c6-2e49-52e0" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d11a-54da-c34c-ed3d" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="a7b4-1de7-bc6f-4120" name="Headhunter w/Heavy Weapon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbf6-90fa-b2cd-3a10" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbf6-90fa-b2cd-3a10" type="max" />
               </constraints>
               <profiles>
                 <profile id="e572-5cd5-aeae-1b80" name="Headhunter" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -3040,24 +3039,24 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="75b3-5de3-bb15-a4c9" name="Ranged:" hidden="false" collective="false" import="true" defaultSelectionEntryId="bba9-0fce-58d2-a748">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d53-95e4-4821-cfed" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85a3-1699-05ef-2424" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d53-95e4-4821-cfed" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85a3-1699-05ef-2424" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="bba9-0fce-58d2-a748" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="07fd-c24a-9235-4206" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a383-9d1a-cf91-b57a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a383-9d1a-cf91-b57a" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="6520-105e-b19e-a7c8" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4fb-e422-45ea-a8b6" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4fb-e422-45ea-a8b6" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -3066,61 +3065,61 @@
               <entryLinks>
                 <entryLink id="e5ea-3aa7-a9c0-3822" name="Power Dagger" hidden="false" collective="false" import="true" targetId="8157-b77c-0dd3-85b2" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8f5-ae4d-f8e8-26cd" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="219a-50aa-e46d-5c42" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8f5-ae4d-f8e8-26cd" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="219a-50aa-e46d-5c42" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="731d-cee4-e25a-8be0" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc94-e771-1c90-4f0a" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e3e-131c-7513-5401" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc94-e771-1c90-4f0a" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e3e-131c-7513-5401" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="f5e5-7fae-89b0-6260" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bbc-dd07-64bd-b09a" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec5d-6172-efaa-19d9" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bbc-dd07-64bd-b09a" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec5d-6172-efaa-19d9" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="3e2a-9004-bd85-b9fa" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99c3-412f-03d0-bd21" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed3d-53a9-3f28-ecc5" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99c3-412f-03d0-bd21" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed3d-53a9-3f28-ecc5" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="2a49-3781-fbdf-cc96" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="270e-4033-f881-390d" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09ed-b18d-8e27-2fc1" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="270e-4033-f881-390d" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09ed-b18d-8e27-2fc1" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="1ed6-4c3a-e08d-d2bd" name="2) Dedicated Transport" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac93-cadf-7798-b832" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac93-cadf-7798-b832" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="8654-833c-cc25-62e3" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="c53f-92ec-a805-ec68" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="true" targetId="bbe8-818d-3068-d79c" type="selectionEntry"/>
+            <entryLink id="c53f-92ec-a805-ec68" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="true" targetId="bbe8-818d-3068-d79c" type="selectionEntry" />
             <entryLink id="ccac-a09d-e1b5-0016" name="Storm Eagle Gunship" hidden="true" collective="false" import="true" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -3129,14 +3128,14 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="47b3-acd0-e43e-cd63" name="Power Dagger" publicationId="09c5-eeae-f398-b653" page="334" hidden="false" collective="true" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
@@ -3153,24 +3152,24 @@
       <infoLinks>
         <infoLink id="2750-8c8f-2dae-3f36" name="Sudden Strike (X)" hidden="false" targetId="58b3-7d84-b92d-1363" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Sudden Strike (1)"/>
+            <modifier type="set" field="name" value="Sudden Strike (1)" />
           </modifiers>
         </infoLink>
         <infoLink id="c8a3-6591-9060-525b" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Breaching (5+)"/>
+            <modifier type="set" field="name" value="Breaching (5+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="1b2e-7f13-38fd-e5c6" name="Banestrike Combi-Bolter" hidden="false" collective="true" import="true" type="upgrade">
       <profiles>
         <profile id="5e80-8dc2-e331-1db3" name="Banestrike Combi-Bolter" publicationId="09c5-eeae-f398-b653" page="284" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
           <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">18"</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
             <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Rapid Fire, Twin-linked, Breaching (6+) </characteristic>
@@ -3180,24 +3179,24 @@
       <infoLinks>
         <infoLink id="e98f-f1bd-5900-e216" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Breaching (6+)"/>
+            <modifier type="set" field="name" value="Breaching (6+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="cfc7-6760-93f1-8dba" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
+        <infoLink id="cfc7-6760-93f1-8dba" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule" />
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="42af-ab98-e733-dc01" name="Armillus Dynat" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e38-f7b6-b684-7d33" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e38-f7b6-b684-7d33" type="max" />
       </constraints>
       <profiles>
         <profile id="0323-8da2-33e5-7eef" name="Armillus Dynat" publicationId="09c5-eeae-f398-b653" page="342" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -3216,24 +3215,24 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="1072-7e31-5ebe-cb69" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule"/>
-        <infoLink id="6843-dcf1-d731-dbc1" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="1072-7e31-5ebe-cb69" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule" />
+        <infoLink id="6843-dcf1-d731-dbc1" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="c88e-5a81-9e52-b8c3" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Precision Strikes (4+)"/>
+            <modifier type="set" field="name" value="Precision Strikes (4+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0162-1ffa-9d07-6d83" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="abbd-7422-7468-daf9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="8359-b586-6975-bb16" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="0162-1ffa-9d07-6d83" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="abbd-7422-7468-daf9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="8359-b586-6975-bb16" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="86b8-39b0-0c18-216a" name="The Prince and the Prophet" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4887-6981-7931-7f32" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f53-06f8-1d9f-4bd8" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4887-6981-7931-7f32" type="min" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f53-06f8-1d9f-4bd8" type="max" />
           </constraints>
           <profiles>
             <profile id="1999-3e06-d22c-5d67" name="The Prince" publicationId="09c5-eeae-f398-b653" page="343" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -3261,92 +3260,92 @@
           <infoLinks>
             <infoLink id="e6b2-05ce-cbca-ab07" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Rending (6+)"/>
+                <modifier type="set" field="name" value="Rending (6+)" />
               </modifiers>
             </infoLink>
-            <infoLink id="dc97-8e79-4c15-73e4" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+            <infoLink id="dc97-8e79-4c15-73e4" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="4332-aa47-3027-a284" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a121-d6c4-f258-c8ed" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4059-5406-969d-cbec" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a121-d6c4-f258-c8ed" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4059-5406-969d-cbec" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="d526-e53d-f917-60d6" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68b5-072b-e9da-359d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d9d-7bc8-aba9-005d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68b5-072b-e9da-359d" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d9d-7bc8-aba9-005d" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="7403-0c39-333d-df9b" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a934-dd52-3655-77a3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a934-dd52-3655-77a3" type="max" />
           </constraints>
           <profiles>
             <profile id="fac7-6996-5103-e879" name="The Harrowing" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">At the start of the battle, before any models are deployed by either player, the controlling player of an army whose Warlord is Armillus Dynat may choose to select three friendly units composed entirely of models with the Legiones Astartes (Alpha Legion) special rule and the Infantry Unit Type and give all models in those units one of the following rules: Infiltrate, Scout, or Counter-attack (1). In addition, an army whose Warlord is Armillus Dynat may make an additional Reaction in the opposing player&apos;s Movement phase, as long as Armillus Dynat has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">At the start of the battle, before any models are deployed by either player, the controlling player of an army whose Warlord is Armillus Dynat may choose to select three friendly units composed entirely of models with the Legiones Astartes (Alpha Legion) special rule and the Infantry Unit Type and give all models in those units one of the following rules: Infiltrate, Scout, or Counter-attack (1). In addition, an army whose Warlord is Armillus Dynat may make an additional Reaction in the opposing player's Movement phase, as long as Armillus Dynat has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
         <entryLink id="04b8-52d3-9e9e-ffbb" name="Venom Spheres" hidden="false" collective="false" import="true" targetId="82f5-cca1-51a0-31dd" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0aaa-182b-8c4e-5986" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c81-c4d3-e41d-723a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0aaa-182b-8c4e-5986" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c81-c4d3-e41d-723a" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="576d-cfbc-8815-fc60" name="Phosphex Bomb" hidden="false" collective="false" import="true" targetId="4188-13ff-cb03-109e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc89-8749-a94e-6a5a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6ff-5d8e-ada9-aeb0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc89-8749-a94e-6a5a" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6ff-5d8e-ada9-aeb0" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="f318-7b31-801d-066a" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cea3-14cc-b5ae-d098" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ced2-28b5-9b0b-385c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cea3-14cc-b5ae-d098" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ced2-28b5-9b0b-385c" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="83f4-3339-7b85-16e2" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1416-1634-fa05-4fa7" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d43d-c184-56c4-f747" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1416-1634-fa05-4fa7" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d43d-c184-56c4-f747" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="1d76-b636-e80b-45be" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce25-2a19-b61c-5c9a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8750-e3b0-cb03-2a7f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce25-2a19-b61c-5c9a" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8750-e3b0-cb03-2a7f" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="96a7-56f8-416c-6934" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc93-cb1c-50c6-f193" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a21e-c99c-9bbb-d369" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc93-cb1c-50c6-f193" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a21e-c99c-9bbb-d369" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="736e-42eb-df51-a73b" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup"/>
+        <entryLink id="736e-42eb-df51-a73b" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="e56e-40d5-e362-0e1c" name="Alpharius" publicationId="09c5-eeae-f398-b653" page="336" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7786-10b0-f222-2c4e" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7786-10b0-f222-2c4e" type="max" />
       </constraints>
       <profiles>
         <profile id="742b-ac49-7473-e674" name="Alpharius" publicationId="09c5-eeae-f398-b653" page="336" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Primarch (Unique)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">7</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">7</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
@@ -3361,10 +3360,10 @@
       </profiles>
       <rules>
         <rule id="523b-f763-4a49-cc39" name="Everywhere and Nowhere" publicationId="09c5-eeae-f398-b653" page="337" hidden="false">
-          <description>At the start of the battle before any models are deployed, Alpharius may be given any one of the following special rules: Infiltrate, Scout or Deep Strike. Alpharius&apos; controlling player may select up to three friendly units composed entirely of models with the Legiones Astartes (Alpha Legion) special rule to receive the same special rule granted to Alpharius by Everywhere and Nowhere.</description>
+          <description>At the start of the battle before any models are deployed, Alpharius may be given any one of the following special rules: Infiltrate, Scout or Deep Strike. Alpharius' controlling player may select up to three friendly units composed entirely of models with the Legiones Astartes (Alpha Legion) special rule to receive the same special rule granted to Alpharius by Everywhere and Nowhere.</description>
         </rule>
         <rule id="e9f2-c215-0152-8111" name="Insidious Mastermind" publicationId="09c5-eeae-f398-b653" page="337" hidden="false">
-          <description>At the start of any turn in which Alpharius&apos; controlling player is the Active player and Alpharius is on the battlefield (including when Embarked on a model with the Transport Sub-type or Building), the controlling player may grant one of the listed special rules to all models in the army with the Legiones Astartes (Alpha Legion) special rule (including Alpharius) that do not also have the Vehicle Unit Type, until the start of the controlling player&apos;s next turn as the Active player. Each of the listed special rules may only be selected once per battle:
+          <description>At the start of any turn in which Alpharius' controlling player is the Active player and Alpharius is on the battlefield (including when Embarked on a model with the Transport Sub-type or Building), the controlling player may grant one of the listed special rules to all models in the army with the Legiones Astartes (Alpha Legion) special rule (including Alpharius) that do not also have the Vehicle Unit Type, until the start of the controlling player's next turn as the Active player. Each of the listed special rules may only be selected once per battle:
 - The Fleet (2) special rule
 - The Preferred Enemy (Everything) special rule
 - The Sudden Strike (1) special rule</description>
@@ -3373,26 +3372,26 @@
       <infoLinks>
         <infoLink id="18bc-b739-a7f1-85eb" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Adamantium Will (3+)"/>
+            <modifier type="set" field="name" value="Adamantium Will (3+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="c6e1-4a83-447d-e63d" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule"/>
-        <infoLink id="f032-2a44-d3a9-a905" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule"/>
+        <infoLink id="c6e1-4a83-447d-e63d" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule" />
+        <infoLink id="f032-2a44-d3a9-a905" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="f996-05bf-ded5-1995" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="3719-acf7-a932-2783" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="f996-05bf-ded5-1995" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="3719-acf7-a932-2783" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="c60e-92ed-d696-b0b9" name="The Hydra&apos;s Spite" publicationId="09c5-eeae-f398-b653" page="337" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="c60e-92ed-d696-b0b9" name="The Hydra's Spite" publicationId="09c5-eeae-f398-b653" page="337" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bec5-cbb6-9cff-10e7" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a40-2dd0-437b-f09b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bec5-cbb6-9cff-10e7" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a40-2dd0-437b-f09b" type="max" />
           </constraints>
           <profiles>
-            <profile id="705d-5740-bbf7-ed37" name="The Hydra&apos;s Spite" publicationId="09c5-eeae-f398-b653" page="337" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="705d-5740-bbf7-ed37" name="The Hydra's Spite" publicationId="09c5-eeae-f398-b653" page="337" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">18"</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 2, Rending (4+), Master-crafted</characteristic>
@@ -3402,19 +3401,19 @@
           <infoLinks>
             <infoLink id="38fe-9961-98da-e4cb" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Rending (4+)"/>
+                <modifier type="set" field="name" value="Rending (4+)" />
               </modifiers>
             </infoLink>
-            <infoLink id="f24c-ae2d-ecc2-d93e" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="f24c-ae2d-ecc2-d93e" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="25b2-384b-9ad5-b146" name="The Pale Spear" publicationId="09c5-eeae-f398-b653" page="337" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1ca-4d50-6965-60d2" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64dd-2163-0b87-139f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1ca-4d50-6965-60d2" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64dd-2163-0b87-139f" type="max" />
           </constraints>
           <profiles>
             <profile id="c35b-0c67-e93e-60ea" name="The Pale Spear" publicationId="09c5-eeae-f398-b653" page="337" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -3427,18 +3426,18 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="ddaf-4c6f-7a7c-1a54" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule"/>
-            <infoLink id="7b8c-b485-9aa3-a919" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
-            <infoLink id="366c-8b66-e16f-0eeb" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+            <infoLink id="ddaf-4c6f-7a7c-1a54" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule" />
+            <infoLink id="7b8c-b485-9aa3-a919" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule" />
+            <infoLink id="366c-8b66-e16f-0eeb" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="ab9c-389d-1f05-e27a" name="The Pythian Scales" publicationId="09c5-eeae-f398-b653" page="337" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4677-90ac-ebdc-160a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8703-0058-6e48-07e4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4677-90ac-ebdc-160a" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8703-0058-6e48-07e4" type="max" />
           </constraints>
           <profiles>
             <profile id="8efb-fc40-2740-83e0" name="The Pythian Scales" publicationId="09c5-eeae-f398-b653" page="337" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
@@ -3448,46 +3447,46 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="a968-2113-25ea-9be6" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e21-3065-c057-f8e1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d111-af77-6abd-60ad" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e21-3065-c057-f8e1" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d111-af77-6abd-60ad" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="33c2-ac53-baae-0a28" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1c6-760d-bd85-36ff" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17e9-4887-4fda-af00" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1c6-760d-bd85-36ff" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17e9-4887-4fda-af00" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="3d06-54ef-a62b-4604" name="Venom Spheres" hidden="false" collective="false" import="true" targetId="82f5-cca1-51a0-31dd" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34bb-d0b4-4fb3-751a" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a725-bed9-2b91-b38d" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34bb-d0b4-4fb3-751a" type="min" />
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a725-bed9-2b91-b38d" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="e936-bd11-5da2-e808" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="713e-e49b-27af-449f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fc1-5343-72e0-8aa1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="713e-e49b-27af-449f" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fc1-5343-72e0-8aa1" type="max" />
           </constraints>
           <profiles>
             <profile id="cf43-cc35-3b66-6d35" name=" Sire of the Alpha Legion" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">At the start of the battle, after all models from all armies have been deployed, including units deployed using the Infiltrator special rule and after any Scout moves have been made, Alpharius&apos; controlling player may select up to three friendly units composed entirely of models with the Legiones Astartes (Alpha Legion) special rule. The selected units may be redeployed to any position in the controlling player&apos;s Deploymen Zone or placed into Reserves. In addition, an army with Alpharius as its Warlord may declare a single Phase at the start of any turn in which Alpharius&apos; controlling player is the Reactive player, gaining an additional Reaction in the chosen Phase as long as Alpharius has not been removed as casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">At the start of the battle, after all models from all armies have been deployed, including units deployed using the Infiltrator special rule and after any Scout moves have been made, Alpharius' controlling player may select up to three friendly units composed entirely of models with the Legiones Astartes (Alpha Legion) special rule. The selected units may be redeployed to any position in the controlling player's Deploymen Zone or placed into Reserves. In addition, an army with Alpharius as its Warlord may declare a single Phase at the start of any turn in which Alpharius' controlling player is the Reactive player, gaining an additional Reaction in the chosen Phase as long as Alpharius has not been removed as casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
-        <entryLink id="04a6-1b16-3d7e-4562" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup"/>
+        <entryLink id="04a6-1b16-3d7e-4562" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="465.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="465.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="b470-1f0d-f0b5-ceeb" name="Autilon Skorr" hidden="false" collective="false" import="true" type="unit">
@@ -3495,7 +3494,7 @@
         <profile id="16ba-a7bf-5295-2795" name="Autilon Skorr" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -3509,18 +3508,18 @@
         </profile>
         <profile id="6b55-fabc-88e0-6d2a" name="Honour the Legion" hidden="false" typeId="b46c-270c-d29e-f0ff" typeName="Ability">
           <characteristics>
-            <characteristic name="Description" typeId="0982-427b-1d4a-d07c">Once per battle, at the start of any of the controlling player’s turns, this rule may be activated. Once activated, take a Leadership test using the Leadership Characteristic 10: if passed then all friendly units that are Pinned or Falling Back and have at least one model that can draw line of sight to the model with this special rule immediately rally, and are no longer Pinned or Falling Back and may act normally this turn.</characteristic>
+            <characteristic name="Description" typeId="0982-427b-1d4a-d07c">Once per battle, at the start of any of the controlling player&#8217;s turns, this rule may be activated. Once activated, take a Leadership test using the Leadership Characteristic 10: if passed then all friendly units that are Pinned or Falling Back and have at least one model that can draw line of sight to the model with this special rule immediately rally, and are no longer Pinned or Falling Back and may act normally this turn.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="070f-f851-49aa-f55f" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule"/>
+        <infoLink id="070f-f851-49aa-f55f" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule" />
       </infoLinks>
       <selectionEntries>
         <selectionEntry id="da79-fbde-669b-8da5" name="Rime-shard" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e36-14fa-1dfe-0efb" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e3e-e52a-70f5-95d2" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e36-14fa-1dfe-0efb" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e3e-e52a-70f5-95d2" type="max" />
           </constraints>
           <profiles>
             <profile id="8f13-5bd1-025d-90ba" name="Rime-shard" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -3533,67 +3532,67 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="f3dd-a4a5-4d7e-586d" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
-            <infoLink id="463e-909f-5724-6334" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="f3dd-a4a5-4d7e-586d" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
+            <infoLink id="463e-909f-5724-6334" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="1308-d9e0-7290-847d" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fbc-d29d-ae31-bdd4" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43ba-bfcb-0cbb-2ae3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fbc-d29d-ae31-bdd4" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43ba-bfcb-0cbb-2ae3" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="7848-3e8c-214d-5ab5" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7127-a71c-020c-0a57" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d4f-583b-7110-f223" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7127-a71c-020c-0a57" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d4f-583b-7110-f223" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="bb89-544d-65dc-6724" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6b8-c520-4b45-4901" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b182-0b14-1b0b-bbca" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6b8-c520-4b45-4901" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b182-0b14-1b0b-bbca" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="3757-079f-3787-381d" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4d7-2c0c-8176-4755" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a97-321f-c606-0d51" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4d7-2c0c-8176-4755" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a97-321f-c606-0d51" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="ae63-1f21-ac63-91ed" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fc9-8945-c3e4-99ea" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77fd-ed1e-1195-15ca" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fc9-8945-c3e4-99ea" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77fd-ed1e-1195-15ca" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="54ca-3475-fb7e-cb47" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa3f-7f2b-ec81-d900" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa3f-7f2b-ec81-d900" type="max" />
           </constraints>
           <profiles>
             <profile id="c141-0e0f-74e0-978a" name="Desperate for Glory" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">On Game Turn One Autilon Skorr has Feel No Pain (6+), increasing to Feel No Pain (5+) on Game Turn Two and Feel No Pain (4+) on Game Turn Three and successive turns until the end of the battle. In addition, the controlling player of an army with Autilon Skorr as its Warlord may select one Phase at the start of the battle, before any models are deployed onto the battlefield. During the chosen Phase of their opponent’s turn, Autilon Skorr and any unit he has joined may make a Reaction without expending any of the army’s Reaction Allotment as long as Autilon Skorr has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">On Game Turn One Autilon Skorr has Feel No Pain (6+), increasing to Feel No Pain (5+) on Game Turn Two and Feel No Pain (4+) on Game Turn Three and successive turns until the end of the battle. In addition, the controlling player of an army with Autilon Skorr as its Warlord may select one Phase at the start of the battle, before any models are deployed onto the battlefield. During the chosen Phase of their opponent&#8217;s turn, Autilon Skorr and any unit he has joined may make a Reaction without expending any of the army&#8217;s Reaction Allotment as long as Autilon Skorr has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
-        <entryLink id="39c2-97b2-3863-bfb8" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup"/>
+        <entryLink id="39c2-97b2-3863-bfb8" name="Retinue" hidden="false" collective="false" import="true" targetId="09f9-933c-a88e-6e38" type="selectionEntryGroup" />
         <entryLink id="6493-5acf-e490-322c" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6afd-234e-59d2-cb59" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="526c-a489-9e44-121f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6afd-234e-59d2-cb59" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="526c-a489-9e44-121f" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -3602,76 +3601,76 @@
       <modifiers>
         <modifier type="set" field="7caa-8b34-6dff-26d1" value="1.0">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d1e-3881-2cab-53c8" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7caa-8b34-6dff-26d1" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d1e-3881-2cab-53c8" type="max" />
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7caa-8b34-6dff-26d1" type="min" />
       </constraints>
       <selectionEntryGroups>
         <selectionEntryGroup id="e00a-d5b4-4582-b9fb" name="XX: Alpha Legion" publicationId="09c5-eeae-f398-b653" page="332" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="greaterThan" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="528e-4e68-8a69-12c4" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="22ac-8732-1836-4f3f" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="528e-4e68-8a69-12c4" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="22ac-8732-1836-4f3f" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="3637-db46-f751-a44b" name="The Mobius Configuration (Loyalist Only)" publicationId="09c5-eeae-f398-b653" page="332" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c5d2-e0af-51ad-becb" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2484-bad9-b1c3-6340" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c5d2-e0af-51ad-becb" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2484-bad9-b1c3-6340" type="max" />
               </constraints>
               <profiles>
                 <profile id="dd64-b7ca-3234-4e42" name="The Mobius Configuration" publicationId="09c5-eeae-f398-b653" page="332" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">An army whose Warlord has this Trait counts any Allied Detachment that has any version of the Legiones Astartes (X) special rule as though it had the Fellow Warriors level of Alliance, regardless of the variant of the Legiones Astartes (X) special rule it has. Units from this Allied Detachment that are removed as casualties do not score Victory points for the opposing player, regardless of the Mission Objectives in play, and if all models that were part of the Allied Detachment have been removed as casualties at the end of the battle, the controlling player gains +1 Victory point. No unit in the Allied Detachment may make Reactions of any kind, but the first unit in the Primary Detachment to make a Reaction each turn does not use up a point of the controlling player’s Reaction Allotment when making that Reaction.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">An army whose Warlord has this Trait counts any Allied Detachment that has any version of the Legiones Astartes (X) special rule as though it had the Fellow Warriors level of Alliance, regardless of the variant of the Legiones Astartes (X) special rule it has. Units from this Allied Detachment that are removed as casualties do not score Victory points for the opposing player, regardless of the Mission Objectives in play, and if all models that were part of the Allied Detachment have been removed as casualties at the end of the battle, the controlling player gains +1 Victory point. No unit in the Allied Detachment may make Reactions of any kind, but the first unit in the Primary Detachment to make a Reaction each turn does not use up a point of the controlling player&#8217;s Reaction Allotment when making that Reaction.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="0673-10db-3eb3-437c" name="Master of Lies" publicationId="09c5-eeae-f398-b653" page="332" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="29a8-af92-ad76-cb99" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8852-7eb8-fb75-ca47" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="29a8-af92-ad76-cb99" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8852-7eb8-fb75-ca47" type="max" />
               </constraints>
               <profiles>
                 <profile id="b5c7-771f-462a-a358" name="Master of Lies" publicationId="09c5-eeae-f398-b653" page="332" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">An army whose Warlord has this Trait, may, at the start of the battle once all players have deployed all of their units onto the battlefield (including Infiltrators and Scouts) and any rolls to Seize the Initiative have been made, select up to three units that are under their control. The selected units may be redeployed as the controlling player wishes, within the constraints of the mission being played – they may be placed into Reserves, but may not be brought out of Reserves and onto the battlefield or assigned to a Deep Strike Assault, Subterranean Assault or Flanking Assault. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">An army whose Warlord has this Trait, may, at the start of the battle once all players have deployed all of their units onto the battlefield (including Infiltrators and Scouts) and any rolls to Seize the Initiative have been made, select up to three units that are under their control. The selected units may be redeployed as the controlling player wishes, within the constraints of the mission being played &#8211; they may be placed into Reserves, but may not be brought out of Reserves and onto the battlefield or assigned to a Deep Strike Assault, Subterranean Assault or Flanking Assault. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="7330-ec27-1fda-a264" name="Hydran Excursor" publicationId="09c5-eeae-f398-b653" page="332" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f222-fb36-bbb0-d973" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d30-3bd7-c4f5-03a4" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f222-fb36-bbb0-d973" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d30-3bd7-c4f5-03a4" type="max" />
               </constraints>
               <profiles>
                 <profile id="ee8e-89d7-5d44-707f" name="Hydran Excursor" publicationId="09c5-eeae-f398-b653" page="332" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
@@ -3681,28 +3680,28 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="60d9-0256-0936-703a" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+        <entryLink id="60d9-0256-0936-703a" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="09f9-933c-a88e-6e38" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ac58-c1d8-56cb-9f48" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ac58-c1d8-56cb-9f48" type="max" />
       </constraints>
       <entryLinks>
-        <entryLink id="c71e-8822-1105-9320" name="Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
-        <entryLink id="3bc0-8b50-e5ce-67ad" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="c71e-8822-1105-9320" name="Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
+        <entryLink id="3bc0-8b50-e5ce-67ad" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
         <entryLink id="808e-5e5b-7974-80ff" name="Command Squad, Cataphractii" hidden="false" collective="false" import="true" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -3711,23 +3710,23 @@
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="22ab-29e1-22f3-7cff" name="LA -   I: Dark Angels" targetId="ee5e-198e-1b19-4b9f" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="a164-9b86-cdff-a77e" name="LA -   III: Emperor&apos;s Children" targetId="72ba-61c2-37ad-c785" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="f3da-bf4c-5557-55ca" name="LA -   IV: Iron Warriors" targetId="2ee4-57ed-db44-8a63" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="a765-0d93-a1aa-429d" name="LA -   V: White Scars" targetId="caa9-c50e-8eed-2259" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="deaf-52e5-4b05-f2d6" name="LA -   VI: Space Wolves" targetId="ca15-13de-89cb-bbb2" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="7d3f-8f37-29e5-3a1e" name="LA -   VII: Imperial Fists" targetId="8866-00ec-715f-f21a" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="e854-80e6-908e-88db" name="LA -   VIII: Night Lords" targetId="36dc-14fc-8872-476b" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="d048-e6d9-e40e-8363" name="LA -  IX: Blood Angels" targetId="cd4d-8765-5387-8409" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="7ea8-b20e-d38f-def3" name="LA -  X: Iron Hands" targetId="b73e-125f-db29-17f2" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="1ab3-19e2-4e09-4cef" name="LA -  XII: World Eaters" targetId="d901-0eca-48b5-304a" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="e1d9-0e0d-dd7c-564b" name="LA -  XIII: Ultramarines" targetId="68ae-9855-b56a-95e6" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="8bd2-e90a-499a-652d" name="LA -  XIV: Death Guard" targetId="d228-55e8-b58c-1b77" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="cb9a-9b14-8dcf-910f" name="LA -  XV: Thousand Sons" targetId="abac-8dd1-df65-e253" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="3289-8848-fef8-7f7a" name="LA -  XVI: Sons of Horus" targetId="62c7-42f4-5523-af1b" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="4c19-55ad-bb7b-187c" name="LA -  XVII: Word Bearers" targetId="1df7-bbbc-b70e-6a3f" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="615e-dbe4-e349-94ca" name="LA -  XVIII: Salamanders" targetId="3547-84d8-d789-bab7" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="0fd7-0093-a46a-ad80" name="LA - XIX: Raven Guard" targetId="d21e-9c80-a7f8-728c" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />
+    <catalogueLink id="22ab-29e1-22f3-7cff" name="LA -   I: Dark Angels" targetId="ee5e-198e-1b19-4b9f" type="catalogue" importRootEntries="true" />
+    <catalogueLink id="a164-9b86-cdff-a77e" name="LA -   III: Emperor's Children" targetId="72ba-61c2-37ad-c785" type="catalogue" importRootEntries="true" />
+    <catalogueLink id="f3da-bf4c-5557-55ca" name="LA -   IV: Iron Warriors" targetId="2ee4-57ed-db44-8a63" type="catalogue" importRootEntries="true" />
+    <catalogueLink id="a765-0d93-a1aa-429d" name="LA -   V: White Scars" targetId="caa9-c50e-8eed-2259" type="catalogue" importRootEntries="true" />
+    <catalogueLink id="deaf-52e5-4b05-f2d6" name="LA -   VI: Space Wolves" targetId="ca15-13de-89cb-bbb2" type="catalogue" importRootEntries="true" />
+    <catalogueLink id="7d3f-8f37-29e5-3a1e" name="LA -   VII: Imperial Fists" targetId="8866-00ec-715f-f21a" type="catalogue" importRootEntries="true" />
+    <catalogueLink id="e854-80e6-908e-88db" name="LA -   VIII: Night Lords" targetId="36dc-14fc-8872-476b" type="catalogue" importRootEntries="true" />
+    <catalogueLink id="d048-e6d9-e40e-8363" name="LA -  IX: Blood Angels" targetId="cd4d-8765-5387-8409" type="catalogue" importRootEntries="true" />
+    <catalogueLink id="7ea8-b20e-d38f-def3" name="LA -  X: Iron Hands" targetId="b73e-125f-db29-17f2" type="catalogue" importRootEntries="true" />
+    <catalogueLink id="1ab3-19e2-4e09-4cef" name="LA -  XII: World Eaters" targetId="d901-0eca-48b5-304a" type="catalogue" importRootEntries="true" />
+    <catalogueLink id="e1d9-0e0d-dd7c-564b" name="LA -  XIII: Ultramarines" targetId="68ae-9855-b56a-95e6" type="catalogue" importRootEntries="true" />
+    <catalogueLink id="8bd2-e90a-499a-652d" name="LA -  XIV: Death Guard" targetId="d228-55e8-b58c-1b77" type="catalogue" importRootEntries="true" />
+    <catalogueLink id="cb9a-9b14-8dcf-910f" name="LA -  XV: Thousand Sons" targetId="abac-8dd1-df65-e253" type="catalogue" importRootEntries="true" />
+    <catalogueLink id="3289-8848-fef8-7f7a" name="LA -  XVI: Sons of Horus" targetId="62c7-42f4-5523-af1b" type="catalogue" importRootEntries="true" />
+    <catalogueLink id="4c19-55ad-bb7b-187c" name="LA -  XVII: Word Bearers" targetId="1df7-bbbc-b70e-6a3f" type="catalogue" importRootEntries="true" />
+    <catalogueLink id="615e-dbe4-e349-94ca" name="LA -  XVIII: Salamanders" targetId="3547-84d8-d789-bab7" type="catalogue" importRootEntries="true" />
+    <catalogueLink id="0fd7-0093-a46a-ad80" name="LA - XIX: Raven Guard" targetId="d21e-9c80-a7f8-728c" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Alpha Legion.cat
+++ b/2022 - LA - Alpha Legion.cat
@@ -1362,7 +1362,7 @@
         <categoryLink id="5083-72be-b0a6-dd03" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="35c4-22cf-690d-9395" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
     <entryLink id="7170-8817-0f9e-2ee0" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="465a-0540-9d96-9b21" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
@@ -1597,7 +1597,7 @@
         <categoryLink id="9521-8f2e-41d3-b746" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="1b94-afca-35f8-fb40" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
     <entryLink id="33a8-d329-4912-7b67" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
@@ -1678,7 +1678,7 @@
         <categoryLink id="cf26-daa7-1824-ee30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="6e5b-2b5c-fb44-50f4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
     <entryLink id="3fb8-86a4-5eaa-c5da" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="575b-37ac-96f7-baa5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -1690,7 +1690,7 @@
         <categoryLink id="8b56-6736-d08c-43fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="d4e9-3255-2b78-fac0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
     <entryLink id="2225-0ca4-1702-8fdb" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="74eb-b246-f3f8-a5b5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -1746,13 +1746,13 @@
         <categoryLink id="19e1-cf1a-de5a-3a75" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="8817-aa93-54a1-bbd8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
     <entryLink id="3e12-cfe5-d35d-2867" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9a1a-b5ea-a356-1928" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="ca5e-2cb8-913e-76fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
     <entryLink id="a563-4ed7-87d2-1d4f" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3e96-2675-f739-a789" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -1771,7 +1771,7 @@
         <categoryLink id="5a84-2565-3576-94de" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
         <categoryLink id="41e6-6306-de04-05ac" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
     <entryLink id="5b3f-b375-7375-5f7a" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8608-d602-5574-25b3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />

--- a/2022 - LA - Blood Angels.cat
+++ b/2022 - LA - Blood Angels.cat
@@ -1,29 +1,28 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cd4d-8765-5387-8409" name="LA -  IX: Blood Angels" revision="26" battleScribeVersion="2.03" authorName="Jon K &quot;Alphalas&quot;" authorContact="Twitter: Alphalas_ Discord: Alphalas#8789" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="29" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="cd4d-8765-5387-8409" name="LA -  IX: Blood Angels" revision="26" battleScribeVersion="2.03" authorName="Jon K &quot;Alphalas&quot;" authorContact="Twitter: Alphalas_ Discord: Alphalas#8789" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="29">
   <entryLinks>
     <entryLink id="1900-3f09-f47b-bed2" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7e95-886f-ed9d-3000" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="4180-caf6-d0dc-7347" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="6422-8dc7-7934-be6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7e95-886f-ed9d-3000" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="4180-caf6-d0dc-7347" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="6422-8dc7-7934-be6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="0493-4e5d-281f-d4f2" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup"/>
-        <entryLink id="e540-6ccd-5bb5-ff32" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup"/>
+        <entryLink id="0493-4e5d-281f-d4f2" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup" />
+        <entryLink id="e540-6ccd-5bb5-ff32" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
     <entryLink id="0bb3-3a91-6450-6bee" name="Chapter Master Raldoron" hidden="false" collective="false" import="false" targetId="59f7-9abf-c171-e9e4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9ebe-3513-9ab7-69db" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="3357-5e6d-c437-5295" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="8eb8-b5f6-a13e-e6a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9ebe-3513-9ab7-69db" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="3357-5e6d-c437-5295" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="8eb8-b5f6-a13e-e6a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="201c-1876-1343-82bd" name="Contemptor-Incaendius Dreadnought" hidden="false" collective="false" import="false" targetId="090c-5656-0180-16c8" type="selectionEntry">
@@ -32,57 +31,57 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f0c3-dea6-a3b3-8814" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="94a0-f009-d095-0a13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f0c3-dea6-a3b3-8814" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="94a0-f009-d095-0a13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="c1af-e2cc-99eb-9c5b" name="Crimson Paladins" hidden="false" collective="false" import="false" targetId="33fe-9683-bde5-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b2fb-57e6-76d1-b70e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="99ad-3f89-2b00-ceea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b2fb-57e6-76d1-b70e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="99ad-3f89-2b00-ceea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="f425-f617-0a7a-ce2b" name="Dawnbreaker Cohort" hidden="false" collective="false" import="false" targetId="3c67-35da-d64a-f22b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2138-4038-c520-9323" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="06d6-2550-bdf0-d9fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2138-4038-c520-9323" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="06d6-2550-bdf0-d9fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="6593-806e-c67a-1797" name="Dominion Zephon" hidden="false" collective="false" import="false" targetId="98d4-555a-6911-7c1a" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="66b1-54b1-9b38-8d89" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="805e-3ba0-5df2-fb4d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="4cf4-9b23-0677-86f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="66b1-54b1-9b38-8d89" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="805e-3ba0-5df2-fb4d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="4cf4-9b23-0677-86f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="8a1e-4de2-5a75-956f" name="Judicar Aster Crohne" hidden="false" collective="false" import="false" targetId="8dba-83cd-4922-bc63" type="selectionEntry">
@@ -91,17 +90,17 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fc0b-2d5b-6e2b-a661" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="18df-f052-5edd-948c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="50a0-d65b-9aed-4040" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fc0b-2d5b-6e2b-a661" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="18df-f052-5edd-948c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="50a0-d65b-9aed-4040" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="6c34-54c1-2c55-e6dc" name="Sanguinius" hidden="false" collective="false" import="false" targetId="2c54-82c1-c1e4-3aee" type="selectionEntry">
@@ -110,1602 +109,1602 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9dac-939c-1711-76ba" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
-        <categoryLink id="b565-cac7-63e5-fb44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9dac-939c-1711-76ba" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true" />
+        <categoryLink id="b565-cac7-63e5-fb44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="d781-5311-119f-a8e2" name="The Angel&apos;s Tears" hidden="false" collective="false" import="false" targetId="dda1-0fcf-0245-6c10" type="selectionEntry">
+    <entryLink id="d781-5311-119f-a8e2" name="The Angel's Tears" hidden="false" collective="false" import="false" targetId="dda1-0fcf-0245-6c10" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bd40-3a9c-fc64-acc2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="f2df-62ef-c931-765a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bd40-3a9c-fc64-acc2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="f2df-62ef-c931-765a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="41ff-7a92-f8e9-0631" name="  IX: Blood Angels" hidden="false" collective="false" import="false" targetId="296e-301e-3ce1-1c15" type="selectionEntry">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0369-3d01-273c-cbf8" type="max"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="003d-a734-8fef-78ec" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0369-3d01-273c-cbf8" type="max" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="003d-a734-8fef-78ec" type="min" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="e29c-aaca-175b-3061" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="e29c-aaca-175b-3061" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="b4bc-0590-372e-0c49" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8449-aca4-0bb8-d8c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6dc5-333f-99b9-b115" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="8449-aca4-0bb8-d8c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6dc5-333f-99b9-b115" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
     <entryLink id="b666-5c25-7b46-de1c" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a585-203e-02db-6fb1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7635-e344-1ec3-cd45" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="a585-203e-02db-6fb1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7635-e344-1ec3-cd45" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
     <entryLink id="1b28-4298-99cc-0ca7" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="07a5-c26e-7b3d-a0fa" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="8519-53ae-67ef-b3b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e1d8-13c3-c6af-c74b" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="07a5-c26e-7b3d-a0fa" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="8519-53ae-67ef-b3b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e1d8-13c3-c6af-c74b" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="67a5-c32f-598e-5dd6" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="89aa-483e-002e-265b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="ee0b-752a-635b-71d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c8eb-043b-8bb7-4dad" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="89aa-483e-002e-265b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="ee0b-752a-635b-71d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c8eb-043b-8bb7-4dad" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
     <entryLink id="309c-c82e-85cc-d283" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8db8-a2c9-2b3c-443a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="9601-f212-af46-31ee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9add-fada-2814-6744" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="8db8-a2c9-2b3c-443a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="9601-f212-af46-31ee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9add-fada-2814-6744" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="1ef3-df62-935c-fb6c" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup"/>
+        <entryLink id="1ef3-df62-935c-fb6c" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup" />
         <entryLink id="292d-3b86-d572-bd35" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
     <entryLink id="bf99-e84a-7181-c531" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cef6-cdf5-96c8-82dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2710-b433-b717-4386" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="3d3a-4e0a-5409-dcca" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="cef6-cdf5-96c8-82dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2710-b433-b717-4386" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="3d3a-4e0a-5409-dcca" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="b2b5-b293-702b-6f65" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup"/>
+        <entryLink id="b2b5-b293-702b-6f65" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup" />
         <entryLink id="5a97-5702-acda-aa60" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
     <entryLink id="2b6a-48fb-166c-8ae2" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fa76-90f6-d696-02c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3058-ad6f-5d38-7791" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="a59b-14c3-16f4-4692" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="fa76-90f6-d696-02c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3058-ad6f-5d38-7791" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="a59b-14c3-16f4-4692" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="efc6-f00c-7dcb-f631" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup"/>
+        <entryLink id="efc6-f00c-7dcb-f631" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup" />
         <entryLink id="fe41-5d4d-0a4c-e28b" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
     <entryLink id="f21c-08b1-43f7-be5d" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5c7b-1610-e3c2-e860" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="3294-835c-506e-922f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5c7b-1610-e3c2-e860" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="3294-835c-506e-922f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
     <entryLink id="7c90-b2c0-b602-0b61" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="db9a-a5ba-128c-80e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8b1d-fc94-eb67-f3b8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="db9a-a5ba-128c-80e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8b1d-fc94-eb67-f3b8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
     <entryLink id="ed74-6166-b1e5-fe90" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5f44-f33b-db1e-5ebd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="b559-18f7-4a13-234a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5f44-f33b-db1e-5ebd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="b559-18f7-4a13-234a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
     <entryLink id="44d8-46b3-d268-8a22" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="54aa-9c4a-61d6-bc89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a445-e6c8-15ad-0f5d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="54aa-9c4a-61d6-bc89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a445-e6c8-15ad-0f5d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
     <entryLink id="9c32-38e5-c57f-baf8" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2b23-1408-f09a-589e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="6ac8-9063-83f9-c8cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0f23-acae-aacd-f289" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="2b23-1408-f09a-589e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="6ac8-9063-83f9-c8cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0f23-acae-aacd-f289" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="d2da-55cb-7c1c-419c" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ddaf-db43-500c-e7dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2597-efab-b09a-aff4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="ddaf-db43-500c-e7dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2597-efab-b09a-aff4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="04c4-57ee-9330-b297" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="405e-623e-e5f6-2e54" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="8ec3-ff6b-9c00-3dbf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="405e-623e-e5f6-2e54" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="8ec3-ff6b-9c00-3dbf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
     <entryLink id="58cf-9f01-9289-7af6" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c418-712f-cb83-6081" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="6a07-32b8-f6b3-4081" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c418-712f-cb83-6081" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="6a07-32b8-f6b3-4081" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
     <entryLink id="1aa1-77c1-ba59-e7a5" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e57f-8fdf-b790-5b9b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="8e2d-c855-646b-2848" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e57f-8fdf-b790-5b9b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="8e2d-c855-646b-2848" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
     <entryLink id="738b-6376-1b98-5956" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f951-f918-a1ac-dc74" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="06b9-5ea1-1f78-1049" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="f951-f918-a1ac-dc74" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="06b9-5ea1-1f78-1049" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
     <entryLink id="3b9d-980f-426c-7452" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b108-7524-fe41-5c36" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="77b3-59ff-faed-23e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b108-7524-fe41-5c36" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="77b3-59ff-faed-23e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
     <entryLink id="e969-bad1-eb73-d543" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="45b5-75ee-4078-8f25" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="3128-073c-12bd-156e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="45b5-75ee-4078-8f25" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="3128-073c-12bd-156e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
     <entryLink id="a4fb-1879-33ac-972d" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="287b-5ff0-2e74-d3cc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f756-428a-3cd9-6555" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="287b-5ff0-2e74-d3cc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f756-428a-3cd9-6555" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
     <entryLink id="5791-6122-9510-c159" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6f5c-11c2-2808-4913" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="ba8c-d805-6945-a17c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6f5c-11c2-2808-4913" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="ba8c-d805-6945-a17c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
     <entryLink id="0ca4-8dde-9f99-32f5" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="60cc-079b-52e3-2847" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="71b8-4713-eeb4-fc43" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="60cc-079b-52e3-2847" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="71b8-4713-eeb4-fc43" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="a1b9-836c-96ef-ae59" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6456-603c-59b4-0798" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="77f0-2905-7c47-0c9e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6456-603c-59b4-0798" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="77f0-2905-7c47-0c9e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
     <entryLink id="7c67-08c8-2695-4cb0" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="14dd-4944-6d81-5430" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="db79-36a0-e6a4-27f4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="14dd-4944-6d81-5430" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="db79-36a0-e6a4-27f4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
     <entryLink id="282b-62cf-f3fa-8117" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="83a2-846e-b20f-1481" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a794-e73d-7b34-b8bc" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="83a2-846e-b20f-1481" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a794-e73d-7b34-b8bc" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
     <entryLink id="0a22-74ff-cd0e-cdad" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1d02-64cb-c6ea-1f33" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ef1b-00b0-9db2-334d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="1d02-64cb-c6ea-1f33" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ef1b-00b0-9db2-334d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
     <entryLink id="a200-16ac-2995-d0bb" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d93a-3e12-f0ae-b242" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="77f6-c777-0825-3e90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d93a-3e12-f0ae-b242" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="77f6-c777-0825-3e90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
     <entryLink id="b8e9-4e46-d433-1722" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5133-2b45-4a98-e100" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="256c-5fe8-0b96-84dd" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="5133-2b45-4a98-e100" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="256c-5fe8-0b96-84dd" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="5e59-19a7-6a71-7626" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bf2e-bde0-aa8c-3a07" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="92c3-01e3-317d-bd5a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bf2e-bde0-aa8c-3a07" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="92c3-01e3-317d-bd5a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="fac3-b4e1-1b98-399c" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="aabc-1276-dbbd-34f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8e36-cd2e-e029-5f9e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="aabc-1276-dbbd-34f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8e36-cd2e-e029-5f9e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="e078-1f38-d383-0d25" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="27d6-2c04-ce68-3af8" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="7a47-347f-71fc-d7ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a711-711b-6a1a-c84d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="27d6-2c04-ce68-3af8" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="7a47-347f-71fc-d7ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a711-711b-6a1a-c84d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="cb0f-ae30-3912-424e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup"/>
-        <entryLink id="513e-6ac2-c328-a031" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup"/>
+        <entryLink id="cb0f-ae30-3912-424e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup" />
+        <entryLink id="513e-6ac2-c328-a031" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
     <entryLink id="e6c0-74e8-adb2-d5f5" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a87c-745e-2032-cd12" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="efa1-94e2-0f4d-f6d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7f63-f80d-b80b-5c91" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="a87c-745e-2032-cd12" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="efa1-94e2-0f4d-f6d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7f63-f80d-b80b-5c91" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="f8fe-130f-08ae-8c53" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup"/>
-        <entryLink id="1ffa-531d-90fb-e892" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup"/>
+        <entryLink id="f8fe-130f-08ae-8c53" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup" />
+        <entryLink id="1ffa-531d-90fb-e892" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
     <entryLink id="2952-bb84-4426-c9a7" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e87d-dc05-0063-e2b7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="213b-34bb-5d9c-3f0b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="94bb-2bca-a880-fe19" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="e87d-dc05-0063-e2b7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="213b-34bb-5d9c-3f0b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="94bb-2bca-a880-fe19" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="da99-9ed2-998e-ead8" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8342-2199-99f5-326d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="db5f-01c7-c186-babf" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="8342-2199-99f5-326d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="db5f-01c7-c186-babf" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="c44d-0cb2-4fde-7028" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2780-754d-31c6-c4b6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="1cae-02ae-aac6-508f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2780-754d-31c6-c4b6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="1cae-02ae-aac6-508f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
     <entryLink id="cef7-8b15-720f-e55d" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="02b9-3c0e-9a2c-3b57" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="9f20-0be9-7e94-5c83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="02b9-3c0e-9a2c-3b57" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="9f20-0be9-7e94-5c83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
     <entryLink id="6300-af54-bb1e-dac6" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="55db-773e-431e-724c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="c8e6-bbfa-5f7e-a176" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="55db-773e-431e-724c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="c8e6-bbfa-5f7e-a176" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
     <entryLink id="21f8-a2d1-382f-c45d" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d0bd-8f37-9460-923c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e6a0-e8e3-6231-48e2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="d0bd-8f37-9460-923c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e6a0-e8e3-6231-48e2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
     <entryLink id="d885-c84a-004e-1434" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1084-d3e7-0e35-2f8e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="91f2-262d-0181-1b37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1084-d3e7-0e35-2f8e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="91f2-262d-0181-1b37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
     <entryLink id="0cf1-7eb3-ead2-eb08" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2d49-94f9-ab52-f33b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9c23-f086-872d-d751" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="2d49-94f9-ab52-f33b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9c23-f086-872d-d751" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
     <entryLink id="4d42-8c04-0781-e403" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c110-f11e-6436-5eb0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fd90-0535-06b7-648d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="c110-f11e-6436-5eb0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="fd90-0535-06b7-648d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
     <entryLink id="4205-9089-861e-1eb7" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bbe9-ebf7-c4e6-3bb4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ffef-47f1-e988-cbc3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="bbe9-ebf7-c4e6-3bb4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ffef-47f1-e988-cbc3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
     <entryLink id="f2a1-fb03-93cf-3873" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b791-5740-ab3b-5718" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3f05-e13c-296a-725b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="b791-5740-ab3b-5718" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3f05-e13c-296a-725b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
     <entryLink id="b6f0-ff45-3001-2060" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0e58-2594-6fd2-9fae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2ad4-a091-c130-7799" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="0e58-2594-6fd2-9fae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2ad4-a091-c130-7799" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="d5da-558a-a924-38d2" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f229-436f-0c32-7809" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cb7b-6b73-907f-0b8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="f229-436f-0c32-7809" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cb7b-6b73-907f-0b8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
     <entryLink id="d5ed-b1e8-1ba0-b21d" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="19e9-be29-4af6-9495" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6b25-6183-ea15-2f23" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="19e9-be29-4af6-9495" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6b25-6183-ea15-2f23" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="9939-d2af-5a3b-9d63" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ccf0-4bc5-277b-e5d8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="6c34-cc3f-dd1b-1da1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ccf0-4bc5-277b-e5d8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="6c34-cc3f-dd1b-1da1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
     <entryLink id="a430-f532-d7d8-276a" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="db89-bd0e-7d13-aded" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="09f5-875b-166f-4b18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="db89-bd0e-7d13-aded" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="09f5-875b-166f-4b18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
     <entryLink id="0e11-8e01-2c03-9e16" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cd4e-563c-c3d0-976d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="57f6-7d87-301a-d4ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="cd4e-563c-c3d0-976d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="57f6-7d87-301a-d4ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
     <entryLink id="beb7-833b-89c7-4aab" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f7b3-d708-bd09-4ce6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8ff6-e37f-3ec5-6f11" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="36a1-380e-6497-73e7" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="f7b3-d708-bd09-4ce6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8ff6-e37f-3ec5-6f11" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="36a1-380e-6497-73e7" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="78ff-d9b4-f2dc-a0b7" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="559b-1613-01a9-5929" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e74a-9640-88af-03fd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="559b-1613-01a9-5929" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e74a-9640-88af-03fd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
     <entryLink id="96db-ede0-759b-af82" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f9ec-5a30-153d-be1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="59af-6365-62b6-0c45" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f9ec-5a30-153d-be1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="59af-6365-62b6-0c45" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
     <entryLink id="be11-d176-f4c0-13d1" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0e4e-609e-26d6-0347" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="38b7-d949-5df1-2c22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0e4e-609e-26d6-0347" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="38b7-d949-5df1-2c22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="0853-5abf-3a9a-70d8" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fc24-2561-23c0-9059" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="0cdb-7ad9-7fdb-bf27" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fc24-2561-23c0-9059" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="0cdb-7ad9-7fdb-bf27" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="7a5f-a4fb-fd86-4bea" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3f74-b023-3ed2-c979" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="0ee4-bda5-11cb-aa51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3f74-b023-3ed2-c979" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="0ee4-bda5-11cb-aa51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
     <entryLink id="a96a-a2dc-9779-a11b" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1546-6bfb-093e-b8b6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="fde9-03d1-3c38-f038" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1546-6bfb-093e-b8b6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="fde9-03d1-3c38-f038" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
     <entryLink id="d423-6885-77d4-a9e8" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="de69-8c9f-cb47-d91d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5d81-ffbb-c2b6-07b0" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="beec-caf7-9d76-2dfb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="de69-8c9f-cb47-d91d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5d81-ffbb-c2b6-07b0" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
+        <categoryLink id="beec-caf7-9d76-2dfb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="9cef-7f1e-ff2d-27a9" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b0cb-6b72-b4f4-5858" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0e1d-6b22-3ca6-afb6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="b0cb-6b72-b4f4-5858" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0e1d-6b22-3ca6-afb6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
     <entryLink id="ffd0-45c9-5028-43f9" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="41f2-b367-db56-6725" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d28a-de73-ffcb-987c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="41f2-b367-db56-6725" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d28a-de73-ffcb-987c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
     <entryLink id="ec42-0835-db7c-c5f1" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="09eb-fb1c-37d8-0817" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1b02-90a1-929c-0966" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="09eb-fb1c-37d8-0817" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1b02-90a1-929c-0966" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
     <entryLink id="8dd6-67d7-980c-1196" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c7c5-bd12-c56a-6842" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="8e46-2df0-367d-e07a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c7c5-bd12-c56a-6842" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="8e46-2df0-367d-e07a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
     <entryLink id="0f11-5ac6-6c19-c56c" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7454-91f1-ef94-7a1c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="f525-25a7-b7df-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7454-91f1-ef94-7a1c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="f525-25a7-b7df-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
     <entryLink id="6345-583c-e6eb-e61a" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f421-c574-a432-349c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="3790-c024-f773-d7bd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f421-c574-a432-349c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="3790-c024-f773-d7bd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
     <entryLink id="7e98-9e39-650a-747d" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3ddb-c8f8-2ead-e8a6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="9096-ad98-5338-fcc4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3ddb-c8f8-2ead-e8a6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="9096-ad98-5338-fcc4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
     <entryLink id="f3ab-8283-b2ad-a39d" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="be0d-d75f-ad1b-b423" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="c06d-0545-e89a-778c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="be0d-d75f-ad1b-b423" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="c06d-0545-e89a-778c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
     <entryLink id="feb4-8654-1317-abe8" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9a48-3366-c330-40cb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="00f0-8b0d-45ad-b105" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9a48-3366-c330-40cb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="00f0-8b0d-45ad-b105" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
     <entryLink id="0979-d1c8-855a-5f44" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="594e-df51-101c-4496" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="994b-0f52-09e3-7ab5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="594e-df51-101c-4496" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="994b-0f52-09e3-7ab5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
     <entryLink id="28bf-e158-9205-494d" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b643-60a0-36e6-66de" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="8496-e2df-38b1-0780" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b643-60a0-36e6-66de" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="8496-e2df-38b1-0780" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
     <entryLink id="8031-0852-bdc2-5b72" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a33f-a3c2-d056-8986" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="d975-2203-72dc-c735" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a33f-a3c2-d056-8986" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="d975-2203-72dc-c735" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
     <entryLink id="d3b9-8778-ee68-0c09" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="da09-d5f3-be70-231a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="3496-9b31-2783-d5c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="da09-d5f3-be70-231a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="3496-9b31-2783-d5c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
     <entryLink id="1f89-2943-e228-0daa" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e05d-56a5-03a8-591d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="1a84-f09d-694b-5932" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e05d-56a5-03a8-591d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="1a84-f09d-694b-5932" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
     <entryLink id="c3f2-9819-e500-ea14" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="19ec-2b52-df21-7788" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="76a8-33ac-0e09-ac8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="19ec-2b52-df21-7788" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="76a8-33ac-0e09-ac8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
     <entryLink id="b1b3-d392-ebe8-1932" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d3a9-19d9-3bdb-2f60" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="09f7-0027-87d6-9265" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d3a9-19d9-3bdb-2f60" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="09f7-0027-87d6-9265" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
     <entryLink id="0522-a1a3-a74c-bcb8" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3c3b-639a-bf12-417d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="3d66-84b4-6a2f-7e29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3c3b-639a-bf12-417d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="3d66-84b4-6a2f-7e29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
     <entryLink id="c496-acde-83ad-3224" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0280-378c-022d-4f16" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="99c6-4d38-c321-2686" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0280-378c-022d-4f16" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="99c6-4d38-c321-2686" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
     <entryLink id="8ed8-4298-c820-c3ad" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="19f0-b993-32a3-16b3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="2be3-a0a9-72a5-1330" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="19f0-b993-32a3-16b3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="2be3-a0a9-72a5-1330" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
     <entryLink id="d55c-ce1a-baee-6066" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dade-d900-b0fc-3a82" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="4a6c-4304-4ac9-7484" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="dade-d900-b0fc-3a82" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="4a6c-4304-4ac9-7484" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
     <entryLink id="9eb3-62b2-a8f8-ee5b" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="833b-20a0-57f1-1173" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="9262-2bc2-1f71-758e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="833b-20a0-57f1-1173" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="9262-2bc2-1f71-758e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
     <entryLink id="c215-15f3-bd65-368f" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="55e2-34c8-cda4-cd62" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="50f4-97e6-6ce1-5168" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="55e2-34c8-cda4-cd62" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="50f4-97e6-6ce1-5168" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
     <entryLink id="7e8d-e597-b719-b2ed" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f8ea-d6f4-97c5-f7d0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="009a-c793-7a3f-f754" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f8ea-d6f4-97c5-f7d0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="009a-c793-7a3f-f754" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
     <entryLink id="fb54-b05d-5f33-db94" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="731f-5824-0696-6f3a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="d150-2634-0ebf-ae0d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="731f-5824-0696-6f3a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="d150-2634-0ebf-ae0d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
     <entryLink id="e9dc-6742-69ec-15a2" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7730-7ea8-3123-2802" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="a77d-1d29-259c-051c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7730-7ea8-3123-2802" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="a77d-1d29-259c-051c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
     <entryLink id="48d8-430d-bb0c-576b" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3d34-2949-190c-ef3a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="9990-9b4f-df96-71b1" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+        <categoryLink id="3d34-2949-190c-ef3a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="9990-9b4f-df96-71b1" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
     <entryLink id="c2aa-0d69-c2d0-2edd" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b34-686b-1a34-09a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="13fd-081f-8aff-ec40" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="5b34-686b-1a34-09a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="13fd-081f-8aff-ec40" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
     <entryLink id="a8f5-7ff9-9e96-10d8" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5bc4-383c-ce47-435d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c6eb-4443-f595-288b" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="5bc4-383c-ce47-435d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c6eb-4443-f595-288b" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
     <entryLink id="7c64-df4d-4b4f-2624" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e799-7857-f2af-a934" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="febc-bfee-27ba-5db3" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="e799-7857-f2af-a934" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="febc-bfee-27ba-5db3" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
     <entryLink id="f983-a88b-b170-fe04" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="92ce-5ee5-9a06-904f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="9cc0-c1a8-8c5b-0b01" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="b31a-66ab-b8e6-5df0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="92ce-5ee5-9a06-904f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="9cc0-c1a8-8c5b-0b01" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="b31a-66ab-b8e6-5df0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
     <entryLink id="1231-26aa-03af-1794" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="54c3-bbd9-c80f-6c0c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="10fe-a627-3353-bff8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="54c3-bbd9-c80f-6c0c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="10fe-a627-3353-bff8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="08a5-32b7-1f42-ee01" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b15-e1d8-79d1-78f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e98c-cf57-ddf1-1f83" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="5b15-e1d8-79d1-78f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e98c-cf57-ddf1-1f83" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="93ca-5f4e-2290-0f7a" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f3cb-125e-3849-5625" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="13f0-a38e-4ae6-7c0d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="04d2-4239-4076-bdb6" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="f3cb-125e-3849-5625" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="13f0-a38e-4ae6-7c0d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="04d2-4239-4076-bdb6" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="dfcd-6644-5852-87a2" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b550-3c51-351e-3dff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8075-67b2-f7be-7a18" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="b550-3c51-351e-3dff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8075-67b2-f7be-7a18" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="0070-dd42-02b5-2d95" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e963-df95-9f26-01f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a764-6fe6-5283-a1e2" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="e963-df95-9f26-01f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a764-6fe6-5283-a1e2" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="3472-813c-829a-5bc8" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9098-910d-0871-246d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="78b9-56ef-fafb-2b3b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9098-910d-0871-246d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="78b9-56ef-fafb-2b3b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="b201-9601-2b05-5ff0" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="60b1-ed85-b7c7-5ce1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b3e4-7625-2315-15f4" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="60b1-ed85-b7c7-5ce1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b3e4-7625-2315-15f4" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="20cf-7b6a-eb78-0871" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e86e-3220-5df3-5f47" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="25b4-9aae-8feb-3d8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e86e-3220-5df3-5f47" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="25b4-9aae-8feb-3d8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="2a92-2e4b-8d8f-06a4" name="Crimson Paladins" hidden="true" collective="false" import="false" targetId="33fe-9683-bde5-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2107-cb19-8471-dcc7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7bb4-00df-bb76-55c2" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2107-cb19-8471-dcc7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7bb4-00df-bb76-55c2" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="6a40-f9ed-c05d-5013" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
@@ -1714,63 +1713,63 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="76a8-6805-10f9-c370" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="63e6-1e67-10e5-df83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4c06-b01e-8404-2acd" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="76a8-6805-10f9-c370" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="63e6-1e67-10e5-df83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4c06-b01e-8404-2acd" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
     <entryLink id="2ebf-e576-f28d-f7bb" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="99bc-9576-89c2-8577" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="a911-69d6-56db-1338" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8b8a-40b0-ebd5-cfa5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="99bc-9576-89c2-8577" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="a911-69d6-56db-1338" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8b8a-40b0-ebd5-cfa5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
     <entryLink id="b46b-7cd0-ef0e-f0ae" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="880b-9da3-7d79-2396" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="77cb-5f8b-7e8c-decd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="74c1-481b-25f5-d2c3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="880b-9da3-7d79-2396" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="77cb-5f8b-7e8c-decd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="74c1-481b-25f5-d2c3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
     <entryLink id="b7af-6f3f-3844-4c33" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0943-5fb4-09cb-1c92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f62e-58bd-15a4-96d1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="0943-5fb4-09cb-1c92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f62e-58bd-15a4-96d1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="2c54-82c1-c1e4-3aee" name="Sanguinius" hidden="false" collective="false" import="true" type="model">
@@ -1779,7 +1778,7 @@
         <profile id="3679-27a6-38ce-1715" name="Sanguinius" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Primarch (Unique)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">8</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">6</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
@@ -1794,28 +1793,28 @@
       </profiles>
       <rules>
         <rule id="384a-287a-50ae-ba39" name="Angelic Presence" hidden="false">
-          <description>Any friendly units that are locked in combat and have at least one model within 6&quot; of Sanguinius, as well as Sanguinius and any unit he has joined, may add +1 to the total number of successful Wounds caused for the purposes of resolving which side has won a combat (this does not stack with any other rules that increase the
+          <description>Any friendly units that are locked in combat and have at least one model within 6" of Sanguinius, as well as Sanguinius and any unit he has joined, may add +1 to the total number of successful Wounds caused for the purposes of resolving which side has won a combat (this does not stack with any other rules that increase the
 Assault result).</description>
         </rule>
         <rule id="1703-b985-b67c-004c" name="Great Wings" hidden="false">
-          <description>At the start of the controlling player’s Movement phase, or when deployed as part of a Deep Strike Assault, Sanguinius’ Movement Characteristic may be set to a value of 14 for the duration of the controlling player’s turn (referred to as ‘activating’ this special rule). This allows Sanguinius to move up to 14&quot;, regardless of the Movement Characteristic shown on his profile and gain any other benefits of a Movement Characteristic of 14 (including the bonus to Charge distance). In addition, Sanguinius may move over Impassable Terrain, vertical terrain or friendly and enemy models or units without penalty while using this special rule, but may not end his movement in Impassable Terrain or within 1&quot; of any model from a unit Sanguinius is not part of. If Sanguinius ends or begins his movement or a Charge in Dangerous Terrain he must take a Dangerous Terrain test when employing this special rule, and treats all Difficult Terrain as Dangerous Terrain.
-Sanguinius may still Run on a turn when his wings have been activated. When making a Run move after having activated his wings, add Sanguinius’ Initiative Characteristic to 14 to determine how far he may move – ignoring terrain and other models while making a Run move with activated wings as noted above, but he may not make Shooting Attacks or declare a Charge in the same turn in which Sanguinius has Run as per the normal rules for Running. Sanguinius’ wings may not be activated to gain any bonus to Sanguinius’ Movement Characteristic during a Reaction.</description>
+          <description>At the start of the controlling player&#8217;s Movement phase, or when deployed as part of a Deep Strike Assault, Sanguinius&#8217; Movement Characteristic may be set to a value of 14 for the duration of the controlling player&#8217;s turn (referred to as &#8216;activating&#8217; this special rule). This allows Sanguinius to move up to 14", regardless of the Movement Characteristic shown on his profile and gain any other benefits of a Movement Characteristic of 14 (including the bonus to Charge distance). In addition, Sanguinius may move over Impassable Terrain, vertical terrain or friendly and enemy models or units without penalty while using this special rule, but may not end his movement in Impassable Terrain or within 1" of any model from a unit Sanguinius is not part of. If Sanguinius ends or begins his movement or a Charge in Dangerous Terrain he must take a Dangerous Terrain test when employing this special rule, and treats all Difficult Terrain as Dangerous Terrain.
+Sanguinius may still Run on a turn when his wings have been activated. When making a Run move after having activated his wings, add Sanguinius&#8217; Initiative Characteristic to 14 to determine how far he may move &#8211; ignoring terrain and other models while making a Run move with activated wings as noted above, but he may not make Shooting Attacks or declare a Charge in the same turn in which Sanguinius has Run as per the normal rules for Running. Sanguinius&#8217; wings may not be activated to gain any bonus to Sanguinius&#8217; Movement Characteristic during a Reaction.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="b1d6-f7af-626b-ae5f" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule"/>
+        <infoLink id="b1d6-f7af-626b-ae5f" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule" />
         <infoLink id="93b9-52c4-31ed-a8cd" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (6)"/>
+            <modifier type="set" field="name" value="Bulky (6)" />
           </modifiers>
         </infoLink>
-        <infoLink id="aebf-6de7-429f-727c" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+        <infoLink id="aebf-6de7-429f-727c" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule" />
       </infoLinks>
       <selectionEntries>
         <selectionEntry id="eb7d-aff3-ce83-30e5" name="The Regalia Resplendant" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efe9-99e0-10b1-1dfd" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e23-269d-702b-35d2" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efe9-99e0-10b1-1dfd" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e23-269d-702b-35d2" type="max" />
           </constraints>
           <profiles>
             <profile id="2af5-04fb-474b-9308" name="The Regalia Resplendant" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
@@ -1825,13 +1824,13 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="bcee-5c0c-f7ad-d9f0" name="Infernus" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="567d-1b9b-6523-7b5f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c16-c8bf-c5f9-35de" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="567d-1b9b-6523-7b5f" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c16-c8bf-c5f9-35de" type="max" />
           </constraints>
           <profiles>
             <profile id="897a-8a0f-f0a0-84b2" name="Infernus" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1844,20 +1843,20 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="9e6f-2a15-74a0-f47c" name="Blade Encarmine:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0789-ba05-6708-7694" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1af2-ea97-c596-1447" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0789-ba05-6708-7694" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1af2-ea97-c596-1447" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="4067-76aa-eb28-b3ec" name="The Blade Encarmine" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c94-92ec-76ee-5761" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c94-92ec-76ee-5761" type="max" />
               </constraints>
               <profiles>
                 <profile id="2a40-64c9-2027-f48c" name="The Blade Encarmine" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1870,12 +1869,12 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="aa76-0f93-c020-d477" name="Spear of Telesto and Moonsliver Blade" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22b7-877d-e7d0-74f9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22b7-877d-e7d0-74f9" type="max" />
               </constraints>
               <profiles>
                 <profile id="17ef-57f9-09be-af76" name="Spear of Telesto" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1891,12 +1890,12 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
                     <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">User</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Master-Crafted, Blind, Duellist&apos;s Edge (1), Moonsilver</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Master-Crafted, Blind, Duellist's Edge (1), Moonsilver</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="6d7f-15d3-ec08-4dcd" name="Spear of Telesto (Shooting)" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">12"</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
                     <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Exoshock (4+), Instant Death, Lance</characteristic>
@@ -1909,12 +1908,12 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
                 </profile>
                 <profile id="29c4-3e8d-3f66-26a7" name="Moonsilver" hidden="false" typeId="b46c-270c-d29e-f0ff" typeName="Ability">
                   <characteristics>
-                    <characteristic name="Description" typeId="0982-427b-1d4a-d07c">Any unsaved Wound caused against a model with the Daemon Unit Type or Psyker Sub-type is instead counted as two Wounds. Wounds caused in excess of the model&apos;s remaining Wounds do not spill over to other models.</characteristic>
+                    <characteristic name="Description" typeId="0982-427b-1d4a-d07c">Any unsaved Wound caused against a model with the Daemon Unit Type or Psyker Sub-type is instead counted as two Wounds. Wounds caused in excess of the model's remaining Wounds do not spill over to other models.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1923,32 +1922,32 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
       <entryLinks>
         <entryLink id="2df4-a271-b4a1-7b49" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6202-978a-7bdd-54d0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48bf-f4b8-3d1e-24be" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6202-978a-7bdd-54d0" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48bf-f4b8-3d1e-24be" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="cbf3-f5d0-2786-65bc" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f5b-13e7-367c-03fd" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4eeb-c50e-4b35-bd33" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f5b-13e7-367c-03fd" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4eeb-c50e-4b35-bd33" type="min" />
           </constraints>
           <profiles>
             <profile id="e25c-ffa8-50ef-91a8" name="Sire of the Blood Angels" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All friendly models with the Legiones Astartes (Blood Angels) special rule in the same army as Sanguinius that either deploys as part of a Deep Strike Assault (or any other deployment method that requires the Deep Strike special rule) or has a Legion Warhawk jump pack gain +1 Weapon Skill on any turn in which they make a successful Charge. In addition, an army with Sanguinius as its Warlord gains an additional Reaction in the opposing player&apos;s Movement phase as long as Sanguinius has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All friendly models with the Legiones Astartes (Blood Angels) special rule in the same army as Sanguinius that either deploys as part of a Deep Strike Assault (or any other deployment method that requires the Deep Strike special rule) or has a Legion Warhawk jump pack gain +1 Weapon Skill on any turn in which they make a successful Charge. In addition, an army with Sanguinius as its Warlord gains an additional Reaction in the opposing player's Movement phase as long as Sanguinius has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
         <entryLink id="7a90-618d-b9a5-79f6" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85ae-b69c-87e8-16ef" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d011-5fa4-3df8-75e0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85ae-b69c-87e8-16ef" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d011-5fa4-3df8-75e0" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="485.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="485.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="8dba-83cd-4922-bc63" name="Judicar Aster Crohne" hidden="false" collective="false" import="true" type="model">
@@ -1971,33 +1970,33 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
       </profiles>
       <rules>
         <rule id="808d-da54-f3db-be02" name="Ghost of Saiph" hidden="false">
-          <description>The first time Judiciar Aster Crohne loses his last wound, or otherwise removed as a casualty, roll a D6. On a 4+, he is placed in Reserves with a single Wound remaining instead of being removed or destroyed. If he enters Reserves on or after turn 4, then he may enter play automatically at the start of the controlling player’s following turn.</description>
+          <description>The first time Judiciar Aster Crohne loses his last wound, or otherwise removed as a casualty, roll a D6. On a 4+, he is placed in Reserves with a single Wound remaining instead of being removed or destroyed. If he enters Reserves on or after turn 4, then he may enter play automatically at the start of the controlling player&#8217;s following turn.</description>
         </rule>
         <rule id="46e0-ce72-f798-0bb0" name="Virtue of Judgement" hidden="false">
-          <description>At the start of the battle, once both players have deployed their armies, including any units with the Infiltrator special rule, Judiciar Aster Crohne’s controlling player may select D3 enemy units – these units are considered ‘Marked for Judgement’. Judiciar Aster Crohne, Blood Angels Angel’s Tears, Legion Destroyers or Legion Mortalis Destroyers with the Legiones Astartes (Blood Angels) special rule in the Detachment that Judiciar Aster Crohne is part of, gain the Shred special rule when making attacks with a weapon with the Flame type, against units that are Marked for Judgement.</description>
+          <description>At the start of the battle, once both players have deployed their armies, including any units with the Infiltrator special rule, Judiciar Aster Crohne&#8217;s controlling player may select D3 enemy units &#8211; these units are considered &#8216;Marked for Judgement&#8217;. Judiciar Aster Crohne, Blood Angels Angel&#8217;s Tears, Legion Destroyers or Legion Mortalis Destroyers with the Legiones Astartes (Blood Angels) special rule in the Detachment that Judiciar Aster Crohne is part of, gain the Shred special rule when making attacks with a weapon with the Flame type, against units that are Marked for Judgement.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="fc76-e97f-b4d4-e19e" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule"/>
-        <infoLink id="8db9-e266-141f-833a" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
+        <infoLink id="fc76-e97f-b4d4-e19e" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule" />
+        <infoLink id="8db9-e266-141f-833a" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule" />
         <infoLink id="1299-41e2-f4e1-2e10" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
           <modifiers>
-            <modifier type="append" field="name" value=" 1"/>
+            <modifier type="append" field="name" value=" 1" />
           </modifiers>
         </infoLink>
-        <infoLink id="b5fb-e24a-7e45-3cb7" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
-        <infoLink id="c3f1-c79c-87d2-f4eb" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
+        <infoLink id="b5fb-e24a-7e45-3cb7" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule" />
+        <infoLink id="c3f1-c79c-87d2-f4eb" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9443-2cc4-be17-c3d0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="e910-b4f4-561a-a680" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="8d3c-13bd-b351-0939" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="9443-2cc4-be17-c3d0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="e910-b4f4-561a-a680" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="8d3c-13bd-b351-0939" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6d52-9172-1a5d-5406" name="Saiphan shard-axe" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e875-9ed3-92e2-73bd" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ad4-bde9-59c0-0b00" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e875-9ed3-92e2-73bd" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ad4-bde9-59c0-0b00" type="max" />
           </constraints>
           <profiles>
             <profile id="d624-d513-266a-128e" name="Saiphan shard-axe" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2005,65 +2004,65 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+1</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Rending (5+),  Duelist&apos;s Edge (1)</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Rending (5+),  Duelist's Edge (1)</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="abc8-20a4-abd4-4057" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc7e-59ff-c89c-fe49" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f794-c955-4097-9b01" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc7e-59ff-c89c-fe49" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f794-c955-4097-9b01" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="c5a6-cb53-1fa9-b05b" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1f9-4942-920b-6940" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcc8-8288-f284-69e1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1f9-4942-920b-6940" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcc8-8288-f284-69e1" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="7758-ffe5-fafa-070f" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea6e-2a45-f280-6fc0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df13-3253-5604-01e8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea6e-2a45-f280-6fc0" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df13-3253-5604-01e8" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="3d0e-25d5-7692-8a3a" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8ca-0c03-a0a3-ed72" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3875-50c0-8035-9d7f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8ca-0c03-a0a3-ed72" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3875-50c0-8035-9d7f" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="5b1d-4404-ae6d-a8b8" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b46b-095b-c53b-7878" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94a9-a81f-6a78-b9eb" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b46b-095b-c53b-7878" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94a9-a81f-6a78-b9eb" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="7289-60d8-0546-cfad" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2472-3864-16ad-28c0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f66-f159-e371-40c0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2472-3864-16ad-28c0" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f66-f159-e371-40c0" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="3e3a-4ef3-210b-f38e" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
+        <entryLink id="3e3a-4ef3-210b-f38e" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry" />
         <entryLink id="2bf0-4ea7-a358-b83c" name="Warlord Traits" hidden="true" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="8dba-83cd-4922-bc63" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+                <condition field="selections" scope="8dba-83cd-4922-bc63" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="155.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="155.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="33fe-9683-bde5-95ca" name="Crimson Paladins" hidden="false" collective="false" import="true" type="unit">
@@ -2073,25 +2072,25 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="cbb3-ebde-f2e8-54b9" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule"/>
-        <infoLink id="52f4-8310-cf81-c7d9" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="cbb3-ebde-f2e8-54b9" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule" />
+        <infoLink id="52f4-8310-cf81-c7d9" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="9864-5014-0135-fcd7" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="append" field="name" value="(2)"/>
+            <modifier type="append" field="name" value="(2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="3441-b4f8-20cc-e523" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+        <infoLink id="3441-b4f8-20cc-e523" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="21ac-518e-b688-7692" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="5bf7-7060-f4e9-3862" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="38d1-09b6-7e6d-9833" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="21ac-518e-b688-7692" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="5bf7-7060-f4e9-3862" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="38d1-09b6-7e6d-9833" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c757-a32a-2351-be7e" name="Crimson Exemplar" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9b5-feaf-c999-c268" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d87-9277-4db4-1e40" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9b5-feaf-c999-c268" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d87-9277-4db4-1e40" type="max" />
           </constraints>
           <profiles>
             <profile id="f374-1497-2b0b-70ce" name="Crimson Exemplar" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2111,35 +2110,35 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="f69b-2b54-8d15-5c73" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink id="c012-908d-abb8-1f88" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-            <categoryLink id="310b-bcb8-52f5-55e7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink id="f69b-2b54-8d15-5c73" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
+            <categoryLink id="c012-908d-abb8-1f88" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+            <categoryLink id="310b-bcb8-52f5-55e7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="59c2-658e-99fa-9d85" name="Arms" hidden="false" collective="false" import="true" defaultSelectionEntryId="42c3-773b-4122-7898">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dc7-b49f-9533-052d" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23b8-551c-6580-c51c" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dc7-b49f-9533-052d" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23b8-551c-6580-c51c" type="min" />
               </constraints>
               <selectionEntries>
                 <selectionEntry id="42c3-773b-4122-7898" name="Power Weapon and Shield" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e66-0d35-40ec-069c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e66-0d35-40ec-069c" type="max" />
                   </constraints>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="7c11-669e-fd86-8725" name="CP PW" hidden="false" collective="false" import="true" defaultSelectionEntryId="778f-99e9-1c85-9383">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc4c-b274-28e0-ec97" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79f2-bc1a-e348-6ab8" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc4c-b274-28e0-ec97" type="min" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79f2-bc1a-e348-6ab8" type="max" />
                       </constraints>
                       <entryLinks>
-                        <entryLink id="67d2-0557-df7e-d990" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
-                        <entryLink id="fb09-4921-6c02-11ba" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry"/>
-                        <entryLink id="419a-45ef-fee4-81ea" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
-                        <entryLink id="778f-99e9-1c85-9383" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
+                        <entryLink id="67d2-0557-df7e-d990" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
+                        <entryLink id="fb09-4921-6c02-11ba" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry" />
+                        <entryLink id="419a-45ef-fee4-81ea" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry" />
+                        <entryLink id="778f-99e9-1c85-9383" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry" />
                         <entryLink id="1223-8176-a9f1-34d6" name="Sunset blade" hidden="false" collective="false" import="true" targetId="2fd3-e09f-173f-6b0a" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3b5-eed9-0a44-06f7" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3b5-eed9-0a44-06f7" type="max" />
                           </constraints>
                         </entryLink>
                       </entryLinks>
@@ -2148,20 +2147,20 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
                   <entryLinks>
                     <entryLink id="b2c8-f3e1-2498-0549" name="Coriolis Pattern Power Shield" hidden="false" collective="false" import="true" targetId="298b-c5d8-2fb0-9dd4" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a16e-40b2-2667-6dca" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e86-8544-9e40-7f5d" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a16e-40b2-2667-6dca" type="max" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e86-8544-9e40-7f5d" type="min" />
                       </constraints>
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
                 <entryLink id="7b3e-5b83-848d-41d6" name="Perdition Weapon" hidden="false" collective="false" import="true" targetId="e909-feba-d9e9-1efa" type="selectionEntryGroup">
                   <modifiers>
-                    <modifier type="set" field="9b7c-2bb2-5687-cefe" value="0.0"/>
+                    <modifier type="set" field="9b7c-2bb2-5687-cefe" value="0.0" />
                   </modifiers>
                 </entryLink>
               </entryLinks>
@@ -2170,24 +2169,24 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
           <entryLinks>
             <entryLink id="ab22-84be-35c8-29d0" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d96-40a1-566e-95e4" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d96-40a1-566e-95e4" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
-            <entryLink id="4bd6-067b-d0fa-3196" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry"/>
+            <entryLink id="4bd6-067b-d0fa-3196" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry" />
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="154e-7212-9dfa-0aed" name="Crimson Paladins" hidden="false" collective="false" import="true" defaultSelectionEntryId="f434-9ec3-7876-6fea">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c934-f587-5033-8a87" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c57-b300-5bd2-65df" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c934-f587-5033-8a87" type="max" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c57-b300-5bd2-65df" type="min" />
           </constraints>
           <profiles>
             <profile id="735c-55d6-860a-f857" name="Crimson Paladins" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2211,120 +2210,120 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
               <selectionEntryGroups>
                 <selectionEntryGroup id="748e-36f2-eab1-9c5e" name="CP PW" hidden="false" collective="false" import="true" defaultSelectionEntryId="5d4c-1509-e8aa-71af">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b820-866a-9fdf-e90b" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a3a-718f-ca93-fcfc" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b820-866a-9fdf-e90b" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a3a-718f-ca93-fcfc" type="max" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="27d7-49a7-b891-cc82" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry"/>
-                    <entryLink id="88ca-bca0-319b-6d89" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
-                    <entryLink id="5d4c-1509-e8aa-71af" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
+                    <entryLink id="27d7-49a7-b891-cc82" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry" />
+                    <entryLink id="88ca-bca0-319b-6d89" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry" />
+                    <entryLink id="5d4c-1509-e8aa-71af" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry" />
                     <entryLink id="ed57-8a84-78ae-ee1d" name="Sunset blade" hidden="false" collective="false" import="true" targetId="2fd3-e09f-173f-6b0a" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8ea-5d3b-a943-15f2" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8ea-5d3b-a943-15f2" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="e486-5f2e-6e1b-308b" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                       <modifiers>
                         <modifier type="decrement" field="04d4-d85b-a9b9-6052" value="1.0">
                           <repeats>
-                            <repeat field="selections" scope="33fe-9683-bde5-95ca" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="3dc0-9787-5fda-f4a4" repeats="1" roundUp="false"/>
+                            <repeat field="selections" scope="33fe-9683-bde5-95ca" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="3dc0-9787-5fda-f4a4" repeats="1" roundUp="false" />
                           </repeats>
                         </modifier>
                       </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdc3-08c1-e44c-533f" type="max"/>
-                        <constraint field="selections" scope="33fe-9683-bde5-95ca" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="04d4-d85b-a9b9-6052" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdc3-08c1-e44c-533f" type="max" />
+                        <constraint field="selections" scope="33fe-9683-bde5-95ca" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="04d4-d85b-a9b9-6052" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="b42b-0298-2344-2ff3" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                       <modifiers>
                         <modifier type="decrement" field="92a5-1182-7671-4b33" value="1.0">
                           <repeats>
-                            <repeat field="selections" scope="33fe-9683-bde5-95ca" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="3dc0-9787-5fda-f4a4" repeats="1" roundUp="false"/>
+                            <repeat field="selections" scope="33fe-9683-bde5-95ca" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="3dc0-9787-5fda-f4a4" repeats="1" roundUp="false" />
                           </repeats>
                         </modifier>
                       </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cc4-c2e2-d12b-7a41" type="max"/>
-                        <constraint field="selections" scope="33fe-9683-bde5-95ca" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="92a5-1182-7671-4b33" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cc4-c2e2-d12b-7a41" type="max" />
+                        <constraint field="selections" scope="33fe-9683-bde5-95ca" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="92a5-1182-7671-4b33" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
-                    <entryLink id="0d96-6e8c-b627-6ea1" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
+                    <entryLink id="0d96-6e8c-b627-6ea1" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
                 <entryLink id="b2ca-8555-d96d-c427" name="Coriolis Pattern Power Shield" hidden="false" collective="false" import="true" targetId="298b-c5d8-2fb0-9dd4" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="325b-3d73-ef69-8b7d" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d86-3868-07f0-583c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="325b-3d73-ef69-8b7d" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d86-3868-07f0-583c" type="max" />
                   </constraints>
                 </entryLink>
-                <entryLink id="62db-98d1-9d87-17f0" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry"/>
+                <entryLink id="62db-98d1-9d87-17f0" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry" />
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="998e-4eec-ef79-063d" name="Heavy Weapon Paladin" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="set" field="6558-2890-84d6-2523" value="2.0">
                   <conditions>
-                    <condition field="selections" scope="33fe-9683-bde5-95ca" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="selections" scope="33fe-9683-bde5-95ca" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6558-2890-84d6-2523" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6558-2890-84d6-2523" type="max" />
               </constraints>
               <selectionEntryGroups>
                 <selectionEntryGroup id="e1b3-5781-a2de-d4e8" name="CCW" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa99-2da8-7388-9727" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="393e-2685-fd9e-c26f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa99-2da8-7388-9727" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="393e-2685-fd9e-c26f" type="max" />
                   </constraints>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="3dc0-9787-5fda-f4a4" name="Fists" hidden="false" collective="false" import="true">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78a0-8fbe-c4f9-2776" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78a0-8fbe-c4f9-2776" type="max" />
                       </constraints>
                       <entryLinks>
                         <entryLink id="603d-30eb-db6e-cea3" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4891-72cd-8d78-fe15" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4891-72cd-8d78-fe15" type="max" />
                           </constraints>
                           <costs>
-                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                           </costs>
                         </entryLink>
                         <entryLink id="5b24-7542-0956-3a92" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="836e-aedd-2bf5-c5eb" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="836e-aedd-2bf5-c5eb" type="max" />
                           </constraints>
                           <costs>
-                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                           </costs>
                         </entryLink>
                       </entryLinks>
                     </selectionEntryGroup>
                     <selectionEntryGroup id="8cff-bb2f-635d-a54f" name="CP PW" hidden="false" collective="false" import="true" defaultSelectionEntryId="a5dc-fcae-750c-bd52">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1540-1322-d666-9996" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1540-1322-d666-9996" type="max" />
                       </constraints>
                       <entryLinks>
-                        <entryLink id="ed7e-6a05-4873-b53a" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
-                        <entryLink id="ae4a-297c-ba7e-5022" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry"/>
-                        <entryLink id="3994-7183-e373-6266" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
-                        <entryLink id="a5dc-fcae-750c-bd52" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
+                        <entryLink id="ed7e-6a05-4873-b53a" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
+                        <entryLink id="ae4a-297c-ba7e-5022" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry" />
+                        <entryLink id="3994-7183-e373-6266" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry" />
+                        <entryLink id="a5dc-fcae-750c-bd52" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry" />
                         <entryLink id="3677-5c4b-9aa1-f42e" name="Sunset blade" hidden="false" collective="false" import="true" targetId="2fd3-e09f-173f-6b0a" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fc6-5067-3a18-ceca" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fc6-5067-3a18-ceca" type="max" />
                           </constraints>
                         </entryLink>
                       </entryLinks>
@@ -2333,49 +2332,49 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
                 </selectionEntryGroup>
                 <selectionEntryGroup id="74f7-7b51-712b-6621" name="Ranged" hidden="false" collective="false" import="true" defaultSelectionEntryId="65f0-b9f0-4c5d-cef1">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f91-c409-eae1-892c" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bc1-d8cf-7947-0fd7" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f91-c409-eae1-892c" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bc1-d8cf-7947-0fd7" type="min" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="bb8c-79e8-4e2e-591d" name="Iliastus Assault Cannon" hidden="false" collective="false" import="true" targetId="10aa-3c70-2bbe-9509" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fee-929b-a815-b559" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fee-929b-a815-b559" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="65f0-b9f0-4c5d-cef1" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbaa-0679-a4ec-1750" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbaa-0679-a4ec-1750" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="e465-bf6a-6b58-2b32" name="Plasma Blaster" hidden="false" collective="false" import="true" targetId="cd52-e9e8-3ab1-995c" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9af-4143-36ef-9381" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9af-4143-36ef-9381" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="e15a-ff0d-c562-0a9c" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry"/>
+                <entryLink id="e15a-ff0d-c562-0a9c" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry" />
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="985f-7ba1-f985-3cad" name="Dedicated Transport" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da6d-5b69-e64e-d5fa" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da6d-5b69-e64e-d5fa" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="dd78-9833-19ee-827d" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
@@ -2384,9 +2383,9 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="33fe-9683-bde5-95ca" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                        <condition field="selections" scope="33fe-9683-bde5-95ca" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -2399,8 +2398,8 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -2413,7 +2412,7 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo" />
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -2426,7 +2425,7 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1977-49f2-7910-f177" type="equalTo" />
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -2437,60 +2436,60 @@ Sanguinius may still Run on a turn when his wings have been activated. When maki
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="090c-5656-0180-16c8" name="Contemptor-Incaendius Dreadnought" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="63a2-999d-1d56-c98b" name="Contemptor-Incaendius Dreadnought" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
           <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066"/>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458"/>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d"/>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9"/>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066" />
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458" />
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d" />
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9" />
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="9387-662d-f57c-6b3b" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule"/>
+        <infoLink id="9387-662d-f57c-6b3b" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="22af-8bdb-ac49-af08" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
-        <categoryLink id="8f2a-d33d-1b36-8cb0" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="22af-8bdb-ac49-af08" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false" />
+        <categoryLink id="8f2a-d33d-1b36-8cb0" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="862e-307d-4c73-4992" name="Incaedius booster pack" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff49-5284-8b4e-9ca1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ab4-a852-40be-43d1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff49-5284-8b4e-9ca1" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ab4-a852-40be-43d1" type="min" />
           </constraints>
           <profiles>
             <profile id="a227-2691-30af-c97b" name="Incaedius booster pack" hidden="false" typeId="b46c-270c-d29e-f0ff" typeName="Ability">
               <characteristics>
-                <characteristic name="Description" typeId="0982-427b-1d4a-d07c">A massive rocket booster pack is installed on the rear torso of the Contemptor-Incendius, with enough fuel for a single prolonged burn. This is used either to drop the Dreadnought from orbit, or to allow it to cover the distance to the foe in a series of long leaps. Once its fuel is exhausted, the booster pack is purged from the Dreadnought&apos;s chassis by a system of explosive bolts, allowing the war machine to fight freely.
+                <characteristic name="Description" typeId="0982-427b-1d4a-d07c">A massive rocket booster pack is installed on the rear torso of the Contemptor-Incendius, with enough fuel for a single prolonged burn. This is used either to drop the Dreadnought from orbit, or to allow it to cover the distance to the foe in a series of long leaps. Once its fuel is exhausted, the booster pack is purged from the Dreadnought's chassis by a system of explosive bolts, allowing the war machine to fight freely.
 The Incaendius booster pack may be used once per battle in one of two ways; these options are mutually exclusive and the use of one means the other may not be used in that battle:
 Deep Strike: At the start of the battle, before any models are deployed onto the battlefield, the controlling player may choose to place the Contemptor-Incendius Dreadnought into Reserves and give it the Deep Strike special rule. It may then take part in a Deep Strike Assault or another deployment that requires the use of the Deep Strike special rule.
-Shock Assault: The controlling player may opt to deploy the Contemptor-Incendius Dreadnought as normal, in this case the use of the Incaendius booster pack may be declared once per battle at the start of any of the controlling player&apos;s Movement phases, including the first. When activated, the Contemptor-Incendius Dreadnought&apos;s Movement Characteristic is set to 12&quot; and gains the Hammer of Wrath (2) special rule for the duration of the controlling player&apos;s turn. While this effect is active, the Contemptor-Incendius Dreadnought may ignore all other models and terrain freely while moving, but may not end its Move in Impassable Terrain or within 1&quot; of another model. However, if the model begins or ends that Movement phase in Difficult Terrain, it must take a Dangerous Terrain test. While the Incendius booster pack is activated the model may not Run.
+Shock Assault: The controlling player may opt to deploy the Contemptor-Incendius Dreadnought as normal, in this case the use of the Incaendius booster pack may be declared once per battle at the start of any of the controlling player's Movement phases, including the first. When activated, the Contemptor-Incendius Dreadnought's Movement Characteristic is set to 12" and gains the Hammer of Wrath (2) special rule for the duration of the controlling player's turn. While this effect is active, the Contemptor-Incendius Dreadnought may ignore all other models and terrain freely while moving, but may not end its Move in Impassable Terrain or within 1" of another model. However, if the model begins or ends that Movement phase in Difficult Terrain, it must take a Dangerous Terrain test. While the Incendius booster pack is activated the model may not Run.
 Note that any Contemptor-Incendius Dreadnought selected as part of a Detachment using the Day of Revelation
 Rite of War must use the Deep Strike option and must be assigned to a Deep Strike Assault.</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="0f2d-0112-9aef-6c21" name="Arm Pairs" hidden="false" collective="false" import="true" defaultSelectionEntryId="a814-7385-824a-7b78">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00ba-4094-a614-dd4e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32bb-2fdc-52ad-ff6a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00ba-4094-a614-dd4e" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32bb-2fdc-52ad-ff6a" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="ccaa-3a5b-e8be-b019" name="Talon of Perdition" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="append" field="name" value=", Pair"/>
+                <modifier type="append" field="name" value=", Pair" />
               </modifiers>
               <profiles>
                 <profile id="cfe7-16ca-d0ee-891e" name="Talon of Perdition" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2503,33 +2502,33 @@ Rite of War must use the Deep Strike option and must be assigned to a Deep Strik
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="a814-7385-824a-7b78" name="Gravis Power Fist" hidden="false" collective="false" import="true" targetId="08be-6994-6a63-6279" type="selectionEntry">
               <modifiers>
-                <modifier type="append" field="name" value=", Pair"/>
+                <modifier type="append" field="name" value=", Pair" />
               </modifiers>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="5626-2a7c-d054-e9d6" name="Inbuilt Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="c0d0-6ab6-64d7-3f31">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce1a-38f1-d8ea-4e49" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1641-de34-ac87-6059" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce1a-38f1-d8ea-4e49" type="min" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1641-de34-ac87-6059" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="3e26-1837-85c2-79e7" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
-            <entryLink id="c0d0-6ab6-64d7-3f31" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry"/>
+            <entryLink id="c0d0-6ab6-64d7-3f31" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry" />
             <entryLink id="6df7-297e-46af-450f" name="Iliastus Assault Cannon" hidden="false" collective="false" import="true" targetId="10aa-3c70-2bbe-9509" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -2538,13 +2537,13 @@ Rite of War must use the Deep Strike option and must be assigned to a Deep Strik
       <entryLinks>
         <entryLink id="d5e6-afde-d5da-c868" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d225-ab76-0a61-b182" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45b1-8a6a-efaa-5def" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d225-ab76-0a61-b182" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45b1-8a6a-efaa-5def" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="59f7-9abf-c171-e9e4" name="Chapter Master Raldoron" hidden="false" collective="false" import="true" type="model">
@@ -2566,24 +2565,24 @@ Rite of War must use the Deep Strike option and must be assigned to a Deep Strik
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="287e-842f-fa00-9c37" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="9d73-b5f5-7d29-eba0" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule"/>
+        <infoLink id="287e-842f-fa00-9c37" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="9d73-b5f5-7d29-eba0" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule" />
         <infoLink id="62fa-224a-16e8-75ff" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
           <modifiers>
-            <modifier type="append" field="name" value="2"/>
+            <modifier type="append" field="name" value="2" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="64a7-e7b9-b689-b20c" name="Independant Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="9b24-0f3e-79a4-f40d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="774a-cc6b-d207-692e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="64a7-e7b9-b689-b20c" name="Independant Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="9b24-0f3e-79a4-f40d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="774a-cc6b-d207-692e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2621-22d9-fc96-f04e" name="The Encarmine Warblade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="361d-24fa-8768-6eed" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc9e-d500-3665-70a7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="361d-24fa-8768-6eed" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc9e-d500-3665-70a7" type="min" />
           </constraints>
           <profiles>
             <profile id="a03f-f127-0fcc-95e4" name="The Encarmine Warblade" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2596,7 +2595,7 @@ Rite of War must use the Deep Strike option and must be assigned to a Deep Strik
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2605,424 +2604,424 @@ Rite of War must use the Deep Strike option and must be assigned to a Deep Strik
           <modifiers>
             <modifier type="set" field="dc00-3563-f64e-a3c4" value="1.0">
               <conditions>
-                <condition field="selections" scope="59f7-9abf-c171-e9e4" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+                <condition field="selections" scope="59f7-9abf-c171-e9e4" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="59f7-9abf-c171-e9e4" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+                <condition field="selections" scope="59f7-9abf-c171-e9e4" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54a1-614c-6c8e-69be" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc00-3563-f64e-a3c4" type="min"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a81a-4fbe-1646-d06d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54a1-614c-6c8e-69be" type="max" />
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc00-3563-f64e-a3c4" type="min" />
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a81a-4fbe-1646-d06d" type="max" />
           </constraints>
           <selectionEntryGroups>
             <selectionEntryGroup id="22d0-70ac-8353-879a" name=" IX: Blood Angels" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f7e2-738c-1ca4-37d6" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f7e2-738c-1ca4-37d6" type="max" />
               </constraints>
               <selectionEntries>
                 <selectionEntry id="621c-1d6d-09e8-7c95" name="Encarmine Paladin" hidden="false" collective="false" import="true" type="upgrade">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aa39-41ae-1149-85c1" type="max"/>
-                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4bc2-2a95-c01d-c0d2" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aa39-41ae-1149-85c1" type="max" />
+                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4bc2-2a95-c01d-c0d2" type="max" />
                   </constraints>
                   <profiles>
                     <profile id="093a-6bba-13ad-4e1f" name="Encarmine Paladin" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                       <characteristics>
                         <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait gains the Fear (1) special rule when the enemy army has the Traitor Allegiance.
-Whenever a Warlord with this Trait is on the winning side of a combat in which the Warlord was Engaged and that includes at least one enemy model with the Traitor Allegiance, he increases the value of his Fear special rule by one point at the end of the Assault phase in which the combat is won, to a maximum of Fear (4). For example, if a Warlord with this Trait and the Fear (1) special rule is locked in combat with an enemy unit with the Traitor Allegiance and wins the resulting combat, his Fear special rule would become Fear (2) at the end of that Assault phase. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&apos;s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+Whenever a Warlord with this Trait is on the winning side of a combat in which the Warlord was Engaged and that includes at least one enemy model with the Traitor Allegiance, he increases the value of his Fear special rule by one point at the end of the Assault phase in which the combat is won, to a maximum of Fear (4). For example, if a Warlord with this Trait and the Fear (1) special rule is locked in combat with an enemy unit with the Traitor Allegiance and wins the resulting combat, his Fear special rule would become Fear (2) at the end of that Assault phase. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player's Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c5c2-393b-0e08-7010" name="Paragon of Unity" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6870-215b-7a95-3806" type="max"/>
-                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d9ce-6a6c-f639-cc87" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6870-215b-7a95-3806" type="max" />
+                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d9ce-6a6c-f639-cc87" type="max" />
                   </constraints>
                   <profiles>
                     <profile id="67d6-358b-aad8-ef73" name="Paragon of Unity" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                       <characteristics>
-                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any friendly unit made up entirely of models with the Legiones Astartes (Blood Angels) special rule that can draw a line of sight to a Warlord with this Trait, to any model in a unit this Warlord has joined, or to any model that is Engaged in a combat which this Warlord is part of, gains a bonus of +1 to their Leadership Characteristic, to a maximum of 10. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&apos;s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any friendly unit made up entirely of models with the Legiones Astartes (Blood Angels) special rule that can draw a line of sight to a Warlord with this Trait, to any model in a unit this Warlord has joined, or to any model that is Engaged in a combat which this Warlord is part of, gains a bonus of +1 to their Leadership Characteristic, to a maximum of 10. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player's Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
             <selectionEntryGroup id="8e62-5fbd-9422-68ec" name="Imperial Fists" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a0d0-e3b7-090a-3caf" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a0d0-e3b7-090a-3caf" type="max" />
               </constraints>
               <selectionEntries>
                 <selectionEntry id="ea56-2930-97c8-85ba" name="Solar Marshal " hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a102-0648-be1a-beee" type="max"/>
-                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="69da-b69c-aabb-78b7" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a102-0648-be1a-beee" type="max" />
+                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="69da-b69c-aabb-78b7" type="max" />
                   </constraints>
                   <profiles>
                     <profile id="e4aa-53da-2db5-5573" name="Solar Marshal " hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                       <characteristics>
                         <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait and all models in any friendly unit that Warlord joins gain +1 to their Weapon Skill
-Characteristic when locked in combat with one or more enemy units that have the Traitor Allegiance. In addition, an army whose Warlord has this Trait may make one additional Reaction per turn in any one of the opposing player&apos;s Phases, as long as the Warlord has not been removed as a casualty. This additional Reaction may only be made by the Warlord&apos;s unit and does not allow any unit to make more than one Reaction per Phase.</characteristic>
+Characteristic when locked in combat with one or more enemy units that have the Traitor Allegiance. In addition, an army whose Warlord has this Trait may make one additional Reaction per turn in any one of the opposing player's Phases, as long as the Warlord has not been removed as a casualty. This additional Reaction may only be made by the Warlord's unit and does not allow any unit to make more than one Reaction per Phase.</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7a87-5709-57b3-9b50" name="Warden of Inwit" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2fb7-c2e6-7fac-fbc6" type="max"/>
-                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="81ef-1a30-b312-7c4a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2fb7-c2e6-7fac-fbc6" type="max" />
+                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="81ef-1a30-b312-7c4a" type="max" />
                   </constraints>
                   <profiles>
                     <profile id="c331-1f95-28e3-da31" name="Warden of Inwit" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                       <characteristics>
-                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When within 6&quot; of an objective, or within their own Deployment Zone, a Warlord with this Trait, and all models in any friendly unit that Warlord joins, automatically pass any Morale checks or Pinning tests they are called upon to make. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&apos;s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When within 6" of an objective, or within their own Deployment Zone, a Warlord with this Trait, and all models in any friendly unit that Warlord joins, automatically pass any Morale checks or Pinning tests they are called upon to make. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player's Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
             <selectionEntryGroup id="81d9-eec8-996f-1026" name="White Scars" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0e05-2882-3e96-4f84" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0e05-2882-3e96-4f84" type="max" />
               </constraints>
               <selectionEntries>
                 <selectionEntry id="6130-2702-a4b5-9f04" name="Born to the Saddle" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8490-bdb8-7f9b-6c97" type="max"/>
-                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="5d03-d8e1-a289-45f1" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8490-bdb8-7f9b-6c97" type="max" />
+                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="5d03-d8e1-a289-45f1" type="max" />
                   </constraints>
                   <profiles>
                     <profile id="3b3b-460c-2713-f743" name="Born to the Saddle" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                       <characteristics>
-                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord and all models in the same army with the Legiones Astartes (White Scars) special rule and the Cavalry Unit Type ignore all the effects of Difficult Terrain and gain a 4+ Invulnerable Save against all Wounds inflicted by failed Dangerous Terrain tests they are called upon to make. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&apos;s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord and all models in the same army with the Legiones Astartes (White Scars) special rule and the Cavalry Unit Type ignore all the effects of Difficult Terrain and gain a 4+ Invulnerable Save against all Wounds inflicted by failed Dangerous Terrain tests they are called upon to make. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player's Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a534-a8a1-f736-f6ec" name="Heroes Never Die" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d8fb-d559-4298-2617" type="max"/>
-                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="946e-ec94-893c-6dd2" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d8fb-d559-4298-2617" type="max" />
+                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="946e-ec94-893c-6dd2" type="max" />
                   </constraints>
                   <profiles>
                     <profile id="a031-22eb-bebd-f13a" name="Heroes Never Die" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                       <characteristics>
-                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and all models in any unit he joins, gains the Stubborn special rule. Furthermore, if the Warlord is removed as a casualty, all models in any friendly unit composed entirely of models with the Legiones Astartes (White Scars) special rule, from which one or more models can draw a line of sight to the Warlord at the point when he is removed as a casualty, gain the Fearless special rule for the remainder of the battle. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&apos;s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and all models in any unit he joins, gains the Stubborn special rule. Furthermore, if the Warlord is removed as a casualty, all models in any friendly unit composed entirely of models with the Legiones Astartes (White Scars) special rule, from which one or more models can draw a line of sight to the Warlord at the point when he is removed as a casualty, gain the Fearless special rule for the remainder of the battle. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player's Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
             <selectionEntryGroup id="b783-311b-a8f0-1538" name="Space Wolves" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3e21-7a40-5ba1-3236" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3e21-7a40-5ba1-3236" type="max" />
               </constraints>
               <selectionEntries>
                 <selectionEntry id="050a-32ec-727e-80b0" name="Howl of Morkai" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8c2e-4f01-4fb9-3bb2" type="max"/>
-                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="46ab-145f-5dbc-e180" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8c2e-4f01-4fb9-3bb2" type="max" />
+                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="46ab-145f-5dbc-e180" type="max" />
                   </constraints>
                   <profiles>
                     <profile id="097d-e985-c00c-3c4d" name="Howl of Morkai" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                       <characteristics>
-                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Once per battle, the controlling player of a Warlord with this Trait may declare the use of this Trait at the start of their player turn. For the duration of that player turn only, all friendly models with the Legiones Astartes (Space Wolves) special rule gain a bonus of +1 Strength if the unit they are part of has successfully Charged an enemy unit. In addition, an army whose Warlord has this Trait may make an additional Reaction in the opposing player&apos;s Movement phase so long as the Warlord has not been removed as a casualty.</characteristic>
+                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Once per battle, the controlling player of a Warlord with this Trait may declare the use of this Trait at the start of their player turn. For the duration of that player turn only, all friendly models with the Legiones Astartes (Space Wolves) special rule gain a bonus of +1 Strength if the unit they are part of has successfully Charged an enemy unit. In addition, an army whose Warlord has this Trait may make an additional Reaction in the opposing player's Movement phase so long as the Warlord has not been removed as a casualty.</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d8f1-e4d3-b786-d969" name="Hunger of the Void" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3a84-1913-7629-e798" type="max"/>
-                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="a5a4-680d-2b1f-7097" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3a84-1913-7629-e798" type="max" />
+                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="a5a4-680d-2b1f-7097" type="max" />
                   </constraints>
                   <profiles>
                     <profile id="00fe-43b8-93ff-0e98" name="Hunger of the Void" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                       <characteristics>
-                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait gains an additional Wound at the end of any Assault phase in which he inflicts at least one unsaved Wound on an enemy model. This can not increase the Warlord&apos;s Wounds Characteristic above his starting value (including any bonuses from Wargear items like /Ether-rune armour), but if this effect is triggered while the Warlord has his maximum possible number of Wounds then he instead gains +1 Attacks and Strength until the end of the controlling player&apos;s next turn. In addition, an army whose Warlord has this Trait may make an additional Reaction in the opposing player&apos;s Assault phase so long as the Warlord has not been removed as a casualty.</characteristic>
+                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait gains an additional Wound at the end of any Assault phase in which he inflicts at least one unsaved Wound on an enemy model. This can not increase the Warlord's Wounds Characteristic above his starting value (including any bonuses from Wargear items like /Ether-rune armour), but if this effect is triggered while the Warlord has his maximum possible number of Wounds then he instead gains +1 Attacks and Strength until the end of the controlling player's next turn. In addition, an army whose Warlord has this Trait may make an additional Reaction in the opposing player's Assault phase so long as the Warlord has not been removed as a casualty.</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cecf-23a2-82dd-16f4" name="Crown Breaker" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4da7-2c83-277c-493d" type="max"/>
-                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="9710-474c-a7de-fac1" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4da7-2c83-277c-493d" type="max" />
+                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="9710-474c-a7de-fac1" type="max" />
                   </constraints>
                   <profiles>
                     <profile id="3711-0e34-98bc-95fb" name="Crown Breaker" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                       <characteristics>
                         <characteristic name="Text" typeId="c68e-2cda-b67b-baca">The Warlord and all models in any unit he has joined gain the Preferred Enemy (Independent Characters) special rule.
-Those models also gain the Feel No Pain (5+) special rule when locked in combat with one or more enemy models with the Independent Character special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction in the opposing player&apos;s Movement phase so long as the Warlord has not been removed as a casualty.</characteristic>
+Those models also gain the Feel No Pain (5+) special rule when locked in combat with one or more enemy models with the Independent Character special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction in the opposing player's Movement phase so long as the Warlord has not been removed as a casualty.</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
             <selectionEntryGroup id="06d9-44ea-e05e-b868" name="Ultramarines" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3dad-8dde-8fe1-1a1e" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3dad-8dde-8fe1-1a1e" type="max" />
               </constraints>
               <selectionEntries>
                 <selectionEntry id="ac40-9072-138a-6d98" name="The Burden of Kings" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3b37-db20-fdf2-8f9e" type="max"/>
-                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="d7ed-38b4-f48c-de92" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3b37-db20-fdf2-8f9e" type="max" />
+                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="d7ed-38b4-f48c-de92" type="max" />
                   </constraints>
                   <profiles>
                     <profile id="5929-63cd-d2e3-58a5" name="The Burden of Kings" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                       <characteristics>
-                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">In any Phase in which one or more Wounds has been allocated to a Warlord with this Trait, whether saved or unsaved, the Warlord gains the It Will Not Die (4+) and Fearless special rules until the end of the Warlord&apos;s controlling player&apos;s next turn. In addition, an army whose Warlord has this Trait may, once in each of the opposing player&apos;s turns, make a single Reaction without spending a point of the controlling player&apos;s Reaction Allotment, as long as the Reaction is made by the Warlord or a unit the Warlord has joined.</characteristic>
+                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">In any Phase in which one or more Wounds has been allocated to a Warlord with this Trait, whether saved or unsaved, the Warlord gains the It Will Not Die (4+) and Fearless special rules until the end of the Warlord's controlling player's next turn. In addition, an army whose Warlord has this Trait may, once in each of the opposing player's turns, make a single Reaction without spending a point of the controlling player's Reaction Allotment, as long as the Reaction is made by the Warlord or a unit the Warlord has joined.</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4d49-a202-7e5c-d2a3" name="The Aegis of Wisdom" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5faa-8a0d-d323-fb91" type="max"/>
-                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e466-1d5c-52c9-dc82" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5faa-8a0d-d323-fb91" type="max" />
+                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e466-1d5c-52c9-dc82" type="max" />
                   </constraints>
                   <profiles>
                     <profile id="234b-6de2-0008-086f" name="The Aegis of Wisdom" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                       <characteristics>
-                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any friendly unit made up entirely of models with the Legiones Astartes (Ultramarines) special rule that can draw a line of sight to a Warlord with this Warlord Trait, may, when called upon to Regroup, use the Warlord&apos;s Leadership Characteristic for that test, and if successful the unit may make Shooting Attacks and declare Charges as normal, ignoring the normal restrictions for units that have Regrouped in the same turn. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&apos;s Shooting phase as long as the Warlord has not been removed as a casualty</characteristic>
+                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any friendly unit made up entirely of models with the Legiones Astartes (Ultramarines) special rule that can draw a line of sight to a Warlord with this Warlord Trait, may, when called upon to Regroup, use the Warlord's Leadership Characteristic for that test, and if successful the unit may make Shooting Attacks and declare Charges as normal, ignoring the normal restrictions for units that have Regrouped in the same turn. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player's Shooting phase as long as the Warlord has not been removed as a casualty</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
             <selectionEntryGroup id="f035-9ea4-3fa1-2dc8" name="Iron Hands" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a9a3-f152-c71c-7248" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a9a3-f152-c71c-7248" type="max" />
               </constraints>
               <selectionEntries>
-                <selectionEntry id="d46e-bf3d-1aec-27ac" name="From Hel&apos;s Heart" hidden="false" collective="false" import="true" type="upgrade">
+                <selectionEntry id="d46e-bf3d-1aec-27ac" name="From Hel's Heart" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d63-05a8-a25a-58d9" type="max"/>
-                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="a53b-8600-7ba6-e362" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d63-05a8-a25a-58d9" type="max" />
+                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="a53b-8600-7ba6-e362" type="max" />
                   </constraints>
                   <profiles>
-                    <profile id="629b-396c-5a51-6b7a" name="From Hel&apos;s Heart" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                    <profile id="629b-396c-5a51-6b7a" name="From Hel's Heart" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                       <characteristics>
-                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and all models in any unit he joins, gain the Fear (1) special rule and should the Warlord be reduced to 0 Wounds, the controlling player may choose to inflict D6 automatic Hits upon the unit whose attacks caused the final Wound, with these Hits allocated as per the standard rules. Each Hit is resolved using the profile of either any one of the Warlord&apos;s ranged weapons if he lost his last Wound to a Shooting Attack, or using the profile of any one of the Warlord&apos;s melee weapons if he lost his last Wound as part of an Assault, with all Hits resolved using the same profile (if the Wound is lost to neither a Shooting Attack nor a Melee Attack then this rule has no effect and no Hits are inflicted). In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&apos;s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and all models in any unit he joins, gain the Fear (1) special rule and should the Warlord be reduced to 0 Wounds, the controlling player may choose to inflict D6 automatic Hits upon the unit whose attacks caused the final Wound, with these Hits allocated as per the standard rules. Each Hit is resolved using the profile of either any one of the Warlord's ranged weapons if he lost his last Wound to a Shooting Attack, or using the profile of any one of the Warlord's melee weapons if he lost his last Wound as part of an Assault, with all Hits resolved using the same profile (if the Wound is lost to neither a Shooting Attack nor a Melee Attack then this rule has no effect and no Hits are inflicted). In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player's Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="15ab-63eb-8305-401b" name="Silver-iron Will" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a47a-816c-0fa5-c9d2" type="max"/>
-                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6f07-0a5a-8aa3-6f4a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a47a-816c-0fa5-c9d2" type="max" />
+                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6f07-0a5a-8aa3-6f4a" type="max" />
                   </constraints>
                   <profiles>
                     <profile id="166b-761e-6f25-fe33" name="Silver-iron Will" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                       <characteristics>
-                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait and all models in any unit he has joined are never affected by any special rule or effect that lowers a Characteristic - including the Fear (X) and Rad-phage special rules and due to losing an assault where the enemy has inflicted more Wounds. In addition, an army whose Warlord has this Trait may not make Reactions during the Movement phase, but may make an additional Reaction in either one of the opposing player&apos;s Shooting or Assault phases (but not both). If the Warlord is removed as a casualty then this additional Reaction is lost, but the army may make Reactions in the Movement phase as normal in any appropriate Phases after the Warlord has been removed as a casualty.</characteristic>
+                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait and all models in any unit he has joined are never affected by any special rule or effect that lowers a Characteristic - including the Fear (X) and Rad-phage special rules and due to losing an assault where the enemy has inflicted more Wounds. In addition, an army whose Warlord has this Trait may not make Reactions during the Movement phase, but may make an additional Reaction in either one of the opposing player's Shooting or Assault phases (but not both). If the Warlord is removed as a casualty then this additional Reaction is lost, but the army may make Reactions in the Movement phase as normal in any appropriate Phases after the Warlord has been removed as a casualty.</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
             <selectionEntryGroup id="01a3-5952-89d2-45af" name="Raven Guard" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c7a7-1084-a803-564d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c7a7-1084-a803-564d" type="max" />
               </constraints>
               <selectionEntries>
                 <selectionEntry id="4377-1aa8-9cdb-bb66" name="The Hidden Hand" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7826-915d-dec9-fe28" type="max"/>
-                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="156e-0472-5537-f3a0" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7826-915d-dec9-fe28" type="max" />
+                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="156e-0472-5537-f3a0" type="max" />
                   </constraints>
                   <profiles>
                     <profile id="c031-54aa-c6d1-4175" name="The Hidden Hand" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                       <characteristics>
-                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">While a Warlord with this Trait is in Reserves, the controlling player may choose to re-roll all failed Reserves rolls and when deployed to the battlefield the Warlord and all models in any unit he has joined gain the Fleet(2) special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&apos;s Movement phase as long as the Warlord has not been removed as a casualty. </characteristic>
+                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">While a Warlord with this Trait is in Reserves, the controlling player may choose to re-roll all failed Reserves rolls and when deployed to the battlefield the Warlord and all models in any unit he has joined gain the Fleet(2) special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player's Movement phase as long as the Warlord has not been removed as a casualty. </characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ccbd-0f31-cdc1-96dc" name="The Bane of Tyrants" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a641-0ada-47b4-4868" type="max"/>
-                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="3bfd-8786-59b9-16bb" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a641-0ada-47b4-4868" type="max" />
+                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="3bfd-8786-59b9-16bb" type="max" />
                   </constraints>
                   <profiles>
                     <profile id="81fa-0a3a-87ea-360f" name="The Bane of Tyrants" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                       <characteristics>
-                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord increases his Attacks and Strength Characteristics by +1 when Engaged in a Challenge, and by +2 when Engaged in a Challenge with the enemy Warlord. In addition, an army whose Warlord has this Trait may make an additional Reaction during their opponent&apos;s Assault phase as long as the Warlord has not been removed as a casualty. (edited)
+                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord increases his Attacks and Strength Characteristics by +1 when Engaged in a Challenge, and by +2 when Engaged in a Challenge with the enemy Warlord. In addition, an army whose Warlord has this Trait may make an additional Reaction during their opponent's Assault phase as long as the Warlord has not been removed as a casualty. (edited)
 [1:15 PM]
 </characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
             <selectionEntryGroup id="84ff-70e4-e949-b251" name="Salamanders" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aac0-f3e8-ad29-81d9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aac0-f3e8-ad29-81d9" type="max" />
               </constraints>
               <selectionEntries>
                 <selectionEntry id="f5f9-0c44-3309-466c" name="The Weight of Duty" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="18e2-de60-bf2b-da28" type="max"/>
-                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="867a-f37c-2334-fbe9" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="18e2-de60-bf2b-da28" type="max" />
+                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="867a-f37c-2334-fbe9" type="max" />
                   </constraints>
                   <profiles>
                     <profile id="ef4f-b960-e347-ea5b" name="The Weight of Duty" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                       <characteristics>
-                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and all models in any unit he has joined, gain a bonus of +1 to their Strength Characteristic when locked in combat with any enemy unit that includes one or more models with any variant of the Fear special rule. Furthermore, this Warlord and any models in a unit he has joined composed entirely of models with the Legiones Astartes (Salamanders) special rule gain the Hatred (Traitors) special rule while the Warlord is part of the unit. An army whose Warlord has this Warlord Trait may not include Legion Destroyer Assault Squads, Legion Mortalis Destroyer Squads or Legion Centurions with the Moritat Consul upgrade that also have the Legiones Astartes (Salamanders) special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&apos;s Assault phase as long as the Warlord has not been removed as a casualty. </characteristic>
+                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and all models in any unit he has joined, gain a bonus of +1 to their Strength Characteristic when locked in combat with any enemy unit that includes one or more models with any variant of the Fear special rule. Furthermore, this Warlord and any models in a unit he has joined composed entirely of models with the Legiones Astartes (Salamanders) special rule gain the Hatred (Traitors) special rule while the Warlord is part of the unit. An army whose Warlord has this Warlord Trait may not include Legion Destroyer Assault Squads, Legion Mortalis Destroyer Squads or Legion Centurions with the Moritat Consul upgrade that also have the Legiones Astartes (Salamanders) special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player's Assault phase as long as the Warlord has not been removed as a casualty. </characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2cbb-44a5-ee52-102d" name="Promethean Will" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fa8c-3cc3-9d52-972c" type="max"/>
-                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="fafb-10ec-8cc4-37ff" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fa8c-3cc3-9d52-972c" type="max" />
+                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="fafb-10ec-8cc4-37ff" type="max" />
                   </constraints>
                   <profiles>
                     <profile id="66f8-15c8-18db-850a" name="Promethean Will" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                       <characteristics>
-                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and all models in any friendly unit composed entirely of models with the Legiones Astartes (Salamanders) special rule that is part of the same Detachment, gains a bonus of +1 to their Leadership Characteristic when making Pinning tests (to a maximum of 11) and reduce the effects of the Fear special rule by 1 (note that this means the Fear (1) special rule has no effect on models granted this benefit, and negative modifiers conferred by other variants of the Fear special rule are reduced in effect by 1). An army whose Warlord has this Warlord Trait may not include Legion Destroyer Assault Squads, Legion Mortalis Destroyer Squads or Legion Centurions with the Moritat Consul upgrade that also have the Legiones Astartes (Salamanders) special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&apos;s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and all models in any friendly unit composed entirely of models with the Legiones Astartes (Salamanders) special rule that is part of the same Detachment, gains a bonus of +1 to their Leadership Characteristic when making Pinning tests (to a maximum of 11) and reduce the effects of the Fear special rule by 1 (note that this means the Fear (1) special rule has no effect on models granted this benefit, and negative modifiers conferred by other variants of the Fear special rule are reduced in effect by 1). An army whose Warlord has this Warlord Trait may not include Legion Destroyer Assault Squads, Legion Mortalis Destroyer Squads or Legion Centurions with the Moritat Consul upgrade that also have the Legiones Astartes (Salamanders) special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player's Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="05e8-17f8-ad69-2f44" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+            <entryLink id="05e8-17f8-ad69-2f44" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="1b04-8704-13f6-3eb2" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3632-9610-0138-2f78" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51f8-120f-3d9e-1b8b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3632-9610-0138-2f78" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51f8-120f-3d9e-1b8b" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="290b-0202-b871-969b" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0469-9061-4cca-e32f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40cc-5c79-0377-5e9c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0469-9061-4cca-e32f" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40cc-5c79-0377-5e9c" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="7aa0-0478-daa4-bfd6" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f19c-14a8-f9ca-1a5c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b6b-1eb8-d32b-e022" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f19c-14a8-f9ca-1a5c" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b6b-1eb8-d32b-e022" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="e9c8-cc0a-02ae-4a26" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7baf-1b30-553d-6302" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57e8-5381-14e8-96d0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7baf-1b30-553d-6302" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57e8-5381-14e8-96d0" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="0481-2ea1-9583-44ff" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e52e-f880-43d9-b8cf" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fb0-adcd-3271-c46b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e52e-f880-43d9-b8cf" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fb0-adcd-3271-c46b" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="f647-e1df-e815-7c94" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="34c4-db99-db36-0f2a" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a80-90a9-6405-7ae9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9581-2c83-dbb2-a9d8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a80-90a9-6405-7ae9" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9581-2c83-dbb2-a9d8" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="808c-4860-ff66-9733" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup"/>
+        <entryLink id="808c-4860-ff66-9733" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup" />
         <entryLink id="9ca8-b3b2-7f0f-f37a" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d34c-598e-511d-1eb4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d34c-598e-511d-1eb4" type="max" />
           </constraints>
           <rules>
             <rule id="fa48-4084-488b-fd92" name="Archein of Wisdom" hidden="false">
-              <description>If Chapter Master Raldoron is selected as the army’s Warlord then his Warlord Trait may be selected from the Core Warlord Traits or from any Legion specific Warlord Trait from any of the following Legions (counting as though Raldoron and all other models with the Legiones Astartes (Blood Angels) special rule in the same Detachment possesses the appropriate variant of the Legiones Astartes special rule, this does not grant them any of that variant’s rules or effects but only allows them to benefit from the effects of the selected Warlord Trait): White Scars, Imperial Fists, Space Wolves, Ultramarines, Iron Hands, Raven Guard and Salamanders. This does not include any Warlord Traits available only to specific named characters, or a Warlord Trait that requires the Traitor Allegiance may not be selected.</description>
+              <description>If Chapter Master Raldoron is selected as the army&#8217;s Warlord then his Warlord Trait may be selected from the Core Warlord Traits or from any Legion specific Warlord Trait from any of the following Legions (counting as though Raldoron and all other models with the Legiones Astartes (Blood Angels) special rule in the same Detachment possesses the appropriate variant of the Legiones Astartes special rule, this does not grant them any of that variant&#8217;s rules or effects but only allows them to benefit from the effects of the selected Warlord Trait): White Scars, Imperial Fists, Space Wolves, Ultramarines, Iron Hands, Raven Guard and Salamanders. This does not include any Warlord Traits available only to specific named characters, or a Warlord Trait that requires the Traitor Allegiance may not be selected.</description>
             </rule>
           </rules>
         </entryLink>
         <entryLink id="ec11-34f3-2fc6-7d88" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6a0-7fc3-b7fe-9efd" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73fa-9e12-ff7c-4a2c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6a0-7fc3-b7fe-9efd" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73fa-9e12-ff7c-4a2c" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="180.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="180.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="98d4-555a-6911-7c1a" name="Dominion Zephon" hidden="false" collective="false" import="true" type="model">
@@ -3045,37 +3044,37 @@ Those models also gain the Feel No Pain (5+) special rule when locked in combat 
       </profiles>
       <rules>
         <rule id="308f-78bb-90b4-76f9" name="Paragon of Restoration" hidden="false">
-          <description>Installed in Zephon&apos;s body by the apocryphal techo-ministrations of Arkhan Land, these intricate bionic enhancements can heal even the most grievous wounds over time and prevent their host-body from slipping into death&apos;s embrace.
+          <description>Installed in Zephon's body by the apocryphal techo-ministrations of Arkhan Land, these intricate bionic enhancements can heal even the most grievous wounds over time and prevent their host-body from slipping into death's embrace.
 The Paragon of Restoration gives Dominion Zephon the Feel No Pain (5+) special rule. In addition, the first time in any battle that Dominion Zephon loses his last Wound, or is otherwise removed from play as a casualty, the controlling player must immediately roll a D6. On a result of 4+, he remains in play with a single Wound remaining instead of being removed or destroyed.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="901c-bb1a-646c-6ea7" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule"/>
-        <infoLink id="333e-456d-2400-6c40" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="901c-bb1a-646c-6ea7" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule" />
+        <infoLink id="333e-456d-2400-6c40" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="ead6-c3eb-3aac-157d" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
           <modifiers>
-            <modifier type="append" field="name" value="1"/>
+            <modifier type="append" field="name" value="1" />
           </modifiers>
         </infoLink>
-        <infoLink id="6e1c-b267-05c0-d4e2" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
-        <infoLink id="6544-cea9-9c06-ba7c" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
+        <infoLink id="6e1c-b267-05c0-d4e2" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
+        <infoLink id="6544-cea9-9c06-ba7c" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="31ae-7034-a2db-dc40" name="Independant Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="feba-d345-0dbc-faa9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="8059-18d2-a192-f6bd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="9f7b-e6db-ff1f-ad62" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
+        <categoryLink id="31ae-7034-a2db-dc40" name="Independant Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="feba-d345-0dbc-faa9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="8059-18d2-a192-f6bd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="9f7b-e6db-ff1f-ad62" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="cae6-5863-3f61-2a37" name="Lament and Grief" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9307-784d-3a06-6737" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2380-b744-1125-b0e5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9307-784d-3a06-6737" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2380-b744-1125-b0e5" type="min" />
           </constraints>
           <profiles>
             <profile id="bd02-53fa-b4d3-8a75" name="Lament and Grief" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">10&quot;</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">10"</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 3, Deflagrate, Blind</characteristic>
@@ -3083,13 +3082,13 @@ The Paragon of Restoration gives Dominion Zephon the Feel No Pain (5+) special r
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="ac7a-84d8-03ec-117c" name="The Spiritum Sanguis" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3783-6d42-da4c-f291" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c7a-4ede-a1a7-457d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3783-6d42-da4c-f291" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c7a-4ede-a1a7-457d" type="min" />
           </constraints>
           <profiles>
             <profile id="a090-842a-a421-8c01" name="The Spiritum Sanguis" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -3102,106 +3101,106 @@ The Paragon of Restoration gives Dominion Zephon the Feel No Pain (5+) special r
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="466b-0c31-8737-4f7c" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e269-85e4-4702-14da" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8f8-2e68-88a8-e19b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e269-85e4-4702-14da" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8f8-2e68-88a8-e19b" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="405e-db36-c3f9-d6ce" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="537f-ac7f-b25c-96c1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5f7-ea49-ead5-4761" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="537f-ac7f-b25c-96c1" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5f7-ea49-ead5-4761" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="4026-a02b-ebf0-ae56" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adf6-f6f8-4199-5882" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a121-b442-e8ae-b8f4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adf6-f6f8-4199-5882" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a121-b442-e8ae-b8f4" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="7d76-c298-0d9d-0140" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bf9-0b31-9e6a-a57a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a247-b6b0-4b04-a25f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bf9-0b31-9e6a-a57a" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a247-b6b0-4b04-a25f" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="74cd-328e-9fe4-454d" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ad8-4e4c-aee2-7e86" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcd3-22dd-92b4-afb7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ad8-4e4c-aee2-7e86" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcd3-22dd-92b4-afb7" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="f8bd-0fed-2703-b6e6" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1623-4c4e-e61e-db7c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1243-dc7e-24d3-8372" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1623-4c4e-e61e-db7c" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1243-dc7e-24d3-8372" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="9a48-386a-3f8a-6364" name="Warhawk Jump Pack" hidden="false" collective="false" import="true" targetId="a298-8584-70ed-18ce" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5c5-4871-95a8-3377" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcb3-3895-6160-367e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5c5-4871-95a8-3377" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcb3-3895-6160-367e" type="min" />
           </constraints>
         </entryLink>
-        <entryLink id="e1a0-6845-0fd9-d859" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup"/>
+        <entryLink id="e1a0-6845-0fd9-d859" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup" />
         <entryLink id="52fc-490d-5d9b-fd91" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="634c-4052-0407-e871" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="634c-4052-0407-e871" type="max" />
           </constraints>
           <profiles>
             <profile id="d317-03bf-f28e-13ac" name="Exarch of the High Host" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If Dominion Zephon is the army&apos;s Warlord then a Legion Destroyer Assault Squad may be selected as part of the same HQ choice.
-A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as Dominion Zephon. The Retinue Squad must be deployed with Dominion Zephon deployed as part of the unit and Dominion Zephon may not voluntarily leave the Retinue Squad during play. All models in a Legion Destroyer Assault Squad chosen using this Warlord Trait gain the Chosen Warriors special rule. If this option is selected then no other unit may be selected for Dominion Zephon using the Retinue special rule. In addition, an army with Dominion Zephon as its Warlord may make an additional Reaction in the opposing player&apos;s Assault phase as long as Dominion Zephon has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If Dominion Zephon is the army's Warlord then a Legion Destroyer Assault Squad may be selected as part of the same HQ choice.
+A unit selected in this manner is considered a 'Retinue Squad? The Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as Dominion Zephon. The Retinue Squad must be deployed with Dominion Zephon deployed as part of the unit and Dominion Zephon may not voluntarily leave the Retinue Squad during play. All models in a Legion Destroyer Assault Squad chosen using this Warlord Trait gain the Chosen Warriors special rule. If this option is selected then no other unit may be selected for Dominion Zephon using the Retinue special rule. In addition, an army with Dominion Zephon as its Warlord may make an additional Reaction in the opposing player's Assault phase as long as Dominion Zephon has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
         <entryLink id="cd01-ba9c-0f0a-933e" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4837-d669-e84f-25b2" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c266-63ba-79d2-ee5a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4837-d669-e84f-25b2" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c266-63ba-79d2-ee5a" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0" />
       </costs>
     </selectionEntry>
-    <selectionEntry id="dda1-0fcf-0245-6c10" name="The Angel&apos;s Tears" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="dda1-0fcf-0245-6c10" name="The Angel's Tears" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="98fc-d95f-7fb1-20f4" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
-        <infoLink id="ac2b-047b-b932-df0b" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
-        <infoLink id="a544-53c8-2a96-e422" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule"/>
+        <infoLink id="98fc-d95f-7fb1-20f4" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
+        <infoLink id="ac2b-047b-b932-df0b" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule" />
+        <infoLink id="a544-53c8-2a96-e422" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule" />
         <infoLink id="e1c9-60eb-31a2-0510" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
           <modifiers>
-            <modifier type="append" field="name" value="(1)"/>
+            <modifier type="append" field="name" value="(1)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="54b5-51ed-7e8b-f3fb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="42e7-a248-5756-01f9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="feb6-58bf-657f-310e" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="7bd8-4f22-3143-1abc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="54b5-51ed-7e8b-f3fb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="42e7-a248-5756-01f9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="feb6-58bf-657f-310e" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="7bd8-4f22-3143-1abc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8b62-d772-1eac-44bc" name="Arch-Erelim" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="763a-839f-f6e3-fb13" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b81-843d-f703-5f05" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="763a-839f-f6e3-fb13" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b81-843d-f703-5f05" type="max" />
           </constraints>
           <profiles>
             <profile id="afe5-4d27-657e-f447" name="Arch-Erelim" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -3215,184 +3214,184 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="c36e-bb39-8df0-74e2" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-            <categoryLink id="b4d7-4ed5-a971-32a5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-            <categoryLink id="191b-abdd-c10c-0657" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink id="3f8c-7a78-380b-d895" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
+            <categoryLink id="c36e-bb39-8df0-74e2" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+            <categoryLink id="b4d7-4ed5-a971-32a5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+            <categoryLink id="191b-abdd-c10c-0657" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
+            <categoryLink id="3f8c-7a78-380b-d895" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="cc0f-26fa-472e-ae51" name="The Arch-Erelim may exchange their chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="01b2-db36-8e0b-cd59">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8397-cb6e-a9a3-e328" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="576e-3898-3187-a657" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8397-cb6e-a9a3-e328" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="576e-3898-3187-a657" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="0de2-df72-a8b7-b3ef" name="Heavy Chainsword" hidden="false" collective="false" import="true" targetId="ba92-3eda-3a71-dabb" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f889-23a0-c001-7af5" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f889-23a0-c001-7af5" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="4bf0-21fe-9205-84e7" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ed3-6084-bb4d-e328" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ed3-6084-bb4d-e328" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="6847-756b-f5e1-ba39" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17cd-386b-7d4a-bb27" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17cd-386b-7d4a-bb27" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="6d85-0475-82b6-fef6" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc1c-ab75-8fca-5417" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc1c-ab75-8fca-5417" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="01b2-db36-8e0b-cd59" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e177-069b-d7a6-7a85" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e177-069b-d7a6-7a85" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="220a-dbe5-2dcb-60c5" name="Power Weapon (Basic)" hidden="false" collective="false" import="true" targetId="bd1f-b4a4-3517-31e4" type="selectionEntryGroup">
                   <modifiers>
-                    <modifier type="set" field="c4e0-9351-6028-69a1" value="0.0"/>
+                    <modifier type="set" field="c4e0-9351-6028-69a1" value="0.0" />
                   </modifiers>
                 </entryLink>
                 <entryLink id="0bca-2d71-49e6-54db" name="Perdition Weapon" hidden="false" collective="false" import="true" targetId="e909-feba-d9e9-1efa" type="selectionEntryGroup">
                   <modifiers>
-                    <modifier type="set" field="9b7c-2bb2-5687-cefe" value="0.0"/>
+                    <modifier type="set" field="9b7c-2bb2-5687-cefe" value="0.0" />
                   </modifiers>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="e8aa-3629-7d00-f8a2" name="May Replace one Volkite Serpenta:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d876-904d-a371-d7d7">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2fd-5f96-9073-6879" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f8c-1e64-ccfb-fb3f" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2fd-5f96-9073-6879" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f8c-1e64-ccfb-fb3f" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="391c-abd2-1da8-7439" name="Angel&apos;s Tears Grenade Launcher" hidden="false" collective="false" import="true" targetId="e789-15b5-1256-4806" type="selectionEntry">
+                <entryLink id="391c-abd2-1da8-7439" name="Angel's Tears Grenade Launcher" hidden="false" collective="false" import="true" targetId="e789-15b5-1256-4806" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e07-801a-8c36-5588" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e07-801a-8c36-5588" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="a8e9-b4be-fbd0-1b5a" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01ad-1cc6-7087-8cb7" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01ad-1cc6-7087-8cb7" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="cea3-7cc1-5097-7aab" name="Iliastus Assault Cannon" hidden="false" collective="false" import="true" targetId="10aa-3c70-2bbe-9509" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="273a-d2ed-1c29-5264" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="273a-d2ed-1c29-5264" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="9c9d-9b7d-902e-59bc" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b261-d4d3-0bc0-1f19" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b261-d4d3-0bc0-1f19" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="8241-ed16-743b-b822" name="Heavy Chainsword" hidden="false" collective="false" import="true" targetId="ba92-3eda-3a71-dabb" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f610-fb14-742b-e3bb" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f610-fb14-742b-e3bb" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="d876-904d-a371-d7d7" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="69f7-3b28-642b-9d41" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="69f7-3b28-642b-9d41" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="c102-7bec-2c77-0678" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3f66-8f12-2a98-d59b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3f66-8f12-2a98-d59b" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="a7f8-47eb-3344-54a0" name="Inferno Pistol" hidden="false" collective="false" import="true" targetId="dcd1-8b2a-9d97-40ef" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
                       <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo" />
                       </conditions>
                     </modifier>
                   </modifiers>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="0f01-2d72-673e-0f22" name="Power Armor:" hidden="false" collective="false" import="true" defaultSelectionEntryId="fcc7-994d-ab1a-abb2">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a86c-42bf-838a-d6a7" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e331-11b7-f38c-d866" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a86c-42bf-838a-d6a7" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e331-11b7-f38c-d866" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="83f9-f15f-221f-662d" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56a4-ee9a-0d0e-19d5" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56a4-ee9a-0d0e-19d5" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="fcc7-994d-ab1a-abb2" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e771-219f-7dce-ed99" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e771-219f-7dce-ed99" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="e160-57e9-3001-0fe7" name="May Replace second Volkite Serpenta:" hidden="false" collective="false" import="true" defaultSelectionEntryId="96db-1445-8d4b-efc0">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abd6-3ede-68a0-935b" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c42-59d4-2730-454f" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abd6-3ede-68a0-935b" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c42-59d4-2730-454f" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="96db-1445-8d4b-efc0" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d4e2-fbe9-486b-deff" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d4e2-fbe9-486b-deff" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="f9d9-ae9c-b074-20b4" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="45bd-044d-2e08-e998" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="45bd-044d-2e08-e998" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="e4a3-9514-4aca-fdcd" name="Inferno Pistol" hidden="false" collective="false" import="true" targetId="dcd1-8b2a-9d97-40ef" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
                       <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo" />
                       </conditions>
                     </modifier>
                   </modifiers>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -3401,43 +3400,43 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
           <entryLinks>
             <entryLink id="4ad0-2d38-7602-3d08" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16c6-4e84-0eba-4d5a" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4abd-df43-0c63-55c1" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16c6-4e84-0eba-4d5a" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4abd-df43-0c63-55c1" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="7f76-f119-4168-858f" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d45-77cd-af26-ec88" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7819-e408-c7d5-eb45" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d45-77cd-af26-ec88" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7819-e408-c7d5-eb45" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="533c-b3c4-d0e2-ec2e" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4be2-c93d-aa2c-6505" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2f7-1c8d-b673-71ba" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4be2-c93d-aa2c-6505" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2f7-1c8d-b673-71ba" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="99e0-b80b-1cc6-f488" name="Warhawk Jump Pack" hidden="false" collective="false" import="true" targetId="a298-8584-70ed-18ce" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c94-e00d-782b-fcac" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1487-7228-eb89-28e8" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c94-e00d-782b-fcac" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1487-7228-eb89-28e8" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="f18a-bf02-4c90-3e1f" name="Erelim" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6fb-7ea6-480d-eec6" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a59-4292-45ab-de3d" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6fb-7ea6-480d-eec6" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a59-4292-45ab-de3d" type="min" />
           </constraints>
           <profiles>
             <profile id="8355-50ba-838d-158e" name="Erelim" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -3453,30 +3452,30 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
           <selectionEntryGroups>
             <selectionEntryGroup id="3abe-1c18-2d60-0225" name="May Replace one Volkite Serpenta:" hidden="false" collective="false" import="true" defaultSelectionEntryId="164c-51e0-d015-94e7">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10f1-907e-02bc-e5ef" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f74b-a425-3f00-cbc5" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10f1-907e-02bc-e5ef" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f74b-a425-3f00-cbc5" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="15e4-7d55-0ac9-6e3b" name="Angel&apos;s Tears Grenade Launcher" hidden="false" collective="false" import="true" targetId="e789-15b5-1256-4806" type="selectionEntry">
+                <entryLink id="15e4-7d55-0ac9-6e3b" name="Angel's Tears Grenade Launcher" hidden="false" collective="false" import="true" targetId="e789-15b5-1256-4806" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="2023-c6dd-8217-9b49" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="ea2b-9908-2d93-787a" name="Iliastus Assault Cannon" hidden="false" collective="false" import="true" targetId="10aa-3c70-2bbe-9509" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="a23c-4f5d-3dbb-b09d" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry"/>
-                <entryLink id="1aa9-6fc2-2cca-0e65" name="Heavy Chainsword" hidden="false" collective="false" import="true" targetId="ba92-3eda-3a71-dabb" type="selectionEntry"/>
+                <entryLink id="a23c-4f5d-3dbb-b09d" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry" />
+                <entryLink id="1aa9-6fc2-2cca-0e65" name="Heavy Chainsword" hidden="false" collective="false" import="true" targetId="ba92-3eda-3a71-dabb" type="selectionEntry" />
                 <entryLink id="164c-51e0-d015-94e7" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cc26-a8e6-f955-c182" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cc26-a8e6-f955-c182" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -3485,109 +3484,109 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
           <entryLinks>
             <entryLink id="a8c3-ddc6-f674-cacc" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87c7-d1f7-69aa-0b86" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3dd9-9bfb-c290-e0e0" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87c7-d1f7-69aa-0b86" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3dd9-9bfb-c290-e0e0" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="8459-9971-ef9e-a3cd" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2552-61cc-26e1-2e07" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8040-e902-80eb-733a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2552-61cc-26e1-2e07" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8040-e902-80eb-733a" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="b148-028b-db15-72fd" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b4d-5e9f-51a4-2523" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3af0-ddcc-9278-2018" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b4d-5e9f-51a4-2523" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3af0-ddcc-9278-2018" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="5883-6f31-a9cd-a4a6" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1ee-a2ca-6a58-c264" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7d0-4a2b-1a16-3123" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1ee-a2ca-6a58-c264" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7d0-4a2b-1a16-3123" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="7d26-dd89-8d72-5aa8" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64d1-19c7-a191-76fe" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8115-95cb-6fd7-fa54" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64d1-19c7-a191-76fe" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8115-95cb-6fd7-fa54" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="c0a2-c8e0-dfbf-7a6a" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c92f-21af-90fe-b408" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3875-6dba-8d14-cc0c" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c92f-21af-90fe-b408" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3875-6dba-8d14-cc0c" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="7c8a-6d57-572a-ee0e" name="Warhawk Jump Pack" hidden="false" collective="false" import="true" targetId="a298-8584-70ed-18ce" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c855-4959-cdae-a763" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2c4-0193-813b-6747" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c855-4959-cdae-a763" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2c4-0193-813b-6747" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="7bb9-6f7e-d482-34df" name="The entire unit may take meltabombs" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="name" value="Meltabombs">
               <conditions>
-                <condition field="selections" scope="dda1-0fcf-0245-6c10" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7bb9-6f7e-d482-34df" type="atLeast"/>
+                <condition field="selections" scope="dda1-0fcf-0245-6c10" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7bb9-6f7e-d482-34df" type="atLeast" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="162b-5bc6-de74-411e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="162b-5bc6-de74-411e" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="2922-1fba-8a53-674f" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c5c-107a-72b0-efff" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b00a-020b-1fc6-6736" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c5c-107a-72b0-efff" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b00a-020b-1fc6-6736" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="3c67-35da-d64a-f22b" name="Dawnbreaker Cohort" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="9f1e-6596-d31d-699e" name="Set the Sky Aflame" hidden="false">
-          <description>When a unit composed entirely of models with this special rule is deployed as part of a Deep Strike Assault, any enemy units within 6&quot; of the unit&apos;s final position suffer a -1 modifier to their Leadership Characteristic when taking any Pinning tests cause by the Deep Strike Assault.</description>
+          <description>When a unit composed entirely of models with this special rule is deployed as part of a Deep Strike Assault, any enemy units within 6" of the unit's final position suffer a -1 modifier to their Leadership Characteristic when taking any Pinning tests cause by the Deep Strike Assault.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="28ea-60de-d869-ac71" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule"/>
+        <infoLink id="28ea-60de-d869-ac71" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule" />
         <infoLink id="8353-5d4b-5e81-1efd" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Furious Charge (1)"/>
+            <modifier type="set" field="name" value="Furious Charge (1)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ea81-014b-635d-47bb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="8925-58cb-6e34-0c0c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="680f-d029-6ed2-3bf6" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
+        <categoryLink id="ea81-014b-635d-47bb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="8925-58cb-6e34-0c0c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="680f-d029-6ed2-3bf6" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e958-de95-0a5b-de1f" name="Dawnbreaker Champion" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4112-7547-7163-8c1d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ee0-99ef-00dd-315c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4112-7547-7163-8c1d" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ee0-99ef-00dd-315c" type="max" />
           </constraints>
           <profiles>
             <profile id="af35-5ccf-088e-e9b2" name="Dawnbreaker Champion" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -3601,37 +3600,37 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="7e67-d421-30d9-0127" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink id="6b93-ada7-2d5d-09a7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink id="7e67-d421-30d9-0127" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
+            <categoryLink id="6b93-ada7-2d5d-09a7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="2683-ff01-5aff-0bf9" name="May replace Falling-star Pattern Spear with:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8973-aea3-2fcf-5ac6">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="418e-b5a0-95d2-a974" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e26f-6e1b-b2e2-0ddf" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="418e-b5a0-95d2-a974" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e26f-6e1b-b2e2-0ddf" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="2984-31a3-b085-3c5c" name="Equinox Power Blade Case" hidden="false" collective="false" import="true" targetId="c117-96cb-919f-f806" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e95-446d-f552-d202" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e95-446d-f552-d202" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="8973-aea3-2fcf-5ac6" name="Falling-Star Power Spear" hidden="false" collective="false" import="true" targetId="ffe1-7b85-01c8-b0c7" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="398e-54da-c85e-98f3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="398e-54da-c85e-98f3" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="ce08-2761-d474-744e" name="Perdition Weapon" hidden="false" collective="false" import="true" targetId="e909-feba-d9e9-1efa" type="selectionEntryGroup">
                   <modifiers>
-                    <modifier type="set" field="9b7c-2bb2-5687-cefe" value="0.0"/>
+                    <modifier type="set" field="9b7c-2bb2-5687-cefe" value="0.0" />
                   </modifiers>
                 </entryLink>
                 <entryLink id="414a-6ad2-4523-e19c" name="Power Weapon (Basic)" hidden="false" collective="false" import="true" targetId="bd1f-b4a4-3517-31e4" type="selectionEntryGroup">
                   <modifiers>
-                    <modifier type="set" field="c4e0-9351-6028-69a1" value="0.0"/>
+                    <modifier type="set" field="c4e0-9351-6028-69a1" value="0.0" />
                   </modifiers>
                 </entryLink>
               </entryLinks>
@@ -3640,60 +3639,60 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
           <entryLinks>
             <entryLink id="be3d-af23-4f08-ad76" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="408c-d464-c905-c102" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a120-e971-61da-b0da" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="408c-d464-c905-c102" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a120-e971-61da-b0da" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="440b-4a00-50e4-5cbd" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="127f-14c4-d1f8-eedb" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0918-1bb0-88dc-4326" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="127f-14c4-d1f8-eedb" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0918-1bb0-88dc-4326" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="749d-4233-2b8e-c34f" name="Grenade Discharger" hidden="false" collective="false" import="true" targetId="5702-2ab3-66f0-dfc1" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7207-4c26-d3e3-aef4" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e02-0b01-311e-0f9b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7207-4c26-d3e3-aef4" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e02-0b01-311e-0f9b" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="0a55-edf9-8a05-379f" name="Warhawk Jump Pack" hidden="false" collective="false" import="true" targetId="a298-8584-70ed-18ce" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f87-4993-7752-14e9" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eede-c105-9021-0ca4" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f87-4993-7752-14e9" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eede-c105-9021-0ca4" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="1c43-a856-a052-a084" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5959-3cb9-68cf-fe12" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f244-2583-3ed2-4e38" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5959-3cb9-68cf-fe12" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f244-2583-3ed2-4e38" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="3ad1-fabb-205d-70ad" name="The Entire unit may take:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fb9-2bd0-35a5-04f6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fb9-2bd0-35a5-04f6" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="1c14-baf4-bde7-d1a3" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6e7-c55c-e504-e7f3" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6e7-c55c-e504-e7f3" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="c0d3-cf06-e413-5e8a" name="Dawnbreakers" hidden="false" collective="true" import="true" defaultSelectionEntryId="c1fb-61b4-5212-ecfb">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e60-f8d7-8307-f17b" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="287f-5548-f90b-4c1c" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e60-f8d7-8307-f17b" type="min" />
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="287f-5548-f90b-4c1c" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="6cc7-6e76-c402-7c2b" name="Dawnbreaker w/ Equinox Power Blade Case" hidden="false" collective="true" import="true" type="upgrade">
@@ -3701,7 +3700,7 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
                 <profile id="13ce-3207-bb2e-eaf0" name="Dawnbreaker" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -3717,43 +3716,43 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
               <entryLinks>
                 <entryLink id="a159-5439-120e-cc0d" name="Equinox Power Blade Case" hidden="false" collective="false" import="true" targetId="c117-96cb-919f-f806" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e44-452d-2161-8139" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61ec-4bdf-7aa9-bbda" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e44-452d-2161-8139" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61ec-4bdf-7aa9-bbda" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="2d2b-e338-2a44-4b6e" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="9196-3af7-9545-e62b" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fcc-1e1f-6651-5304" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2553-9086-4a88-cf9a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fcc-1e1f-6651-5304" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2553-9086-4a88-cf9a" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="7165-ae8a-21bd-5d64" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="4fd8-9e1f-ae28-3004" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90d2-0fc0-61c4-68a1" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de2e-6d04-fc69-8751" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90d2-0fc0-61c4-68a1" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de2e-6d04-fc69-8751" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="592e-fa38-5790-ec20" name="Grenade Discharger" hidden="false" collective="false" import="true" targetId="0eba-48ae-95a0-81e5" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79bc-3402-6dcc-39d4" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca1e-bfcb-cfd2-f416" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79bc-3402-6dcc-39d4" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca1e-bfcb-cfd2-f416" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="57a8-3230-c657-ab5d" name="Warhawk Jump Pack" hidden="false" collective="false" import="true" targetId="e7bc-371f-3d14-4968" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5874-0c8b-8560-88b7" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06ed-b40d-7eeb-394f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5874-0c8b-8560-88b7" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06ed-b40d-7eeb-394f" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="62f0-4d20-1404-f796" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="3739-1019-344e-761d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e08-8eaa-d615-4b41" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4397-2b58-109d-99ec" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e08-8eaa-d615-4b41" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4397-2b58-109d-99ec" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="c1fb-61b4-5212-ecfb" name="Dawnbreaker w/ Falling-Star Power Spear" hidden="false" collective="true" import="true" type="upgrade">
@@ -3761,7 +3760,7 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
                 <profile id="e7de-3ade-8f9a-9c0c" name="Dawnbreaker" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -3777,50 +3776,50 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
               <entryLinks>
                 <entryLink id="524d-3acc-b602-1126" name="Falling-Star Power Spear" hidden="false" collective="false" import="true" targetId="ffe1-7b85-01c8-b0c7" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e547-cabe-0c44-a7e5" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="305c-5ad7-188b-7e11" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e547-cabe-0c44-a7e5" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="305c-5ad7-188b-7e11" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="d85a-2041-b84f-ddcc" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="9196-3af7-9545-e62b" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fed1-514b-c488-b332" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43e9-bf92-7d7e-60e1" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fed1-514b-c488-b332" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43e9-bf92-7d7e-60e1" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="5338-609f-e2bf-314d" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="4fd8-9e1f-ae28-3004" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18a0-247e-3ac3-6c8d" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a6b-1cfa-847b-771e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18a0-247e-3ac3-6c8d" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a6b-1cfa-847b-771e" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="fe1f-93a9-e005-5120" name="Grenade Discharger" hidden="false" collective="false" import="true" targetId="0eba-48ae-95a0-81e5" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e817-8a36-20f8-95fc" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b96a-d4b6-bb0d-29c8" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e817-8a36-20f8-95fc" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b96a-d4b6-bb0d-29c8" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="c792-8769-5173-8ea4" name="Warhawk Jump Pack" hidden="false" collective="false" import="true" targetId="e7bc-371f-3d14-4968" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="227f-9502-b3b7-e416" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a669-250a-6e7e-7162" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="227f-9502-b3b7-e416" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a669-250a-6e7e-7162" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="ac43-e578-b3c7-b2c4" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="3739-1019-344e-761d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6331-03ef-6c10-c66c" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c65-9ccc-ccfa-6552" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6331-03ef-6c10-c66c" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c65-9ccc-ccfa-6552" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="c117-96cb-919f-f806" name="Equinox Power Blade Case" hidden="false" collective="true" import="true" type="upgrade">
@@ -3848,21 +3847,21 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="8c20-dfd5-08e5-afa0" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+        <infoLink id="8c20-dfd5-08e5-afa0" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
         <infoLink id="d8e6-cef5-69b3-aca4" name="Sudden Strike (X)" hidden="false" targetId="58b3-7d84-b92d-1363" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Sudden Strike (1)"/>
+            <modifier type="set" field="name" value="Sudden Strike (1)" />
           </modifiers>
         </infoLink>
         <infoLink id="3ced-d821-8308-6d25" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Rending (5+)"/>
+            <modifier type="set" field="name" value="Rending (5+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="6c31-cff8-a750-a197" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+        <infoLink id="6c31-cff8-a750-a197" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule" />
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="ffe1-7b85-01c8-b0c7" name="Falling-Star Power Spear" hidden="false" collective="true" import="true" type="upgrade">
@@ -3879,17 +3878,17 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
       <infoLinks>
         <infoLink id="62e2-440f-7c1d-c67b" name="Reach (X)" hidden="false" targetId="19bf-62a2-5737-890b" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Reach (1)"/>
+            <modifier type="set" field="name" value="Reach (1)" />
           </modifiers>
         </infoLink>
         <infoLink id="7699-9b2e-dcb7-9ed5" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value=" Rending (5+)"/>
+            <modifier type="set" field="name" value=" Rending (5+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="298b-c5d8-2fb0-9dd4" name="Coriolis Pattern Power Shield" hidden="false" collective="false" import="true" type="upgrade">
@@ -3901,7 +3900,7 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
         </profile>
       </profiles>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="2fd3-e09f-173f-6b0a" name="Sunset blade" hidden="false" collective="false" import="true" type="upgrade">
@@ -3916,22 +3915,22 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="4509-45e0-1ae2-667e" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+        <infoLink id="4509-45e0-1ae2-667e" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule" />
         <infoLink id="ef4b-8771-0271-c21a" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Rending (5+)"/>
+            <modifier type="set" field="name" value="Rending (5+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="0eba-48ae-95a0-81e5" name="Grenade Discharger" hidden="false" collective="true" import="true" type="upgrade">
       <profiles>
         <profile id="a273-206f-0e23-5745" name="Grenade discharger - Frag bombs" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
           <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12"</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">3</characteristic>
             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
             <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 3, Pinning</characteristic>
@@ -3939,7 +3938,7 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
         </profile>
         <profile id="4e6c-aff2-c03f-ff46" name="Grenade discharger - Krak bombs" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
           <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12"</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
             <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1</characteristic>
@@ -3947,26 +3946,26 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="445f-37fe-5208-2146" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+        <infoLink id="445f-37fe-5208-2146" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule" />
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="6307-ed53-0ac4-0212" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="571f-5691-ee84-aa5e" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="571f-5691-ee84-aa5e" type="max" />
       </constraints>
       <entryLinks>
-        <entryLink id="4a6c-474f-33fc-0f86" name="Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
-        <entryLink id="49df-5b2a-eb7e-6aa1" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="4a6c-474f-33fc-0f86" name="Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
+        <entryLink id="49df-5b2a-eb7e-6aa1" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
         <entryLink id="0104-7ed8-b76f-2dec" name="Destroyer Assault Squad" hidden="true" collective="false" import="true" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="98d4-555a-6911-7c1a" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="98d4-555a-6911-7c1a" type="instanceOf" />
               </conditions>
             </modifier>
           </modifiers>
@@ -3975,7 +3974,7 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -3986,98 +3985,98 @@ A unit selected in this manner is considered a &apos;Retinue Squad? The Retinue 
       <modifiers>
         <modifier type="set" field="8545-d13b-480b-69a2" value="1.0">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d4e-a7a7-ed1e-714b" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8545-d13b-480b-69a2" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d4e-a7a7-ed1e-714b" type="max" />
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8545-d13b-480b-69a2" type="min" />
       </constraints>
       <selectionEntryGroups>
         <selectionEntryGroup id="d194-9ef1-942f-417d" name=" IX: Blood Angels" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d30f-595a-e373-1ad8" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0aca-6319-d08e-3e5d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d30f-595a-e373-1ad8" type="max" />
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0aca-6319-d08e-3e5d" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="2b52-0f19-a4f2-c9c4" name="Encarmine Paladin" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c26-3d7a-b8a0-5ebb" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="faf5-6fdf-259d-90ad" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c26-3d7a-b8a0-5ebb" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="faf5-6fdf-259d-90ad" type="max" />
               </constraints>
               <profiles>
                 <profile id="ae21-d08a-2c26-d122" name="Encarmine Paladin" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait gains the Fear (1) special rule when the enemy army has the Traitor Allegiance.
-Whenever a Warlord with this Trait is on the winning side of a combat in which the Warlord was Engaged and that includes at least one enemy model with the Traitor Allegiance, he increases the value of his Fear special rule by one point at the end of the Assault phase in which the combat is won, to a maximum of Fear (4). For example, if a Warlord with this Trait and the Fear (1) special rule is locked in combat with an enemy unit with the Traitor Allegiance and wins the resulting combat, his Fear special rule would become Fear (2) at the end of that Assault phase. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&apos;s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+Whenever a Warlord with this Trait is on the winning side of a combat in which the Warlord was Engaged and that includes at least one enemy model with the Traitor Allegiance, he increases the value of his Fear special rule by one point at the end of the Assault phase in which the combat is won, to a maximum of Fear (4). For example, if a Warlord with this Trait and the Fear (1) special rule is locked in combat with an enemy unit with the Traitor Allegiance and wins the resulting combat, his Fear special rule would become Fear (2) at the end of that Assault phase. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player's Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="0af6-769b-d019-b52a" name="Paragon of Unity" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b356-b802-be5f-4ccb" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0159-3708-0bbf-89f9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b356-b802-be5f-4ccb" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0159-3708-0bbf-89f9" type="max" />
               </constraints>
               <profiles>
                 <profile id="ff53-3982-a99e-258f" name="Paragon of Unity" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any friendly unit made up entirely of models with the Legiones Astartes (Blood Angels) special rule that can draw a line of sight to a Warlord with this Trait, to any model in a unit this Warlord has joined, or to any model that is Engaged in a combat which this Warlord is part of, gains a bonus of +1 to their Leadership Characteristic, to a maximum of 10. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&apos;s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any friendly unit made up entirely of models with the Legiones Astartes (Blood Angels) special rule that can draw a line of sight to a Warlord with this Trait, to any model in a unit this Warlord has joined, or to any model that is Engaged in a combat which this Warlord is part of, gains a bonus of +1 to their Leadership Characteristic, to a maximum of 10. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player's Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="bc05-7771-4f30-fc54" name="Thrall of the Red Thirst" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="614b-de90-6e72-4e2c" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="da7f-bb46-8357-48d3" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="614b-de90-6e72-4e2c" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="da7f-bb46-8357-48d3" type="max" />
               </constraints>
               <profiles>
                 <profile id="f800-b2ad-3452-43a4" name="Thrall of the Red Thirst" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If, at the start of the controlling player&apos;s Charge sub-phase, there are any enemy units with at least one model within 12&quot; of a Warlord with this Trait, or any model in a unit this Warlord has joined, and the Warlord and any unit he has joined are eligible to make a Charge, then the controlling player must declare a Charge for the Warlord and any unit he has joined targeting that enemy unit. If there is more than one potential target then the Warlord&apos;s controlling player may select any of those units to be the target of the Charge. Whenever this Warlord and any unit he has joined make a successful Charge that is not Disordered, the Warlord and all other models in a unit the Warlord has joined gain +2 attacks, instead of the standard +1 attack granted for Charging. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&apos;s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If, at the start of the controlling player's Charge sub-phase, there are any enemy units with at least one model within 12" of a Warlord with this Trait, or any model in a unit this Warlord has joined, and the Warlord and any unit he has joined are eligible to make a Charge, then the controlling player must declare a Charge for the Warlord and any unit he has joined targeting that enemy unit. If there is more than one potential target then the Warlord's controlling player may select any of those units to be the target of the Charge. Whenever this Warlord and any unit he has joined make a successful Charge that is not Disordered, the Warlord and all other models in a unit the Warlord has joined gain +2 attacks, instead of the standard +1 attack granted for Charging. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player's Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="18d4-468d-91f5-b256" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+        <entryLink id="18d4-468d-91f5-b256" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="9a4b-b42e-d077-a3c7" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="9a4b-b42e-d077-a3c7" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Blood Angels.cat
+++ b/2022 - LA - Blood Angels.cat
@@ -309,7 +309,7 @@
         <categoryLink id="db9a-a5ba-128c-80e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="8b1d-fc94-eb67-f3b8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
     <entryLink id="ed74-6166-b1e5-fe90" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -698,13 +698,13 @@
         <categoryLink id="213b-34bb-5d9c-3f0b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
         <categoryLink id="94bb-2bca-a880-fe19" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
     <entryLink id="da99-9ed2-998e-ead8" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8342-2199-99f5-326d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="db5f-01c7-c186-babf" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
     <entryLink id="c44d-0cb2-4fde-7028" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
@@ -852,7 +852,7 @@
         <categoryLink id="0e58-2594-6fd2-9fae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="2ad4-a091-c130-7799" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
     <entryLink id="d5da-558a-a924-38d2" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -876,7 +876,7 @@
         <categoryLink id="19e9-be29-4af6-9495" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="6b25-6183-ea15-2f23" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
     <entryLink id="9939-d2af-5a3b-9d63" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -968,13 +968,13 @@
         <categoryLink id="0e4e-609e-26d6-0347" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="38b7-d949-5df1-2c22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
     <entryLink id="0853-5abf-3a9a-70d8" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="fc24-2561-23c0-9059" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="0cdb-7ad9-7fdb-bf27" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
     <entryLink id="7a5f-a4fb-fd86-4bea" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -1018,7 +1018,7 @@
         <categoryLink id="5d81-ffbb-c2b6-07b0" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
         <categoryLink id="beec-caf7-9d76-2dfb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
     <entryLink id="9cef-7f1e-ff2d-27a9" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">

--- a/2022 - LA - Blood Angels.cat
+++ b/2022 - LA - Blood Angels.cat
@@ -3980,7 +3980,7 @@ A unit selected in this manner is considered a 'Retinue Squad? The Retinue Squad
           </modifiers>
         </entryLink>
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_be38-a066-4f8e-ae54</comment></selectionEntryGroup>
     <selectionEntryGroup id="4f09-6be3-276d-2756" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="8545-d13b-480b-69a2" value="1.0">
@@ -4074,7 +4074,7 @@ Whenever a Warlord with this Trait is on the winning side of a combat in which t
       <entryLinks>
         <entryLink id="18d4-468d-91f5-b256" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_7dee-602c-4b47-be09</comment></selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
     <catalogueLink id="9a4b-b42e-d077-a3c7" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />

--- a/2022 - LA - Blood Angels.cat
+++ b/2022 - LA - Blood Angels.cat
@@ -1,17 +1,14 @@
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="cd4d-8765-5387-8409" name="LA -  IX: Blood Angels" revision="26" battleScribeVersion="2.03" authorName="Jon K &quot;Alphalas&quot;" authorContact="Twitter: Alphalas_ Discord: Alphalas#8789" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="29">
-  <entryLinks>
-    <entryLink id="1900-3f09-f47b-bed2" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7e95-886f-ed9d-3000" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="4180-caf6-d0dc-7347" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="6422-8dc7-7934-be6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+  <entryLinks><entryLink id="1900-3f09-f47b-bed2" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry"><categoryLinks>
+        <categoryLink id="573a-6577-4196-be29" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_b084-df23-4f99-812f</comment></categoryLink>
+        <categoryLink id="dd35-efeb-4f2e-ab57" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_84fc-9304-4e9e-ab78</comment></categoryLink>
+        <categoryLink id="9de2-c12e-4aa3-ad12" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d06a-7939-4691-9aed</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="0493-4e5d-281f-d4f2" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup" />
-        <entryLink id="e540-6ccd-5bb5-ff32" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup" />
+        <entryLink id="8cb9-eb73-4d24-907a" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup"><comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+        <entryLink id="7f60-ccd1-4bab-bd79" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup"><comment>    template_id_741d-8c09-4211-ada6    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
-    <entryLink id="0bb3-3a91-6450-6bee" name="Chapter Master Raldoron" hidden="false" collective="false" import="false" targetId="59f7-9abf-c171-e9e4" type="selectionEntry">
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink><entryLink id="0bb3-3a91-6450-6bee" name="Chapter Master Raldoron" hidden="false" collective="false" import="false" targetId="59f7-9abf-c171-e9e4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -143,1554 +140,1847 @@
         <categoryLink id="e29c-aaca-175b-3061" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="b4bc-0590-372e-0c49" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8449-aca4-0bb8-d8c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6dc5-333f-99b9-b115" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <entryLink id="b4bc-0590-372e-0c49" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="a715-36c7-49a3-a257" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6d4-581f-4746-bec3</comment></categoryLink>
+        <categoryLink id="7e6f-5790-4d44-9d5b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_2489-ee2a-45dd-b384</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
-    <entryLink id="b666-5c25-7b46-de1c" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink><entryLink id="b666-5c25-7b46-de1c" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b02f-e65f-4a88-a175</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_b87b-bf35-4238-b7c6</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1aff-27af-435e-8102</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_fdf9-4906-4180-a39d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a585-203e-02db-6fb1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7635-e344-1ec3-cd45" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="0ab2-f388-466a-9026" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8378-ede4-476d-b657</comment></categoryLink>
+        <categoryLink id="32c7-f22f-4460-b94c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_d64f-ad19-426c-adf7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
-    <entryLink id="1b28-4298-99cc-0ca7" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink><entryLink id="1b28-4298-99cc-0ca7" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_7fd1-8ce8-4d10-82e7</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_eaae-8c43-4d30-898c</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_f67d-8cf3-424f-b491</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_b949-6414-4f3d-b268</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="07a5-c26e-7b3d-a0fa" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="8519-53ae-67ef-b3b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e1d8-13c3-c6af-c74b" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="beae-7f9e-4bf4-9d94" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_ac26-e639-4d53-9b8b</comment></categoryLink>
+        <categoryLink id="afe8-cb28-4bd8-a296" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_49af-0d08-4c7e-8ce6</comment></categoryLink>
+        <categoryLink id="fced-ad93-4c6a-be55" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_b606-de16-4659-95cd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
-    <entryLink id="67a5-c32f-598e-5dd6" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink><entryLink id="67a5-c32f-598e-5dd6" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_27a3-1e4c-4b76-a594</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_d59a-dcd0-44fd-b866</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_0c8b-2b92-49ed-98c7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_bafe-f799-41d9-ac85</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_6369-288c-4fec-a640</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_fe53-8858-41dc-8ec4</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="89aa-483e-002e-265b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="ee0b-752a-635b-71d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c8eb-043b-8bb7-4dad" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="ec79-bc73-4272-b272" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_3a22-caae-4eea-9bc5</comment></categoryLink>
+        <categoryLink id="5a6c-a4d1-4a5a-abfe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f759-f33e-4698-9f8a</comment></categoryLink>
+        <categoryLink id="6fe5-7d49-474a-a0ff" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_c624-3ae0-46c0-9b06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
-    <entryLink id="309c-c82e-85cc-d283" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8db8-a2c9-2b3c-443a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="9601-f212-af46-31ee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9add-fada-2814-6744" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink><entryLink id="309c-c82e-85cc-d283" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry"><categoryLinks>
+        <categoryLink id="5471-19f0-44af-a912" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_2599-24e3-44e5-9568</comment></categoryLink>
+        <categoryLink id="9ebf-d3ec-45d3-a779" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_285f-6e56-473b-b2fe</comment></categoryLink>
+        <categoryLink id="7418-60ac-429a-bec7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_685e-022f-4e2f-a568</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="1ef3-df62-935c-fb6c" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup" />
-        <entryLink id="292d-3b86-d572-bd35" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup">
+        <entryLink id="e252-4b87-4ed8-ba7a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup"><comment>    template_id_2a38-6544-4267-b584    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="c952-1129-4e50-afd0" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_8287-16ff-46ba-9838</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_81c1-fca9-44dc-ba4c</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_6e59-4592-47ef-b76d    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
-    <entryLink id="bf99-e84a-7181-c531" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink><entryLink id="bf99-e84a-7181-c531" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ad5d-3c79-4239-9116</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_60b1-049b-4a5f-85c2</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cef6-cdf5-96c8-82dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2710-b433-b717-4386" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="3d3a-4e0a-5409-dcca" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="016b-757d-49d9-8e7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bd6a-0cda-4e0f-80ae</comment></categoryLink>
+        <categoryLink id="e674-c8cf-4709-8d63" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_ae75-7cca-4701-9d56</comment></categoryLink>
+        <categoryLink id="3d88-ff13-4c03-a6b9" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_e517-62d4-48f7-8174</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="b2b5-b293-702b-6f65" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup" />
-        <entryLink id="5a97-5702-acda-aa60" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup">
+        <entryLink id="408e-2aa9-4726-94cc" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup"><comment>    template_id_fafb-6414-474a-8a09    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="9e30-0791-4b92-9613" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_1e43-c980-4508-8ec2</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_4140-36a7-4203-b5e9</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_a6a6-9bc7-4d4e-86a7    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
-    <entryLink id="2b6a-48fb-166c-8ae2" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="fa76-90f6-d696-02c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3058-ad6f-5d38-7791" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="a59b-14c3-16f4-4692" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink><entryLink id="2b6a-48fb-166c-8ae2" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d4db-819a-4d48-9df4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fc9d-03d1-4bbd-a1c4</comment></categoryLink>
+        <categoryLink id="982c-2909-40e4-b9fe" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_f51c-73d7-4f29-be1c</comment></categoryLink>
+        <categoryLink id="2bc1-4d39-44a1-99f5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_257d-78c0-4bab-ba65</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="efc6-f00c-7dcb-f631" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup" />
-        <entryLink id="fe41-5d4d-0a4c-e28b" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup">
+        <entryLink id="5163-27a9-4035-ba41" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup"><comment>    template_id_ac26-33db-40a7-bdba    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="aae5-714e-43ae-93c0" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_189b-db75-4db6-9fe9</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_cbdb-2500-4e13-876a</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_dc8e-2801-46d6-84f8    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
-    <entryLink id="f21c-08b1-43f7-be5d" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink><entryLink id="f21c-08b1-43f7-be5d" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b43b-547f-472e-9076</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_8ff9-0498-4540-8552</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fbfe-931a-489b-a589</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f4c3-5aa6-4caa-abf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_17f8-f055-4c9c-b757</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5c7b-1610-e3c2-e860" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="3294-835c-506e-922f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8e16-0988-4c10-a8c1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f1c8-27fd-4f98-8527</comment></categoryLink>
+        <categoryLink id="3e05-7678-4937-924f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2b20-1a8b-4753-b657</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
-    <entryLink id="7c90-b2c0-b602-0b61" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink><entryLink id="7c90-b2c0-b602-0b61" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_23fa-06dd-49f9-a7db</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_5b26-059e-40b3-9d93</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f7bf-3a1c-4103-aed8</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="db9a-a5ba-128c-80e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8b1d-fc94-eb67-f3b8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="895c-3d6c-44f8-b5a5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dd44-e0a8-42a8-bdcc</comment></categoryLink>
+        <categoryLink id="86ea-d295-4247-ac82" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_c5b0-f9ae-468d-924a</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
-    <entryLink id="ed74-6166-b1e5-fe90" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink><entryLink id="ed74-6166-b1e5-fe90" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8396-e51c-4e2b-bada</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_13bb-9fb5-4580-92cf</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_bfb8-8125-4548-92f5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25e3-b8f5-4448-a7c8</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5f44-f33b-db1e-5ebd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="b559-18f7-4a13-234a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0b2c-a157-44de-ada8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_f926-27fd-4a92-97a1</comment></categoryLink>
+        <categoryLink id="4bd1-50e0-4e1d-9875" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_82e3-36e1-4e85-8fcb</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
-    <entryLink id="44d8-46b3-d268-8a22" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink><entryLink id="44d8-46b3-d268-8a22" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_658f-b1ad-4347-a998</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_12bc-3db2-4d28-abce</comment>
+            </condition>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_9d83-7691-41d6-8dad</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_add7-ba48-46d4-8a02</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_1fb0-2421-40a4-9e49</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="54aa-9c4a-61d6-bc89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a445-e6c8-15ad-0f5d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="540d-27c0-4b26-a6ea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7004-b00d-481f-b740</comment></categoryLink>
+        <categoryLink id="0016-ab76-499d-9aed" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4f88-2fc3-491c-bfb7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
-    <entryLink id="9c32-38e5-c57f-baf8" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink><entryLink id="9c32-38e5-c57f-baf8" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_8ed4-376d-4030-9439</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_8a11-c2a0-4335-99ef</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_fa8e-1af7-4d41-ac8c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_94bd-c771-4a85-8581</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2b23-1408-f09a-589e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="6ac8-9063-83f9-c8cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0f23-acae-aacd-f289" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="e0bd-98d3-4439-8016" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_361e-fb90-4b0e-ac3d</comment></categoryLink>
+        <categoryLink id="195b-bd76-484f-9858" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d4ef-1074-45a9-959e</comment></categoryLink>
+        <categoryLink id="7cb2-3bc3-45ab-9771" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_febb-f536-4d25-a8ab</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
-    <entryLink id="d2da-55cb-7c1c-419c" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ddaf-db43-500c-e7dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2597-efab-b09a-aff4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink><entryLink id="d2da-55cb-7c1c-419c" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="577d-dbb8-48fa-81b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_473b-e812-4158-9416</comment></categoryLink>
+        <categoryLink id="83c8-94b3-40bb-8fba" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_00a2-63ff-4698-a35b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
-    <entryLink id="04c4-57ee-9330-b297" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink><entryLink id="04c4-57ee-9330-b297" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7cf3-8a72-4f82-8cdc</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_228c-5681-4ce8-b726</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_01bb-8abd-4253-9a4d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="405e-623e-e5f6-2e54" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="8ec3-ff6b-9c00-3dbf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c982-77af-4a45-a8e5" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2a08-4432-42ad-bfdb</comment></categoryLink>
+        <categoryLink id="f2fe-52c0-434b-9a94" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_422e-0808-4897-8630</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
-    <entryLink id="58cf-9f01-9289-7af6" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink><entryLink id="58cf-9f01-9289-7af6" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1af8-4459-4717-8e3b</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_06b4-92b9-438c-b1a5</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6c8d-8b28-417b-9a7c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_715d-8186-4aa6-b40c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_390e-358c-4f8e-ade8</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c418-712f-cb83-6081" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="6a07-32b8-f6b3-4081" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="12a7-517f-47f9-937b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f4c0-4396-4f39-a34f</comment></categoryLink>
+        <categoryLink id="b4d1-ed2b-4e61-a2e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1301-8415-490e-8f06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
-    <entryLink id="1aa1-77c1-ba59-e7a5" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink><entryLink id="1aa1-77c1-ba59-e7a5" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d0c9-9a26-4324-b030</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_4e9e-a61d-42f2-bacb</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ed9e-b634-4bec-9eb0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4614-ad0f-4fba-adaf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_8d08-24f6-41be-8931</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e57f-8fdf-b790-5b9b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="8e2d-c855-646b-2848" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6cb1-8e62-4434-90b8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_caf6-5548-4b89-8102</comment></categoryLink>
+        <categoryLink id="409c-d4de-4d5f-8b7b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_63a3-be61-428d-ab29</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
-    <entryLink id="738b-6376-1b98-5956" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink><entryLink id="738b-6376-1b98-5956" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f318-4b03-4767-8c7f</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_b8ef-7245-4df8-a8c4</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_6bce-ec44-48cb-873a</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f951-f918-a1ac-dc74" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="06b9-5ea1-1f78-1049" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="2004-6828-4236-9663" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0678-4fdd-48e6-8f61</comment></categoryLink>
+        <categoryLink id="3e1d-38c4-4ee6-8a4b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0d82-10a9-4de2-8ad7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
-    <entryLink id="3b9d-980f-426c-7452" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink><entryLink id="3b9d-980f-426c-7452" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ada1-1e18-4cbc-9598</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_b1d1-ac44-47dd-9159</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5d64-f00c-4464-891b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25f0-f825-4a83-8f0d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_64b1-9e36-44da-b36a</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b108-7524-fe41-5c36" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="77b3-59ff-faed-23e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="feba-7303-4c83-a249" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_d53e-113f-4a40-a3d5</comment></categoryLink>
+        <categoryLink id="b10d-3577-4130-a02d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1939-76b5-4279-9f8c</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
-    <entryLink id="e969-bad1-eb73-d543" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink><entryLink id="e969-bad1-eb73-d543" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d765-3bb2-4b48-bd12</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_0ca1-cfb4-4a56-ab3b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="45b5-75ee-4078-8f25" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="3128-073c-12bd-156e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1e20-6fe1-49d5-bd0b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e6f7-a6ca-4825-bfc5</comment></categoryLink>
+        <categoryLink id="d9b6-8a33-48c2-9179" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dbec-e027-4ec1-8514</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
-    <entryLink id="a4fb-1879-33ac-972d" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink><entryLink id="a4fb-1879-33ac-972d" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d8ee-81ed-45f9-8b79</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_8f4e-e8cb-4ac9-a415</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="287b-5ff0-2e74-d3cc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f756-428a-3cd9-6555" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="2621-c9a2-42b6-a4d0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_cefb-cfd7-4dc8-99c4</comment></categoryLink>
+        <categoryLink id="bde1-773c-4b9c-a4b0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a9fd-9d16-4a5e-855c</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
-    <entryLink id="5791-6122-9510-c159" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink><entryLink id="5791-6122-9510-c159" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e76b-46ca-4ab8-a93d</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_8035-75b8-43bb-97c9</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_71a4-31e7-4927-a0ab</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6f5c-11c2-2808-4913" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="ba8c-d805-6945-a17c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f185-1a6a-465e-b04f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_a56d-347b-4b09-a918</comment></categoryLink>
+        <categoryLink id="6db0-aadb-4beb-859d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_96e5-4531-4213-903e</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
-    <entryLink id="0ca4-8dde-9f99-32f5" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink><entryLink id="0ca4-8dde-9f99-32f5" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1fb5-2375-4c22-b41e</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_7d7c-255d-49b6-96b9</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5321-254b-4890-9bf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ddf8-b8b7-4afb-b6dd</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="60cc-079b-52e3-2847" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="71b8-4713-eeb4-fc43" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="9d47-6d25-4c98-9b51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9441-d79b-4720-9667</comment></categoryLink>
+        <categoryLink id="8e49-7f34-4cdd-9859" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7d7e-32d3-4692-b401</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
-    <entryLink id="a1b9-836c-96ef-ae59" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink><entryLink id="a1b9-836c-96ef-ae59" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ae67-ef52-4cac-958c</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_fc61-7306-4d99-acde</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1be0-67e7-45a1-bdbb</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_42a8-7fda-4e05-af0d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6456-603c-59b4-0798" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="77f0-2905-7c47-0c9e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="85f6-966e-424b-9fc0" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_565a-1592-491f-8b9b</comment></categoryLink>
+        <categoryLink id="41f4-aba3-489e-9f03" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_81d5-c14a-42ab-bdde</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
-    <entryLink id="7c67-08c8-2695-4cb0" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink><entryLink id="7c67-08c8-2695-4cb0" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1ae7-c41b-4818-be71</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_08a5-b1bb-4ba1-ba42</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d677-b5ad-4838-8746</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_537f-bc1f-4aaa-b0dc</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="14dd-4944-6d81-5430" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="db79-36a0-e6a4-27f4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="378b-5c5c-42a2-89ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bc67-ce1f-4004-aeb7</comment></categoryLink>
+        <categoryLink id="9b63-a6b7-4900-8e4f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_9a45-9699-4475-aeef</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
-    <entryLink id="282b-62cf-f3fa-8117" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink><entryLink id="282b-62cf-f3fa-8117" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_c28f-4109-44c4-ab64</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_fdc1-a894-48bc-9e7c</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_4936-a68c-4524-9088</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb37-ac0c-49ae-9d6f</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="83a2-846e-b20f-1481" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a794-e73d-7b34-b8bc" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="71ed-f24a-41d3-9153" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3afe-cfc0-4da6-a985</comment></categoryLink>
+        <categoryLink id="c8c7-2a4d-4f90-90d7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_04a8-6aae-45ae-bd4c</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
-    <entryLink id="0a22-74ff-cd0e-cdad" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink><entryLink id="0a22-74ff-cd0e-cdad" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_773a-1ea4-41a0-b766</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_9d4d-6fb8-4131-a5a3</comment>
+            </condition>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e3bc-02f8-4ece-a5ea</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_c371-76d9-4a4d-bc00</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b4c6-d4ba-4b2e-9b99</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1d02-64cb-c6ea-1f33" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ef1b-00b0-9db2-334d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="7e29-4a9e-44b5-9bd1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6ea9-a7e5-437d-9e35</comment></categoryLink>
+        <categoryLink id="46b5-c7d2-4b01-b0e1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_3cec-f053-42ab-a6eb</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
-    <entryLink id="a200-16ac-2995-d0bb" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink><entryLink id="a200-16ac-2995-d0bb" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1e60-42ba-4c8b-9077</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_9860-f593-425e-b89b</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_c842-10e8-4509-8eda</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ea52-ff41-40f6-8cf3</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_51e6-c5e1-4003-96bc</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d93a-3e12-f0ae-b242" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="77f6-c777-0825-3e90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7738-3ea9-4a1e-bc04" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4d7c-201f-4c99-b89a</comment></categoryLink>
+        <categoryLink id="6c80-9fbe-4c30-957f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_10f9-4718-4e07-bb32</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
-    <entryLink id="b8e9-4e46-d433-1722" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5133-2b45-4a98-e100" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="256c-5fe8-0b96-84dd" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink><entryLink id="b8e9-4e46-d433-1722" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry"><categoryLinks>
+        <categoryLink id="733f-4aaa-4a0a-a74b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6140-2404-46f9-bd42</comment></categoryLink>
+        <categoryLink id="c98d-d84c-48de-92f5" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_1c86-fad8-46ec-a0b0</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
-    <entryLink id="5e59-19a7-6a71-7626" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink><entryLink id="5e59-19a7-6a71-7626" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bf2e-bde0-aa8c-3a07" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="92c3-01e3-317d-bd5a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cd2a-7f81-43c8-adc6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_dc16-16d0-4890-a8e8</comment></categoryLink>
+        <categoryLink id="0567-9e1d-4e40-b478" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4b1e-3f1f-49cb-8343</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
-    <entryLink id="fac3-b4e1-1b98-399c" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="aabc-1276-dbbd-34f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8e36-cd2e-e029-5f9e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink><entryLink id="fac3-b4e1-1b98-399c" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry"><categoryLinks>
+        <categoryLink id="dcfb-f685-4079-8fdd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ff9f-01cb-41b9-800e</comment></categoryLink>
+        <categoryLink id="2ef2-ed4d-493b-8e5c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_1315-6051-4a46-b070</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
-    <entryLink id="e078-1f38-d383-0d25" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink><entryLink id="e078-1f38-d383-0d25" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_54a4-6ec8-4c61-9c3e</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_f7fd-2d16-4603-a065</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="27d6-2c04-ce68-3af8" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="7a47-347f-71fc-d7ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a711-711b-6a1a-c84d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="e5b5-8161-4589-a208" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_c0ac-4b8c-421c-a21b</comment></categoryLink>
+        <categoryLink id="6e97-e2a9-415e-9f16" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8db9-079e-4482-b200</comment></categoryLink>
+        <categoryLink id="d547-ce47-458d-bab8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_413c-9273-4308-b546</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="cb0f-ae30-3912-424e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup" />
-        <entryLink id="513e-6ac2-c328-a031" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup" />
+        <entryLink id="c3d8-066e-4e72-90ef" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup"><comment>    template_id_bbc4-33fc-4664-a18e    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="0021-3bae-47c4-8129" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup"><comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
-    <entryLink id="e6c0-74e8-adb2-d5f5" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a87c-745e-2032-cd12" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="efa1-94e2-0f4d-f6d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7f63-f80d-b80b-5c91" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink><entryLink id="e6c0-74e8-adb2-d5f5" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry"><categoryLinks>
+        <categoryLink id="f19e-7f1d-4851-b150" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_4c8d-96f6-48f9-9590</comment></categoryLink>
+        <categoryLink id="c26a-513b-4711-99a1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_049c-0fa5-4575-8fa8</comment></categoryLink>
+        <categoryLink id="6c0d-3dd0-40e7-b8e2" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_7358-52d7-4aae-8e07</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="f8fe-130f-08ae-8c53" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup" />
-        <entryLink id="1ffa-531d-90fb-e892" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup" />
+        <entryLink id="5750-f347-4da3-b4e2" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4f09-6be3-276d-2756" type="selectionEntryGroup"><comment>    template_id_4784-b370-444b-93ae    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="e2df-4a46-44bb-8d09" name="Retinue" hidden="false" collective="false" import="true" targetId="6307-ed53-0ac4-0212" type="selectionEntryGroup"><comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
-    <entryLink id="2952-bb84-4426-c9a7" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink><entryLink id="2952-bb84-4426-c9a7" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e87d-dc05-0063-e2b7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="213b-34bb-5d9c-3f0b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="94bb-2bca-a880-fe19" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="15b8-a7f7-4fde-b1c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_32cb-7077-4d54-9f38</comment></categoryLink>
+        <categoryLink id="c990-a89f-4c4e-8ae3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_2c35-def7-4c44-9b02</comment></categoryLink>
+        <categoryLink id="ab74-1b9b-4775-82cc" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_0c9a-d272-491c-a4a0</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
-    <entryLink id="da99-9ed2-998e-ead8" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8342-2199-99f5-326d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="db5f-01c7-c186-babf" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink><entryLink id="da99-9ed2-998e-ead8" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry"><categoryLinks>
+        <categoryLink id="e552-6fd2-42b7-bdc8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_75a7-dc06-445b-b2dc</comment></categoryLink>
+        <categoryLink id="724a-bc27-4293-8b9a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_e21a-c03b-4885-ac46</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
-    <entryLink id="c44d-0cb2-4fde-7028" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink><entryLink id="c44d-0cb2-4fde-7028" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9a08-5fe6-4010-bbc3</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_72cf-cfce-4e02-b379</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2780-754d-31c6-c4b6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="1cae-02ae-aac6-508f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="911e-0d22-4de1-b2de" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_f55b-7555-444b-beee</comment></categoryLink>
+        <categoryLink id="e863-0913-45e8-8bab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3386-c9ad-4d74-9474</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
-    <entryLink id="cef7-8b15-720f-e55d" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink><entryLink id="cef7-8b15-720f-e55d" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry"><modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_a0f6-9606-4b75-a2f8</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_94b3-1331-474b-885b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="02b9-3c0e-9a2c-3b57" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="9f20-0be9-7e94-5c83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="309e-0eea-4c29-9e32" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_79fa-3370-4ae0-9e12</comment></categoryLink>
+        <categoryLink id="c7d0-3275-4bbc-bd58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bb53-4e65-4fb6-9dd7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
-    <entryLink id="6300-af54-bb1e-dac6" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink><entryLink id="6300-af54-bb1e-dac6" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f8cc-833a-4ac1-bf89</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+              <comment>    node_id_5988-c012-4dad-9a66</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="55db-773e-431e-724c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="c8e6-bbfa-5f7e-a176" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="73dc-01fb-4e6e-a5ab" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_8d82-3279-4481-84bb</comment></categoryLink>
+        <categoryLink id="e76e-74a9-4907-b49b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e25c-925e-4b96-8bb3</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
-    <entryLink id="21f8-a2d1-382f-c45d" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink><entryLink id="21f8-a2d1-382f-c45d" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6b73-b21c-4e2b-9d14</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_a7fe-cc62-4a6f-a781</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5be1-1937-4964-a455</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_da1d-b2bc-4117-82a4</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d0bd-8f37-9460-923c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e6a0-e8e3-6231-48e2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="7f27-b4d1-4b94-bce2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7010-be56-4709-b058</comment></categoryLink>
+        <categoryLink id="29e1-e7e9-4de6-9a11" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7379-a740-47ba-a054</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
-    <entryLink id="d885-c84a-004e-1434" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink><entryLink id="d885-c84a-004e-1434" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry"><modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_dd34-83cf-47d7-b557</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_be88-afef-49b3-bd1e</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1084-d3e7-0e35-2f8e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="91f2-262d-0181-1b37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c18d-92e0-461f-88bc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_944f-7420-4982-8ea9</comment></categoryLink>
+        <categoryLink id="5d9a-ffef-4cf4-9596" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ea80-0efe-457d-a450</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
-    <entryLink id="0cf1-7eb3-ead2-eb08" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2d49-94f9-ab52-f33b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9c23-f086-872d-d751" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink><entryLink id="0cf1-7eb3-ead2-eb08" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><categoryLinks>
+        <categoryLink id="98ca-4c49-4f7e-b8a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9a36-f261-43cc-9bd1</comment></categoryLink>
+        <categoryLink id="8e17-3d9f-4789-bb32" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a648-8396-442a-af59</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
-    <entryLink id="4d42-8c04-0781-e403" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink><entryLink id="4d42-8c04-0781-e403" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_cb81-0303-4b88-ae53</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_9648-31e3-43aa-8cf3</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_0507-da81-4023-bfcf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0e84-54ff-488d-b066</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c110-f11e-6436-5eb0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="fd90-0535-06b7-648d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="416f-50a3-4c87-8515" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6ff-0977-4c92-bb28</comment></categoryLink>
+        <categoryLink id="c2e7-827b-46d4-885d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f555-7d39-458f-84c9</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
-    <entryLink id="4205-9089-861e-1eb7" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink><entryLink id="4205-9089-861e-1eb7" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8203-5b00-497b-b939</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_40ee-3e71-4978-b1e4</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f6a8-f660-46dc-b3c5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_d988-3af6-48bf-b0a8</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bbe9-ebf7-c4e6-3bb4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ffef-47f1-e988-cbc3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="bfe9-ea0a-42cf-ad8e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_39e5-eda5-45d1-a643</comment></categoryLink>
+        <categoryLink id="b012-f513-4135-9bf5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_6416-21bb-4df4-9de8</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
-    <entryLink id="f2a1-fb03-93cf-3873" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink><entryLink id="f2a1-fb03-93cf-3873" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b03e-5d91-4be3-8adc</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_0443-29c0-46e9-ad1d</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f2c9-7356-4c27-a22f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0e9-4a9e-4b2b-a9d5</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b791-5740-ab3b-5718" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3f05-e13c-296a-725b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="9d77-2f64-48b0-b4ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5528-2dac-4be5-900c</comment></categoryLink>
+        <categoryLink id="94da-63b9-4579-bdcc" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_dc8f-d888-4585-991d</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
-    <entryLink id="b6f0-ff45-3001-2060" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink><entryLink id="b6f0-ff45-3001-2060" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1d3c-8e17-489f-9002</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_5725-8bee-4bcc-878d</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_be47-0d6f-49f2-9f4b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_863c-f3a4-4802-b80c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0e58-2594-6fd2-9fae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2ad4-a091-c130-7799" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="958e-ec83-48d4-a38b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_899e-b052-4d5b-8c18</comment></categoryLink>
+        <categoryLink id="4bc9-02a4-411b-8a79" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f5e9-cff6-41d2-a016</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
-    <entryLink id="d5da-558a-a924-38d2" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink><entryLink id="d5da-558a-a924-38d2" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_72da-1513-4e02-b595</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_7a48-a3b0-4a26-849b</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e232-25f3-4cb7-8ab2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_9aa4-5660-4697-8ab2</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f229-436f-0c32-7809" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="cb7b-6b73-907f-0b8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="c54b-a4f8-446f-b28a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_09cd-2176-40af-bba6</comment></categoryLink>
+        <categoryLink id="c2d0-1866-4d40-bdfb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_05e6-7c63-4a35-9ba0</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
-    <entryLink id="d5ed-b1e8-1ba0-b21d" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="19e9-be29-4af6-9495" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6b25-6183-ea15-2f23" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink><entryLink id="d5ed-b1e8-1ba0-b21d" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry"><categoryLinks>
+        <categoryLink id="60cf-af72-4e32-a9cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0dfa-4004-4751-8022</comment></categoryLink>
+        <categoryLink id="3be0-7480-4511-acae" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a669-0f5d-4fd3-811b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
-    <entryLink id="9939-d2af-5a3b-9d63" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink><entryLink id="9939-d2af-5a3b-9d63" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_09b5-4e3b-4c84-a574</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_32e5-ebba-41fb-9ff2</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_838e-0ccf-4d3a-aabd</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_dfef-0ec2-49fb-a534</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ccf0-4bc5-277b-e5d8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="6c34-cc3f-dd1b-1da1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="96fa-05bb-4a89-ba4b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4f60-472b-45a9-ab9e</comment></categoryLink>
+        <categoryLink id="fb16-4044-4619-9d69" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e2e3-af36-45a6-a955</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
-    <entryLink id="a430-f532-d7d8-276a" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink><entryLink id="a430-f532-d7d8-276a" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_936f-1ef7-472e-840e</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+              <comment>    node_id_d73d-d52e-4c75-8ac0</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="db89-bd0e-7d13-aded" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="09f5-875b-166f-4b18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0d92-f924-407f-ad16" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_7a55-ecb4-4e5d-b955</comment></categoryLink>
+        <categoryLink id="3a45-3df8-4190-84f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f28c-710e-4ff8-9810</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
-    <entryLink id="0e11-8e01-2c03-9e16" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink><entryLink id="0e11-8e01-2c03-9e16" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_a743-0cc2-45ae-a7eb</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_2721-e88d-41f7-bedc</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_e10f-1390-4b33-8fcc</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cd4e-563c-c3d0-976d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="57f6-7d87-301a-d4ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="079d-ad7a-4ae5-8d3d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2008-f1c4-4285-a14f</comment></categoryLink>
+        <categoryLink id="d036-0a5b-483e-9b91" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e88b-a95a-4647-af3b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
-    <entryLink id="beb7-833b-89c7-4aab" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink><entryLink id="beb7-833b-89c7-4aab" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_25d8-330b-4574-b515</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_7836-6878-47a8-8827</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_5ea9-46dd-4a11-9410</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_ab5d-961b-4924-a705</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f7b3-d708-bd09-4ce6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8ff6-e37f-3ec5-6f11" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="36a1-380e-6497-73e7" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="6b9b-9550-4676-805a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9189-836c-475d-a52e</comment></categoryLink>
+        <categoryLink id="9aa1-4755-4717-b052" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_e1fa-b7d8-47b0-a88a</comment></categoryLink>
+        <categoryLink id="f2b2-2d4f-4c2b-b497" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_a137-e3c0-4d63-a48c</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
-    <entryLink id="78ff-d9b4-f2dc-a0b7" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="559b-1613-01a9-5929" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e74a-9640-88af-03fd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink><entryLink id="78ff-d9b4-f2dc-a0b7" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry"><categoryLinks>
+        <categoryLink id="f1dc-4c2e-4e6b-9d35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b1d5-fd75-4f17-bbf4</comment></categoryLink>
+        <categoryLink id="c59d-9ef6-44e7-8ead" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_f221-bf81-4045-849b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
-    <entryLink id="96db-ede0-759b-af82" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f9ec-5a30-153d-be1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="59af-6365-62b6-0c45" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink><entryLink id="96db-ede0-759b-af82" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry"><categoryLinks>
+        <categoryLink id="78cc-704b-4faf-b864" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_51af-a137-4a1c-97a4</comment></categoryLink>
+        <categoryLink id="e26c-7a4f-4cf9-a13b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ec1f-c326-40a8-9d1f</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
-    <entryLink id="be11-d176-f4c0-13d1" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink><entryLink id="be11-d176-f4c0-13d1" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_c111-feb0-4012-98cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_63d7-8427-431d-9ae6</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0e4e-609e-26d6-0347" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="38b7-d949-5df1-2c22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8f9f-5032-4c06-8188" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_e707-fde1-457f-91c4</comment></categoryLink>
+        <categoryLink id="2872-c42d-4c51-a7e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ec67-8573-4460-89db</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
-    <entryLink id="0853-5abf-3a9a-70d8" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="fc24-2561-23c0-9059" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="0cdb-7ad9-7fdb-bf27" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink><entryLink id="0853-5abf-3a9a-70d8" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry"><categoryLinks>
+        <categoryLink id="09f0-cf41-4504-87a8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ac1c-b3bf-4011-918a</comment></categoryLink>
+        <categoryLink id="5d7a-9083-4717-b7d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_589c-1d0e-4b7d-be6b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
-    <entryLink id="7a5f-a4fb-fd86-4bea" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink><entryLink id="7a5f-a4fb-fd86-4bea" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6087-a5e5-4d3c-9ebd</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_c7e1-5f42-4528-bf07</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1950-08dc-4544-ab01</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_daf3-31ed-42c0-85dc</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3f74-b023-3ed2-c979" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="0ee4-bda5-11cb-aa51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0942-1e5d-486e-88d5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_7d4f-547c-43ed-a520</comment></categoryLink>
+        <categoryLink id="ee08-2c10-4192-acf6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f04e-04e8-4891-9b1f</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
-    <entryLink id="a96a-a2dc-9779-a11b" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink><entryLink id="a96a-a2dc-9779-a11b" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d512-fd07-4a29-863a</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_55c6-a35f-485a-9f0d</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d89e-cf1f-4ceb-b3de</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e2c9-0d01-403c-900e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_a7b8-c835-4cb2-b3d5</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1546-6bfb-093e-b8b6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="fde9-03d1-3c38-f038" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9091-500f-4547-a8b9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_e22a-c5f8-4825-a45f</comment></categoryLink>
+        <categoryLink id="9a92-dc4a-4424-822a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03fc-6a7f-45a5-bcb8</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
-    <entryLink id="d423-6885-77d4-a9e8" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="de69-8c9f-cb47-d91d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5d81-ffbb-c2b6-07b0" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
-        <categoryLink id="beec-caf7-9d76-2dfb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink><entryLink id="d423-6885-77d4-a9e8" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry"><categoryLinks>
+        <categoryLink id="63cf-4467-4a20-b6b8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0aff-4f6e-4b03-a23c</comment></categoryLink>
+        <categoryLink id="9c20-a9a2-4bab-ab8a" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"><comment>    template_id_7d5a-62e7-43ee-b79b</comment></categoryLink>
+        <categoryLink id="3d03-97d3-4bb6-8202" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_4986-9157-49f2-b670</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
-    <entryLink id="9cef-7f1e-ff2d-27a9" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink><entryLink id="9cef-7f1e-ff2d-27a9" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_319e-90d4-44a3-8e83</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_28db-d943-4099-9abd</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1a45-a592-49df-9465</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb31-d0b2-4677-928e</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b0cb-6b72-b4f4-5858" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0e1d-6b22-3ca6-afb6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="ed8f-285b-4279-9541" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1b86-0977-4a8b-adac</comment></categoryLink>
+        <categoryLink id="6461-1235-41e4-9576" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_b449-403a-4e42-9239</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
-    <entryLink id="ffd0-45c9-5028-43f9" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink><entryLink id="ffd0-45c9-5028-43f9" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_fbfa-8d78-4d6d-8a05</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_21f2-0916-46bf-b75a</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_4fbd-633b-4dd6-9fdd</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="41f2-b367-db56-6725" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d28a-de73-ffcb-987c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="b7cb-1e5c-4453-b1ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4f71-446f-4cff-afda</comment></categoryLink>
+        <categoryLink id="93c8-c4b9-41e6-b819" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_3f44-8647-43a4-ac22</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
-    <entryLink id="ec42-0835-db7c-c5f1" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="09eb-fb1c-37d8-0817" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1b02-90a1-929c-0966" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink><entryLink id="ec42-0835-db7c-c5f1" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry"><categoryLinks>
+        <categoryLink id="1551-ed40-4cf0-81dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4207-8d8f-4b1a-836b</comment></categoryLink>
+        <categoryLink id="e7ff-aeaf-46c3-97ea" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_2b34-077f-4279-86fb</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
-    <entryLink id="8dd6-67d7-980c-1196" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink><entryLink id="8dd6-67d7-980c-1196" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7583-6fa0-4089-a19e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_0e5c-99ab-41d3-a42e</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c296-e8e8-4a7a-989a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_8868-5bcb-4604-ba8e</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c7c5-bd12-c56a-6842" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="8e46-2df0-367d-e07a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="dce0-d263-4b91-9832" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a009-a597-4b51-b228</comment></categoryLink>
+        <categoryLink id="fe5e-0f9a-43e3-95fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_24f4-9145-4016-80d4</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
-    <entryLink id="0f11-5ac6-6c19-c56c" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink><entryLink id="0f11-5ac6-6c19-c56c" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_e732-7499-47bf-9748</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_81a5-a959-46b7-baa4</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7ec3-447a-4644-b012</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_71e2-c430-4c99-a559</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_df7b-3fb9-4f65-9165</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7454-91f1-ef94-7a1c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="f525-25a7-b7df-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9f71-7a96-4398-aa4a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c165-3906-463a-9c73</comment></categoryLink>
+        <categoryLink id="8d78-f591-4f47-b399" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6d1-d14c-473f-be09</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
-    <entryLink id="6345-583c-e6eb-e61a" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink><entryLink id="6345-583c-e6eb-e61a" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_13b3-ce1e-4f9d-8319</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_d681-9d81-4abd-b11b</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a57-e48b-4534-bca5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_1859-5641-4674-9097</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f421-c574-a432-349c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="3790-c024-f773-d7bd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ffeb-fd83-4d0a-b7a6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_251a-df5b-4bfd-ad63</comment></categoryLink>
+        <categoryLink id="2cae-cdca-494d-9c85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4644-98ab-4e3f-b1fd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
-    <entryLink id="7e98-9e39-650a-747d" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink><entryLink id="7e98-9e39-650a-747d" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_591d-d028-4663-918d</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_0482-c5f9-4c95-9597</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3ddb-c8f8-2ead-e8a6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="9096-ad98-5338-fcc4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
-    <entryLink id="f3ab-8283-b2ad-a39d" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="be0d-d75f-ad1b-b423" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="c06d-0545-e89a-778c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
-    <entryLink id="feb4-8654-1317-abe8" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9a48-3366-c330-40cb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="00f0-8b0d-45ad-b105" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
-    <entryLink id="0979-d1c8-855a-5f44" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="594e-df51-101c-4496" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="994b-0f52-09e3-7ab5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
-    <entryLink id="28bf-e158-9205-494d" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="b643-60a0-36e6-66de" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="8496-e2df-38b1-0780" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
-    <entryLink id="8031-0852-bdc2-5b72" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="a33f-a3c2-d056-8986" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="d975-2203-72dc-c735" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
-    <entryLink id="d3b9-8778-ee68-0c09" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="da09-d5f3-be70-231a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="3496-9b31-2783-d5c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
-    <entryLink id="1f89-2943-e228-0daa" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e05d-56a5-03a8-591d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="1a84-f09d-694b-5932" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
-    <entryLink id="c3f2-9819-e500-ea14" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="19ec-2b52-df21-7788" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="76a8-33ac-0e09-ac8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
-    <entryLink id="b1b3-d392-ebe8-1932" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d3a9-19d9-3bdb-2f60" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="09f7-0027-87d6-9265" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
-    <entryLink id="0522-a1a3-a74c-bcb8" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3c3b-639a-bf12-417d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="3d66-84b4-6a2f-7e29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
-    <entryLink id="c496-acde-83ad-3224" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0280-378c-022d-4f16" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="99c6-4d38-c321-2686" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
-    <entryLink id="8ed8-4298-c820-c3ad" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="19f0-b993-32a3-16b3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="2be3-a0a9-72a5-1330" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
-    <entryLink id="d55c-ce1a-baee-6066" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="dade-d900-b0fc-3a82" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="4a6c-4304-4ac9-7484" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
-    <entryLink id="9eb3-62b2-a8f8-ee5b" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="833b-20a0-57f1-1173" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="9262-2bc2-1f71-758e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
-    <entryLink id="c215-15f3-bd65-368f" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="55e2-34c8-cda4-cd62" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="50f4-97e6-6ce1-5168" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
-    <entryLink id="7e8d-e597-b719-b2ed" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_75a7-971d-4978-a83f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_a7d5-2bfe-4621-ac0c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9f13-b460-4f27-b0cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_31fc-e265-45a7-bb5b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f8ea-d6f4-97c5-f7d0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="009a-c793-7a3f-f754" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="680f-169a-4195-b8fe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_67c2-df43-44fc-92d1</comment></categoryLink>
+        <categoryLink id="9955-2473-4288-acbf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4136-bb4e-4dd4-99f9</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
-    <entryLink id="fb54-b05d-5f33-db94" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink><entryLink id="f3ab-8283-b2ad-a39d" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_99fc-5fe7-4b37-a62f</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_25f4-f6b8-4b44-8350</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_81f7-2311-4cce-95bc</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_09aa-af2a-4012-91d1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_00ae-fad3-4df6-9cb9</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="731f-5824-0696-6f3a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="d150-2634-0ebf-ae0d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e2d6-6e95-471a-8853" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f65b-8958-49b3-92a5</comment></categoryLink>
+        <categoryLink id="e961-2a31-4f84-a4c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0451-1929-4942-8c3f</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
-    <entryLink id="e9dc-6742-69ec-15a2" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink><entryLink id="feb4-8654-1317-abe8" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_edc4-4915-40ba-bbf0</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_105f-ba26-4146-bc54</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7a2c-a76c-421c-a8a2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_05c9-0543-47ee-ba81</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e6ad-f0d7-4627-921b</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7730-7ea8-3123-2802" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="a77d-1d29-259c-051c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="057c-fb99-4b31-87b8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c6a8-22a8-4d41-b969</comment></categoryLink>
+        <categoryLink id="42cc-3552-46b6-afcf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03ca-12cc-4e0a-b628</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
-    <entryLink id="48d8-430d-bb0c-576b" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink><entryLink id="0979-d1c8-855a-5f44" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ae19-30c0-43c5-920e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_6ebe-1bf3-4d78-9dd0</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1887-152d-48b7-b13f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_a7c4-ee6a-4f0b-8ab0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bd85-fa90-47ff-9f84</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_7bd6-9043-4d7e-ba37</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3d34-2949-190c-ef3a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="9990-9b4f-df96-71b1" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false" />
+        <categoryLink id="4971-aeef-45e8-a7fa" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3610-c975-4d55-bdfe</comment></categoryLink>
+        <categoryLink id="e0e1-5b97-4a12-9d2a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2fc2-f636-4c80-9608</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
-    <entryLink id="c2aa-0d69-c2d0-2edd" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink><entryLink id="28bf-e158-9205-494d" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
+          <comment>    node_id_85c5-d4d9-4b23-9e4d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_80e8-d50b-4906-8153</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_b93b-d4f1-45eb-8a69</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e183-f183-4db7-83b5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0f39-204a-4217-b896</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_eee9-7bfd-4fea-a1bd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b34-686b-1a34-09a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="13fd-081f-8aff-ec40" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="94cf-1507-4f79-983f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f81d-9435-4f11-99c1</comment></categoryLink>
+        <categoryLink id="9d47-6fc0-4ecf-8ce2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9568-6142-4fdd-be3a</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
-    <entryLink id="a8f5-7ff9-9e96-10d8" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink><entryLink id="8031-0852-bdc2-5b72" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_005e-6607-4e2c-8dd2</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_7745-260c-4c36-b719</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_ba25-a4b2-4ba9-b023</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ddeb-f4c8-4091-9153</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4904-fd2f-429f-9cf7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_faea-b21b-43c5-b918</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8bb4-15e3-41dd-a661" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_b24f-3ae0-4cbb-b016</comment></categoryLink>
+        <categoryLink id="4542-fec2-4601-ac1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fd26-8e6b-4521-92b9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink><entryLink id="d3b9-8778-ee68-0c09" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6ecb-28e2-43ed-a6a0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_c067-1118-4d96-b28b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_250e-23c0-4e43-bf74</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1553-a6e6-4291-853f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_aab6-797b-427a-9fd8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7d71-2428-40b4-b1fd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c77f-0819-473b-a8a2</comment></categoryLink>
+        <categoryLink id="d995-b3fb-4051-b253" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_89fb-c924-4daf-923d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink><entryLink id="1f89-2943-e228-0daa" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d72c-519a-451f-81b6</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_3d16-444c-42c9-aad1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_f4b2-6371-494b-863a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_797f-a84b-42f6-8e66</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0d78-fe38-4829-9b12</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0b4c-2d90-4379-bbcc" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0397-c837-4fea-a527</comment></categoryLink>
+        <categoryLink id="77b8-9a65-47be-8ee3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_060b-bccb-4776-bd83</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink><entryLink id="c3f2-9819-e500-ea14" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3c84-6d74-4c42-b38d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_5b15-7aa4-4897-aaf1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_3326-31ed-4151-9b37</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6a0e-1b65-4057-ba5d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f8c7-abc9-45ec-955f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_2538-8dc5-446c-8344</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2a32-7e36-464f-bb49" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_c1cf-cea4-4278-8f27</comment></categoryLink>
+        <categoryLink id="8d2b-8a8a-4093-9c3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5f51-2734-4a46-9f72</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink><entryLink id="b1b3-d392-ebe8-1932" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af71-f3ff-49b1-83e9</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_1c9e-b3bf-4e88-a43f</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_6d0d-1b1d-4065-89cf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d0b7-8686-491e-9d33</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_7db8-0874-487a-be6f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1034-29a0-44b1-a85f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9e2d-cd1b-417e-b40b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_0c16-6841-42b2-b02d</comment></categoryLink>
+        <categoryLink id="93e8-de2a-4f55-96dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_602d-2d2d-4ff4-a82a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink><entryLink id="0522-a1a3-a74c-bcb8" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_22bd-baae-45f9-b366</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_52bd-55de-4d53-ba55</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_df1b-7476-4ab8-8d2f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_49fa-0dcf-4a61-a5b1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0ea-1443-4993-86e7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2a8-3fbe-448c-9902</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="afae-ce2e-4037-a02c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3632-0b5d-4622-ae33</comment></categoryLink>
+        <categoryLink id="b057-fb11-4897-b334" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_da44-7815-4fdd-981c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink><entryLink id="c496-acde-83ad-3224" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2bfa-b203-47e2-a828</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a39b-8a3c-49cf-bf62</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2a05-07b3-49c5-8145</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f730-87fb-44bd-b68e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_2d0e-6c49-4493-a022</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2e2-50c1-40c3-b4dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dc1c-c75d-42eb-a441" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_5ad5-8701-42cd-b2b6</comment></categoryLink>
+        <categoryLink id="4359-9587-413f-9028" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_20a4-4346-4a3b-a7d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink><entryLink id="8ed8-4298-c820-c3ad" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="72bd-c94b-46f1-b075" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4e52-ad1b-48d4-8eed</comment></categoryLink>
+        <categoryLink id="633a-0dae-4047-b6a1" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_6979-1ed3-4f1f-a025</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink><entryLink id="d55c-ce1a-baee-6066" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4729-bc86-456b-b73d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_cf0f-e3f4-4fb4-989d</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1cc8-5611-4d9a-9218</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_2e32-ca02-48f0-a8dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5cb2-8404-4b48-9f3c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_0af1-d052-4bd7-aab6</comment></categoryLink>
+        <categoryLink id="1f54-6454-45a0-96e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_45ce-e338-43c9-b63e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink><entryLink id="9eb3-62b2-a8f8-ee5b" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_db78-4d49-42ab-954a</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_f14d-9943-47b6-866c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a95-938f-4a07-9727</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_7775-78e1-44cc-87c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="05cb-1b0d-41c6-8119" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_b822-3417-4613-be37</comment></categoryLink>
+        <categoryLink id="06df-2ad4-45bd-a5d0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_25db-b03f-4881-b310</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink><entryLink id="c215-15f3-bd65-368f" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_b743-7a00-43e4-beb8</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d12f-2c98-4e62-a716</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d4d7-ba67-47aa-962f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+                  <comment>    node_id_1637-edee-457a-bb0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5ab5-d329-4fd9-a0cc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_f203-bc26-421f-b79e</comment></categoryLink>
+        <categoryLink id="3816-caf2-4f78-97f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_a53e-59d9-4ac2-a21f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink><entryLink id="7e8d-e597-b719-b2ed" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3348-16e4-4a9a-a549</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_bea4-c4a8-4843-b9fe</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2970-17ff-4be1-91e5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_503a-46e7-40e7-bd07</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_4555-15e1-43ff-80a0</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5bc4-383c-ce47-435d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c6eb-4443-f595-288b" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="dd6d-a814-4bd9-9902" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_fce3-801c-49c8-85d4</comment></categoryLink>
+        <categoryLink id="079c-649d-4dfd-94f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0c2d-2349-44b6-9831</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
-    <entryLink id="7c64-df4d-4b4f-2624" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e799-7857-f2af-a934" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="febc-bfee-27ba-5db3" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
-    <entryLink id="f983-a88b-b170-fe04" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink><entryLink id="fb54-b05d-5f33-db94" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2f46-a0b6-48a5-a0ee</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_636f-0f8a-43f1-910b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c883-39c8-4a74-aeaa</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_0796-e467-4438-89b3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="471e-2d49-4ad0-b701" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_5a04-9847-4c91-a49a</comment></categoryLink>
+        <categoryLink id="bbaf-5055-4a74-8f3e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b4b4-daeb-483c-a306</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink><entryLink id="e9dc-6742-69ec-15a2" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_dfdc-f6f6-49d2-a7b3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_354c-c71f-472f-b268</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1127-c974-4663-874d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_0843-bef2-4767-8307</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f747-c7d7-47ea-abcf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_28e0-91e7-4ada-9fac</comment></categoryLink>
+        <categoryLink id="f3a1-e19e-4b1a-8500" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4448-a712-4dd7-bf6d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink><entryLink id="48d8-430d-bb0c-576b" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafa-470f-4c2c-8be3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_e2ba-a855-4de2-9f46</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_0171-b30d-44ee-9389</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fdfb-119b-4774-934a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_3891-9a00-4f8f-b95f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ced5-c1a8-454e-b0db" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e5df-17d4-4521-9d5b</comment></categoryLink>
+        <categoryLink id="3e86-7916-435b-be9e" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"><comment>    template_id_0ecd-4873-4d3a-b28b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink><entryLink id="c2aa-0d69-c2d0-2edd" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af15-2c71-4f8b-833e</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_d95a-80b9-4463-af55</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="92ce-5ee5-9a06-904f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="9cc0-c1a8-8c5b-0b01" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="b31a-66ab-b8e6-5df0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7843-b6f7-4e2b-8c89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6b1-886e-4194-8bcd</comment></categoryLink>
+        <categoryLink id="6ecb-1481-4707-9e2b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_51b5-f9c1-4587-8fc7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
-    <entryLink id="1231-26aa-03af-1794" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink><entryLink id="a8f5-7ff9-9e96-10d8" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a38a-dfe9-445e-9222" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6577-e0fb-4fda-834e</comment></categoryLink>
+        <categoryLink id="55df-2300-4a01-8e0a" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_5d59-09bf-4566-b7e1</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink><entryLink id="7c64-df4d-4b4f-2624" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"><categoryLinks>
+        <categoryLink id="34e9-adb8-47de-a028" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_aa93-057d-42f6-82d7</comment></categoryLink>
+        <categoryLink id="5cb9-15c5-4a29-b6d6" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_403c-4e9c-4af5-84ec</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink><entryLink id="f983-a88b-b170-fe04" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5f66-bd79-4034-a466" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_5b41-a9f0-4801-9dff</comment></categoryLink>
+        <categoryLink id="b1f8-481a-412b-974b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_d64e-e976-4668-bb95</comment></categoryLink>
+        <categoryLink id="ffa5-e4d3-446a-8e38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_17a6-f363-4094-9a7c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink><entryLink id="1231-26aa-03af-1794" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_3c03-a823-4466-9bd6</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_8bbb-f95b-413f-b6f4</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_41b0-6b0a-482a-919e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e1f7-3cc6-4794-8b6d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="54c3-bbd9-c80f-6c0c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="10fe-a627-3353-bff8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="e37e-c03a-48a0-8c50" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_05ce-cc31-40ad-9320</comment></categoryLink>
+        <categoryLink id="7ecc-7f7a-4519-8a91" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f13c-f8e1-4a50-bfe3</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
-    <entryLink id="08a5-32b7-1f42-ee01" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink><entryLink id="08a5-32b7-1f42-ee01" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b15-e1d8-79d1-78f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e98c-cf57-ddf1-1f83" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="ae83-4bc5-49ca-9756" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fe4f-c8f2-470f-901c</comment></categoryLink>
+        <categoryLink id="5553-0519-40c1-95d8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_f3f0-973b-4a45-ac41</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
-    <entryLink id="93ca-5f4e-2290-0f7a" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink><entryLink id="93ca-5f4e-2290-0f7a" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3531-57d1-4081-882d</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_f233-2361-4177-8ba7</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b932-667a-4b43-8331</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f3cb-125e-3849-5625" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="13f0-a38e-4ae6-7c0d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="04d2-4239-4076-bdb6" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+        <categoryLink id="8d2b-5023-44d7-b8ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_63ff-0a92-42ab-ae8c</comment></categoryLink>
+        <categoryLink id="b43f-eff3-4984-aaae" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_204c-7b0f-4fb9-b1b3</comment></categoryLink>
+        <categoryLink id="0dee-430e-458e-a030" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"><comment>    template_id_85e6-cb31-427c-a040</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
-    <entryLink id="dfcd-6644-5852-87a2" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink><entryLink id="dfcd-6644-5852-87a2" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b550-3c51-351e-3dff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8075-67b2-f7be-7a18" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="39f5-2ddc-4a5a-8308" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_68dd-fc0f-4fde-8adc</comment></categoryLink>
+        <categoryLink id="249e-844f-4b48-885e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_74ca-dd4f-46be-8be7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
-    <entryLink id="0070-dd42-02b5-2d95" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink><entryLink id="0070-dd42-02b5-2d95" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4dce-8632-4f7c-813e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_8a71-3995-4155-ac33</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d206-f2ce-41b8-945a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan">
+                  <comment>    node_id_2e02-cf1c-4a71-861c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ec81-bd33-45a8-8550</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_3344-743c-45d3-b930</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e963-df95-9f26-01f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a764-6fe6-5283-a1e2" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="81cf-89a0-4ccd-9d0c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4272-9b9d-4c59-95f0</comment></categoryLink>
+        <categoryLink id="1ef1-268f-4740-9c9a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_d85b-1ae7-40d5-9341</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
-    <entryLink id="3472-813c-829a-5bc8" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink><entryLink id="3472-813c-829a-5bc8" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9098-910d-0871-246d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="78b9-56ef-fafb-2b3b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ea63-e223-4a12-bf4d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_3129-6f59-4365-906b</comment></categoryLink>
+        <categoryLink id="2c30-59d8-4a63-958c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2bcb-0af1-4aea-9191</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
-    <entryLink id="b201-9601-2b05-5ff0" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink><entryLink id="b201-9601-2b05-5ff0" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ede2-d453-4e34-8cda</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_2907-3215-4b01-96ff</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_c90c-959f-40fb-a4cb</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="60b1-ed85-b7c7-5ce1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b3e4-7625-2315-15f4" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="dc05-b118-453b-b138" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ba2d-50ad-45f1-91c9</comment></categoryLink>
+        <categoryLink id="f45b-364e-4be5-b827" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_0e88-485e-43c2-8bef</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
-    <entryLink id="20cf-7b6a-eb78-0871" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink><entryLink id="20cf-7b6a-eb78-0871" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_409c-0a5d-4ef8-a871</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_7078-c1c7-4af2-b43d</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_9a69-0fdc-4957-8982</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e86e-3220-5df3-5f47" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="25b4-9aae-8feb-3d8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="504e-46b0-47b5-bb85" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_1a4c-69b5-4219-8502</comment></categoryLink>
+        <categoryLink id="4364-8f0a-49f8-90bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fba0-3ea7-4eaf-b33a</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
-    <entryLink id="2a92-2e4b-8d8f-06a4" name="Crimson Paladins" hidden="true" collective="false" import="false" targetId="33fe-9683-bde5-95ca" type="selectionEntry">
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink><entryLink id="2a92-2e4b-8d8f-06a4" name="Crimson Paladins" hidden="true" collective="false" import="false" targetId="33fe-9683-bde5-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -1707,71 +1997,76 @@
         <categoryLink id="7bb4-00df-bb76-55c2" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="6a40-f9ed-c05d-5013" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
-      <modifiers>
+    <entryLink id="6a40-f9ed-c05d-5013" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="76a8-6805-10f9-c370" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
-        <categoryLink id="63e6-1e67-10e5-df83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4c06-b01e-8404-2acd" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="10d4-86c5-4786-808a" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_0d5b-be56-47af-a22e</comment></categoryLink>
+        <categoryLink id="f25a-864e-417d-89ae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2e59-1043-4719-96c4</comment></categoryLink>
+        <categoryLink id="3ce8-ef09-4dc8-b7ce" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_52fa-8c3c-49d4-a321</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
-    <entryLink id="2ebf-e576-f28d-f7bb" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink><entryLink id="2ebf-e576-f28d-f7bb" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="99bc-9576-89c2-8577" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
-        <categoryLink id="a911-69d6-56db-1338" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8b8a-40b0-ebd5-cfa5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="98d4-6fb0-48e1-9b83" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_1fef-4409-4fab-93fc</comment></categoryLink>
+        <categoryLink id="c763-f8c8-4a02-bcd1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ca2d-245e-48b4-a1cf</comment></categoryLink>
+        <categoryLink id="1cb3-dd6b-41a6-abaf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_6692-6e39-44f0-ad8e</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
-    <entryLink id="b46b-7cd0-ef0e-f0ae" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink><entryLink id="b46b-7cd0-ef0e-f0ae" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="880b-9da3-7d79-2396" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="77cb-5f8b-7e8c-decd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="74c1-481b-25f5-d2c3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="7b12-1775-4e92-955a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9261-acb5-4230-8d89</comment></categoryLink>
+        <categoryLink id="2277-e9fa-48be-878b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_1a5d-cbc8-418f-91a3</comment></categoryLink>
+        <categoryLink id="b8f1-31dd-49a7-b4d0" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_c0cb-406f-4b46-9d8d</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
-    <entryLink id="b7af-6f3f-3844-4c33" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink><entryLink id="b7af-6f3f-3844-4c33" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0943-5fb4-09cb-1c92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f62e-58bd-15a4-96d1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2ee9-bddc-4fe3-88e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c0b2-dd90-46c1-a2a9</comment></categoryLink>
+        <categoryLink id="8f1e-11b7-4102-b7a9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_9a94-76fb-4a89-ad5d</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
-  </entryLinks>
-  <sharedSelectionEntries>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink></entryLinks><sharedSelectionEntries>
     <selectionEntry id="2c54-82c1-c1e4-3aee" name="Sanguinius" hidden="false" collective="false" import="true" type="model">
       <comment> (WEAPONS NEED PROFILES)</comment>
       <profiles>

--- a/2022 - LA - Blood Angels.cat
+++ b/2022 - LA - Blood Angels.cat
@@ -649,7 +649,7 @@
         <categoryLink id="bf2e-bde0-aa8c-3a07" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="92c3-01e3-317d-bd5a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
     <entryLink id="fac3-b4e1-1b98-399c" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="aabc-1276-dbbd-34f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -1724,7 +1724,7 @@
         <categoryLink id="63e6-1e67-10e5-df83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="4c06-b01e-8404-2acd" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
     <entryLink id="2ebf-e576-f28d-f7bb" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">

--- a/2022 - LA - Dark Angels.cat
+++ b/2022 - LA - Dark Angels.cat
@@ -1439,6 +1439,193 @@
         <categoryLink id="246b-51e3-8f63-d7f1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
     <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
+  <entryLink id="ad04-6306-459c-a371" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
+    <entryLink id="d3c1-105c-4f60-bb44" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4e52-ad1b-48d4-8eed" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="6979-1ed3-4f1f-a025" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
+    <entryLink id="753e-f38c-4194-8776" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
+    <entryLink id="284d-5009-4763-bc9b" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <entryLink id="5840-93eb-4a89-afc5" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <entryLink id="2a8b-f2c4-40d9-9729" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
+    <entryLink id="4309-20eb-4d21-963c" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
+    <entryLink id="0a91-29b9-4d86-b4cf" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
+    <entryLink id="299a-0c26-45ad-9731" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="4097-b2b4-d9da-da99" name="Corswain" hidden="false" collective="false" import="true" type="unit">

--- a/2022 - LA - Dark Angels.cat
+++ b/2022 - LA - Dark Angels.cat
@@ -368,7 +368,7 @@
         <categoryLink id="800e-9f53-d647-877e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="75f6-0592-4625-5c55" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
     <entryLink id="2cac-8ef5-3ff1-aa7f" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <infoLinks>
         <infoLink id="3ff3-e189-37e0-0701" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule" />
@@ -621,7 +621,7 @@
         <categoryLink id="8228-23b5-f8e6-08e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="9f62-9dde-27c7-bc6b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
     <entryLink id="c199-e101-141a-c98c" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
@@ -702,7 +702,7 @@
         <categoryLink id="e4c8-a63c-9b21-d3c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="0243-9ea0-53a6-8c37" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
     <entryLink id="1371-2c69-e70d-9290" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2b8f-9a19-92ac-377c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -714,7 +714,7 @@
         <categoryLink id="26fd-1ac6-6495-5711" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="6f3c-e8e0-e87c-f983" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
     <entryLink id="bce7-861c-99b7-cb2f" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="db9b-9ea5-b949-851d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -798,7 +798,7 @@
         <categoryLink id="1f32-5bdd-e2cf-31de" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="90ac-0a82-ee1c-f20c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
     <entryLink id="5134-76e5-8746-0fef" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -822,7 +822,7 @@
         <categoryLink id="b955-1f0b-01c0-2e69" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="29d6-efb7-4f96-7083" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
     <entryLink id="182d-f4ed-5866-691d" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a6fe-90d6-4d99-f75b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -841,7 +841,7 @@
         <categoryLink id="e92d-d512-e86f-b0b0" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
         <categoryLink id="91a1-3807-f49f-6f7a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
     <entryLink id="37a7-9999-cf46-e386" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f76e-d3f4-27e5-6d16" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -1221,7 +1221,7 @@
         <categoryLink id="248b-933d-96ce-0e54" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
         <categoryLink id="c671-f10e-b16e-df59" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
       </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
     <entryLink id="95b2-e65d-0630-3f78" name="Kratos Squadron" hidden="true" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">

--- a/2022 - LA - Dark Angels.cat
+++ b/2022 - LA - Dark Angels.cat
@@ -1,10 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ee5e-198e-1b19-4b9f" name="LA -   I: Dark Angels" revision="17" battleScribeVersion="2.03" authorName="revivedtitan" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="29" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="ee5e-198e-1b19-4b9f" name="LA -   I: Dark Angels" revision="17" battleScribeVersion="2.03" authorName="revivedtitan" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="29">
   <entryLinks>
     <entryLink id="7653-8041-8d1c-c872" name="Dreadwing Interemptor Squad" hidden="false" collective="false" import="false" targetId="3008-e8ed-9e97-71c9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b375-4d79-dba1-0791" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="73f2-8df7-0fa9-dd37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b375-4d79-dba1-0791" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="73f2-8df7-0fa9-dd37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="7089-ea3d-51ac-2dc2" name="Corswain" hidden="true" collective="false" import="false" targetId="4097-b2b4-d9da-da99" type="selectionEntry">
@@ -13,17 +12,17 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a4a2-0795-10b3-814b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7b72-0a2d-ea5f-e088" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="e12a-8c05-d094-5857" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="a4a2-0795-10b3-814b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7b72-0a2d-ea5f-e088" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="e12a-8c05-d094-5857" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="f659-7581-5953-ae59" name="Excindio Battle-automata" hidden="true" collective="false" import="false" targetId="cf23-fd3a-15a0-7347" type="selectionEntry">
@@ -32,29 +31,29 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="55c1-d230-9b2a-bc6c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="abcd-0d59-34c8-6814" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="55c1-d230-9b2a-bc6c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="abcd-0d59-34c8-6814" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="c177-60f6-4324-8398" name="Inner Circle Knights Cenobium" hidden="false" collective="false" import="false" targetId="9946-61c0-3656-36dd" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="694a-cf77-3824-c33c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="f12a-bca3-dacd-dafe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="694a-cf77-3824-c33c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="f12a-bca3-dacd-dafe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="f4cc-eb88-0035-2e1b" name="Inner Circle Knights Cenobium - Order of the Broken Claws" hidden="true" collective="false" import="false" targetId="b9ad-ab3e-437e-c373" type="selectionEntry">
@@ -63,33 +62,33 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="96bb-7267-db95-12f9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="bc8b-eb32-5fdd-202b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="96bb-7267-db95-12f9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="bc8b-eb32-5fdd-202b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="9607-feb8-a864-9192" name="Lion El&apos;Jonson " hidden="true" collective="false" import="false" targetId="0689-b550-0b0e-63d6" type="selectionEntry">
+    <entryLink id="9607-feb8-a864-9192" name="Lion El'Jonson " hidden="true" collective="false" import="false" targetId="0689-b550-0b0e-63d6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9d97-2b3e-e904-a1c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ab33-7225-f48a-340c" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="9d97-2b3e-e904-a1c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ab33-7225-f48a-340c" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="5233-1cc8-f2d5-9023" name="Marduk Sedras" hidden="true" collective="false" import="false" targetId="9136-b5e8-13f9-0c0f" type="selectionEntry">
@@ -98,17 +97,17 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e67b-8c05-a2d9-646e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="65f5-a164-400b-1ccb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="c8ff-1043-75af-8a7d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="e67b-8c05-a2d9-646e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="65f5-a164-400b-1ccb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c8ff-1043-75af-8a7d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="7995-b170-5ac4-af2b" name="Farith Redloss" hidden="true" collective="false" import="false" targetId="28ab-ad48-d8b3-0d5d" type="selectionEntry">
@@ -117,17 +116,17 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8bf4-9640-3056-cb98" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f522-bc46-1dcc-5c12" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="dbda-9f35-26f3-f2bf" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="8bf4-9640-3056-cb98" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f522-bc46-1dcc-5c12" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="dbda-9f35-26f3-f2bf" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="b977-4bae-f84a-1cba" name="Holguin" hidden="true" collective="false" import="false" targetId="902d-5951-9b95-19fb" type="selectionEntry">
@@ -136,1332 +135,1332 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bebe-9b3c-7ba0-ed35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="75ff-379c-b33c-2438" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="7e2b-77a4-fe27-c674" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="bebe-9b3c-7ba0-ed35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="75ff-379c-b33c-2438" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="7e2b-77a4-fe27-c674" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="3a8f-2121-9fa4-6d74" name="Firewing Enigmatus Cabal" hidden="true" collective="false" import="false" targetId="3731-e0df-bd0c-a33e" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6790-aaee-430e-8b31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dd86-2ee5-56d6-27c7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="6790-aaee-430e-8b31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="dd86-2ee5-56d6-27c7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="cf27-5a4c-7672-62b9" name="   I: Dark Angels" hidden="false" collective="false" import="false" targetId="b2b4-2198-0b90-dd9f" type="selectionEntry">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9751-6008-860a-5298" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e692-8686-cae7-1ec4" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9751-6008-860a-5298" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e692-8686-cae7-1ec4" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="94dd-b497-2933-d015" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="94dd-b497-2933-d015" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="4964-7bcf-88a5-5cfd" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="84d1-5fce-4399-c5fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a94a-f1d7-8d56-330a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="84d1-5fce-4399-c5fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a94a-f1d7-8d56-330a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
     <entryLink id="091b-b797-9197-956e" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="76c5-9477-a767-459c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fc0c-f41f-e0bc-ee06" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="76c5-9477-a767-459c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="fc0c-f41f-e0bc-ee06" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
     <entryLink id="db79-8bda-3f20-3087" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="58f4-5efb-796b-85bd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="e451-4053-070a-8c83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f1fa-fed8-1461-7cfc" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="58f4-5efb-796b-85bd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="e451-4053-070a-8c83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f1fa-fed8-1461-7cfc" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
       <entryLinks>
         <entryLink id="79e6-ae67-22cc-24e7" name="Centurion (Storm of War)" hidden="true" collective="false" import="true" targetId="6305-99cb-5a76-be11" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo"/>
-                <condition field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6650-b0cd-fb32-b405" type="atLeast"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo" />
+                <condition field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6650-b0cd-fb32-b405" type="atLeast" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18e4-7d20-667c-409b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18e4-7d20-667c-409b" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="39db-3517-48bb-514a" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4dc9-6765-9e9d-cec2" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="3cab-3815-a10e-ef74" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="911f-0dfb-085a-2b17" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="4dc9-6765-9e9d-cec2" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="3cab-3815-a10e-ef74" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="911f-0dfb-085a-2b17" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
     <entryLink id="73eb-db6c-9c3f-7406" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="89a9-3e97-50f9-7766" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="f47c-3b19-a492-cc7f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="89a9-3e97-50f9-7766" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="f47c-3b19-a492-cc7f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
     <entryLink id="d5b2-f823-d621-330f" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="be8d-fbfe-68a5-fd77" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="d13c-3257-6832-03b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="45d5-06cc-64d0-eb57" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="be8d-fbfe-68a5-fd77" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d13c-3257-6832-03b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="45d5-06cc-64d0-eb57" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="16c0-2142-5f5c-4dad" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="bb85-3277-2090-6576" type="selectionEntryGroup"/>
+        <entryLink id="16c0-2142-5f5c-4dad" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="bb85-3277-2090-6576" type="selectionEntryGroup" />
         <entryLink id="5263-1281-0cb7-0e8f" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="b68c-376d-b2df-be26" name="Hexagrammaton Choice" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
+        <entryLink id="b68c-376d-b2df-be26" name="Hexagrammaton Choice" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
     <entryLink id="90da-858e-9bf9-7458" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="def8-7fb8-af1a-732a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3b52-8600-5632-0bb4" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="624d-ec13-ebfe-252d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="def8-7fb8-af1a-732a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3b52-8600-5632-0bb4" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="624d-ec13-ebfe-252d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="a0a2-f470-e1d9-d139" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="bb85-3277-2090-6576" type="selectionEntryGroup"/>
+        <entryLink id="a0a2-f470-e1d9-d139" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="bb85-3277-2090-6576" type="selectionEntryGroup" />
         <entryLink id="808f-bb9a-b549-abbb" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="1583-3791-ad3f-415e" name="Hexagrammaton Choice" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
+        <entryLink id="1583-3791-ad3f-415e" name="Hexagrammaton Choice" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
     <entryLink id="9ab3-c31b-6807-621d" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2631-13ac-b8ba-207a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a78-52af-91e9-5b42" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="7540-5928-b79d-7f97" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="2631-13ac-b8ba-207a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a78-52af-91e9-5b42" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="7540-5928-b79d-7f97" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="0186-e75a-8589-28e8" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="bb85-3277-2090-6576" type="selectionEntryGroup"/>
+        <entryLink id="0186-e75a-8589-28e8" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="bb85-3277-2090-6576" type="selectionEntryGroup" />
         <entryLink id="a6bd-3548-1aaa-ff53" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="fdc2-9684-389e-91af" name="Hexagrammaton Choice" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
+        <entryLink id="fdc2-9684-389e-91af" name="Hexagrammaton Choice" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
     <entryLink id="749e-547a-3413-fc89" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="098d-b390-5331-2b62" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="8899-78cc-8e41-0087" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="098d-b390-5331-2b62" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="8899-78cc-8e41-0087" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
     <entryLink id="66a3-50a1-18b4-6a49" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
       <modifiers>
-        <modifier type="set" field="hidden" value="true"/>
+        <modifier type="set" field="hidden" value="true" />
       </modifiers>
       <categoryLinks>
-        <categoryLink id="409c-667a-cd3b-787d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bd8c-ad60-028c-44e6" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="409c-667a-cd3b-787d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bd8c-ad60-028c-44e6" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
     <entryLink id="944b-431e-0266-806a" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bd83-88ad-c226-08c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2503-db14-ebf9-3f8b" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="bd83-88ad-c226-08c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2503-db14-ebf9-3f8b" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
     <entryLink id="4fa8-8b77-1e3c-4654" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
       <modifiers>
-        <modifier type="set" field="hidden" value="true"/>
+        <modifier type="set" field="hidden" value="true" />
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f5e4-c880-6e68-4e28" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c8ca-2cb0-7997-1a00" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="f5e4-c880-6e68-4e28" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c8ca-2cb0-7997-1a00" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
     <entryLink id="339f-af2f-d50a-0be6" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="800e-9f53-d647-877e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="75f6-0592-4625-5c55" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="800e-9f53-d647-877e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="75f6-0592-4625-5c55" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
     <entryLink id="2cac-8ef5-3ff1-aa7f" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <infoLinks>
-        <infoLink id="3ff3-e189-37e0-0701" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule"/>
+        <infoLink id="3ff3-e189-37e0-0701" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="a979-6641-5f2b-8cfc" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="e162-0d4b-7615-902f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a979-6641-5f2b-8cfc" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="e162-0d4b-7615-902f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
     <entryLink id="a674-aa50-7c3e-6c34" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2b31-6145-5478-ce70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e47c-6a89-de1b-c5e5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="2b31-6145-5478-ce70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e47c-6a89-de1b-c5e5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
     <entryLink id="add1-33dc-1d02-c0d6" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9e92-b0e9-a0ad-fab5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="8080-1ad9-81bd-ae25" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="73c0-3b11-5105-6f71" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="9e92-b0e9-a0ad-fab5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="8080-1ad9-81bd-ae25" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="73c0-3b11-5105-6f71" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
       <entryLinks>
         <entryLink id="5d58-b1ba-af89-a8ab" name="Centurion (Storm of War)" hidden="true" collective="false" import="true" targetId="6305-99cb-5a76-be11" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo"/>
-                <condition field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd53-72cd-7c20-3bc8" type="atLeast"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo" />
+                <condition field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd53-72cd-7c20-3bc8" type="atLeast" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e08-f5ed-9b27-a9fc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e08-f5ed-9b27-a9fc" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="77de-36dc-ac0e-c241" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ff51-2669-d709-63cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d632-08b3-3613-4628" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="ff51-2669-d709-63cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d632-08b3-3613-4628" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="8626-0b82-87d7-ea4c" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2b26-3803-a23a-87d0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="5442-09cb-6083-fc96" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2b26-3803-a23a-87d0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="5442-09cb-6083-fc96" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
     <entryLink id="b7a0-fedc-e0a4-7a45" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4e04-baff-3d25-4703" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="b2f0-3641-09a8-fa69" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4e04-baff-3d25-4703" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="b2f0-3641-09a8-fa69" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
     <entryLink id="7922-2c4d-b936-b55b" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3950-15b1-cc51-437d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="e6c6-43e5-6c90-5f0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3950-15b1-cc51-437d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="e6c6-43e5-6c90-5f0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
     <entryLink id="34a3-a9a9-d139-a0e9" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="220e-c996-8040-c965" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f9c7-ecfb-5110-387f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="220e-c996-8040-c965" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f9c7-ecfb-5110-387f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
     <entryLink id="dfd8-32ec-2846-e289" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d081-da98-04e1-afc0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="cf0c-1f34-8c79-4d59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d081-da98-04e1-afc0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="cf0c-1f34-8c79-4d59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
     <entryLink id="9f14-6ec4-3e9b-3812" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="64b0-377d-20a2-58b9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="af07-bbe7-79bf-52e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="64b0-377d-20a2-58b9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="af07-bbe7-79bf-52e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
     <entryLink id="ae0e-6ec2-1c2c-2103" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2aba-51fb-832d-2026" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="90b3-43e1-7947-1f0c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="2aba-51fb-832d-2026" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="90b3-43e1-7947-1f0c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
     <entryLink id="5cf5-7d89-c838-8431" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6611-5705-4666-a738" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="fbce-6c82-7cd7-e67b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6611-5705-4666-a738" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="fbce-6c82-7cd7-e67b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
     <entryLink id="1646-80f1-ce5f-9fbf" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d7f1-5d19-62e2-b5cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2ab5-0cec-e3a9-1a18" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="d7f1-5d19-62e2-b5cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2ab5-0cec-e3a9-1a18" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="46f6-60cc-1fca-2b78" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c376-abc0-67bd-7976" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="4849-2c4b-0a9e-1aa8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c376-abc0-67bd-7976" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="4849-2c4b-0a9e-1aa8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
     <entryLink id="4a3c-ccd7-0209-c4c3" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0099-221c-c756-3e82" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="22cf-8806-d2b2-9c27" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="0099-221c-c756-3e82" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="22cf-8806-d2b2-9c27" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
     <entryLink id="2c86-cb97-d947-538b" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c545-bae1-2624-0d56" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2f06-49d1-ede4-1ca0" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="c545-bae1-2624-0d56" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2f06-49d1-ede4-1ca0" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
     <entryLink id="c304-2036-0ac2-09af" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fdc6-552c-1998-b3b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d5f1-155b-b78f-f987" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="fdc6-552c-1998-b3b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d5f1-155b-b78f-f987" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
     <entryLink id="2b5e-f26d-d049-f233" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0240-a7e6-50a5-8f7d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="108b-aacd-baf5-6594" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0240-a7e6-50a5-8f7d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="108b-aacd-baf5-6594" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
     <entryLink id="7150-94b2-a5fd-ecc8" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5d6e-c680-110b-d492" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5e65-8493-e3ff-adae" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="5d6e-c680-110b-d492" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5e65-8493-e3ff-adae" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="0155-a66b-1896-2dbe" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="22d7-29b0-4997-641c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="8375-d31d-346a-acdc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="22d7-29b0-4997-641c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="8375-d31d-346a-acdc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="00cf-bbd5-6ab5-6a62" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="eb1c-7483-c217-720e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7523-ee60-859f-c063" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="eb1c-7483-c217-720e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7523-ee60-859f-c063" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="7de7-fdfa-c41d-45f3" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fb23-8b6b-0611-ed86" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="eb5d-715f-63b5-af5e" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="5c7e-a83d-2108-1c5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fb23-8b6b-0611-ed86" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="eb5d-715f-63b5-af5e" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="5c7e-a83d-2108-1c5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="d4ac-24af-d933-2f2c" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup"/>
-        <entryLink id="acc6-b2e2-54a4-8a96" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="bb85-3277-2090-6576" type="selectionEntryGroup"/>
+        <entryLink id="d4ac-24af-d933-2f2c" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup" />
+        <entryLink id="acc6-b2e2-54a4-8a96" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="bb85-3277-2090-6576" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
     <entryLink id="b87c-fb27-63b8-4034" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="57ca-71c3-668a-713a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="5113-74c7-910e-99c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b117-006c-1fff-ee11" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="57ca-71c3-668a-713a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="5113-74c7-910e-99c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b117-006c-1fff-ee11" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="9e66-d0a2-70b5-9ef5" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="bb85-3277-2090-6576" type="selectionEntryGroup"/>
-        <entryLink id="dc79-215f-e4bd-b880" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup"/>
+        <entryLink id="9e66-d0a2-70b5-9ef5" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="bb85-3277-2090-6576" type="selectionEntryGroup" />
+        <entryLink id="dc79-215f-e4bd-b880" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
     <entryLink id="61cd-b574-f879-2210" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e744-eac1-056f-f807" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="5e9f-e07b-31a6-8417" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7c32-f2d1-ed72-1680" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="e744-eac1-056f-f807" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="5e9f-e07b-31a6-8417" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7c32-f2d1-ed72-1680" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="70cb-4492-374c-e009" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="bb85-3277-2090-6576" type="selectionEntryGroup"/>
-        <entryLink id="81f9-70e8-150b-e9f0" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup"/>
+        <entryLink id="70cb-4492-374c-e009" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="bb85-3277-2090-6576" type="selectionEntryGroup" />
+        <entryLink id="81f9-70e8-150b-e9f0" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
     <entryLink id="3229-1a84-2be3-3d14" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d0c9-8676-404f-56ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6c32-61bf-7a61-bd70" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="d0c9-8676-404f-56ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6c32-61bf-7a61-bd70" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="768f-2f1c-7db1-ec95" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8228-23b5-f8e6-08e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9f62-9dde-27c7-bc6b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="8228-23b5-f8e6-08e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9f62-9dde-27c7-bc6b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="c199-e101-141a-c98c" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="26da-c3f4-a2fd-85cd" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="e029-2f3c-8004-ab6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="26da-c3f4-a2fd-85cd" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="e029-2f3c-8004-ab6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
     <entryLink id="364f-8f20-ff7c-1755" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="de2f-8629-3e21-aeb3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="83ba-817e-185c-f8c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="de2f-8629-3e21-aeb3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="83ba-817e-185c-f8c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
     <entryLink id="7d1c-08bb-ba5a-0e0c" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9d75-84ba-2462-3c99" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="9030-8c26-50ae-09fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9d75-84ba-2462-3c99" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="9030-8c26-50ae-09fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
     <entryLink id="5230-0dc6-1389-c5a5" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3148-e641-e109-5e3d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dcd3-2fb1-6ea2-5107" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3148-e641-e109-5e3d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="dcd3-2fb1-6ea2-5107" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
     <entryLink id="9f04-cc5c-38b2-5ccc" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7ca0-ebf9-5e1c-c640" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="175c-468c-28f4-11d6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7ca0-ebf9-5e1c-c640" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="175c-468c-28f4-11d6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
     <entryLink id="5427-ec57-9e1f-d48a" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ca88-aecc-c5c1-c287" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d321-2af4-cfc9-016b" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="ca88-aecc-c5c1-c287" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d321-2af4-cfc9-016b" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
     <entryLink id="782b-fa17-c0e8-59a7" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4793-7c03-b46b-35e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="073a-b2be-7f22-2783" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="4793-7c03-b46b-35e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="073a-b2be-7f22-2783" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
     <entryLink id="20d7-4161-0067-f4da" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f7fd-029d-98de-8d09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4b7f-6969-0c0d-dab1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="f7fd-029d-98de-8d09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4b7f-6969-0c0d-dab1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
     <entryLink id="0251-2bc9-75a8-0d24" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0d36-d572-7fb5-7730" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c99b-62ff-a283-d448" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="0d36-d572-7fb5-7730" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c99b-62ff-a283-d448" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
     <entryLink id="a616-1e39-f3d8-5b3c" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e4c8-a63c-9b21-d3c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0243-9ea0-53a6-8c37" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="e4c8-a63c-9b21-d3c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0243-9ea0-53a6-8c37" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="1371-2c69-e70d-9290" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2b8f-9a19-92ac-377c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3f40-8771-9f37-de2a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="2b8f-9a19-92ac-377c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3f40-8771-9f37-de2a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
     <entryLink id="6753-fb6d-0fd5-23e8" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="26fd-1ac6-6495-5711" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6f3c-e8e0-e87c-f983" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="26fd-1ac6-6495-5711" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6f3c-e8e0-e87c-f983" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="bce7-861c-99b7-cb2f" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="db9b-9ea5-b949-851d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="3b6d-2eb9-4ecc-17ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="db9b-9ea5-b949-851d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="3b6d-2eb9-4ecc-17ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
     <entryLink id="0f6b-7f4f-71ff-c667" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6ca6-219e-671d-6822" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="dd3b-dc0d-1b0c-8cc0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6ca6-219e-671d-6822" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="dd3b-dc0d-1b0c-8cc0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
     <entryLink id="85ad-df1d-eb49-900c" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c9f3-ba68-aba9-9632" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="f362-c81c-0949-cd49" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c9f3-ba68-aba9-9632" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="f362-c81c-0949-cd49" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
     <entryLink id="9fb0-76df-cdd9-ff22" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="33ce-33a3-824e-7449" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fbe0-87e9-18d3-d36e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="5880-c8f6-27ae-b438" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="33ce-33a3-824e-7449" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="fbe0-87e9-18d3-d36e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="5880-c8f6-27ae-b438" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
       <entryLinks>
         <entryLink id="fc43-10d6-da0b-bacb" name="Centurion (Storm of War)" hidden="true" collective="false" import="true" targetId="6305-99cb-5a76-be11" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo"/>
-                <condition field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f115-cfc4-4199-f8be" type="atLeast"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo" />
+                <condition field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f115-cfc4-4199-f8be" type="atLeast" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9be-e644-7185-9884" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9be-e644-7185-9884" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="533f-a106-ed1b-f457" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b3d9-83c2-da09-fdcb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6992-7d8d-606c-8b27" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="b3d9-83c2-da09-fdcb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6992-7d8d-606c-8b27" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
     <entryLink id="c49b-35e7-4119-d223" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2450-c5a8-e488-d7cc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6c3e-2dfa-c609-d082" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="2450-c5a8-e488-d7cc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6c3e-2dfa-c609-d082" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
     <entryLink id="e130-7c8b-6cf9-29c5" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1f32-5bdd-e2cf-31de" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="90ac-0a82-ee1c-f20c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1f32-5bdd-e2cf-31de" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="90ac-0a82-ee1c-f20c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="5134-76e5-8746-0fef" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="203c-456b-22b5-c12f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="2f3b-bb86-38b1-732b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="203c-456b-22b5-c12f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2f3b-bb86-38b1-732b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
     <entryLink id="1431-cf29-f3a6-9a24" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b955-1f0b-01c0-2e69" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="29d6-efb7-4f96-7083" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b955-1f0b-01c0-2e69" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="29d6-efb7-4f96-7083" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="182d-f4ed-5866-691d" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a6fe-90d6-4d99-f75b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="2ee3-ef14-7158-09e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a6fe-90d6-4d99-f75b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="2ee3-ef14-7158-09e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
     <entryLink id="1987-c23d-e533-d50c" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7c4f-41f5-015f-9d08" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="b574-8088-0962-d845" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7c4f-41f5-015f-9d08" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="b574-8088-0962-d845" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
     <entryLink id="a6bc-c982-26bf-7caf" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d710-bd41-02c7-c3e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e92d-d512-e86f-b0b0" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="91a1-3807-f49f-6f7a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="d710-bd41-02c7-c3e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e92d-d512-e86f-b0b0" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
+        <categoryLink id="91a1-3807-f49f-6f7a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="37a7-9999-cf46-e386" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f76e-d3f4-27e5-6d16" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="06b1-de01-6413-6ba0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="f76e-d3f4-27e5-6d16" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="06b1-de01-6413-6ba0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
     <entryLink id="bdce-5cd5-1072-2020" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9d37-ebcf-d90f-b433" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a8e5-a7dd-01fc-e2e6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="9d37-ebcf-d90f-b433" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a8e5-a7dd-01fc-e2e6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
     <entryLink id="5f4f-a0b7-1ea3-a1cf" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b500-803d-772c-5e10" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b500-803d-772c-5e10" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d8ac-ff1f-014d-5042" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9382-ceeb-671a-8173" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="d8ac-ff1f-014d-5042" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9382-ceeb-671a-8173" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
     <entryLink id="7ad7-3420-c909-489a" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2bc7-9954-5dfb-fb60" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="e1bf-3b3d-4d2c-9711" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2bc7-9954-5dfb-fb60" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="e1bf-3b3d-4d2c-9711" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
     <entryLink id="539c-334b-a731-94b8" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3a9a-8244-f733-d979" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="de90-f2ca-f8cf-22db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3a9a-8244-f733-d979" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="de90-f2ca-f8cf-22db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
     <entryLink id="d60d-2615-fce1-c010" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8af2-16a7-ff44-6632" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="ec1d-f9a8-b945-3b21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8af2-16a7-ff44-6632" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="ec1d-f9a8-b945-3b21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
     <entryLink id="9be5-08fb-db3f-c785" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a886-c2b1-62fc-d2bf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="05eb-169d-0787-ab1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a886-c2b1-62fc-d2bf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="05eb-169d-0787-ab1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
     <entryLink id="9db9-0eb0-22f9-7a49" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e068-e3b6-7097-6c68" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="7b75-a363-34e2-7fee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e068-e3b6-7097-6c68" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="7b75-a363-34e2-7fee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
     <entryLink id="c371-9f7c-ceb8-5ea4" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="aed7-b59f-6039-2e8a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="06c6-14f2-d465-9516" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="aed7-b59f-6039-2e8a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="06c6-14f2-d465-9516" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="ef03-c820-675a-60f0" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b55b-d7c5-6b07-585d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="3bc4-08e6-f571-5ce4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b55b-d7c5-6b07-585d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="3bc4-08e6-f571-5ce4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
     <entryLink id="6ede-d5a0-a861-79d3" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5dca-6147-c8d9-0b55" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="5f05-858f-5f35-292d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5dca-6147-c8d9-0b55" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="5f05-858f-5f35-292d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
     <entryLink id="8a66-31c1-53a5-0a9b" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e89b-c855-2e05-8bbf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="66e1-e02a-d031-26c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e89b-c855-2e05-8bbf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="66e1-e02a-d031-26c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
     <entryLink id="a09f-4dba-b6ec-1808" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="49d8-f3e8-d400-7b41" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="bbe6-fc48-3bf0-a37e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="49d8-f3e8-d400-7b41" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="bbe6-fc48-3bf0-a37e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
     <entryLink id="433e-7929-bf4a-e079" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2010-69f6-3360-23b4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="25de-c95b-03f4-4efe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2010-69f6-3360-23b4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="25de-c95b-03f4-4efe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
     <entryLink id="dec5-edaa-8803-5f4f" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <infoLinks>
-        <infoLink id="1506-fe95-af50-0a28" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule"/>
+        <infoLink id="1506-fe95-af50-0a28" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8789-a461-22e1-918d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="0089-32a6-2136-2e75" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8789-a461-22e1-918d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="0089-32a6-2136-2e75" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
     <entryLink id="6f49-bb34-6ad2-f602" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2a9c-8044-ff4b-7593" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="3346-69f2-f841-acdf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2a9c-8044-ff4b-7593" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="3346-69f2-f841-acdf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
     <entryLink id="d9b5-1989-b0ac-b8b6" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="da35-6498-31ee-2e2e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="a18e-317a-24ad-00d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="da35-6498-31ee-2e2e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="a18e-317a-24ad-00d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
     <entryLink id="2e74-86d5-020d-49ba" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1f8d-f244-e904-cfa3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="9339-ccbb-5846-7ff9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1f8d-f244-e904-cfa3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="9339-ccbb-5846-7ff9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
     <entryLink id="967b-b746-1503-e02c" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6bd8-a5bb-9033-14b3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="2c67-04f1-5aaa-ef7b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6bd8-a5bb-9033-14b3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="2c67-04f1-5aaa-ef7b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
     <entryLink id="7588-40d2-e4c5-57cd" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="26d8-e61b-f351-9461" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="b92e-1644-4a92-c664" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="26d8-e61b-f351-9461" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="b92e-1644-4a92-c664" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
     <entryLink id="4ca5-8ac0-74ec-4039" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a26e-92f2-2eee-95ec" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="8af2-ab51-a6e5-2272" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a26e-92f2-2eee-95ec" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="8af2-ab51-a6e5-2272" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
     <entryLink id="ea1c-6f1a-fc5d-ad83" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e42c-b09e-78f2-a854" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="53c5-1af1-7f34-60a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e42c-b09e-78f2-a854" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="53c5-1af1-7f34-60a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
     <entryLink id="b294-4d60-0b60-0406" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="98dc-2b29-4617-a8b1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="9005-8ba4-cf9d-e3c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="98dc-2b29-4617-a8b1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="9005-8ba4-cf9d-e3c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
     <entryLink id="4d31-8f19-953a-d6af" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="93b1-25f2-46b9-ff46" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="05aa-0816-072c-4afa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="93b1-25f2-46b9-ff46" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="05aa-0816-072c-4afa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
     <entryLink id="b86f-7e3d-1cb1-b152" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06cc-c559-d71e-b75e" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06cc-c559-d71e-b75e" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9e50-1031-43f3-0244" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="b5e1-ee53-9c93-660f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9e50-1031-43f3-0244" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="b5e1-ee53-9c93-660f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="cc7c-408c-ee93-34de" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06cc-c559-d71e-b75e" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06cc-c559-d71e-b75e" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7000-368d-9295-a95d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="6f25-22d7-9a73-da82" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7000-368d-9295-a95d" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="6f25-22d7-9a73-da82" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="e5ec-35d1-2b06-b61d" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06cc-c559-d71e-b75e" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06cc-c559-d71e-b75e" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bfeb-5b52-e6b1-8382" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e20f-50b3-fdc8-eb42" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="bfeb-5b52-e6b1-8382" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e20f-50b3-fdc8-eb42" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="9dd4-c660-4f8b-fae3" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="907e-21b4-1aef-10be" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="907e-21b4-1aef-10be" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="248b-933d-96ce-0e54" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="c671-f10e-b16e-df59" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="248b-933d-96ce-0e54" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="c671-f10e-b16e-df59" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="95b2-e65d-0630-3f78" name="Kratos Squadron" hidden="true" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="907e-21b4-1aef-10be" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="907e-21b4-1aef-10be" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="23eb-63a4-66aa-d07b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="a295-1670-5b0d-ebc2" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="23eb-63a4-66aa-d07b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="a295-1670-5b0d-ebc2" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="6f72-c712-0b1d-f422" name="Destroyer Assault Squad" hidden="true" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b01c-f5a0-9f68-605a" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b01c-f5a0-9f68-605a" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0ac7-0ef1-b9df-aaad" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="8e8e-ceee-8bf4-37b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0ac7-0ef1-b9df-aaad" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="8e8e-ceee-8bf4-37b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="72b2-20ef-754c-6a9d" name="Mortalis Destroyer Squad" hidden="true" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b01c-f5a0-9f68-605a" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b01c-f5a0-9f68-605a" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="90a3-1058-c7e7-7531" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="2fbb-ead3-2607-81c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="90a3-1058-c7e7-7531" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2fbb-ead3-2607-81c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="5805-6167-9e39-9c7b" name="Dreadwing Interemptor Squad" hidden="true" collective="false" import="false" targetId="3008-e8ed-9e97-71c9" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b01c-f5a0-9f68-605a" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b01c-f5a0-9f68-605a" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d7ce-7417-0aea-1e6a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="fa60-ad41-6354-7894" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d7ce-7417-0aea-1e6a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fa60-ad41-6354-7894" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="2e48-3cfb-b821-441e" name="Assault Squad" hidden="true" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e4ff-1e49-4ec4-eb6d" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="4dcd-2da0-6459-75fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e4ff-1e49-4ec4-eb6d" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4dcd-2da0-6459-75fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
       <entryLinks>
         <entryLink id="a70a-39f3-b1ce-61e0" name="Centurion (Storm of War)" hidden="true" collective="false" import="true" targetId="6305-99cb-5a76-be11" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo"/>
-                <condition field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6650-b0cd-fb32-b405" type="atLeast"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo" />
+                <condition field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6650-b0cd-fb32-b405" type="atLeast" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0007-b0ef-f5e8-48e7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0007-b0ef-f5e8-48e7" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="08cf-4821-926b-6e00" name="Despoiler Squad" hidden="true" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5d4c-8216-02fb-a96d" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="f601-7817-4d0c-da54" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5d4c-8216-02fb-a96d" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="f601-7817-4d0c-da54" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
       <entryLinks>
         <entryLink id="2e29-eede-e8ab-25e3" name="Centurion (Storm of War)" hidden="false" collective="false" import="true" targetId="6305-99cb-5a76-be11" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo"/>
-                <condition field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd53-72cd-7c20-3bc8" type="atLeast"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo" />
+                <condition field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd53-72cd-7c20-3bc8" type="atLeast" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fef-6274-06e4-a849" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fef-6274-06e4-a849" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="a015-c49d-a619-bafa" name="Assault Squad" hidden="true" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a9ae-a0cb-6e28-cec9" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="91a9-ca66-6195-a18e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a9ae-a0cb-6e28-cec9" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="91a9-ca66-6195-a18e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
       <entryLinks>
         <entryLink id="2cd1-393d-21d2-4fb9" name="Centurion (Storm of War)" hidden="true" collective="false" import="true" targetId="6305-99cb-5a76-be11" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo"/>
-                <condition field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6650-b0cd-fb32-b405" type="atLeast"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo" />
+                <condition field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6650-b0cd-fb32-b405" type="atLeast" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e791-92fb-5c2e-f81f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e791-92fb-5c2e-f81f" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="9c72-8e1d-abf7-5b93" name="Tactical Squad" hidden="true" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="348d-ed8c-2a2c-170b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="d226-8c29-dd7f-d2d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="348d-ed8c-2a2c-170b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="d226-8c29-dd7f-d2d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
       <entryLinks>
         <entryLink id="07f6-10a8-4a78-54dc" name="Centurion (Storm of War)" hidden="true" collective="false" import="true" targetId="6305-99cb-5a76-be11" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo"/>
-                <condition field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f115-cfc4-4199-f8be" type="atLeast"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4d-26dd-c703-2723" type="equalTo" />
+                <condition field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f115-cfc4-4199-f8be" type="atLeast" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f1b-c03e-9634-ba26" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f1b-c03e-9634-ba26" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="3919-f840-929b-166a" name="Outrider Squadron" hidden="true" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="20d9-ae98-5324-6bb3" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="20d9-ae98-5324-6bb3" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2baa-9922-8bca-6ac0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="3667-ec70-9854-6fe1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2baa-9922-8bca-6ac0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="3667-ec70-9854-6fe1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="ac5e-f4f8-290c-b181" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="20d9-ae98-5324-6bb3" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="20d9-ae98-5324-6bb3" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="beb7-738e-0985-73fc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="4fcd-d122-c685-5be7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="beb7-738e-0985-73fc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="4fcd-d122-c685-5be7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="7765-ad00-f0c0-c354" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c2d1-1f28-900c-a078" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="246b-51e3-8f63-d7f1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="c2d1-1f28-900c-a078" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="246b-51e3-8f63-d7f1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="4097-b2b4-d9da-da99" name="Corswain" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1fa5-9904-5936-b781" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1fa5-9904-5936-b781" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="dada-97ba-b9da-7a55" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="e21c-e91f-1504-340b" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="4c67-e0ac-3d2b-391a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="dada-97ba-b9da-7a55" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="e21c-e91f-1504-340b" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="4c67-e0ac-3d2b-391a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0fec-c66f-9639-612f" name="Corswain" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7942-9fe9-3025-82df" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ddf-0c0d-ffdf-4abe" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7942-9fe9-3025-82df" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ddf-0c0d-ffdf-4abe" type="max" />
           </constraints>
           <profiles>
             <profile id="e077-ce6a-0f0a-5adc" name="Corswain" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Unique, Character, Deathwing)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">7</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1475,31 +1474,31 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="86ac-3562-5477-790e" name="Deathwing" hidden="false" targetId="5e82-8a8f-d64f-0839" type="rule"/>
-            <infoLink id="349a-60a6-f51d-1d55" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule"/>
-            <infoLink id="5098-af63-7e4a-f076" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+            <infoLink id="86ac-3562-5477-790e" name="Deathwing" hidden="false" targetId="5e82-8a8f-d64f-0839" type="rule" />
+            <infoLink id="349a-60a6-f51d-1d55" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule" />
+            <infoLink id="5098-af63-7e4a-f076" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
             <infoLink id="d838-8d31-5be5-f2b3" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Precision Strikes (4+)"/>
+                <modifier type="set" field="name" value="Precision Strikes (4+)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <entryLinks>
             <entryLink id="c166-70af-d709-a450" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="292d-f0bb-75c6-89be" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6016-143d-e646-4224" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="292d-f0bb-75c6-89be" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6016-143d-e646-4224" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="80c5-e797-2dc1-2e07" name="Armour of the Forest and the Mantle of the Champion" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d56b-987b-0b62-bb90" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebb2-3e31-311b-4090" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d56b-987b-0b62-bb90" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebb2-3e31-311b-4090" type="max" />
           </constraints>
           <profiles>
             <profile id="6fa1-3c67-269f-b4e1" name="Armour of the Forest and the Mantle of the Champion" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
@@ -1509,13 +1508,13 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="13c7-9a26-8137-1a5b" name="The Blade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9c7-983a-aa62-e494" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f25-0475-3f1b-47d8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9c7-983a-aa62-e494" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f25-0475-3f1b-47d8" type="max" />
           </constraints>
           <profiles>
             <profile id="712d-a63b-2608-4b58" name="The Blade*" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1523,7 +1522,7 @@
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+2</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Two-handed, Master-crafted, Duellist&apos;s Edge (2), Murderous Strike (4+)</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Two-handed, Master-crafted, Duellist's Edge (2), Murderous Strike (4+)</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -1533,94 +1532,94 @@
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="92fd-2938-7622-7e02" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
-            <infoLink id="971b-e4cc-2b45-8bd8" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
-            <infoLink id="5e90-7da8-bc84-180b" name="Duellist’s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule">
+            <infoLink id="92fd-2938-7622-7e02" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
+            <infoLink id="971b-e4cc-2b45-8bd8" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
+            <infoLink id="5e90-7da8-bc84-180b" name="Duellist&#8217;s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Duellist’s Edge (2)"/>
+                <modifier type="set" field="name" value="Duellist&#8217;s Edge (2)" />
               </modifiers>
             </infoLink>
             <infoLink id="2f85-cbf8-dff2-1b21" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Murderous Strike (4+)"/>
+                <modifier type="set" field="name" value="Murderous Strike (4+)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="fb6e-c7a8-5ee1-f45d" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2100-8dfe-c408-29df" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c10-bd51-aedb-f971" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2100-8dfe-c408-29df" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c10-bd51-aedb-f971" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="1feb-6aa7-3336-1727" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8d6-0222-8ac5-1d1c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f873-f79d-b6ce-8472" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8d6-0222-8ac5-1d1c" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f873-f79d-b6ce-8472" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="08b6-2573-3a7e-c37f" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78b4-85b7-86fa-5230" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fb0-db30-081d-c3f4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78b4-85b7-86fa-5230" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fb0-db30-081d-c3f4" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="83ce-3ca3-7ac0-f8ed" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94fd-f359-9865-2df5" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6039-ff04-77c9-afb2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94fd-f359-9865-2df5" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6039-ff04-77c9-afb2" type="min" />
           </constraints>
         </entryLink>
-        <entryLink id="1b7d-f88c-e31d-5687" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup"/>
+        <entryLink id="1b7d-f88c-e31d-5687" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup" />
         <entryLink id="a770-f30b-221d-9755" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1450-55a0-960f-3074" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1450-55a0-960f-3074" type="max" />
           </constraints>
           <infoLinks>
             <infoLink id="0414-838c-0797-5be1" name="Marshal of the Crown" hidden="false" targetId="7b52-e033-811f-dd15" type="profile">
               <modifiers>
-                <modifier type="set" field="name" value="Marshal of the Crown (Deathwing)"/>
+                <modifier type="set" field="name" value="Marshal of the Crown (Deathwing)" />
               </modifiers>
             </infoLink>
           </infoLinks>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="3008-e8ed-9e97-71c9" name="Dreadwing Interemptor Squad" publicationId="817a-6288-e016-7469" page="162" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="f95d-9f22-186a-4784" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="f95d-9f22-186a-4784" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
         <infoLink id="b353-8179-c8e9-7f92" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Counter Attack (1)"/>
+            <modifier type="set" field="name" value="Counter Attack (1)" />
           </modifiers>
         </infoLink>
-        <infoLink id="39de-9864-e0e1-5a7f" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
-        <infoLink id="aa20-671e-8cb3-3aad" name="Dreadwing" hidden="false" targetId="bbfb-b03e-a6c8-ecae" type="rule"/>
+        <infoLink id="39de-9864-e0e1-5a7f" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule" />
+        <infoLink id="aa20-671e-8cb3-3aad" name="Dreadwing" hidden="false" targetId="bbfb-b03e-a6c8-ecae" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="bf1a-56af-8a6a-87da" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="2d85-3f36-554c-2bf1" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="bf1a-56af-8a6a-87da" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="2d85-3f36-554c-2bf1" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="941e-52ca-922e-26b7" name="Interemptor Praefectus" publicationId="817a-6288-e016-7469" page="162" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcc0-5be3-3b19-fc35" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c58-bf95-d164-8d94" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcc0-5be3-3b19-fc35" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c58-bf95-d164-8d94" type="max" />
           </constraints>
           <profiles>
             <profile id="6250-ab5b-2baa-2979" name="Interemptor Praefectus" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="3008-e8ed-9e97-71c9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac63-6604-bd49-6de0" type="equalTo"/>
+                    <condition field="selections" scope="3008-e8ed-9e97-71c9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac63-6604-bd49-6de0" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1640,13 +1639,13 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="f5d5-440f-9caf-ae9f" name="Interemptors" publicationId="817a-6288-e016-7469" page="162" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="866b-2103-8a6c-8cb8" type="min"/>
-            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2812-405c-b478-4c0f" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="866b-2103-8a6c-8cb8" type="min" />
+            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2812-405c-b478-4c0f" type="max" />
           </constraints>
           <profiles>
             <profile id="27d7-6a2c-7fc5-46e3" name="Interemptor" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -1666,7 +1665,7 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1675,19 +1674,19 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f5d5-440f-9caf-ae9f" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f5d5-440f-9caf-ae9f" type="greaterThan" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1259-618a-54a8-4e94" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1259-618a-54a8-4e94" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="1043-4b74-b2b0-a68e" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1696,7 +1695,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1705,7 +1704,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1716,26 +1715,26 @@
           <entryLinks>
             <entryLink id="8336-e8cd-0b55-1fa6" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94af-2b75-4234-9fb8" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94af-2b75-4234-9fb8" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="c4f8-467c-f8f9-f9fa" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c0d-1f77-996f-27c9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c0d-1f77-996f-27c9" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="f28d-733a-9506-50b6" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ca5-9a6f-7f01-9c3f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ca5-9a6f-7f01-9c3f" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -1744,37 +1743,37 @@
           <modifiers>
             <modifier type="increment" field="b5cd-9e06-c31a-89cf" value="1.0">
               <repeats>
-                <repeat field="selections" scope="3008-e8ed-9e97-71c9" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="3008-e8ed-9e97-71c9" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b5cd-9e06-c31a-89cf" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b5cd-9e06-c31a-89cf" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="2890-114e-321c-edc9" name="Plasma Incinerator" hidden="false" collective="false" import="true" targetId="e0ff-7d2c-a195-6a45" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </entryLink>
             <entryLink id="6a9f-055a-cd93-8fd4" name="Missile Launcher (With suspensor web and rad missiles only)" hidden="false" collective="false" import="true" targetId="d000-9713-6bc2-e93b" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="name" value="Missile Launcher (with suspensor web, rad &amp; stasis missiles)">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fae4-6429-a591-d82f" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fae4-6429-a591-d82f" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <entryLinks>
                 <entryLink id="c734-dafd-78af-3aec" name="Stasis Missiles" hidden="false" collective="false" import="true" targetId="fae4-6429-a591-d82f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3cf1-bf04-2997-c2d0" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79c8-c098-3f99-668b" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3cf1-bf04-2997-c2d0" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79c8-c098-3f99-668b" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -1783,20 +1782,20 @@
           <entryLinks>
             <entryLink id="f9fc-52a7-f8c1-c097" name="Phosphex Bomb" hidden="false" collective="false" import="true" targetId="4188-13ff-cb03-109e" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a07f-fc5a-5a59-1b02" type="min"/>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef86-3d7b-3c3f-ce75" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a07f-fc5a-5a59-1b02" type="min" />
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef86-3d7b-3c3f-ce75" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="6692-c7d3-8358-9ed0" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e706-4b25-dc43-a58d" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c080-41bb-9f92-99ea" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e706-4b25-dc43-a58d" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c080-41bb-9f92-99ea" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -1805,10 +1804,10 @@
           <entryLinks>
             <entryLink id="ac63-6604-bd49-6de0" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bb3-8c3e-2b8c-2d47" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bb3-8c3e-2b8c-2d47" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -1817,43 +1816,43 @@
       <entryLinks>
         <entryLink id="13ee-c726-5977-f14e" name="Plasma Burner" hidden="false" collective="false" import="true" targetId="de47-02c8-3273-2f9b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4e7-c866-eb7f-e052" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebf1-e62f-ac25-b4cd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4e7-c866-eb7f-e052" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebf1-e62f-ac25-b4cd" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="9341-f263-0d01-1a9f" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b096-e389-12d0-7682" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5310-af81-c0dc-7755" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b096-e389-12d0-7682" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5310-af81-c0dc-7755" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="6971-71db-9ddd-4b5c" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5a5-2e7e-758d-aed3" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2cc-e9db-b24c-1c40" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5a5-2e7e-758d-aed3" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2cc-e9db-b24c-1c40" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="7e28-335f-c209-3d6e" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53cb-baf1-e511-d4b1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="136a-cf9a-7d01-e49b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53cb-baf1-e511-d4b1" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="136a-cf9a-7d01-e49b" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="3b58-39f7-b1d6-07c5" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cc4-6164-cb76-0e05" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7dd-fc87-7308-df63" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cc4-6164-cb76-0e05" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7dd-fc87-7308-df63" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="8e38-3651-b9ae-db30" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4052-8491-0d69-e122" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee64-d681-81e6-9793" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4052-8491-0d69-e122" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee64-d681-81e6-9793" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="cf23-fd3a-15a0-7347" name="Excindio Battle-automata" publicationId="d0df-7166-5cd3-89fd" page="54" hidden="false" collective="false" import="true" type="unit">
@@ -1862,7 +1861,7 @@
           <modifiers>
             <modifier type="decrement" field="f111-2ce5-dd12-d6b0" value="1">
               <conditions>
-                <condition field="selections" scope="cf23-fd3a-15a0-7347" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2d0f-1d06-3cdc-5de1" type="equalTo"/>
+                <condition field="selections" scope="cf23-fd3a-15a0-7347" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2d0f-1d06-3cdc-5de1" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -1882,7 +1881,7 @@
         </profile>
         <profile id="aef2-c8df-6a1a-fb48" name="Internal Refractor Field" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
           <characteristics>
-            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">This model has a 5+ Invulnerable save. In addition, should the model lose its last wound then all models within D6+4&quot; suffer a Str 8 AP - hit.</characteristic>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">This model has a 5+ Invulnerable save. In addition, should the model lose its last wound then all models within D6+4" suffer a Str 8 AP - hit.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -1890,10 +1889,10 @@
         <rule id="ec39-0eaa-c0d6-6447" name="Vengeful Rage" publicationId="d0df-7166-5cd3-89fd" page="56" hidden="false">
           <description>At the end of any turn in which this model suffers one or more unsaved wounds, take a Leadership test. If the test is failed, the unit enters a Vengeful Rage and must abide by all of the following restrictions during every phase of each following turn for the remainder of the game. While in a Vengeful Rage, the Excindio may be targeted as though it was an enemy model by friendly units:
 
-• During the Movement phase, the model must move towards the nearest visible unit, friendly or enemy.
-• If no unit is visible, or more than one unit is equidistant to the unit then the controlling player may move the model toward an enemy unit of the controlling player&apos;s choice.
-• During the Shooting phase, the model must target the nearest unit, friendly or enemy, with all available weapons. If two units are both equally close then the controlling player may choose which will be targeted.
-• During the Assault phase, the model must declare a Charge targeting the nearest visible unit, friendly or enemy. If two units are both equally close then the controlling player may choose which will be targeted. If this unit succeeds in charging a friendly unit, it will proceed to attack them in the Fight sub-phase, treating them as enemy models for the duration of the combat.</description>
+&#8226; During the Movement phase, the model must move towards the nearest visible unit, friendly or enemy.
+&#8226; If no unit is visible, or more than one unit is equidistant to the unit then the controlling player may move the model toward an enemy unit of the controlling player's choice.
+&#8226; During the Shooting phase, the model must target the nearest unit, friendly or enemy, with all available weapons. If two units are both equally close then the controlling player may choose which will be targeted.
+&#8226; During the Assault phase, the model must declare a Charge targeting the nearest visible unit, friendly or enemy. If two units are both equally close then the controlling player may choose which will be targeted. If this unit succeeds in charging a friendly unit, it will proceed to attack them in the Fight sub-phase, treating them as enemy models for the duration of the combat.</description>
         </rule>
         <rule id="47cc-8e78-0978-4af0" name="Cybernetica Exterminator" publicationId="d0df-7166-5cd3-89fd" page="55" hidden="false">
           <description>The Excindio Battle-automata has the Animatus Excindor Cybertheurgic Weapon from the Artificia Machina Cybertheurgic  Arcana found on page 94 of Liber Mechanicum, but may not select any other Cybertheurgic Arcana, Cybertheurgic Rites or  Cybertheurgic Weapons.</description>
@@ -1902,95 +1901,95 @@
       <infoLinks>
         <infoLink id="c3de-0ae5-57a6-c385" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="It Will Not Die (4+)"/>
+            <modifier type="set" field="name" value="It Will Not Die (4+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="6efd-8f1a-fc43-564f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="41dc-2f36-d265-13b9" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="4a74-0b7b-e4f1-ac5d" name="Cybertheurgist" hidden="false" targetId="57a1-ae47-ff1b-36e4" primary="false"/>
+        <categoryLink id="6efd-8f1a-fc43-564f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="41dc-2f36-d265-13b9" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="4a74-0b7b-e4f1-ac5d" name="Cybertheurgist" hidden="false" targetId="57a1-ae47-ff1b-36e4" primary="false" />
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="f512-ae27-71ee-88f1" name="4) Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="752a-c5e3-15b2-9986" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="752a-c5e3-15b2-9986" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="2116-479e-7909-f7c9" name="Dreadnought Drop Pod" hidden="false" collective="false" import="true" targetId="1ffe-82e4-12db-538d" type="selectionEntry"/>
-            <entryLink id="7100-7f88-abcc-c34e" name="Kharybdis Assault Claw" hidden="false" collective="false" import="true" targetId="f64a-90b7-19c8-182a" type="selectionEntry"/>
+            <entryLink id="2116-479e-7909-f7c9" name="Dreadnought Drop Pod" hidden="false" collective="false" import="true" targetId="1ffe-82e4-12db-538d" type="selectionEntry" />
+            <entryLink id="7100-7f88-abcc-c34e" name="Kharybdis Assault Claw" hidden="false" collective="false" import="true" targetId="f64a-90b7-19c8-182a" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="a2b8-3923-d229-3f42" name="1) May exchange an Extinctor power claw and a manipulator arm for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2d0f-1d06-3cdc-5de1">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0426-e88f-f850-5b92" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afeb-65db-a539-d02b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0426-e88f-f850-5b92" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afeb-65db-a539-d02b" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="2d0f-1d06-3cdc-5de1" name="Extinctor power claw and a manipulator arm" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="4654-de05-9ede-37d0" name="Extinctor power claw and a manipulator arm" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066"/>
-                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458"/>
-                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d"/>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9"/>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066" />
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458" />
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d" />
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9" />
                   </characteristics>
                 </profile>
               </profiles>
               <entryLinks>
                 <entryLink id="22ff-1930-ed76-f45d" name="Manipulator Arm" hidden="false" collective="false" import="true" targetId="e2e3-64c6-4820-aa91" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa8b-5f06-907c-5d1c" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2965-3a6e-2d14-777c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa8b-5f06-907c-5d1c" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2965-3a6e-2d14-777c" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="74f6-6c59-e661-4592" name="Extinctor power claw" hidden="false" collective="false" import="true" targetId="919d-b99c-78c3-5732" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17ef-b549-d439-9940" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dc3-cd01-04ba-565d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17ef-b549-d439-9940" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dc3-cd01-04ba-565d" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="2b53-467d-5d03-0113" name="Athanax pattern phosphex canister launcher" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="1bc2-c6c3-3e59-ee0f" name="Athanax pattern phosphex canister launcher" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">18"</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Blast (3&quot;), Barrage, Poisoned (3+), Crawling Fire, Lingering Death</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Blast (3"), Barrage, Poisoned (3+), Crawling Fire, Lingering Death</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <infoLinks>
                 <infoLink id="e0d3-cc59-67f2-b91d" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Blast (3&quot;)"/>
+                    <modifier type="set" field="name" value="Blast (3&quot;)" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="1f1e-f35a-44f3-4e62" name="Lingering Death" hidden="false" targetId="be87-f0e5-7446-972b" type="rule"/>
-                <infoLink id="3d2a-13ad-c9b0-38bf" name="Crawling Fire" hidden="false" targetId="8258-a7af-e4df-531d" type="rule"/>
+                <infoLink id="1f1e-f35a-44f3-4e62" name="Lingering Death" hidden="false" targetId="be87-f0e5-7446-972b" type="rule" />
+                <infoLink id="3d2a-13ad-c9b0-38bf" name="Crawling Fire" hidden="false" targetId="8258-a7af-e4df-531d" type="rule" />
                 <infoLink id="3a63-3bdb-7db7-97b2" name="Poisoned (X)" hidden="false" targetId="e70e-23ea-3251-0edb" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Poisoned (3+)"/>
+                    <modifier type="set" field="name" value="Poisoned (3+)" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="7cf4-97b8-1169-05d8" name="Barrage" hidden="false" targetId="7255-b5ee-c3f4-3037" type="rule"/>
+                <infoLink id="7cf4-97b8-1169-05d8" name="Barrage" hidden="false" targetId="7255-b5ee-c3f4-3037" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="9d6d-fef9-5876-69f4" name="Tyrhenius pattern nerve induction shredder" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="31ac-b0c3-1e7a-9ce1" name="Tyrhenius pattern nerve induction shredder" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">24"</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">1</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
                     <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 8, Poisoned (4+), Breaching (4+), Pinning</characteristic>
@@ -2000,25 +1999,25 @@
               <infoLinks>
                 <infoLink id="9f03-a6d7-a2b9-9969" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Breaching (4+)"/>
+                    <modifier type="set" field="name" value="Breaching (4+)" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="3bda-b15e-ab7b-8e2b" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+                <infoLink id="3bda-b15e-ab7b-8e2b" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule" />
                 <infoLink id="4353-fb99-d37a-475a" name="Poisoned (X)" hidden="false" targetId="e70e-23ea-3251-0edb" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Poisoned (4+)"/>
+                    <modifier type="set" field="name" value="Poisoned (4+)" />
                   </modifiers>
                 </infoLink>
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="e810-be74-abfc-84aa" name="Magaron pattern atomantic pulse cannon" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="d699-4ff8-775d-9993" name="Magaron pattern atomantic pulse cannon" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">24"</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
                     <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 2, Lance, Shock Pulse</characteristic>
@@ -2026,11 +2025,11 @@
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="b1bd-c2a3-f971-3926" name="Lance" hidden="false" targetId="3d6b-9e0b-56f0-8a1e" type="rule"/>
-                <infoLink id="1493-3d6d-38a8-3d64" name="Shock Pulse" hidden="false" targetId="9222-f6c5-dc19-905a" type="rule"/>
+                <infoLink id="b1bd-c2a3-f971-3926" name="Lance" hidden="false" targetId="3d6b-9e0b-56f0-8a1e" type="rule" />
+                <infoLink id="1493-3d6d-38a8-3d64" name="Shock Pulse" hidden="false" targetId="9222-f6c5-dc19-905a" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="d417-b98f-131e-2ac8" name="Cytheron pattern graviton flux projector" hidden="false" collective="false" import="true" type="upgrade">
@@ -2038,56 +2037,56 @@
                 <profile id="0e90-05c1-7948-dd67" name="Cytheron pattern graviton flux projector" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="95ba-cda7-b831-6066">Template</characteristic>
-                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">†</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">&#8224;</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, †Graviton Collapse, Torsion Crusher, Ignores Cover, Concussive (1)</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, &#8224;Graviton Collapse, Torsion Crusher, Ignores Cover, Concussive (1)</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="de81-b415-a40d-5447" name="2) May exchange both of its combi-bolters for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="e4b7-27e7-ca20-69ad">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a345-d81d-18a4-b358" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f73a-62ab-1957-fb36" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a345-d81d-18a4-b358" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f73a-62ab-1957-fb36" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="e4b7-27e7-ca20-69ad" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="name" value="2x Combi-Bolters"/>
+                <modifier type="set" field="name" value="2x Combi-Bolters" />
               </modifiers>
             </entryLink>
             <entryLink id="544a-a73e-d24a-253e" name="Plasma Repeater" hidden="false" collective="false" import="true" targetId="7aa4-cb4e-0e15-6213" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="name" value="2x Plasma Repeaters"/>
+                <modifier type="set" field="name" value="2x Plasma Repeaters" />
               </modifiers>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
               </costs>
             </entryLink>
             <entryLink id="39d4-fbfa-5477-92c7" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="name" value="2x Graviton Guns"/>
+                <modifier type="set" field="name" value="2x Graviton Guns" />
               </modifiers>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="b7e1-ac5a-5b2f-3531" name="3) May take:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6295-9d12-2d5d-15e9" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6aa7-437d-b2d0-b055" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6295-9d12-2d5d-15e9" type="min" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6aa7-437d-b2d0-b055" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="c6d1-527c-2805-1445" name="Hunter-Killer Missile" hidden="false" collective="false" import="true" targetId="1bf8-72f8-c331-6900" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -2096,36 +2095,36 @@
       <entryLinks>
         <entryLink id="43b9-d8d9-d1e6-324d" name="Extinctor power claw" hidden="false" collective="false" import="true" targetId="919d-b99c-78c3-5732" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a100-ec58-588c-f2df" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb49-1edc-8b1d-2477" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a100-ec58-588c-f2df" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb49-1edc-8b1d-2477" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="a7a0-b305-e15e-6802" name="Manipulator Arm" hidden="false" collective="false" import="true" targetId="e2e3-64c6-4820-aa91" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a1a-b050-615a-e3b5" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d111-f381-1b07-a587" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a1a-b050-615a-e3b5" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d111-f381-1b07-a587" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="42cc-cf88-b137-d2de" name="Animatus Excindor (Cybertheurgic Weapon)" hidden="false" collective="false" import="true" targetId="caa2-99d2-b7a0-21b7" type="selectionEntry"/>
+        <entryLink id="42cc-cf88-b137-d2de" name="Animatus Excindor (Cybertheurgic Weapon)" hidden="false" collective="false" import="true" targetId="caa2-99d2-b7a0-21b7" type="selectionEntry" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="350.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="350.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="28ab-ad48-d8b3-0d5d" name="Farith Redloss" publicationId="d0df-7166-5cd3-89fd" page="45" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7c0a-d13c-972b-eebb" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7c0a-d13c-972b-eebb" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="5703-f989-0ae4-1a33" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="aceb-a3da-6ce7-ff40" name="Independant Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="2fea-f85f-069a-1843" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="5703-f989-0ae4-1a33" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="aceb-a3da-6ce7-ff40" name="Independant Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="2fea-f85f-069a-1843" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3b2a-dabb-fad5-a404" name="Farith Redloss" publicationId="d0df-7166-5cd3-89fd" page="45" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eef8-8f8b-2ecd-6a31" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="edec-4a92-799b-ab08" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eef8-8f8b-2ecd-6a31" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="edec-4a92-799b-ab08" type="max" />
           </constraints>
           <profiles>
             <profile id="8dc9-5e2f-f833-4c69" name="Farith Redloss" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2146,33 +2145,33 @@
           </profiles>
           <rules>
             <rule id="5ce2-e9bb-3ed3-3013" name="Scion of the Dreadwing" hidden="false">
-              <description>An Infrantry model with this special rule and any Infantry unit it joins with the Legion Astartes (Dark Angels) special rule may choose to move 4&quot; through difficult terrain rather than rolling any dice and may re-roll failed Dangerous Terrain tests.</description>
+              <description>An Infrantry model with this special rule and any Infantry unit it joins with the Legion Astartes (Dark Angels) special rule may choose to move 4" through difficult terrain rather than rolling any dice and may re-roll failed Dangerous Terrain tests.</description>
             </rule>
           </rules>
           <infoLinks>
             <infoLink id="ad88-6f77-8499-6969" name="Battle-Hardened (X)" hidden="false" targetId="5c3b-ed0b-4ad0-d547" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Battle-Hardened (1)"/>
+                <modifier type="set" field="name" value="Battle-Hardened (1)" />
               </modifiers>
             </infoLink>
-            <infoLink id="be33-716a-8b05-8aa3" name="Dreadwing" hidden="false" targetId="bbfb-b03e-a6c8-ecae" type="rule"/>
+            <infoLink id="be33-716a-8b05-8aa3" name="Dreadwing" hidden="false" targetId="bbfb-b03e-a6c8-ecae" type="rule" />
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="396a-84f3-e63f-bd04" name="The Axe of Castigation" publicationId="d0df-7166-5cd3-89fd" page="45" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b0b-43f0-da6e-66cb" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4088-1105-bf4a-c753" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b0b-43f0-da6e-66cb" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4088-1105-bf4a-c753" type="max" />
               </constraints>
               <rules>
                 <rule id="d252-3ffd-6e56-6601" name="The Axe of Castigation" publicationId="d0df-7166-5cd3-89fd" page="45" hidden="false">
-                  <description>The Axe of Castigation is considered a single weapon with two profiles that represent different fighting styles employed by Farith Redloss. In each Fight sub-phase Farith Redloss’ controlling player must choose one of these two profiles to use for all of his attacks. The Axe of Castigation is counted as a ‘Power’ weapon for those rules that affect such weapons.</description>
+                  <description>The Axe of Castigation is considered a single weapon with two profiles that represent different fighting styles employed by Farith Redloss. In each Fight sub-phase Farith Redloss&#8217; controlling player must choose one of these two profiles to use for all of his attacks. The Axe of Castigation is counted as a &#8216;Power&#8217; weapon for those rules that affect such weapons.</description>
                 </rule>
               </rules>
               <selectionEntries>
                 <selectionEntry id="bf6f-cc11-97b5-7218" name="The Axe of Castigation (Overhead Strike)" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb40-3e7d-2579-0673" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9652-0fa3-9277-511f" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb40-3e7d-2579-0673" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9652-0fa3-9277-511f" type="min" />
                   </constraints>
                   <profiles>
                     <profile id="8627-ce16-40f1-cd6c" name="The Axe of Castigation (Overhead Strike)" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2185,18 +2184,18 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink id="e673-dff8-275c-58c4" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
-                    <infoLink id="0633-5020-ffff-bffc" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
-                    <infoLink id="0078-b4b8-0d27-a8f0" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+                    <infoLink id="e673-dff8-275c-58c4" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
+                    <infoLink id="0633-5020-ffff-bffc" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
+                    <infoLink id="0078-b4b8-0d27-a8f0" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
                   </infoLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="098d-d0e8-591b-c385" name="The Axe of Castigation (Sweeping Strike)" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b799-fc68-7d66-3d22" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f972-d130-0968-49ec" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b799-fc68-7d66-3d22" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f972-d130-0968-49ec" type="min" />
                   </constraints>
                   <profiles>
                     <profile id="a1d6-7ad2-81e0-bc24" name="The Axe of Castigation (Sweeping Strike)" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2211,83 +2210,83 @@
                   <infoLinks>
                     <infoLink id="6891-02f2-2b6f-9c35" name="Reaping Blow (X)" hidden="false" targetId="bd8c-4f52-d682-1b40" type="rule">
                       <modifiers>
-                        <modifier type="set" field="name" value="Reaping Blow (3)"/>
+                        <modifier type="set" field="name" value="Reaping Blow (3)" />
                       </modifiers>
                     </infoLink>
-                    <infoLink id="88b7-7ca6-b64a-4f3b" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                    <infoLink id="88b7-7ca6-b64a-4f3b" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
                   </infoLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
-            <selectionEntry id="728f-2ece-f8f3-8318" name="The Dreadbringer’s Plate" publicationId="d0df-7166-5cd3-89fd" page="45" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="728f-2ece-f8f3-8318" name="The Dreadbringer&#8217;s Plate" publicationId="d0df-7166-5cd3-89fd" page="45" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="606f-31be-aa79-1a2d" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0726-4ddd-cc15-eafb" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="606f-31be-aa79-1a2d" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0726-4ddd-cc15-eafb" type="max" />
               </constraints>
               <profiles>
-                <profile id="2f33-2bd0-1ceb-f2d0" name="The Dreadbringer’s Plate" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+                <profile id="2f33-2bd0-1ceb-f2d0" name="The Dreadbringer&#8217;s Plate" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
                   <characteristics>
-                    <characteristic name="Description" typeId="347e-ee4a-764f-6be3">The Dreadbringer’s Plate grants a 2+ Armour Save and a 4+ Invulnerable Save. In addition, against any weapon with the Crawling Fire or Armourbane (Melta) special rules, this Invulnerable Save is increased to 2+ and any weapon with the Poisoned (X) special rule can only wound Farith Redloss on the roll of 6+.</characteristic>
+                    <characteristic name="Description" typeId="347e-ee4a-764f-6be3">The Dreadbringer&#8217;s Plate grants a 2+ Armour Save and a 4+ Invulnerable Save. In addition, against any weapon with the Crawling Fire or Armourbane (Melta) special rules, this Invulnerable Save is increased to 2+ and any weapon with the Poisoned (X) special rule can only wound Farith Redloss on the roll of 6+.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="ca1c-94b6-31f5-afd0" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f24-035d-f065-7829" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96a2-6793-3b0f-7cd4" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f24-035d-f065-7829" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96a2-6793-3b0f-7cd4" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="8c52-f84e-d56f-3146" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95a2-380a-0a62-6080" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7803-492c-c401-3f68" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95a2-380a-0a62-6080" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7803-492c-c401-3f68" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="2302-174a-dfe0-107a" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc7b-f0ee-cb0d-d1a5" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e178-b979-2d4e-e626" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc7b-f0ee-cb0d-d1a5" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e178-b979-2d4e-e626" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="001a-9d92-f77d-ec30" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4db-478b-c578-cc46" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="292a-6141-35f6-ddf8" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4db-478b-c578-cc46" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="292a-6141-35f6-ddf8" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="91e6-bfff-a8eb-bdc7" name="Phosphex Bomb" hidden="false" collective="false" import="true" targetId="4188-13ff-cb03-109e" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db0f-b959-0d36-1a80" type="min"/>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91dd-bfdd-d782-7fa6" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db0f-b959-0d36-1a80" type="min" />
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91dd-bfdd-d782-7fa6" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="fe1d-0aba-5eb6-e3c9" name="Master of the Arsenal" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b96c-ef15-3409-36cf" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b42-7d44-1fb9-50c3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b96c-ef15-3409-36cf" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b42-7d44-1fb9-50c3" type="max" />
           </constraints>
           <rules>
             <rule id="7adf-ea05-8905-486d" name="Master of the Arsenal" hidden="false">
-              <description>At the start of any battle, the controlling player may select one of the following weapons – Farith Redloss gains the use of that weapon for the duration of the battle:
+              <description>At the start of any battle, the controlling player may select one of the following weapons &#8211; Farith Redloss gains the use of that weapon for the duration of the battle:
 Tyrhenian pattern Neural Shredder Carbine
 Magaron pattern Atomantic Pulse Pistol
 Selenite Shard-bolt Pistol</description>
@@ -2298,7 +2297,7 @@ Selenite Shard-bolt Pistol</description>
               <profiles>
                 <profile id="f574-9c41-3f58-295c" name="Atomantic Pulse Pistol" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">6&quot;</characteristic>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">6"</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
                     <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol (1), Lance, Shock Pulse</characteristic>
@@ -2306,18 +2305,18 @@ Selenite Shard-bolt Pistol</description>
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="8a09-29b1-d314-d8dd" name="Shock Pulse" hidden="false" targetId="9222-f6c5-dc19-905a" type="rule"/>
-                <infoLink id="13d0-91a9-6718-3ff2" name="Lance" hidden="false" targetId="3d6b-9e0b-56f0-8a1e" type="rule"/>
+                <infoLink id="8a09-29b1-d314-d8dd" name="Shock Pulse" hidden="false" targetId="9222-f6c5-dc19-905a" type="rule" />
+                <infoLink id="13d0-91a9-6718-3ff2" name="Lance" hidden="false" targetId="3d6b-9e0b-56f0-8a1e" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="3165-8a35-9944-c438" name="Selenite Shard-bolt Pistol" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="2e85-6659-46a7-b467" name="Shard-bolt Pistol" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">12"</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
                     <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol (4), Rending (6+), Moonsilver</characteristic>
@@ -2326,25 +2325,25 @@ Selenite Shard-bolt Pistol</description>
               </profiles>
               <rules>
                 <rule id="28f4-6161-a17a-cd6e" name="Moonsilver" hidden="false">
-                  <description>Any unsaved Wound caused against a model with the Daemon Unit Type or Psyker Sub-type is instead counted as two Wounds. Wounds caused in excess of the model&apos;s remaining Wounds do not spill over to other models.</description>
+                  <description>Any unsaved Wound caused against a model with the Daemon Unit Type or Psyker Sub-type is instead counted as two Wounds. Wounds caused in excess of the model's remaining Wounds do not spill over to other models.</description>
                 </rule>
               </rules>
               <infoLinks>
                 <infoLink id="3a54-3fd5-5edc-8496" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Rending (6+)"/>
+                    <modifier type="set" field="name" value="Rending (6+)" />
                   </modifiers>
                 </infoLink>
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="0845-f71c-79e1-85c0" name="Tyrhenian pattern Neural Shredder Carbine" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="e1ab-de9f-1200-5f17" name="Neural Shredder Carbine" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">18"</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">1</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
                     <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 2, Poison (4+), Ignores Cover, Pinning</characteristic>
@@ -2352,16 +2351,16 @@ Selenite Shard-bolt Pistol</description>
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="8dfe-32a4-5593-0167" name="Ignores Cover" hidden="false" targetId="fdb5-59e2-c446-1cbc" type="rule"/>
+                <infoLink id="8dfe-32a4-5593-0167" name="Ignores Cover" hidden="false" targetId="fdb5-59e2-c446-1cbc" type="rule" />
                 <infoLink id="daeb-62d1-69c2-df98" name="Poisoned (X)" hidden="false" targetId="e70e-23ea-3251-0edb" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Poisoned (4+)"/>
+                    <modifier type="set" field="name" value="Poisoned (4+)" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="4aff-ffe1-fe93-471f" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+                <infoLink id="4aff-ffe1-fe93-471f" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2370,39 +2369,39 @@ Selenite Shard-bolt Pistol</description>
       <entryLinks>
         <entryLink id="d3b5-d859-3ff6-c7ee" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="372e-b30c-3969-a187" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba02-54df-20f8-fe3c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="372e-b30c-3969-a187" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba02-54df-20f8-fe3c" type="min" />
           </constraints>
         </entryLink>
-        <entryLink id="aadb-6d1c-bf5f-9619" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup"/>
+        <entryLink id="aadb-6d1c-bf5f-9619" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup" />
         <entryLink id="c8aa-b5ff-3eee-79ce" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eced-ad30-af98-9f2b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eced-ad30-af98-9f2b" type="max" />
           </constraints>
           <infoLinks>
             <infoLink id="0788-0df4-c608-ff0f" name="Marshal of the Crown" hidden="false" targetId="7b52-e033-811f-dd15" type="profile">
               <modifiers>
-                <modifier type="set" field="name" value="Marshal of the Crown (Deathwing)"/>
+                <modifier type="set" field="name" value="Marshal of the Crown (Deathwing)" />
               </modifiers>
             </infoLink>
           </infoLinks>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="3731-e0df-bd0c-a33e" name="Firewing Enigmatus Cabal" publicationId="d0df-7166-5cd3-89fd" page="52" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="3a4b-b4f9-aeeb-da68" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="8c89-c8a4-6609-6878" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
-        <categoryLink id="1edd-14b2-f178-4fba" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="3a4b-b4f9-aeeb-da68" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="8c89-c8a4-6609-6878" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false" />
+        <categoryLink id="1edd-14b2-f178-4fba" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9549-9717-b59c-3f41" name="Firewing Enigmatii" publicationId="817a-6288-e016-7469" page="52" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48cf-b772-c40e-6dee" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8f1-cdf0-b32d-c284" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48cf-b772-c40e-6dee" type="min" />
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8f1-cdf0-b32d-c284" type="max" />
           </constraints>
           <profiles>
             <profile id="1684-232c-b50e-aa96" name="Firewing Enigmatii" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2422,17 +2421,17 @@ Selenite Shard-bolt Pistol</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="4310-3520-bf35-b87d" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
-            <infoLink id="96a1-48a7-9164-533c" name="Marked For Death" hidden="false" targetId="4f41-4c04-9cd8-c5a1" type="rule"/>
-            <infoLink id="09a7-ea8a-8cfb-9c0f" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule"/>
-            <infoLink id="566a-ab58-d975-1834" name="Firewing" hidden="false" targetId="1e3b-0c10-9bb0-8e44" type="rule"/>
-            <infoLink id="7aef-0f7c-7898-499c" name="Legion Warhawk Jump Pack" hidden="false" targetId="3a39-4e88-05fb-48ec" type="rule"/>
+            <infoLink id="4310-3520-bf35-b87d" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
+            <infoLink id="96a1-48a7-9164-533c" name="Marked For Death" hidden="false" targetId="4f41-4c04-9cd8-c5a1" type="rule" />
+            <infoLink id="09a7-ea8a-8cfb-9c0f" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule" />
+            <infoLink id="566a-ab58-d975-1834" name="Firewing" hidden="false" targetId="1e3b-0c10-9bb0-8e44" type="rule" />
+            <infoLink id="7aef-0f7c-7898-499c" name="Legion Warhawk Jump Pack" hidden="false" targetId="3a39-4e88-05fb-48ec" type="rule" />
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="80bb-dfb5-9fc3-3f22" name="Calibanite charge-blade" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9279-cb75-959f-4e1c" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c610-fe46-6022-8349" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9279-cb75-959f-4e1c" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c610-fe46-6022-8349" type="max" />
               </constraints>
               <profiles>
                 <profile id="23d3-bd89-51f1-5a9c" name="Calibanite charge-blade" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2446,29 +2445,29 @@ Selenite Shard-bolt Pistol</description>
               </profiles>
               <rules>
                 <rule id="fbd8-5d81-3afd-4e6a" name="Blade charge" hidden="false">
-                  <description>Once per battle, a unit that includes any models with weapons with this special rule may declare a Blade Charge at the start of any of the controlling player’s Assault phases. For the duration of that Phase, the attacks made by all models in the unit with weapons with the Blade Charge special rule gain the Rending (3+) special rule in addition to any other effects their weapons might have. This does not replace or improve any other versions of the Rending (X) special rule already possessed by  the unit.</description>
+                  <description>Once per battle, a unit that includes any models with weapons with this special rule may declare a Blade Charge at the start of any of the controlling player&#8217;s Assault phases. For the duration of that Phase, the attacks made by all models in the unit with weapons with the Blade Charge special rule gain the Rending (3+) special rule in addition to any other effects their weapons might have. This does not replace or improve any other versions of the Rending (X) special rule already possessed by  the unit.</description>
                 </rule>
               </rules>
               <infoLinks>
                 <infoLink id="c9a0-b869-ae49-d4c2" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Rending (6+)"/>
+                    <modifier type="set" field="name" value="Rending (6+)" />
                   </modifiers>
                 </infoLink>
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="973c-6901-3be6-b136" name="Needle Pistol" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5334-2672-435e-f149" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cda7-e41c-98b0-1d8b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5334-2672-435e-f149" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cda7-e41c-98b0-1d8b" type="max" />
               </constraints>
               <profiles>
                 <profile id="6e65-cf25-e9d6-049b" name="Needle Pistol" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">12"</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">2</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
                     <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 2, Poisoned (3+), Pinning</characteristic>
@@ -2478,19 +2477,19 @@ Selenite Shard-bolt Pistol</description>
               <infoLinks>
                 <infoLink id="6f68-5bf6-f3fb-4d14" name="Poisoned (X)" hidden="false" targetId="e70e-23ea-3251-0edb" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Poisoned (3+)"/>
+                    <modifier type="set" field="name" value="Poisoned (3+)" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="a15a-ee1d-da32-10a5" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+                <infoLink id="a15a-ee1d-da32-10a5" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="da5f-b919-b4e1-5f9d" name="Enigmatus Exhaust Projector" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0fe-38c9-803e-5964" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97c6-107b-e50d-2eee" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0fe-38c9-803e-5964" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97c6-107b-e50d-2eee" type="max" />
               </constraints>
               <rules>
                 <rule id="d599-1a7a-5141-52fd" name="Enigmatus Exhaust Projector" hidden="false">
@@ -2500,85 +2499,85 @@ Selenite Shard-bolt Pistol</description>
               <infoLinks>
                 <infoLink id="11d4-c47a-7618-a6c7" name="Shrouded (X)" hidden="false" targetId="10c3-fdb0-089f-ca65" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Shrouded (4+)"/>
+                    <modifier type="set" field="name" value="Shrouded (4+)" />
                   </modifiers>
                 </infoLink>
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="4d35-afa7-cb46-2cdc" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff6b-0081-bbce-96b3" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3473-7eef-228c-5bec" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff6b-0081-bbce-96b3" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3473-7eef-228c-5bec" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="0349-427c-d68c-1015" name="Shroud Bombs" hidden="false" collective="false" import="true" targetId="5d4d-36b7-6bf5-fc92" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2f3-b587-b6b0-52c3" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb93-6868-27a4-a862" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2f3-b587-b6b0-52c3" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb93-6868-27a4-a862" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="93fe-9b39-0997-269d" name=" One Firewing Enigmatii in the unit may take:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f80c-f3d2-fa37-3aad" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89fe-986e-f75d-57b1" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f80c-f3d2-fa37-3aad" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89fe-986e-f75d-57b1" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="577d-1773-da27-a736" name="Missile launcher (with suspensor web and frag, krak and stasis shells)" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="b00d-988f-65db-e191" name="Missile Launcher - Frag" hidden="false" collective="false" import="true" targetId="92c9-17c7-1702-6eeb" type="selectionEntry"/>
-                <entryLink id="3415-9d78-dbd6-fa38" name="Missile Launcher - Krak" hidden="false" collective="false" import="true" targetId="4a40-08ba-8b0f-82ec" type="selectionEntry"/>
+                <entryLink id="b00d-988f-65db-e191" name="Missile Launcher - Frag" hidden="false" collective="false" import="true" targetId="92c9-17c7-1702-6eeb" type="selectionEntry" />
+                <entryLink id="3415-9d78-dbd6-fa38" name="Missile Launcher - Krak" hidden="false" collective="false" import="true" targetId="4a40-08ba-8b0f-82ec" type="selectionEntry" />
                 <entryLink id="5c9c-34b6-fa46-65eb" name="Suspensor Web" hidden="false" collective="false" import="true" targetId="6472-db7f-08b0-d7c7" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8018-9cef-b277-fcc1" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5feb-7a72-5940-d1a0" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8018-9cef-b277-fcc1" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5feb-7a72-5940-d1a0" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="f421-75ed-a3b1-01af" name="Stasis Missiles" hidden="false" collective="false" import="true" targetId="fae4-6429-a591-d82f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3de-864c-f75f-d0d8" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c64-e7b0-e772-2f36" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3de-864c-f75f-d0d8" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c64-e7b0-e772-2f36" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="902d-5951-9b95-19fb" name="Holguin" publicationId="d0df-7166-5cd3-89fd" page="47" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0af1-a178-7ad3-c6af" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0af1-a178-7ad3-c6af" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="02a1-f083-b1fa-673a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="ef49-f8a7-3bda-0fba" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="2dec-96ad-9237-42f0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="21de-4e57-9f08-b389" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="4708-b98d-9e99-73eb" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="02a1-f083-b1fa-673a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="ef49-f8a7-3bda-0fba" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="2dec-96ad-9237-42f0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="21de-4e57-9f08-b389" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
+        <categoryLink id="4708-b98d-9e99-73eb" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="902d-a2c3-bd20-dbf1" name="Holguin" publicationId="d0df-7166-5cd3-89fd" page="47" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="801a-fd30-a9cd-aa9a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51d8-7de5-fa58-1967" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="801a-fd30-a9cd-aa9a" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51d8-7de5-fa58-1967" type="max" />
           </constraints>
           <profiles>
             <profile id="1191-6356-f053-3957" name="Holguin" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2598,20 +2597,20 @@ Selenite Shard-bolt Pistol</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="4bce-ae69-daf0-4ad9" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+            <infoLink id="4bce-ae69-daf0-4ad9" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
             <infoLink id="0467-bb3e-1726-f481" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Buky (2)"/>
+                <modifier type="set" field="name" value="Buky (2)" />
               </modifiers>
             </infoLink>
-            <infoLink id="1430-31e5-43d5-ab10" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
-            <infoLink id="39a6-71cc-71ec-23e4" name="Deathwing" hidden="false" targetId="5e82-8a8f-d64f-0839" type="rule"/>
+            <infoLink id="1430-31e5-43d5-ab10" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
+            <infoLink id="39a6-71cc-71ec-23e4" name="Deathwing" hidden="false" targetId="5e82-8a8f-d64f-0839" type="rule" />
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="1e58-344d-b10e-99cb" name="The Viridian Blade" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5877-4827-9591-7cf0" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9c8-7e80-401f-4f78" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5877-4827-9591-7cf0" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9c8-7e80-401f-4f78" type="max" />
               </constraints>
               <profiles>
                 <profile id="b2c3-b1c7-128f-079b" name="Viridian Blade" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2630,103 +2629,103 @@ special rule.</description>
                 </rule>
               </rules>
               <infoLinks>
-                <infoLink id="43ec-5f1c-d77d-92b8" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
-                <infoLink id="7eb4-010e-8b0c-d9eb" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="43ec-5f1c-d77d-92b8" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
+                <infoLink id="7eb4-010e-8b0c-d9eb" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
                 <infoLink id="fd9f-0d92-6151-1bc6" name="Reaping Blow (X)" hidden="false" targetId="bd8c-4f52-d682-1b40" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Reaping Blow (2)"/>
+                    <modifier type="set" field="name" value="Reaping Blow (2)" />
                   </modifiers>
                 </infoLink>
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
-            <selectionEntry id="6716-32a0-7b37-5ba3" name="The Deathbringer’s Aegis" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="6716-32a0-7b37-5ba3" name="The Deathbringer&#8217;s Aegis" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="313d-cecc-84a6-a8df" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1e2-b487-2596-07ec" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="313d-cecc-84a6-a8df" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1e2-b487-2596-07ec" type="max" />
               </constraints>
               <rules>
-                <rule id="7e7d-c43f-5b32-e3de" name="The Deathbringer’s Aegis" hidden="false">
-                  <description>The Deathbringer’s Aegis grants a 2+ Armour Save and a 4+ Invulnerable Save and additionally, the Feel No Pain (5+) special rule.</description>
+                <rule id="7e7d-c43f-5b32-e3de" name="The Deathbringer&#8217;s Aegis" hidden="false">
+                  <description>The Deathbringer&#8217;s Aegis grants a 2+ Armour Save and a 4+ Invulnerable Save and additionally, the Feel No Pain (5+) special rule.</description>
                 </rule>
               </rules>
               <infoLinks>
                 <infoLink id="6b5d-e66b-55a8-689d" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+                    <modifier type="set" field="name" value="Feel No Pain (5+)" />
                   </modifiers>
                 </infoLink>
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="d4a9-1203-a539-ecca" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2e2-7763-52b8-3d64" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d78-928d-7397-d904" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2e2-7763-52b8-3d64" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d78-928d-7397-d904" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="2414-b923-73e8-5999" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1418-e94b-5b6c-319a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70d3-873d-d468-293d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1418-e94b-5b6c-319a" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70d3-873d-d468-293d" type="min" />
           </constraints>
         </entryLink>
-        <entryLink id="a9be-b140-2312-769a" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup"/>
+        <entryLink id="a9be-b140-2312-769a" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup" />
         <entryLink id="de4a-547c-30ba-aa42" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1157-3802-c638-c16f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1157-3802-c638-c16f" type="max" />
           </constraints>
           <infoLinks>
             <infoLink id="22b1-3774-4b7e-0778" name="Marshal of the Crown" hidden="false" targetId="7b52-e033-811f-dd15" type="profile">
               <modifiers>
-                <modifier type="set" field="name" value="Marshal of the Crown (Deathwing)"/>
+                <modifier type="set" field="name" value="Marshal of the Crown (Deathwing)" />
               </modifiers>
             </infoLink>
           </infoLinks>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="150.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="150.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="9946-61c0-3656-36dd" name="Inner Circle Knights Cenobium" publicationId="09b3-d525-cdea-260c" page="7" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="5b04-1c3f-aad1-72c8" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="5b04-1c3f-aad1-72c8" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="f1e3-36fc-2ec6-5c8d" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="66d4-ddcd-b730-1b91" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="66d4-ddcd-b730-1b91" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
         <infoLink id="d127-7748-d49b-e06c" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Adamantium Will (3+)"/>
+            <modifier type="set" field="name" value="Adamantium Will (3+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="359e-1590-1dcc-33d3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="c379-1039-7f09-252d" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="94ed-ef24-43f7-ea1e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="359e-1590-1dcc-33d3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="c379-1039-7f09-252d" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="94ed-ef24-43f7-ea1e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b71f-8496-1f24-f116" name=" Order Preceptor" publicationId="09b3-d525-cdea-260c" page="7" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1289-cbb2-16bb-de4e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a69-cd46-051b-7c26" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1289-cbb2-16bb-de4e" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a69-cd46-051b-7c26" type="max" />
           </constraints>
           <profiles>
             <profile id="d61b-78bc-b74f-a04a" name="Order Preceptor" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2748,35 +2747,35 @@ special rule.</description>
           <selectionEntryGroups>
             <selectionEntryGroup id="2d17-672b-d5f0-2648" name=" Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="be5e-aab5-ebee-8220">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b1b-d438-e7e0-d8c0" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88bc-8125-5d60-dc5b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b1b-d438-e7e0-d8c0" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88bc-8125-5d60-dc5b" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="fb22-8af6-ad71-855b" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry"/>
-                <entryLink id="be5e-aab5-ebee-8220" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="68b3-a64c-a609-6615" type="selectionEntry"/>
+                <entryLink id="fb22-8af6-ad71-855b" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry" />
+                <entryLink id="be5e-aab5-ebee-8220" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="68b3-a64c-a609-6615" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="36c8-9f50-a3fe-b515" name="May take the following:" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="499f-38fa-3d42-ae4a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="499f-38fa-3d42-ae4a" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="f1a1-4f8e-5215-5c92" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="041e-d501-774a-a54b" name="Order Cenobites" publicationId="09b3-d525-cdea-260c" page="7" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="841c-c499-618e-2dac" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35ed-4ba3-aedc-c699" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="841c-c499-618e-2dac" type="min" />
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35ed-4ba3-aedc-c699" type="max" />
           </constraints>
           <profiles>
             <profile id="dc37-aac1-0329-d898" name="Order Cenobites" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2798,21 +2797,21 @@ special rule.</description>
           <selectionEntryGroups>
             <selectionEntryGroup id="5a3c-c473-82b7-8f86" name="Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="dabe-c265-b65c-4c57">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="045b-77d4-eb2d-c059" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="719f-fa5f-ca28-eddf" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="045b-77d4-eb2d-c059" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="719f-fa5f-ca28-eddf" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="cdd6-aac0-4548-f755" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c594-ee20-08bc-dbeb" type="min"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c594-ee20-08bc-dbeb" type="min" />
                   </constraints>
                 </entryLink>
-                <entryLink id="dabe-c265-b65c-4c57" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="68b3-a64c-a609-6615" type="selectionEntry"/>
+                <entryLink id="dabe-c265-b65c-4c57" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="68b3-a64c-a609-6615" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2821,25 +2820,25 @@ special rule.</description>
           <entryLinks>
             <entryLink id="4061-5ea2-3977-5837" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f0e-7ec9-ec98-c773" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f0e-7ec9-ec98-c773" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="457a-6883-f0b8-a66c" name="3) Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6574-0ccd-4f8b-7724" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6574-0ccd-4f8b-7724" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="4396-ef6e-afd3-c3b2" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"/>
+            <entryLink id="4396-ef6e-afd3-c3b2" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry" />
             <entryLink id="4dc5-5201-f9f8-e4b7" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="041e-d501-774a-a54b" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="041e-d501-774a-a54b" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -2850,13 +2849,13 @@ special rule.</description>
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78bf-14d5-2721-6154" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cca3-cf6e-0b28-e411" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78bf-14d5-2721-6154" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cca3-cf6e-0b28-e411" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="7b03-a316-ebfc-f197" name="Augurs of Weakness" publicationId="817a-6288-e016-7469" page="161" hidden="false" collective="false" import="true" type="upgrade">
@@ -2866,7 +2865,7 @@ special rule.</description>
                 </rule>
               </rules>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="ea47-e0d2-e3ed-e35a" name="Icons of Resolve" publicationId="817a-6288-e016-7469" page="161" hidden="false" collective="false" import="true" type="upgrade">
@@ -2876,27 +2875,27 @@ special rule.</description>
                 </rule>
               </rules>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="c79d-c85d-fc09-195f" name="Slayers of Kings" publicationId="817a-6288-e016-7469" page="161" hidden="false" collective="false" import="true" type="upgrade">
               <rules>
                 <rule id="c9b1-e3ce-0a55-a54d" name="Slayers of Kings" publicationId="817a-6288-e016-7469" page="161" hidden="false">
-                  <description>This model may re-roll failed To Hit rolls of &apos;1&apos; when Engaged in combat with any model with a Weapon Skill of 5 or higher or in a Challenge with any model with a Weapon Skill of 5 or higher.</description>
+                  <description>This model may re-roll failed To Hit rolls of '1' when Engaged in combat with any model with a Weapon Skill of 5 or higher or in a Challenge with any model with a Weapon Skill of 5 or higher.</description>
                 </rule>
               </rules>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="6c3a-bc38-62a2-fb14" name="Hunter of Beasts" publicationId="817a-6288-e016-7469" page="161" hidden="false" collective="false" import="true" type="upgrade">
               <rules>
                 <rule id="9db7-54d9-ad3c-bbae" name="Hunter of Beasts" publicationId="817a-6288-e016-7469" page="161" hidden="false">
-                  <description>This model may re-roll failed To Wound rolls of &apos;1&apos; when any enemy unit it is Engaged in combat with includes one or more models with a Toughness of 5, or any failed To Wound roll if the target&apos;s Toughness is 6 or higher.</description>
+                  <description>This model may re-roll failed To Wound rolls of '1' when any enemy unit it is Engaged in combat with includes one or more models with a Toughness of 5, or any failed To Wound roll if the target's Toughness is 6 or higher.</description>
                 </rule>
               </rules>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="baf2-ace7-dc1f-e914" name="Reaper of Hosts" publicationId="817a-6288-e016-7469" page="161" hidden="false" collective="false" import="true" type="upgrade">
@@ -2906,7 +2905,7 @@ special rule.</description>
                 </rule>
               </rules>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="9eed-7e1c-0e7b-c249" name="Breaker of Witches" publicationId="817a-6288-e016-7469" page="161" hidden="false" collective="false" import="true" type="upgrade">
@@ -2916,7 +2915,7 @@ special rule.</description>
                 </rule>
               </rules>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2925,20 +2924,20 @@ special rule.</description>
       <entryLinks>
         <entryLink id="ae5b-67cc-6d01-d8ea" name="Plasma-Caster" hidden="false" collective="false" import="true" targetId="1951-78d7-bb2c-6219" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f789-7bfc-22b0-d40b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e28-48fc-4e0a-b1ae" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f789-7bfc-22b0-d40b" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e28-48fc-4e0a-b1ae" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="0042-5cae-518f-be2c" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afe4-8d92-4f08-68c1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d07-3650-d099-3094" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afe4-8d92-4f08-68c1" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d07-3650-d099-3094" type="min" />
           </constraints>
         </entryLink>
-        <entryLink id="11e9-037c-5cd4-0ae5" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
+        <entryLink id="11e9-037c-5cd4-0ae5" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="b9ad-ab3e-437e-c373" name="Inner Circle Knights Cenobium - Order of the Broken Claws" publicationId="09b3-d525-cdea-260c" page="7" hidden="false" collective="false" import="true" type="unit">
@@ -2948,29 +2947,29 @@ special rule.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="cb63-4c93-98a4-dfca" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="cb63-4c93-98a4-dfca" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="9cc3-f1df-d3ee-3469" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="5392-4341-414b-f1c0" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="5392-4341-414b-f1c0" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
         <infoLink id="e95c-b472-45a3-d0e4" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Adamantium Will (3+)"/>
+            <modifier type="set" field="name" value="Adamantium Will (3+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="5ae3-be22-48b5-7f36" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="9a31-0a49-48f9-57ca" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="ca24-0dcb-67f2-0a38" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="5ae3-be22-48b5-7f36" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="9a31-0a49-48f9-57ca" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="ca24-0dcb-67f2-0a38" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="cfcb-776f-05b4-6c67" name=" Order Preceptor" publicationId="09b3-d525-cdea-260c" page="7" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2255-91b6-372e-b06e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c445-2e42-d54f-32c6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2255-91b6-372e-b06e" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c445-2e42-d54f-32c6" type="max" />
           </constraints>
           <profiles>
             <profile id="e9fb-1377-7028-d701" name="Order Preceptor" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2992,45 +2991,45 @@ special rule.</description>
           <selectionEntryGroups>
             <selectionEntryGroup id="5941-6904-f888-6db7" name=" Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="720f-e9d8-32f0-8582">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cda-d35d-98c3-53f6" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d25-f226-a2a1-86f6" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cda-d35d-98c3-53f6" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d25-f226-a2a1-86f6" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="ad78-bf51-98dd-dd52" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry"/>
+                <entryLink id="ad78-bf51-98dd-dd52" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry" />
                 <entryLink id="4b29-e590-9e95-4482" name="Advex-mors Greatsword" hidden="false" collective="false" import="true" targetId="12b8-ffd2-d5d6-28c5" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="720f-e9d8-32f0-8582" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="68b3-a64c-a609-6615" type="selectionEntry"/>
+                <entryLink id="720f-e9d8-32f0-8582" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="68b3-a64c-a609-6615" type="selectionEntry" />
                 <entryLink id="7803-e692-4ae1-a135" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="2ab9-0e45-405e-056b" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="a8c8-5c83-1317-b3e2" name="May take:" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="531c-1f4c-e8ad-1a12" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="531c-1f4c-e8ad-1a12" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="d969-ce36-2c7e-575f" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="a2ae-5fac-436a-c4f6" name="Order Cenobites" publicationId="09b3-d525-cdea-260c" page="7" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcd0-9b16-6960-0886" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="672b-9b5b-8630-b086" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcd0-9b16-6960-0886" type="min" />
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="672b-9b5b-8630-b086" type="max" />
           </constraints>
           <profiles>
             <profile id="3ce9-98fd-460c-6f88" name="Order Cenobites" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -3052,22 +3051,22 @@ special rule.</description>
           <selectionEntryGroups>
             <selectionEntryGroup id="60d0-d739-ac76-6097" name="Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9bbd-aafd-68b4-2b06">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91f2-08ca-cba7-89ff" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="084b-502e-5bf9-b573" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91f2-08ca-cba7-89ff" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="084b-502e-5bf9-b573" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="1c3a-f1ec-8393-5b75" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry"/>
+                <entryLink id="1c3a-f1ec-8393-5b75" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry" />
                 <entryLink id="29ca-468c-1dcf-2f9d" name="Advex-mors Greatsword" hidden="false" collective="false" import="true" targetId="12b8-ffd2-d5d6-28c5" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="9bbd-aafd-68b4-2b06" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="68b3-a64c-a609-6615" type="selectionEntry"/>
+                <entryLink id="9bbd-aafd-68b4-2b06" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="68b3-a64c-a609-6615" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -3076,25 +3075,25 @@ special rule.</description>
           <entryLinks>
             <entryLink id="a686-26ad-3e16-7384" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1791-9899-2321-aac6" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1791-9899-2321-aac6" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="318a-bbf5-3e51-da95" name="Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96bd-31e0-63c0-479a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96bd-31e0-63c0-479a" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="ca0c-79ec-8f77-8eed" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"/>
+            <entryLink id="ca0c-79ec-8f77-8eed" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry" />
             <entryLink id="2fd6-2384-079c-d4fe" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2ae-5fac-436a-c4f6" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2ae-5fac-436a-c4f6" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -3105,42 +3104,42 @@ special rule.</description>
       <entryLinks>
         <entryLink id="39ca-fe57-bd4f-4b92" name="Plasma-Caster" hidden="false" collective="false" import="true" targetId="1951-78d7-bb2c-6219" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f317-4a52-f75b-3c33" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f871-694c-d53f-f3b3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f317-4a52-f75b-3c33" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f871-694c-d53f-f3b3" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="0acc-d703-374a-373b" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dec6-532c-1456-65cc" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f06b-6665-f93c-bec0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dec6-532c-1456-65cc" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f06b-6665-f93c-bec0" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="1333-866a-74b1-6a19" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
+        <entryLink id="1333-866a-74b1-6a19" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0" />
       </costs>
     </selectionEntry>
-    <selectionEntry id="0689-b550-0b0e-63d6" name="Lion El&apos;Jonson " hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="0689-b550-0b0e-63d6" name="Lion El'Jonson " hidden="false" collective="false" import="true" type="unit">
       <comment>Hexagrammaton</comment>
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fe1f-71bf-448a-cb04" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fe1f-71bf-448a-cb04" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="1159-e4ba-1ed9-3218" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="f149-e20a-bc3b-9a43" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="1159-e4ba-1ed9-3218" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="f149-e20a-bc3b-9a43" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="ea6d-8560-75cc-fbca" name="Lion El&apos;Jonson" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="ea6d-8560-75cc-fbca" name="Lion El'Jonson" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf74-7b2b-4c6c-72fa" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b77a-1f36-bfd7-7a60" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf74-7b2b-4c6c-72fa" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b77a-1f36-bfd7-7a60" type="max" />
           </constraints>
           <profiles>
-            <profile id="e365-0094-b3b9-a993" name="Lion El&apos;Jonson" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+            <profile id="e365-0094-b3b9-a993" name="Lion El'Jonson" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Primarch (Unique)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">8</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">6</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
@@ -3155,59 +3154,59 @@ special rule.</description>
           </profiles>
           <rules>
             <rule id="ca81-67ef-2137-b233" name="The Point of the Blade" hidden="false">
-              <description>After declaring a Charge for Lion El’Jonson and any unit he has joined, the controlling player may choose not to make a Charge Distance roll and instead make a Charge move of 8&quot; for Lion El’Jonson and any unit he has joined, ignoring the effects of Difficult Terrain and Dangerous Terrain and adding no bonuses to the distance moved for the unit’s Movement Characteristic or Wargear.</description>
+              <description>After declaring a Charge for Lion El&#8217;Jonson and any unit he has joined, the controlling player may choose not to make a Charge Distance roll and instead make a Charge move of 8" for Lion El&#8217;Jonson and any unit he has joined, ignoring the effects of Difficult Terrain and Dangerous Terrain and adding no bonuses to the distance moved for the unit&#8217;s Movement Characteristic or Wargear.</description>
             </rule>
-            <rule id="34c3-c00f-62ff-1120" name="The Lion&apos;s Choler" hidden="false">
-              <description>When reduced to 4 Wounds or less Lion El’Jonson gains +1 Attack, increased to +2 Attacks when reduced to 2 Wounds or less.</description>
+            <rule id="34c3-c00f-62ff-1120" name="The Lion's Choler" hidden="false">
+              <description>When reduced to 4 Wounds or less Lion El&#8217;Jonson gains +1 Attack, increased to +2 Attacks when reduced to 2 Wounds or less.</description>
             </rule>
             <rule id="d747-c520-2c03-9f01" name="Legiones Astartes (Dark Angels (The Lion))" hidden="false">
-              <description>*Lion El’Jonson does not pick one Hexagrammaton Unit Sub-type at the start of the battle, instead at the start of each of the controlling player’s turns one of the Hexagrammaton Unit Sub-types may be selected for him – Lion El’Jonson gains this Hexagrammaton Sub-type until the start of the controlling player’s next turn, at which point a new Sub-type may be chosen (or the one currently in use retained).Speed.</description>
+              <description>*Lion El&#8217;Jonson does not pick one Hexagrammaton Unit Sub-type at the start of the battle, instead at the start of each of the controlling player&#8217;s turns one of the Hexagrammaton Unit Sub-types may be selected for him &#8211; Lion El&#8217;Jonson gains this Hexagrammaton Sub-type until the start of the controlling player&#8217;s next turn, at which point a new Sub-type may be chosen (or the one currently in use retained).Speed.</description>
             </rule>
           </rules>
           <infoLinks>
             <infoLink id="ea42-09fa-f71a-319c" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Adamantium Will (3+)"/>
+                <modifier type="set" field="name" value="Adamantium Will (3+)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <entryLinks>
             <entryLink id="27c9-d1cf-acf2-778b" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d302-cb23-e5df-bdbd" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b71-4890-4764-5aab" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d302-cb23-e5df-bdbd" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b71-4890-4764-5aab" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="63d3-7399-583d-b352" name="The Leonine Panoply" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee7c-8043-b4be-6eab" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9e2-d9aa-fd00-08f2" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee7c-8043-b4be-6eab" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9e2-d9aa-fd00-08f2" type="max" />
           </constraints>
           <profiles>
             <profile id="8dc0-c42e-aee5-981e" name="The Leonine Panoply" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
               <characteristics>
-                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">The Leonine Panoply provides a 2+ Armour Save and a 4+ Invulnerable Save. The first failed Invulnerable Save made for Lion El’Jonson each turn may be re-rolled.</characteristic>
+                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">The Leonine Panoply provides a 2+ Armour Save and a 4+ Invulnerable Save. The first failed Invulnerable Save made for Lion El&#8217;Jonson each turn may be re-rolled.</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="2761-1c6d-f0e3-0863" name="The Fusil Actinaeus" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a714-8d40-a8d5-bf41" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c776-8344-0cd8-a155" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a714-8d40-a8d5-bf41" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c776-8344-0cd8-a155" type="max" />
           </constraints>
           <profiles>
             <profile id="c3ad-d00d-66c4-115c" name="The Fusil Actinaeus" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">18"</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assult 2, Twin-linked, Blind, Rending (3+)</characteristic>
@@ -3216,44 +3215,44 @@ special rule.</description>
           </profiles>
           <rules>
             <rule id="39ec-f24c-c662-01c9" name="The Fusil Actinaeus*" hidden="false">
-              <description>The Fusil Actinaeus benefits from the +1 To Hit from the Stormwing Unit sub-type during any turn where Lion El’Jonson is using that Unit Sub-type.</description>
+              <description>The Fusil Actinaeus benefits from the +1 To Hit from the Stormwing Unit sub-type during any turn where Lion El&#8217;Jonson is using that Unit Sub-type.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="d614-411a-5e59-6c30" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
-            <infoLink id="42ee-47d7-cd14-f6be" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule"/>
+            <infoLink id="d614-411a-5e59-6c30" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule" />
+            <infoLink id="42ee-47d7-cd14-f6be" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule" />
             <infoLink id="6a26-cb33-6924-b6bf" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Rending (3+)"/>
+                <modifier type="set" field="name" value="Rending (3+)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="9149-a03d-2083-8315" name="Stasis Grenades" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfb0-70c6-a7d1-4a03" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c03-0eae-b23e-2de2" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfb0-70c6-a7d1-4a03" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c03-0eae-b23e-2de2" type="max" />
           </constraints>
           <profiles>
             <profile id="fa96-367b-10bd-9344" name="Stasis Grenades" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
               <characteristics>
-                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Once per battle, Lion El’Jonson’s controlling player may choose to use stasis grenades when a Charge is declared for Lion El’Jonson and any unit he has joined. If the Charge for which the stasis grenades are used is successful then the target enemy unit or units must take an Initiative test (using the majority Initiative value of the unit(s)). If the Initiative test is passed then there is no further effect. If the Test is failed then all enemy models in the target unit must reduce their Initiative by -1 for the duration of the Assault phase in which the Charge was made.</characteristic>
+                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Once per battle, Lion El&#8217;Jonson&#8217;s controlling player may choose to use stasis grenades when a Charge is declared for Lion El&#8217;Jonson and any unit he has joined. If the Charge for which the stasis grenades are used is successful then the target enemy unit or units must take an Initiative test (using the majority Initiative value of the unit(s)). If the Initiative test is passed then there is no further effect. If the Test is failed then all enemy models in the target unit must reduce their Initiative by -1 for the duration of the Assault phase in which the Charge was made.</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="1e37-d2d0-c7a3-c47d" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="4741-916b-9278-e400">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d9c-8286-08e9-c932" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3687-7452-379c-b00b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d9c-8286-08e9-c932" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3687-7452-379c-b00b" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="4741-916b-9278-e400" name="The Lion Sword " hidden="false" collective="false" import="true" type="upgrade">
@@ -3269,22 +3268,22 @@ special rule.</description>
               </profiles>
               <rules>
                 <rule id="d23c-3e2e-102c-0808" name="Melee Weapon*" hidden="false">
-                  <description>Both the Lion Sword and the Wolf Blade benefit from the +1 To Hit from the Deathwing Unit Sub-type during any turn where Lion El’Jonson is using that Unit Sub-type.</description>
+                  <description>Both the Lion Sword and the Wolf Blade benefit from the +1 To Hit from the Deathwing Unit Sub-type during any turn where Lion El&#8217;Jonson is using that Unit Sub-type.</description>
                 </rule>
               </rules>
               <infoLinks>
                 <infoLink id="1595-893c-ab60-49b4" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Armourbane (Melee)"/>
+                    <modifier type="set" field="name" value="Armourbane (Melee)" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="cd8c-6126-5990-39cd" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
-                <infoLink id="ca04-2ef0-6f6a-5087" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
-                <infoLink id="ba39-75fa-dfcb-8150" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
-                <infoLink id="5769-de59-960f-7d2c" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+                <infoLink id="cd8c-6126-5990-39cd" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule" />
+                <infoLink id="ca04-2ef0-6f6a-5087" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
+                <infoLink id="ba39-75fa-dfcb-8150" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule" />
+                <infoLink id="5769-de59-960f-7d2c" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="5f20-0e6b-ef3c-9a25" name="The Wolf Blade " hidden="false" collective="false" import="true" type="upgrade">
@@ -3303,26 +3302,26 @@ special rule.</description>
                   <description>The controlling player of any unit which suffers one or more casualties from this weapon and makes a Morale check during the Assault phase must roll an additional D6 for that Check and keep the two highest dice to determine the result of that Morale check.</description>
                 </rule>
                 <rule id="72db-fc64-1632-ee1c" name="Melee Weapon*" hidden="false">
-                  <description>Both the Lion Sword and the Wolf Blade benefit from the +1 To Hit from the Deathwing Unit Sub-type during any turn where Lion El’Jonson is using that Unit Sub-type.</description>
+                  <description>Both the Lion Sword and the Wolf Blade benefit from the +1 To Hit from the Deathwing Unit Sub-type during any turn where Lion El&#8217;Jonson is using that Unit Sub-type.</description>
                 </rule>
               </rules>
               <infoLinks>
-                <infoLink id="a2f6-87aa-56cf-d439" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
-                <infoLink id="18d4-6592-01a1-e1e9" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+                <infoLink id="a2f6-87aa-56cf-d439" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
+                <infoLink id="18d4-6592-01a1-e1e9" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
                 <infoLink id="6084-601e-48d0-258c" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Breaching (4+)"/>
+                    <modifier type="set" field="name" value="Breaching (4+)" />
                   </modifiers>
                 </infoLink>
                 <infoLink id="4777-a312-c94d-0b0b" name="Reaping Blow (X)" hidden="false" targetId="bd8c-4f52-d682-1b40" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Reaping Blow (2)"/>
+                    <modifier type="set" field="name" value="Reaping Blow (2)" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="2f47-d434-0772-7f33" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="2f47-d434-0772-7f33" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3331,31 +3330,31 @@ special rule.</description>
       <entryLinks>
         <entryLink id="068a-68fa-f37b-c9c9" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9735-76af-ddeb-2e1d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d148-6d13-1b19-59d4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9735-76af-ddeb-2e1d" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d148-6d13-1b19-59d4" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="3d5e-056f-ec4c-56af" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b90-49d1-5cc2-f12f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41d3-ba38-8bfe-bcc5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b90-49d1-5cc2-f12f" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41d3-ba38-8bfe-bcc5" type="min" />
           </constraints>
           <profiles>
             <profile id="4e52-1ac6-1b2f-2572" name="Sire of the Dark Angels" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any units with the Legiones Astartes (Dark Angels) special rule in the same army as Lion El&apos;Jonson gain the Crusader special rule, and any friendly models with the Legiones Astartes (Dark Angels) special rule that can draw line of sight to Lion El&apos;Jonson may add +1 to their Leadership (To a maximum of Ld 10). In addition, an army with Lion El&apos;Jonson as its Warlord may make an additional Reaction in the opposing player&apos;s Shooting phase as long as Lion El&apos;Jonson has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any units with the Legiones Astartes (Dark Angels) special rule in the same army as Lion El'Jonson gain the Crusader special rule, and any friendly models with the Legiones Astartes (Dark Angels) special rule that can draw line of sight to Lion El'Jonson may add +1 to their Leadership (To a maximum of Ld 10). In addition, an army with Lion El'Jonson as its Warlord may make an additional Reaction in the opposing player's Shooting phase as long as Lion El'Jonson has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="460.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="460.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="9136-b5e8-13f9-0c0f" name="Marduk Sedras" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3851-3332-143a-ea71" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3851-3332-143a-ea71" type="max" />
       </constraints>
       <profiles>
         <profile id="be84-23da-17c3-ed1b" name="Marduk Sedras" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -3376,25 +3375,25 @@ special rule.</description>
       </profiles>
       <rules>
         <rule id="14a8-3cea-225b-a998" name="Ancient of War" hidden="false">
-          <description>At the start of the battle, after deployment but before the first turn has begun, the controlling player may select a single Faction from the Allies in the Age of Darkness table, including either the Agents of the Emperor/Warmaster, that is represented in the enemy army. Marduk Sedras, and any friendly units with the Legiones Astartes (Dark Angels) special rule that have at least one model within 6&quot; of Marduk Sedras or a model with the Transport Subtype on which he is Embarked when all models have been deployed, but before the first Game Turn, gain the Preferred Enemy (Chosen Faction) special rule for all models in that unit for the duration of the battle. If Marduk Sedras is in Reserves, this special rule has no effect.</description>
+          <description>At the start of the battle, after deployment but before the first turn has begun, the controlling player may select a single Faction from the Allies in the Age of Darkness table, including either the Agents of the Emperor/Warmaster, that is represented in the enemy army. Marduk Sedras, and any friendly units with the Legiones Astartes (Dark Angels) special rule that have at least one model within 6" of Marduk Sedras or a model with the Transport Subtype on which he is Embarked when all models have been deployed, but before the first Game Turn, gain the Preferred Enemy (Chosen Faction) special rule for all models in that unit for the duration of the battle. If Marduk Sedras is in Reserves, this special rule has no effect.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="a8c4-6038-988b-7ee1" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule"/>
-        <infoLink id="5289-0ca6-d64f-b1b0" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="a8c4-6038-988b-7ee1" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule" />
+        <infoLink id="5289-0ca6-d64f-b1b0" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="2601-e1ee-e7fc-4791" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="ee1c-afee-f2c8-3259" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="7596-3e24-f641-1552" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="2687-f1d9-6b82-5dc4" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="ffb0-fffb-d657-d8f2" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="2601-e1ee-e7fc-4791" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="ee1c-afee-f2c8-3259" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="7596-3e24-f641-1552" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="2687-f1d9-6b82-5dc4" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
+        <categoryLink id="ffb0-fffb-d657-d8f2" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3f28-07ff-77b7-bd25" name="Regalia of the Shattered Sceptre" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53c3-b164-dd20-a348" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdf9-6873-98b9-f8a9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53c3-b164-dd20-a348" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdf9-6873-98b9-f8a9" type="max" />
           </constraints>
           <profiles>
             <profile id="7509-8e0b-38ff-5111" name="Regalia of the Shattered Sceptre" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
@@ -3404,13 +3403,13 @@ special rule.</description>
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="eca9-8c65-b968-9c26" name="The Death of Worlds" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9813-f045-a614-c8c8" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3646-3f81-f272-870b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9813-f045-a614-c8c8" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3646-3f81-f272-870b" type="max" />
           </constraints>
           <profiles>
             <profile id="8cf4-2e3c-334d-fc47" name="The Death of Worlds" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -3428,49 +3427,49 @@ special rule.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="d18a-b346-a7ff-7db0" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
-            <infoLink id="fbc5-d578-57b0-78c5" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+            <infoLink id="d18a-b346-a7ff-7db0" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
+            <infoLink id="fbc5-d578-57b0-78c5" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="2dec-fd34-32cd-eefc" name="Phosphex Bomb" hidden="false" collective="false" import="true" targetId="4188-13ff-cb03-109e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4d2-4686-c385-4147" type="max"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0896-e4b6-dcea-1cd8" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4d2-4686-c385-4147" type="max" />
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0896-e4b6-dcea-1cd8" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="1867-35f1-6ddf-0ca3" name="Plasma Burner" hidden="false" collective="false" import="true" targetId="de47-02c8-3273-2f9b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f676-ff54-47b6-38cb" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62a9-1593-1050-7768" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f676-ff54-47b6-38cb" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62a9-1593-1050-7768" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="ad38-7eac-46d3-5dfd" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b191-3649-22eb-3bdc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b191-3649-22eb-3bdc" type="max" />
           </constraints>
           <profiles>
             <profile id="fb11-9743-63bf-505d" name="Preceptor of the Shattered Sceptre" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If Marduk Sedras is the army’s Warlord then a unit of Inner Circle Knights Cenobium may be selected as part of the same HQ choice. A unit selected in this manner is considered a ‘Retinue Squad’. The Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as Marduk Sedras. The Retinue Squad must be deployed with Marduk Sedras deployed as part of the unit and Marduk Sedras may not voluntarily leave the Retinue Squad during play. However, if this option is selected then no other unit may be selected for Marduk Sedras using the Retinue or Deathwing Retinue special rules. In addition, an army with Marduk Sedras as its Warlord may make an additional Reaction in the opposing player’s Assault phase as long as Marduk Sedras has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If Marduk Sedras is the army&#8217;s Warlord then a unit of Inner Circle Knights Cenobium may be selected as part of the same HQ choice. A unit selected in this manner is considered a &#8216;Retinue Squad&#8217;. The Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as Marduk Sedras. The Retinue Squad must be deployed with Marduk Sedras deployed as part of the unit and Marduk Sedras may not voluntarily leave the Retinue Squad during play. However, if this option is selected then no other unit may be selected for Marduk Sedras using the Retinue or Deathwing Retinue special rules. In addition, an army with Marduk Sedras as its Warlord may make an additional Reaction in the opposing player&#8217;s Assault phase as long as Marduk Sedras has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
-        <entryLink id="387b-2081-be3d-ee99" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup"/>
+        <entryLink id="387b-2081-be3d-ee99" name="Retinue" hidden="false" collective="false" import="true" targetId="66e9-e8f8-5eb6-1cf6" type="selectionEntryGroup" />
         <entryLink id="d8a2-ec1e-a765-9ca2" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="740e-4b91-6718-63ca" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44cd-93fe-8803-4b80" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="740e-4b91-6718-63ca" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44cd-93fe-8803-4b80" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="919d-b99c-78c3-5732" name="Extinctor power claw" hidden="false" collective="false" import="true" type="upgrade">
@@ -3487,12 +3486,12 @@ special rule.</description>
       <infoLinks>
         <infoLink id="b857-f18e-5760-fd64" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Brutal (2)"/>
+            <modifier type="set" field="name" value="Brutal (2)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="e2e3-64c6-4820-aa91" name="Manipulator Arm" hidden="false" collective="false" import="true" type="upgrade">
@@ -3507,46 +3506,46 @@ special rule.</description>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="edf9-9d44-6bb2-4d47" name="Lance" hidden="false" targetId="3d6b-9e0b-56f0-8a1e" type="rule"/>
+        <infoLink id="edf9-9d44-6bb2-4d47" name="Lance" hidden="false" targetId="3d6b-9e0b-56f0-8a1e" type="rule" />
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="a9b5-ef4c-31db-4104" name="Deathwing Companion Detachment" publicationId="817a-6288-e016-7469" page="164" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="add" field="category" value="eee8-3c7c-2762-e33e">
           <conditions>
-            <condition field="selections" scope="a9b5-ef4c-31db-4104" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a298-8584-70ed-18ce" type="equalTo"/>
+            <condition field="selections" scope="a9b5-ef4c-31db-4104" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a298-8584-70ed-18ce" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <rules>
         <rule id="a2d3-7903-d187-909f" name="Deathwing Retinue" publicationId="817a-6288-e016-7469" page="165" hidden="true">
-          <description>A Deathwing Companion Detachment my only be selected as part of a Detachment that includes at least one model with both the Master of the Legion and the Legiones Astartes (Dark Angels) special rules. A unit selected in this manner is considered a &apos;Retinue Squad&apos; and the model with both the Master of the Legion and Legiones Astartes (Dark Angels) special rules is reffered to as the Retinue Squad&apos;s Leader for the purposes of this special rule (if the Detachment includes more than one eligible Leader then the controlling player selects one as the unit&apos;s Leader). The Retinue squad does not use up a Force Organization slot and is considered part of the same unit as the model selected as its Leader. The Retinue Squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Retinue Squad during play. A Deathwing Companion Detachment may not be selected as part of an army without a Leader.</description>
+          <description>A Deathwing Companion Detachment my only be selected as part of a Detachment that includes at least one model with both the Master of the Legion and the Legiones Astartes (Dark Angels) special rules. A unit selected in this manner is considered a 'Retinue Squad' and the model with both the Master of the Legion and Legiones Astartes (Dark Angels) special rules is reffered to as the Retinue Squad's Leader for the purposes of this special rule (if the Detachment includes more than one eligible Leader then the controlling player selects one as the unit's Leader). The Retinue squad does not use up a Force Organization slot and is considered part of the same unit as the model selected as its Leader. The Retinue Squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Retinue Squad during play. A Deathwing Companion Detachment may not be selected as part of an army without a Leader.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="60a6-3320-c36a-585d" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
-        <infoLink id="2cf9-11e4-f8ae-436d" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="7a6b-8163-5e46-aed7" name="Death-sworn Companions" hidden="false" targetId="2f3e-89a5-27e0-33b7" type="rule"/>
-        <infoLink id="59ff-5b38-cf74-711d" name="Deathwing" hidden="false" targetId="5e82-8a8f-d64f-0839" type="rule"/>
+        <infoLink id="60a6-3320-c36a-585d" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
+        <infoLink id="2cf9-11e4-f8ae-436d" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="7a6b-8163-5e46-aed7" name="Death-sworn Companions" hidden="false" targetId="2f3e-89a5-27e0-33b7" type="rule" />
+        <infoLink id="59ff-5b38-cf74-711d" name="Deathwing" hidden="false" targetId="5e82-8a8f-d64f-0839" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="1bb7-7e7e-ca18-0224" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="34be-5dc6-9701-910b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="1bb7-7e7e-ca18-0224" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="34be-5dc6-9701-910b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="788a-3a92-655f-63ca" name=" Deathwing Oathbearer" publicationId="817a-6288-e016-7469" page="164" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a58-5da9-9544-db5e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04aa-418b-8784-aacd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a58-5da9-9544-db5e" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04aa-418b-8784-aacd" type="max" />
           </constraints>
           <profiles>
             <profile id="fbea-968c-c1e2-3fe3" name="Deathwing Oathbearer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Deathwing)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -3560,95 +3559,95 @@ special rule.</description>
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="5386-ddf5-eca5-316a" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="5386-ddf5-eca5-316a" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3bc5-2913-e35c-5675" name="May exchange its Calibanite warblade for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2b2c-26e0-deb2-9d9b">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e300-c85b-ade5-023f" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb29-4103-8f10-bcaf" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e300-c85b-ade5-023f" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb29-4103-8f10-bcaf" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="f73f-a117-60c8-cb09" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="68b3-a64c-a609-6615" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="fa45-3d46-3b9b-7ab5" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="2b2c-26e0-deb2-9d9b" name="Calibanite Warblade" hidden="false" collective="false" import="true" targetId="88ee-fc77-42ea-872d" type="selectionEntry"/>
+                <entryLink id="2b2c-26e0-deb2-9d9b" name="Calibanite Warblade" hidden="false" collective="false" import="true" targetId="88ee-fc77-42ea-872d" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="aa4d-ea36-736d-82eb" name="May exhange its bolter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="96f9-c03c-52e5-6cca">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6503-e36d-ed02-8aae" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8bb-3eec-6cd5-cf30" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6503-e36d-ed02-8aae" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8bb-3eec-6cd5-cf30" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="8ff5-b874-737e-2816" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="fb8a-6b1a-1a3e-b306" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="34c4-db99-db36-0f2a" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="0152-f2ce-89c9-ce28" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="0d1c-227e-a3f8-cd63" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="8161-d04d-a771-0550" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="cc98-8596-c713-516c" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="d467-6846-d9ed-5ba6" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="7e5c-3d25-5c88-32e0" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="5b0d-30c5-8053-dd8c" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="aa3c-f5a5-9ce9-1497" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="af23-2a6b-8222-c93b" name="Cytheron Pattern Aegis" hidden="false" collective="false" import="true" targetId="72bc-434b-22cd-e63e" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="96f9-c03c-52e5-6cca" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry"/>
+                <entryLink id="96f9-c03c-52e5-6cca" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
             <entryLink id="2dd5-7d9a-72c3-8d0a" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fa2-85cc-46b5-282f" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c69-0989-5cd9-8a1b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fa2-85cc-46b5-282f" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c69-0989-5cd9-8a1b" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="2c16-323f-7f4b-0be3" name="Deathwing Companion" publicationId="817a-6288-e016-7469" page="164" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9d0-5586-7a51-3ef6" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a61-8a78-e686-bc8a" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9d0-5586-7a51-3ef6" type="min" />
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a61-8a78-e686-bc8a" type="max" />
           </constraints>
           <profiles>
             <profile id="1b08-de78-9eee-c70b" name="Deathwing Companion" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Deathwing)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -3664,83 +3663,83 @@ special rule.</description>
           <selectionEntryGroups>
             <selectionEntryGroup id="81d0-3773-69f9-e753" name="May exchange its Calibanite warblade for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="35bf-50d9-4acb-8569">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b2f6-6a03-afd1-c299" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="01aa-182e-b11c-7630" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b2f6-6a03-afd1-c299" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="01aa-182e-b11c-7630" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="7c74-5066-1099-5b52" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="68b3-a64c-a609-6615" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="0a82-fdc1-fd45-fb6c" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="35bf-50d9-4acb-8569" name="Calibanite Warblade" hidden="false" collective="false" import="true" targetId="88ee-fc77-42ea-872d" type="selectionEntry"/>
+                <entryLink id="35bf-50d9-4acb-8569" name="Calibanite Warblade" hidden="false" collective="false" import="true" targetId="88ee-fc77-42ea-872d" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="41bd-c61c-089f-51fd" name="May exhange its bolter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="74c9-413f-760c-39da">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ffc0-2149-fe4c-10af" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f07c-1052-0265-6d3e" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ffc0-2149-fe4c-10af" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f07c-1052-0265-6d3e" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="7b13-804c-a29c-3d82" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="4a52-7f7e-93d4-36fd" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="abb6-aebe-0208-71af" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="3b6e-43bd-0e8c-871d" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="53c7-dc5c-a11f-598b" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="e928-6acf-8262-b42e" name="Cytheron Pattern Aegis" hidden="false" collective="false" import="true" targetId="72bc-434b-22cd-e63e" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="74c9-413f-760c-39da" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry"/>
+                <entryLink id="74c9-413f-760c-39da" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry" />
                 <entryLink id="55b8-ab05-454e-a2e2" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="eb59-e080-c64c-1a85" name="All models may take:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d14-6a55-c72e-7f70" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95e1-8e2c-c71e-1b72" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d14-6a55-c72e-7f70" type="max" />
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95e1-8e2c-c71e-1b72" type="min" />
           </constraints>
           <entryLinks>
             <entryLink id="f7e9-72f5-8900-d778" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -3749,10 +3748,10 @@ special rule.</description>
           <entryLinks>
             <entryLink id="d4fe-a3f5-759e-6729" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a05e-4786-51bb-65e9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a05e-4786-51bb-65e9" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -3763,26 +3762,26 @@ special rule.</description>
               <modifiers>
                 <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="10.0">
                   <repeats>
-                    <repeat field="selections" scope="a9b5-ef4c-31db-4104" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="a9b5-ef4c-31db-4104" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d0e-d679-a15a-3000" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d0e-d679-a15a-3000" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="3eb1-efa5-f2ea-f9ce" name="Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fca-312e-8966-964f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fca-312e-8966-964f" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="c362-6e92-0e32-efff" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -3791,7 +3790,7 @@ special rule.</description>
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -3800,7 +3799,7 @@ special rule.</description>
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -3811,22 +3810,22 @@ special rule.</description>
           <modifiers>
             <modifier type="increment" field="e1a2-7cbd-f918-57d1" value="1.0">
               <repeats>
-                <repeat field="selections" scope="a9b5-ef4c-31db-4104" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1ade-0c02-5612-252b" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="a9b5-ef4c-31db-4104" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1ade-0c02-5612-252b" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1a2-7cbd-f918-57d1" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1a2-7cbd-f918-57d1" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="a78f-670c-48db-451b" name="Bayonet" hidden="false" collective="false" import="true" targetId="6904-6936-d6ca-a0eb" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0" />
               </costs>
             </entryLink>
             <entryLink id="b7c3-75e5-7d1d-64fc" name="Chain Bayonet" hidden="false" collective="false" import="true" targetId="bd82-cef6-67f8-19b5" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -3835,68 +3834,68 @@ special rule.</description>
       <entryLinks>
         <entryLink id="ce45-22a0-5983-bf2d" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="faaf-b6a8-bd1e-8f1a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5611-6693-9df1-5445" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="faaf-b6a8-bd1e-8f1a" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5611-6693-9df1-5445" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="dfe1-b2ee-9b6b-0bbd" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7792-b306-be26-178f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d4d-c507-33d0-af5a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7792-b306-be26-178f" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d4d-c507-33d0-af5a" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="5ce1-9a63-ccab-32bc" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1079-0f2f-b26d-2fbf" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15f9-1291-97b8-9a06" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1079-0f2f-b26d-2fbf" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15f9-1291-97b8-9a06" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="2bab-1e78-e49b-6577" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6f1-3bca-b0f6-68b1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44c6-6032-8e4e-ccd5" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6f1-3bca-b0f6-68b1" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44c6-6032-8e4e-ccd5" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="0f58-8273-a8b5-196e" name="Deathwing Terminator Cataphractii Companions" publicationId="d0df-7166-5cd3-89fd" page="48" hidden="true" collective="false" import="true" type="unit">
       <rules>
         <rule id="814d-2301-e7c5-18d6" name="Deathwing Terminator Cataphractii Retinue" publicationId="09b3-d525-cdea-260c" page="49" hidden="true">
-          <description>A Deathwing Cataphractii Terminator Companion squad may only be selected as part of a Detachment that includes at least one model with both the Master of the Legion and the Legiones Astartes (Dark Angels) special rules and is equipped with Cataphractii Terminator armour. A unit selected in this manner is considered a ‘Retinue Squad’ and the model with both the Master of the Legion and Legiones Astartes (Dark Angels) special rules is referred to as the retinue squad’s Leader for the purposes of this special rule (if the Detachment includes more than one eligible Leader then the controlling player selects one as the unit’s Leader). The retinue squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. The retinue squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the retinue squad during play. A Deathwing Cataphractii Terminator Companion Detachment may not be selected as part of an army without a Leader.</description>
+          <description>A Deathwing Cataphractii Terminator Companion squad may only be selected as part of a Detachment that includes at least one model with both the Master of the Legion and the Legiones Astartes (Dark Angels) special rules and is equipped with Cataphractii Terminator armour. A unit selected in this manner is considered a &#8216;Retinue Squad&#8217; and the model with both the Master of the Legion and Legiones Astartes (Dark Angels) special rules is referred to as the retinue squad&#8217;s Leader for the purposes of this special rule (if the Detachment includes more than one eligible Leader then the controlling player selects one as the unit&#8217;s Leader). The retinue squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. The retinue squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the retinue squad during play. A Deathwing Cataphractii Terminator Companion Detachment may not be selected as part of an army without a Leader.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="b597-2fdf-cd89-e38e" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
-        <infoLink id="bcf4-35c9-87f2-9bbc" name="Death-sworn Companions" hidden="false" targetId="2f3e-89a5-27e0-33b7" type="rule"/>
-        <infoLink id="7048-3c51-4254-0dfc" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="b597-2fdf-cd89-e38e" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
+        <infoLink id="bcf4-35c9-87f2-9bbc" name="Death-sworn Companions" hidden="false" targetId="2f3e-89a5-27e0-33b7" type="rule" />
+        <infoLink id="7048-3c51-4254-0dfc" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="8b75-98c3-5562-15a3" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="1edd-7ab5-a625-5964" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule"/>
-        <infoLink id="218e-1f6d-d495-8d7b" name="Deathwing" hidden="false" targetId="5e82-8a8f-d64f-0839" type="rule"/>
+        <infoLink id="1edd-7ab5-a625-5964" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule" />
+        <infoLink id="218e-1f6d-d495-8d7b" name="Deathwing" hidden="false" targetId="5e82-8a8f-d64f-0839" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="e21c-04da-da7e-bb0e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="d44a-5429-5007-3517" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="4c36-2523-addd-8242" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="d90b-68bb-e362-fd4d" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="e21c-04da-da7e-bb0e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="d44a-5429-5007-3517" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
+        <categoryLink id="4c36-2523-addd-8242" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="d90b-68bb-e362-fd4d" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4f8a-d905-51a0-aa44" name="Deathwing Cataphractii Oathbearer" publicationId="d0df-7166-5cd3-89fd" page="48" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13fb-80f8-6891-6b48" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa5d-6db7-8ba9-8b47" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13fb-80f8-6891-6b48" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa5d-6db7-8ba9-8b47" type="max" />
           </constraints>
           <profiles>
             <profile id="0dc7-2f57-a2af-7493" name="Deathwing Cataphractii Oathbearer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character, Deathwing)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -3910,17 +3909,17 @@ special rule.</description>
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="0fd9-666f-e9e3-f3ca" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="0fd9-666f-e9e3-f3ca" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="9f78-55c5-f254-bc7f" name="May take a:" hidden="false" collective="false" import="true">
               <entryLinks>
                 <entryLink id="696f-f32b-b9bf-89c5" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99eb-437f-0c94-141e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99eb-437f-0c94-141e" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -3929,99 +3928,99 @@ special rule.</description>
               <modifiers>
                 <modifier type="set" field="caeb-0217-0422-a36b" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="5c61-dba7-88b7-8a83" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c61-dba7-88b7-8a83" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="caeb-0217-0422-a36b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c61-dba7-88b7-8a83" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="caeb-0217-0422-a36b" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="4f20-0d50-3b8c-b2a7" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="68b3-a64c-a609-6615" type="selectionEntry"/>
-                <entryLink id="5308-7ec9-0672-7257" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry"/>
+                <entryLink id="4f20-0d50-3b8c-b2a7" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="68b3-a64c-a609-6615" type="selectionEntry" />
+                <entryLink id="5308-7ec9-0672-7257" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry" />
                 <entryLink id="de2c-7310-9f51-8cd9" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="7baf-5ffc-dba1-a818" name="Calibanite Warblade" hidden="false" collective="false" import="true" targetId="88ee-fc77-42ea-872d" type="selectionEntry"/>
+                <entryLink id="7baf-5ffc-dba1-a818" name="Calibanite Warblade" hidden="false" collective="false" import="true" targetId="88ee-fc77-42ea-872d" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="90b7-eec0-ca2c-3620" name="2) May exchange his combi-bolter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="24a2-c57b-67c2-808a">
               <modifiers>
                 <modifier type="set" field="b1a4-7ca7-c223-b184" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="94d8-8c94-b029-1219" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1a4-7ca7-c223-b184" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94d8-8c94-b029-1219" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1a4-7ca7-c223-b184" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94d8-8c94-b029-1219" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="a989-0c29-fdc5-e469" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="34c4-db99-db36-0f2a" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="d709-af42-bc5f-bbe0" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="0d1c-227e-a3f8-cd63" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="f0d1-5e4c-8c8b-31f4" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="cc98-8596-c713-516c" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="643f-3d47-e60b-4ade" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="7e5c-3d25-5c88-32e0" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="29e1-c535-19ee-b009" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="aa3c-f5a5-9ce9-1497" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="24a2-c57b-67c2-808a" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                <entryLink id="24a2-c57b-67c2-808a" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="980f-89a7-5e3a-8da3" name="3) May exchange both for:" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f430-5788-2816-446e" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f430-5788-2816-446e" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="cb6c-ac38-54fc-9abc" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry"/>
+                <entryLink id="cb6c-ac38-54fc-9abc" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="bdd6-1af9-b43d-6c01" name="Deathwing Cataphractii Companion" publicationId="d0df-7166-5cd3-89fd" page="48" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f7d-285b-5ac0-6876" type="min"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84c5-85ea-66a1-2c2f" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f7d-285b-5ac0-6876" type="min" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84c5-85ea-66a1-2c2f" type="max" />
           </constraints>
           <profiles>
             <profile id="bb51-6864-4f94-2a63" name="Deathwing Cataphractii Companion" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Deathwing)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -4039,147 +4038,147 @@ special rule.</description>
               <modifiers>
                 <modifier type="set" field="c2c9-ac0a-7bef-7313" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="eed3-6274-f2e9-9c93" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2c9-ac0a-7bef-7313" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eed3-6274-f2e9-9c93" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2c9-ac0a-7bef-7313" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eed3-6274-f2e9-9c93" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="020e-9bc0-6a1a-e6d4" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="34c4-db99-db36-0f2a" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="2105-7af4-8739-b68d" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="0d1c-227e-a3f8-cd63" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="6228-3bfc-d044-1223" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="cc98-8596-c713-516c" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="4867-12ab-1154-e4d7" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="7e5c-3d25-5c88-32e0" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="bf29-3e47-b228-0ab0" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="aa3c-f5a5-9ce9-1497" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="3c0c-f416-4292-e257" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                <entryLink id="3c0c-f416-4292-e257" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="0e66-da5a-22c5-5549" name="1) May exchange his Calibanite warblade for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="c341-8975-511b-a2ce">
               <modifiers>
                 <modifier type="set" field="3c4c-318b-9648-1ff5" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="ecab-6da0-6ab8-7ec6" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c4c-318b-9648-1ff5" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecab-6da0-6ab8-7ec6" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c4c-318b-9648-1ff5" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecab-6da0-6ab8-7ec6" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="8c81-bb21-6017-a2ed" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="68b3-a64c-a609-6615" type="selectionEntry"/>
-                <entryLink id="1614-b5ba-bc2c-96af" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry"/>
+                <entryLink id="8c81-bb21-6017-a2ed" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="68b3-a64c-a609-6615" type="selectionEntry" />
+                <entryLink id="1614-b5ba-bc2c-96af" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry" />
                 <entryLink id="134e-ce8e-870f-ac6d" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="c341-8975-511b-a2ce" name="Calibanite Warblade" hidden="false" collective="false" import="true" targetId="88ee-fc77-42ea-872d" type="selectionEntry"/>
+                <entryLink id="c341-8975-511b-a2ce" name="Calibanite Warblade" hidden="false" collective="false" import="true" targetId="88ee-fc77-42ea-872d" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="cdd8-b876-9bf1-42d9" name="3) May exchange both for:" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2c7-3dbf-eddf-171a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2c7-3dbf-eddf-171a" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="615a-0cec-aa38-ad32" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry"/>
+                <entryLink id="615a-0cec-aa38-ad32" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="d90c-3698-4748-99bb" name="Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e01-b32b-bcb8-b188" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e01-b32b-bcb8-b188" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="0bf6-7e07-b8ad-df07" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry"/>
+            <entryLink id="0bf6-7e07-b8ad-df07" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="94ff-decb-8ffa-ef79" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="831c-9d89-0bc0-35bc" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db27-56ed-559e-0019" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="831c-9d89-0bc0-35bc" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db27-56ed-559e-0019" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="240.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="240.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="3053-608b-d111-6fd7" name="Deathwing Terminator Tartaros Companions" publicationId="d0df-7166-5cd3-89fd" page="50" hidden="true" collective="false" import="true" type="unit">
       <rules>
         <rule id="b0a9-3a21-bd6d-1ccc" name="Deathwing Terminator Tartaros Retinue" publicationId="09b3-d525-cdea-260c" page="51" hidden="true">
-          <description>A Deathwing Tartaros Terminator Companion squad may only be selected as part of a Detachment that includes at least one model with both the Master of the Legion and the Legiones Astartes (Dark Angels) special rules and is equipped with Tartaros Terminator armour. A unit selected in this manner is considered a ‘Retinue Squad’ and the model with both the Master of the
-Legion and Legiones Astartes (Dark Angels) special rules is referred to as the retinue squad’s Leader for the purposes of this special rule (if the Detachment includes more than one eligible Leader then the controlling player selects one as the unit’s Leader). The retinue squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. The retinue squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the retinue squad during play. A Deathwing Tartaros Terminator Companion Detachment may not be selected as part of an army without a Leader.</description>
+          <description>A Deathwing Tartaros Terminator Companion squad may only be selected as part of a Detachment that includes at least one model with both the Master of the Legion and the Legiones Astartes (Dark Angels) special rules and is equipped with Tartaros Terminator armour. A unit selected in this manner is considered a &#8216;Retinue Squad&#8217; and the model with both the Master of the
+Legion and Legiones Astartes (Dark Angels) special rules is referred to as the retinue squad&#8217;s Leader for the purposes of this special rule (if the Detachment includes more than one eligible Leader then the controlling player selects one as the unit&#8217;s Leader). The retinue squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. The retinue squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the retinue squad during play. A Deathwing Tartaros Terminator Companion Detachment may not be selected as part of an army without a Leader.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="c7de-98e3-ed82-30ca" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
-        <infoLink id="cd9f-c411-b1ef-eef0" name="Death-sworn Companions" hidden="false" targetId="2f3e-89a5-27e0-33b7" type="rule"/>
-        <infoLink id="4a8b-7858-8e1c-4df7" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule"/>
-        <infoLink id="028d-782a-5796-d25b" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="c7de-98e3-ed82-30ca" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
+        <infoLink id="cd9f-c411-b1ef-eef0" name="Death-sworn Companions" hidden="false" targetId="2f3e-89a5-27e0-33b7" type="rule" />
+        <infoLink id="4a8b-7858-8e1c-4df7" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule" />
+        <infoLink id="028d-782a-5796-d25b" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="077d-94a9-a913-daaf" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="7310-7ac3-e6ec-450c" name="Deathwing" hidden="false" targetId="5e82-8a8f-d64f-0839" type="rule"/>
+        <infoLink id="7310-7ac3-e6ec-450c" name="Deathwing" hidden="false" targetId="5e82-8a8f-d64f-0839" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="1685-35af-8fdd-ad14" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="f047-d090-eb49-7696" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="1489-93f7-05f0-75c3" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="1685-35af-8fdd-ad14" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="f047-d090-eb49-7696" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="1489-93f7-05f0-75c3" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="bf35-1f7a-dba1-a5a1" name="Deathwing Tartaros Companion" publicationId="d0df-7166-5cd3-89fd" page="48" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfcc-b258-48f7-ea21" type="min"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc12-a490-2a76-c749" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfcc-b258-48f7-ea21" type="min" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc12-a490-2a76-c749" type="max" />
           </constraints>
           <profiles>
             <profile id="2b31-212f-2edd-e60a" name="Deathwing Tartaros Companion" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Deathwing)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -4197,99 +4196,99 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
               <modifiers>
                 <modifier type="set" field="eb63-6dc7-c10b-fc78" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="7410-169c-e2ac-a85b" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb63-6dc7-c10b-fc78" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7410-169c-e2ac-a85b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb63-6dc7-c10b-fc78" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7410-169c-e2ac-a85b" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="e26a-737e-dab6-507f" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="34c4-db99-db36-0f2a" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="d5ee-5639-f2e0-fc7c" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="0d1c-227e-a3f8-cd63" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="9d5f-de48-bf96-5b91" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="cc98-8596-c713-516c" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="1cfd-5966-891e-75f4" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="7e5c-3d25-5c88-32e0" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="c793-f09f-f5a1-df62" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="aa3c-f5a5-9ce9-1497" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="bc1e-75b4-fa4c-2923" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                <entryLink id="bc1e-75b4-fa4c-2923" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="0f3e-e50f-c99c-6089" name="1) May exchange his Calibanite warblade for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="3610-3500-38e1-5f7e">
               <modifiers>
                 <modifier type="set" field="fb3c-3510-3203-fe69" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="e40b-5a24-c107-7de1" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e40b-5a24-c107-7de1" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb3c-3510-3203-fe69" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e40b-5a24-c107-7de1" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb3c-3510-3203-fe69" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="3c1e-9afa-0ef0-f711" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="68b3-a64c-a609-6615" type="selectionEntry"/>
-                <entryLink id="d89c-c535-dd32-bd44" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry"/>
+                <entryLink id="3c1e-9afa-0ef0-f711" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="68b3-a64c-a609-6615" type="selectionEntry" />
+                <entryLink id="d89c-c535-dd32-bd44" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry" />
                 <entryLink id="a795-57c2-ff95-9355" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="3610-3500-38e1-5f7e" name="Calibanite Warblade" hidden="false" collective="false" import="true" targetId="88ee-fc77-42ea-872d" type="selectionEntry"/>
+                <entryLink id="3610-3500-38e1-5f7e" name="Calibanite Warblade" hidden="false" collective="false" import="true" targetId="88ee-fc77-42ea-872d" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="a3e4-9be1-c2b3-630f" name="3) May exchange both for:" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a8f-56bc-2a4e-bb5f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a8f-56bc-2a4e-bb5f" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="f81c-045e-50d4-8433" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry"/>
+                <entryLink id="f81c-045e-50d4-8433" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="c3a4-224b-ffb7-12f7" name="Deathwing Tartaros Oathbearer" publicationId="d0df-7166-5cd3-89fd" page="48" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c07c-27c1-e275-9088" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff3e-4bbe-dceb-53df" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c07c-27c1-e275-9088" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff3e-4bbe-dceb-53df" type="max" />
           </constraints>
           <profiles>
             <profile id="5ca6-3723-6f32-af59" name="Deathwing Tartaros Oathbearer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Deathwing)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -4303,17 +4302,17 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="78d1-af37-64f4-55f6" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="78d1-af37-64f4-55f6" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="240b-051a-8626-4d01" name="May take a:" hidden="false" collective="false" import="true">
               <entryLinks>
                 <entryLink id="6a0d-51e2-efbf-e7bc" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2a3-58bb-f57c-d8a7" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2a3-58bb-f57c-d8a7" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -4322,118 +4321,118 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
               <modifiers>
                 <modifier type="set" field="52c9-d5d4-987d-5a6a" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="6911-f81d-9874-b162" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6911-f81d-9874-b162" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52c9-d5d4-987d-5a6a" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6911-f81d-9874-b162" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52c9-d5d4-987d-5a6a" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="b985-510d-6cb8-28b6" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="68b3-a64c-a609-6615" type="selectionEntry"/>
-                <entryLink id="092a-aafc-dbe3-f9b6" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry"/>
+                <entryLink id="b985-510d-6cb8-28b6" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="68b3-a64c-a609-6615" type="selectionEntry" />
+                <entryLink id="092a-aafc-dbe3-f9b6" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry" />
                 <entryLink id="a433-397c-73df-3e6f" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="bdd8-569f-d9d3-780e" name="Calibanite Warblade" hidden="false" collective="false" import="true" targetId="88ee-fc77-42ea-872d" type="selectionEntry"/>
+                <entryLink id="bdd8-569f-d9d3-780e" name="Calibanite Warblade" hidden="false" collective="false" import="true" targetId="88ee-fc77-42ea-872d" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="8bac-8884-1fbd-a823" name="2) May exchange his combi-bolter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ab4d-7be3-4e8a-9146">
               <modifiers>
                 <modifier type="set" field="fa43-8157-69ca-304c" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="2bda-cde8-2280-366b" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="405f-030d-0343-ade8" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bda-cde8-2280-366b" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa43-8157-69ca-304c" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bda-cde8-2280-366b" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa43-8157-69ca-304c" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="0338-19e4-bafe-3a92" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="34c4-db99-db36-0f2a" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="163b-0b1c-417e-74e1" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="0d1c-227e-a3f8-cd63" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="28f3-211d-e7dd-0c17" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="cc98-8596-c713-516c" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="31cb-4efc-deb7-7578" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="7e5c-3d25-5c88-32e0" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="058c-ffd9-cd54-b494" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="aa3c-f5a5-9ce9-1497" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="ab4d-7be3-4e8a-9146" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                <entryLink id="ab4d-7be3-4e8a-9146" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="d114-e4ab-06fc-f675" name="3) May exchange both for:" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d116-1db4-4216-8d8d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d116-1db4-4216-8d8d" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="fee0-b92d-de4c-0a21" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry"/>
+                <entryLink id="fee0-b92d-de4c-0a21" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="a3bf-abf7-c02b-fd51" name="Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4652-390f-b45f-b553" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4652-390f-b45f-b553" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="20f9-b23a-dbef-eb52" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry"/>
+            <entryLink id="20f9-b23a-dbef-eb52" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="225.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="225.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="6305-99cb-5a76-be11" name="Centurion (Storm of War)" hidden="true" collective="false" import="true" type="unit">
       <entryLinks>
-        <entryLink id="bc32-07a6-cda5-2aa6" name="Legion Centurion" hidden="false" collective="false" import="true" targetId="c681-938e-6d11-cd43" type="selectionEntry"/>
-        <entryLink id="e2e4-4d83-fb92-aed6" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
+        <entryLink id="bc32-07a6-cda5-2aa6" name="Legion Centurion" hidden="false" collective="false" import="true" targetId="c681-938e-6d11-cd43" type="selectionEntry" />
+        <entryLink id="e2e4-4d83-fb92-aed6" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="66e9-e8f8-5eb6-1cf6" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7288-7dbc-f140-c039" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7288-7dbc-f140-c039" type="max" />
       </constraints>
       <entryLinks>
         <entryLink id="8783-323c-0221-6aa6" name="Inner Circle Knights Cenobium" hidden="true" collective="false" import="true" targetId="9946-61c0-3656-36dd" type="selectionEntry">
@@ -4442,14 +4441,14 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9136-b5e8-13f9-0c0f" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9136-b5e8-13f9-0c0f" type="notInstanceOf" />
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -4460,17 +4459,17 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="902d-5951-9b95-19fb" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3766-ea98-0aa7-62d0" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b79-1951-5a63-4b9e" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9136-b5e8-13f9-0c0f" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="902d-5951-9b95-19fb" type="instanceOf" />
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3766-ea98-0aa7-62d0" type="instanceOf" />
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b79-1951-5a63-4b9e" type="instanceOf" />
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9136-b5e8-13f9-0c0f" type="instanceOf" />
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -4481,28 +4480,28 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3760-204e-444c-1044" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f806-8a4e-d0d6-beaa" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3760-204e-444c-1044" type="instanceOf" />
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f806-8a4e-d0d6-beaa" type="instanceOf" />
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="60e2-167c-bb6e-450f" name="Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
-        <entryLink id="68f3-363d-e7a5-17d0" name="Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
+        <entryLink id="60e2-167c-bb6e-450f" name="Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
+        <entryLink id="68f3-363d-e7a5-17d0" name="Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
         <entryLink id="0982-69a0-7e63-8f73" name="Command Squad, Cataphractii" hidden="false" collective="false" import="true" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
         <entryLink id="a778-c26c-f27d-d527" name="Deathwing Companion Detachment" hidden="false" collective="false" import="true" targetId="a9b5-ef4c-31db-4104" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="hidden" value="false"/>
+            <modifier type="set" field="hidden" value="false" />
           </modifiers>
         </entryLink>
         <entryLink id="6cfa-19c7-0b09-4b5e" name="Inner Circle Knights Cenobium - Order of the Broken Claws" hidden="true" collective="false" import="true" targetId="b9ad-ab3e-437e-c373" type="selectionEntry">
@@ -4511,14 +4510,14 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9136-b5e8-13f9-0c0f" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9136-b5e8-13f9-0c0f" type="notInstanceOf" />
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -4529,81 +4528,81 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="33b5-39af-0fe4-c964" value="1.0">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="be57-6917-cbe5-b571" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33b5-39af-0fe4-c964" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="be57-6917-cbe5-b571" type="max" />
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33b5-39af-0fe4-c964" type="min" />
       </constraints>
       <selectionEntryGroups>
         <selectionEntryGroup id="5ced-784f-824e-986b" name="  I: Dark Angels" publicationId="817a-6288-e016-7469" page="152" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="43df-248c-010c-c19f" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fed8-f75a-8784-19f0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="43df-248c-010c-c19f" type="max" />
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fed8-f75a-8784-19f0" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="3650-496b-f42c-2585" name="Marshal of the Crown" publicationId="817a-6288-e016-7469" page="152" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b2f-ace8-4c44-f30b" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1854-d291-2c45-f20e" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b2f-ace8-4c44-f30b" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1854-d291-2c45-f20e" type="max" />
               </constraints>
               <profiles>
                 <profile id="068a-e271-6679-4c59" name="Marshal of the Crown" publicationId="817a-6288-e016-7469" page="152" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait must select one of the Hexagrammaton Unit Sub-types. All units that include at least one model with the corresponding Unit Sub-type and at least one model with line of sight to the Warlord gain +1 Leadership (to a maximum of 10). In addition, an army whose Warlord has this Trait may make an additional Reaction in a Phase of the opponent’s turn dictated by the Hexagrammaton Unit Sub-type possessed by the Warlord:
-• Deathwing, Dreadwing – Assault phase
-• Stormwing, Ironwing – Shooting phase
-• Ravenwing, Firewing – Movement phase
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait must select one of the Hexagrammaton Unit Sub-types. All units that include at least one model with the corresponding Unit Sub-type and at least one model with line of sight to the Warlord gain +1 Leadership (to a maximum of 10). In addition, an army whose Warlord has this Trait may make an additional Reaction in a Phase of the opponent&#8217;s turn dictated by the Hexagrammaton Unit Sub-type possessed by the Warlord:
+&#8226; Deathwing, Dreadwing &#8211; Assault phase
+&#8226; Stormwing, Ironwing &#8211; Shooting phase
+&#8226; Ravenwing, Firewing &#8211; Movement phase
 This additional Reaction may only be made as long as the Warlord has not been removed as a casualty</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="254e-5311-1610-6576" name="Seneschal of the Keys" publicationId="817a-6288-e016-7469" page="152" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d9c2-ec3b-fe30-15c0" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9764-5346-d0d9-4a6b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d9c2-ec3b-fe30-15c0" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9764-5346-d0d9-4a6b" type="max" />
               </constraints>
               <profiles>
                 <profile id="104a-242b-ca22-cbe5" name="Seneschal of the Keys" publicationId="817a-6288-e016-7469" page="152" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca" />
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="b6b3-0e1d-0817-9578" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+        <entryLink id="b6b3-0e1d-0817-9578" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedProfiles>
     <profile id="7b52-e033-811f-dd15" name="Marshal of the Crown" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
       <characteristics>
-        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait must select one of the Hexagrammaton Unit Sub-types. All units that include at least one model with the corresponding Unit Sub-type and at least one model with line of sight to the Warlord gain +1 Leadership (to a maximum of 10). In addition, an army whose Warlord has this trait may make an additional Reaction in a Phase of the opponent&apos;s turn dictated by the Hexagrammaton Unit Sub-type possessed by the Warlord:
+        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait must select one of the Hexagrammaton Unit Sub-types. All units that include at least one model with the corresponding Unit Sub-type and at least one model with line of sight to the Warlord gain +1 Leadership (to a maximum of 10). In addition, an army whose Warlord has this trait may make an additional Reaction in a Phase of the opponent's turn dictated by the Hexagrammaton Unit Sub-type possessed by the Warlord:
 Deathwing, Dreadwing - Assault phase
 Stormwing, Ironwing - Shooting phase
 Ravenwing, Firewing - Movement phase
@@ -4612,6 +4611,6 @@ This additional Reaction may on be made as long as the Warlord has not been remo
     </profile>
   </sharedProfiles>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Dark Angels.cat
+++ b/2022 - LA - Dark Angels.cat
@@ -4523,7 +4523,7 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
           </modifiers>
         </entryLink>
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_be38-a066-4f8e-ae54</comment></selectionEntryGroup>
     <selectionEntryGroup id="bb85-3277-2090-6576" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -4597,7 +4597,7 @@ This additional Reaction may only be made as long as the Warlord has not been re
       <entryLinks>
         <entryLink id="b6b3-0e1d-0817-9578" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_7dee-602c-4b47-be09</comment></selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedProfiles>
     <profile id="7b52-e033-811f-dd15" name="Marshal of the Crown" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">

--- a/2022 - LA - Death Guard.cat
+++ b/2022 - LA - Death Guard.cat
@@ -335,7 +335,7 @@
         <categoryLink id="bc07-161b-073b-fe51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="b08a-5031-8104-4556" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
     <entryLink id="7194-5a5e-656b-17ff" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="edb5-a892-57aa-baf5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
@@ -763,7 +763,7 @@
         <categoryLink id="0757-5c73-2ec4-73cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="a49e-d5cb-868c-1379" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
     <entryLink id="6d99-d6e2-4836-5b15" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
@@ -844,7 +844,7 @@
         <categoryLink id="1f52-0793-b77f-aa71" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="86a8-2a5a-5e1d-febe" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
     <entryLink id="8dfd-52fe-18de-e010" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f0bf-128a-f446-ea18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -856,7 +856,7 @@
         <categoryLink id="7500-4599-5f05-5d29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="e0c9-cf19-0ba4-d686" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
     <entryLink id="30bd-085b-0e7c-39a9" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="12ca-5aa1-a90d-9538" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -938,7 +938,7 @@
         <categoryLink id="afec-53ef-a706-ba32" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="a690-ec72-c6e7-2fae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
     <entryLink id="1043-8d0f-2838-9f79" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
@@ -966,7 +966,7 @@
         <categoryLink id="6ac3-58f6-2662-ac7d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="659b-6e8c-97c7-1bfc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
     <entryLink id="6c25-69a3-62eb-3f42" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -1016,7 +1016,7 @@
         <categoryLink id="a2a2-f888-8129-cd0c" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
         <categoryLink id="148d-b489-c8ae-b615" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
     <entryLink id="b9bd-df3d-1321-f365" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7f28-a1c8-2801-aec7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />

--- a/2022 - LA - Death Guard.cat
+++ b/2022 - LA - Death Guard.cat
@@ -2540,7 +2540,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
         <entryLink id="e962-2f46-9618-fa58" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
         <entryLink id="c083-d710-edfa-5fc2" name="Deathshroud Terminator Squad" hidden="false" collective="false" import="true" targetId="7669-a6c0-7f86-e641" type="selectionEntry" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_be38-a066-4f8e-ae54</comment></selectionEntryGroup>
     <selectionEntryGroup id="7f03-6720-21ba-0d7b" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="6088-2073-3138-1861" value="1.0">
@@ -2634,7 +2634,7 @@ Any enemy unit with at least one model within 12" of a Warlord with this Trait m
       <entryLinks>
         <entryLink id="7890-e1c6-2bc7-dfdf" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_7dee-602c-4b47-be09</comment></selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="2a8e-65b7-11c5-f84a" name="Shrouded in Death" hidden="false">

--- a/2022 - LA - Death Guard.cat
+++ b/2022 - LA - Death Guard.cat
@@ -1,17 +1,16 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d228-55e8-b58c-1b77" name="LA -  XIV: Death Guard" revision="14" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="28" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="d228-55e8-b58c-1b77" name="LA -  XIV: Death Guard" revision="14" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="28">
   <entryLinks>
     <entryLink id="fb89-32c1-bdc5-2e3d" name="Mortarion" hidden="false" collective="false" import="false" targetId="7427-bdfa-c359-ebb8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="44be-4e1f-6984-02f2" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
-        <categoryLink id="edd2-1a56-37a4-4b58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="44be-4e1f-6984-02f2" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true" />
+        <categoryLink id="edd2-1a56-37a4-4b58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="72f2-159d-02fd-662b" name="Calas Typhon" hidden="false" collective="false" import="false" targetId="e830-3788-1a0d-0c02" type="selectionEntry">
@@ -20,47 +19,47 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="004e-da45-354f-882d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0fd1-c287-ea0a-743e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="763f-933b-5168-70a4" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="004e-da45-354f-882d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0fd1-c287-ea0a-743e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="763f-933b-5168-70a4" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="ecb3-9b17-ac05-a9e0" name="Mortus Poisoner Squad" hidden="true" collective="false" import="false" targetId="dd7b-fe21-cf53-0ebc" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d8e2-0a1e-ab02-3e0b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="a4a4-7b67-e98d-27bd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d8e2-0a1e-ab02-3e0b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="a4a4-7b67-e98d-27bd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="dc48-119e-d8cc-26e9" name="Grave Warden Terminator Squad" hidden="false" collective="false" import="false" targetId="be32-77c9-fe55-7dc0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="85f0-1143-bf32-04ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="214a-b147-8867-83e7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="85f0-1143-bf32-04ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="214a-b147-8867-83e7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="894f-ef82-2bcc-b7f5" name="Crysos Morturg" hidden="false" collective="false" import="false" targetId="56d5-bad2-14e6-2277" type="selectionEntry">
@@ -69,22 +68,22 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7cec-7e9a-41cf-e2cb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="84cb-a551-d3fd-4401" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8bc4-d33a-bea2-a8f0" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="7cec-7e9a-41cf-e2cb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="84cb-a551-d3fd-4401" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8bc4-d33a-bea2-a8f0" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="781d-4c08-a032-b54e" name="Marshal Durak Rask" hidden="true" collective="false" import="false" targetId="bd75-611c-23bb-7064" type="selectionEntry">
@@ -93,1011 +92,1011 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6535-1408-9914-1567" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="952c-b3c9-50e1-b074" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bd34-12ec-2df1-8239" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="6535-1408-9914-1567" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="952c-b3c9-50e1-b074" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bd34-12ec-2df1-8239" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="47ce-73d3-f6bf-7f54" name="  XIV: Death Guard" hidden="false" collective="false" import="false" targetId="dd1f-1c51-706c-e5f7" type="selectionEntry">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c962-a999-231c-0058" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a15e-901a-3e4f-8f42" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c962-a999-231c-0058" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a15e-901a-3e4f-8f42" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="1e82-64bc-993b-72e3" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="1e82-64bc-993b-72e3" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="f353-7810-9fd4-e0f2" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a7cd-b983-ad18-df82" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="eef5-e492-2d90-196e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="a7cd-b983-ad18-df82" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="eef5-e492-2d90-196e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
     <entryLink id="d329-7f73-114a-7ec6" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9e83-a3bf-2884-1293" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8970-b123-afdc-56df" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="9e83-a3bf-2884-1293" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8970-b123-afdc-56df" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
     <entryLink id="7dd0-94d5-4727-58ee" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3ba4-6f75-b11f-5ac3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="4746-1ae6-ff31-80e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7e80-ec37-5a82-64e0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="3ba4-6f75-b11f-5ac3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="4746-1ae6-ff31-80e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7e80-ec37-5a82-64e0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="a631-793e-4efd-16e7" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5d31-4a18-d9f2-e89e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="8fdc-4b16-e930-5a29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5d31-4a18-d9f2-e89e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="8fdc-4b16-e930-5a29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
     <entryLink id="3986-d74e-fc23-0d92" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e639-48f5-49aa-ff9a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="e870-5e18-c785-c323" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="e639-48f5-49aa-ff9a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="e870-5e18-c785-c323" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
     <entryLink id="e814-78ae-e106-ac52" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="777e-d175-06f6-89bf" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="d303-2916-45fd-fba5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="85f9-5904-d2a9-c9a7" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="777e-d175-06f6-89bf" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="d303-2916-45fd-fba5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="85f9-5904-d2a9-c9a7" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
     <entryLink id="8878-8104-48e2-ce7b" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d88e-aa77-dc43-334a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="b49b-40c0-1ac0-b3a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d88e-aa77-dc43-334a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="b49b-40c0-1ac0-b3a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
     <entryLink id="1da5-7f9a-9878-5879" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="482b-2f8d-9d72-50a8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="0481-65eb-da3b-aba7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="482b-2f8d-9d72-50a8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="0481-65eb-da3b-aba7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
     <entryLink id="d511-e33b-0116-f0ec" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8dc6-70c4-8d3f-2988" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="a40a-ceb0-ca7e-8b85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3ec5-5fa2-83ac-c298" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="8dc6-70c4-8d3f-2988" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="a40a-ceb0-ca7e-8b85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3ec5-5fa2-83ac-c298" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="7556-f64a-fd29-5959" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup"/>
+        <entryLink id="7556-f64a-fd29-5959" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup" />
         <entryLink id="00d1-3087-3a68-1b6a" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
     <entryLink id="11e9-7781-707f-d4a5" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dd47-b153-40f0-f377" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="434d-ce12-d83b-9d38" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="9dd7-ac13-2a00-3c24" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="dd47-b153-40f0-f377" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="434d-ce12-d83b-9d38" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="9dd7-ac13-2a00-3c24" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="a708-88f7-eb16-6a78" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup"/>
+        <entryLink id="a708-88f7-eb16-6a78" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup" />
         <entryLink id="ac33-6b79-25bf-9e5c" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
     <entryLink id="85dc-e6e8-1ad3-d878" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3a9c-99ea-897d-4f7a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c64a-bf11-2916-1c5c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="3d5d-57c4-648a-e586" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="3a9c-99ea-897d-4f7a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c64a-bf11-2916-1c5c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="3d5d-57c4-648a-e586" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="d508-0870-5048-998b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup"/>
+        <entryLink id="d508-0870-5048-998b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup" />
         <entryLink id="8e62-f926-f4c0-5a70" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
     <entryLink id="5ad7-48c5-141b-5727" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e33f-dd24-3350-148d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="01f5-b8c3-fbe0-c192" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e33f-dd24-3350-148d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="01f5-b8c3-fbe0-c192" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
     <entryLink id="6542-9165-2e72-f5e6" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5d42-eff6-e751-ca46" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1cad-1ae8-08f0-24f6" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="5d42-eff6-e751-ca46" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1cad-1ae8-08f0-24f6" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
     <entryLink id="6124-e860-1360-d4a4" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="eed2-d3a4-9c47-57ee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2985-3f6c-9903-2a0e" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="eed2-d3a4-9c47-57ee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2985-3f6c-9903-2a0e" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
     <entryLink id="a7e8-35f5-42bf-eb25" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="64a1-531b-a449-6a3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="70e1-63ab-5a36-b928" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="64a1-531b-a449-6a3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="70e1-63ab-5a36-b928" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
     <entryLink id="df48-72df-2033-e20a" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="bc07-161b-073b-fe51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b08a-5031-8104-4556" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="bc07-161b-073b-fe51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b08a-5031-8104-4556" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
     <entryLink id="7194-5a5e-656b-17ff" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="edb5-a892-57aa-baf5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="4d1c-5482-4ab8-89d2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="edb5-a892-57aa-baf5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="4d1c-5482-4ab8-89d2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
     <entryLink id="ac38-5436-73dc-d4bb" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c888-75ff-1ced-e0fa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="ad57-d4e3-1730-d0e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c888-75ff-1ced-e0fa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="ad57-d4e3-1730-d0e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="5127-a941-5fe2-155b" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6aa1-eea8-9b20-39a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0a5e-e4a6-8c88-8dc7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6aa1-eea8-9b20-39a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0a5e-e4a6-8c88-8dc7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
     <entryLink id="938a-6fc6-b597-2112" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5a74-10d2-56b2-767b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="1483-ddc4-dd74-487d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4c53-b957-b735-9e5b" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="5a74-10d2-56b2-767b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="1483-ddc4-dd74-487d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4c53-b957-b735-9e5b" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="a7f0-3ea5-1465-bcc6" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="31b9-3567-565d-1194" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3769-5c27-37d3-e2df" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="31b9-3567-565d-1194" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3769-5c27-37d3-e2df" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="31a6-4f5c-b6b9-1e82" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8229-ea7a-f6fa-54ee" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="5aa1-1743-6028-ca5b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8229-ea7a-f6fa-54ee" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="5aa1-1743-6028-ca5b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
     <entryLink id="85a0-ff11-6e9a-c5cd" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ded9-d2d7-03f4-e8a6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="e350-66f1-029c-72cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ded9-d2d7-03f4-e8a6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="e350-66f1-029c-72cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
     <entryLink id="f598-6f7d-54d2-5dd4" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0d4c-07fb-8ff6-6b48" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="301c-3185-56ef-dd73" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0d4c-07fb-8ff6-6b48" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="301c-3185-56ef-dd73" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
     <entryLink id="a968-0378-9216-a941" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c561-0f53-9f05-16f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a52a-182e-48b4-551f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="c561-0f53-9f05-16f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a52a-182e-48b4-551f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
     <entryLink id="8569-3903-fbf1-b0d9" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="eccf-478b-daa1-42c1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="db42-0b07-fe22-0866" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="eccf-478b-daa1-42c1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="db42-0b07-fe22-0866" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
     <entryLink id="a260-1302-3355-5a51" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1eb9-469a-22d2-1d92" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="bb6b-f003-c684-9a90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1eb9-469a-22d2-1d92" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="bb6b-f003-c684-9a90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
     <entryLink id="2285-cb66-db81-cf76" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0766-380d-ab3f-14a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dca5-8ba9-e888-f006" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="0766-380d-ab3f-14a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="dca5-8ba9-e888-f006" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
     <entryLink id="9255-8f5e-ff11-5896" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b8e8-4124-1cfe-bd91" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="7f33-a86b-d196-fc0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b8e8-4124-1cfe-bd91" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="7f33-a86b-d196-fc0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
     <entryLink id="7a57-45f5-cdbb-a03e" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9469-b766-13de-0333" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bf1b-d6bf-8bcf-c322" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="9469-b766-13de-0333" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bf1b-d6bf-8bcf-c322" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="7abc-67a6-7626-c9a6" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0b5a-37ab-0025-305a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="7ecc-16b1-3f2f-4fc0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0b5a-37ab-0025-305a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="7ecc-16b1-3f2f-4fc0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
     <entryLink id="da40-d086-07e1-a697" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d566-23bc-72e5-ee98" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="28af-d396-df27-0fa5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d566-23bc-72e5-ee98" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="28af-d396-df27-0fa5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
     <entryLink id="5b4f-55db-f031-f9b4" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2933-29df-5e64-18cf" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="894b-b641-8821-c302" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2933-29df-5e64-18cf" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="894b-b641-8821-c302" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
     <entryLink id="553c-2ee8-0c44-ef3a" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="dd78-bf40-72b9-caca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dbd4-3d4f-0ced-8b8c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="dd78-bf40-72b9-caca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="dbd4-3d4f-0ced-8b8c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
     <entryLink id="4b4f-6bef-f01f-a292" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="822c-2cae-c534-4980" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5bd8-87a7-56f6-2f34" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="822c-2cae-c534-4980" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5bd8-87a7-56f6-2f34" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
     <entryLink id="66d0-a8a4-5ec7-c138" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="87ee-97b2-4b16-839b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="112d-983a-9242-0823" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="87ee-97b2-4b16-839b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="112d-983a-9242-0823" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
     <entryLink id="fe98-dcea-59fc-82e3" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7cef-e262-b55d-12f8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="f754-036a-01ff-b739" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7cef-e262-b55d-12f8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="f754-036a-01ff-b739" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
     <entryLink id="4bcd-21dd-c6ab-7eca" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fc5a-1f81-d036-84e9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="36e3-3558-0cd4-aa19" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fc5a-1f81-d036-84e9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="36e3-3558-0cd4-aa19" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
     <entryLink id="5339-a665-932e-b58c" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ce16-f7c5-5da4-cbe4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="fe4f-ec17-d2c3-9de8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ce16-f7c5-5da4-cbe4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="fe4f-ec17-d2c3-9de8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
     <entryLink id="12a0-1772-0dc0-29cd" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b2fd-bdaf-33d3-c0a5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="14da-e7fd-6506-ba97" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b2fd-bdaf-33d3-c0a5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="14da-e7fd-6506-ba97" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
     <entryLink id="049b-d9fd-b0a9-e697" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b335-10b9-3cff-8641" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="de8d-ba01-0131-19e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b335-10b9-3cff-8641" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="de8d-ba01-0131-19e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
     <entryLink id="d147-888b-e699-84cb" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="63f9-13a1-64fc-1b60" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="d47f-030d-7433-7049" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="63f9-13a1-64fc-1b60" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="d47f-030d-7433-7049" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
     <entryLink id="7987-d97a-08b6-680c" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5592-15ea-e76f-ddea" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="5609-eb08-b5ae-2252" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5592-15ea-e76f-ddea" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="5609-eb08-b5ae-2252" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
     <entryLink id="d35e-0701-4192-aab3" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b428-9b1a-3de9-dd66" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c0a9-71fd-f964-6050" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b428-9b1a-3de9-dd66" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="c0a9-71fd-f964-6050" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
     <entryLink id="d27d-e3be-c85a-467b" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8c74-5498-d6d3-7e28" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2976-edf4-6d1a-94f4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="8c74-5498-d6d3-7e28" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2976-edf4-6d1a-94f4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
     <entryLink id="cedf-4f4f-8ec1-9097" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="328a-99f2-094c-b390" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c760-bd0b-3cdc-6f46" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="328a-99f2-094c-b390" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="c760-bd0b-3cdc-6f46" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
     <entryLink id="50b4-e9f5-dcf5-80bc" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="032b-5892-7749-6517" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="0eac-7019-e1a1-938f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="032b-5892-7749-6517" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="0eac-7019-e1a1-938f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
     <entryLink id="4280-e7f6-3922-360f" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="51a4-3c5f-5ad7-f06d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ab07-1c6e-f28c-a715" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="51a4-3c5f-5ad7-f06d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ab07-1c6e-f28c-a715" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="ba4f-ee9d-8991-9f71" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6b40-d7e9-7cec-0d0e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="f0e8-1d96-4203-0e9a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6b40-d7e9-7cec-0d0e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="f0e8-1d96-4203-0e9a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="0cd9-5f8a-0da5-5223" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7846-f1cc-c0e4-1b5f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="3ada-4ff8-c523-2054" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7846-f1cc-c0e4-1b5f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="3ada-4ff8-c523-2054" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
     <entryLink id="3e5a-0eea-259c-c4e7" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="df61-6eea-0717-7d5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="32a9-161e-907b-306c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="df61-6eea-0717-7d5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="32a9-161e-907b-306c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="0fac-cfce-3ed8-0bda" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0d80-eba7-777d-70bd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="a157-f083-513f-06a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9fec-6b2d-04f8-1d85" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="0d80-eba7-777d-70bd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="a157-f083-513f-06a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9fec-6b2d-04f8-1d85" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="abbe-707f-33d6-9c4f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup"/>
-        <entryLink id="78b4-4a4f-8442-d4e1" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup"/>
+        <entryLink id="abbe-707f-33d6-9c4f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup" />
+        <entryLink id="78b4-4a4f-8442-d4e1" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
     <entryLink id="f009-4a6f-2372-d502" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="34d9-41e4-9dd5-e46b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="4f04-5391-4c61-c6c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="83d6-d890-ff34-c332" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="34d9-41e4-9dd5-e46b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="4f04-5391-4c61-c6c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="83d6-d890-ff34-c332" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="d795-2643-a8dd-2513" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup"/>
-        <entryLink id="9d85-e6e0-126b-712e" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup"/>
+        <entryLink id="d795-2643-a8dd-2513" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup" />
+        <entryLink id="9d85-e6e0-126b-712e" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
     <entryLink id="de3a-123d-3cfd-21eb" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7664-92e2-bda2-8759" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="feed-359b-e963-2b2b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="88cf-2cd2-5242-84fa" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="7664-92e2-bda2-8759" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="feed-359b-e963-2b2b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="88cf-2cd2-5242-84fa" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="0208-3392-8cb4-4409" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup"/>
-        <entryLink id="6bf7-6af2-6258-07e4" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup"/>
+        <entryLink id="0208-3392-8cb4-4409" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup" />
+        <entryLink id="6bf7-6af2-6258-07e4" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
     <entryLink id="7003-1c3a-438a-3d28" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="dff2-a9e0-4c87-33d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2e77-5129-a623-52d1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="dff2-a9e0-4c87-33d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2e77-5129-a623-52d1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="4570-1d63-b161-86da" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="92b0-cf7b-a4c1-a2be" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="1c36-8e5f-0b0a-5f7b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="92b0-cf7b-a4c1-a2be" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="1c36-8e5f-0b0a-5f7b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
     <entryLink id="c793-cb2f-9479-0aad" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0757-5c73-2ec4-73cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a49e-d5cb-868c-1379" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="0757-5c73-2ec4-73cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a49e-d5cb-868c-1379" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="6d99-d6e2-4836-5b15" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="286a-f434-5cd4-471b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="3c3e-29cd-4c48-3a61" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="286a-f434-5cd4-471b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="3c3e-29cd-4c48-3a61" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
     <entryLink id="4d50-a28a-15f0-6b9d" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4bdc-6119-8f9e-b739" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="b61a-d21e-6d85-f70f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4bdc-6119-8f9e-b739" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="b61a-d21e-6d85-f70f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
     <entryLink id="925e-039d-df0e-6c82" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="bd02-a4b5-72ff-b9de" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="dd71-b488-22c7-1a57" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bd02-a4b5-72ff-b9de" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="dd71-b488-22c7-1a57" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
     <entryLink id="c362-07c0-c7a6-4e21" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2906-5c2f-46f0-2f22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3cc6-592f-cafb-53b9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="2906-5c2f-46f0-2f22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3cc6-592f-cafb-53b9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
     <entryLink id="c59d-949c-def6-156e" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d466-ef14-1aab-e266" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="6a89-799f-bae4-e727" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d466-ef14-1aab-e266" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="6a89-799f-bae4-e727" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
     <entryLink id="381d-b233-7191-e417" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0063-8735-7060-c44f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="886a-fb2d-1f8f-3b25" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="0063-8735-7060-c44f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="886a-fb2d-1f8f-3b25" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
     <entryLink id="685e-e480-ab3f-104f" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="291c-88fe-0a3e-b147" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c52a-54ab-f3c0-4674" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="291c-88fe-0a3e-b147" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c52a-54ab-f3c0-4674" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
     <entryLink id="b29b-b6d8-64b0-ad57" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d296-0a74-7adc-eb37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a92f-c63a-674d-5d6b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="d296-0a74-7adc-eb37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a92f-c63a-674d-5d6b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
     <entryLink id="6acd-f4f9-fb46-a306" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e382-f9ba-1025-ef6d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5faa-7160-603e-7392" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="e382-f9ba-1025-ef6d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5faa-7160-603e-7392" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
     <entryLink id="7ab5-27ee-8c1c-bddb" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1f52-0793-b77f-aa71" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="86a8-2a5a-5e1d-febe" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="1f52-0793-b77f-aa71" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="86a8-2a5a-5e1d-febe" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="8dfd-52fe-18de-e010" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f0bf-128a-f446-ea18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d21e-0c3f-4cb3-15ca" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="f0bf-128a-f446-ea18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d21e-0c3f-4cb3-15ca" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
     <entryLink id="800b-aaa3-22ee-521e" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7500-4599-5f05-5d29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e0c9-cf19-0ba4-d686" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="7500-4599-5f05-5d29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e0c9-cf19-0ba4-d686" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="30bd-085b-0e7c-39a9" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="12ca-5aa1-a90d-9538" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="0f02-6375-6c11-8faf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="12ca-5aa1-a90d-9538" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="0f02-6375-6c11-8faf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
     <entryLink id="5aef-8d2d-c34d-25d0" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9d14-54f7-f4d0-4702" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="cd2a-7548-6447-1afd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9d14-54f7-f4d0-4702" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="cd2a-7548-6447-1afd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
     <entryLink id="aa0c-2200-bdf0-90bd" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7c72-0819-aaaa-1f8d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="76a1-db25-00dd-0ea7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7c72-0819-aaaa-1f8d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="76a1-db25-00dd-0ea7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
     <entryLink id="9fb8-08f8-9024-1015" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="eee7-ecc7-788c-23d2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="75b4-c3de-bc9b-f5a7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="19f0-bad2-aeef-3a93" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="eee7-ecc7-788c-23d2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="75b4-c3de-bc9b-f5a7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="19f0-bad2-aeef-3a93" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="b2b5-234c-2ba8-c05b" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8c9f-e2a5-47d6-d8aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5f28-fcba-9bdb-2a9e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="8c9f-e2a5-47d6-d8aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5f28-fcba-9bdb-2a9e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
     <entryLink id="af58-68f6-b173-4756" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c86f-456b-ea6d-1574" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="f21a-83be-767a-b735" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c86f-456b-ea6d-1574" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="f21a-83be-767a-b735" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
     <entryLink id="a47c-06f3-bc77-fca0" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="dab8-c369-2729-1174" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d5cf-2bc2-e065-a6a2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="dab8-c369-2729-1174" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d5cf-2bc2-e065-a6a2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
     <entryLink id="2e04-1055-0e5f-c413" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="afec-53ef-a706-ba32" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="a690-ec72-c6e7-2fae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="afec-53ef-a706-ba32" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="a690-ec72-c6e7-2fae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="1043-8d0f-2838-9f79" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="379f-423c-1b26-4af6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="3992-b442-e809-5dde" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="379f-423c-1b26-4af6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="3992-b442-e809-5dde" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
     <entryLink id="83ae-538e-57d9-ce01" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6ac3-58f6-2662-ac7d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="659b-6e8c-97c7-1bfc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6ac3-58f6-2662-ac7d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="659b-6e8c-97c7-1bfc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="6c25-69a3-62eb-3f42" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d803-e5ae-434c-877f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="0376-967e-1f15-9eb6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d803-e5ae-434c-877f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="0376-967e-1f15-9eb6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
     <entryLink id="2792-ab38-fd66-fe12" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="964b-f758-9f21-90d9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="51b0-bdd5-5105-8150" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="964b-f758-9f21-90d9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="51b0-bdd5-5105-8150" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
     <entryLink id="a70f-fc8b-42cd-5f02" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="69cd-7a55-451d-c920" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="0767-f8eb-83c2-1ef0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="69cd-7a55-451d-c920" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="0767-f8eb-83c2-1ef0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
     <entryLink id="c92c-4514-d7bb-0cd9" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="16dc-aa80-44ee-dbb6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="f718-09c7-8831-44ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="16dc-aa80-44ee-dbb6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="f718-09c7-8831-44ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
     <entryLink id="8883-a80c-8cd9-bb29" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a756-512d-3bbb-0e21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a2a2-f888-8129-cd0c" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="148d-b489-c8ae-b615" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="a756-512d-3bbb-0e21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a2a2-f888-8129-cd0c" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
+        <categoryLink id="148d-b489-c8ae-b615" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="b9bd-df3d-1321-f365" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7f28-a1c8-2801-aec7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8f35-a0cd-5dd6-6281" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="7f28-a1c8-2801-aec7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8f35-a0cd-5dd6-6281" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
     <entryLink id="a225-e55e-9b3d-960b" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1ae1-84be-5e69-aba1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="21d0-7c77-561c-58f8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1ae1-84be-5e69-aba1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="21d0-7c77-561c-58f8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
     <entryLink id="85f4-6e9a-4797-7534" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="76aa-6ce8-d11e-cd51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e9e9-1b4e-334a-ac0f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="76aa-6ce8-d11e-cd51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e9e9-1b4e-334a-ac0f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
     <entryLink id="9d6f-9f11-1095-5ab8" name="Deathshroud Terminator Squad" hidden="false" collective="false" import="false" targetId="7669-a6c0-7f86-e641" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="de3d-153c-8b6a-ee1b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="c965-8eea-54a5-dbbe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="de3d-153c-8b6a-ee1b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="c965-8eea-54a5-dbbe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="bf98-3ce4-bbae-27f4" name="Deathshroud Terminator Squad" hidden="false" collective="false" import="false" targetId="7669-a6c0-7f86-e641" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b426-11a9-a374-dc73" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
-        <categoryLink id="9101-b7e1-a69a-8690" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b426-11a9-a374-dc73" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="9101-b7e1-a69a-8690" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="1f21-083f-ed75-5d38" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <infoLinks>
-        <infoLink id="bfa3-df31-9e63-694f" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule"/>
+        <infoLink id="bfa3-df31-9e63-694f" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="3756-dc59-4b6f-1d17" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6628-588b-3f5f-005f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="3756-dc59-4b6f-1d17" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6628-588b-3f5f-005f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="e830-3788-1a0d-0c02" name="Calas Typhon" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d78-9648-8e21-ec44" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d78-9648-8e21-ec44" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="def1-b261-8261-02fc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="33f7-f2cd-2c9b-34cb" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="8177-1aab-8a85-3acc" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="e01c-ad05-c3de-4026" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="2f7a-f3e1-0ebe-7f53" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="043c-bb03-e878-0086" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
-        <categoryLink id="8ef4-70d2-ba35-70b9" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="def1-b261-8261-02fc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="33f7-f2cd-2c9b-34cb" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="8177-1aab-8a85-3acc" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
+        <categoryLink id="e01c-ad05-c3de-4026" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="2f7a-f3e1-0ebe-7f53" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="043c-bb03-e878-0086" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false" />
+        <categoryLink id="8ef4-70d2-ba35-70b9" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="598d-9b12-2059-e804" name="Calas Typhon" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f92b-4666-40f5-30c2" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f64-f31e-4308-e6a4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f92b-4666-40f5-30c2" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f64-f31e-4308-e6a4" type="max" />
           </constraints>
           <profiles>
             <profile id="c52c-95f8-5247-dbe5" name="Calas Typhon" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character, Unique, Psyker)
 </characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1116,32 +1115,32 @@
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="373a-ebb6-68f5-0f5c" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-            <infoLink id="86b2-6184-32cd-62e5" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule"/>
+            <infoLink id="373a-ebb6-68f5-0f5c" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+            <infoLink id="86b2-6184-32cd-62e5" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule" />
             <infoLink id="ecb4-956f-1298-6094" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Bulky (2)"/>
+                <modifier type="set" field="name" value="Bulky (2)" />
               </modifiers>
             </infoLink>
-            <infoLink id="bfbb-e7cc-c77b-c76e" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule"/>
-            <infoLink id="da5e-4c99-e1cd-21d0" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+            <infoLink id="bfbb-e7cc-c77b-c76e" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule" />
+            <infoLink id="da5e-4c99-e1cd-21d0" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
             <infoLink id="35dd-9996-538c-5f18" name="Firing Protocols (X)" hidden="false" targetId="32a3-f599-5c92-2945" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Firing Protocols (2)"/>
+                <modifier type="set" field="name" value="Firing Protocols (2)" />
               </modifiers>
             </infoLink>
             <infoLink id="f1cf-1e92-8933-4f3d" name="Shrouded (X)" hidden="false" targetId="10c3-fdb0-089f-ca65" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Shrouded (6+)"/>
+                <modifier type="set" field="name" value="Shrouded (6+)" />
               </modifiers>
             </infoLink>
-            <infoLink id="279c-dac2-f898-a2ea" name="Shrouded in Death" hidden="false" targetId="2a8e-65b7-11c5-f84a" type="rule"/>
+            <infoLink id="279c-dac2-f898-a2ea" name="Shrouded in Death" hidden="false" targetId="2a8e-65b7-11c5-f84a" type="rule" />
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="7bc7-2992-c9b2-4ffd" name="Lakrimae" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4210-c768-0b9e-804f" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aed9-fc74-45cd-b751" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4210-c768-0b9e-804f" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aed9-fc74-45cd-b751" type="max" />
               </constraints>
               <profiles>
                 <profile id="3340-e507-1fd1-0ed4" name="Lakrimae" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1154,60 +1153,60 @@
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="9d02-ac5e-e0f7-3eaf" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
-                <infoLink id="af33-79f3-d896-039b" name="Reaping Blow (X)" hidden="false" targetId="bd8c-4f52-d682-1b40" type="rule"/>
-                <infoLink id="e56c-8fdd-3425-077f" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
+                <infoLink id="9d02-ac5e-e0f7-3eaf" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
+                <infoLink id="af33-79f3-d896-039b" name="Reaping Blow (X)" hidden="false" targetId="bd8c-4f52-d682-1b40" type="rule" />
+                <infoLink id="e56c-8fdd-3425-077f" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
             <selectionEntryGroup id="774f-3b57-9042-0047" name="Psychic Powers" hidden="false" collective="false" import="true" defaultSelectionEntryId="bce2-5933-df34-76f0">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aba0-a8a6-ce04-4a51" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c5a-1fcb-80b6-ee87" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aba0-a8a6-ce04-4a51" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c5a-1fcb-80b6-ee87" type="min" />
               </constraints>
               <selectionEntries>
                 <selectionEntry id="bce2-5933-df34-76f0" name="Psychic Powers" hidden="false" collective="false" import="true" type="upgrade">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
                       <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7427-bdfa-c359-ebb8" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7427-bdfa-c359-ebb8" type="equalTo" />
                       </conditions>
                     </modifier>
                   </modifiers>
                   <profiles>
                     <profile id="cbc9-4758-39ef-ffb6" name="Witchsense" hidden="false" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power">
                       <characteristics>
-                        <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">At the start of any Assault Phase Calas Typhon’s controlling player may choose to make a Psychic check for him. If that Check is passed then Calas Typhon’s Weapon Skill Characteristic is increased by +1 and his Attacks Characteristic is increased by D3 for the duration of that Assault Phase. If the Check is failed then Calas Typhon suffers Perils of the Warp.</characteristic>
+                        <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">At the start of any Assault Phase Calas Typhon&#8217;s controlling player may choose to make a Psychic check for him. If that Check is passed then Calas Typhon&#8217;s Weapon Skill Characteristic is increased by +1 and his Attacks Characteristic is increased by D3 for the duration of that Assault Phase. If the Check is failed then Calas Typhon suffers Perils of the Warp.</characteristic>
                       </characteristics>
                     </profile>
                     <profile id="cd0e-e3a9-e58a-3826" name="Toxin Cloud " hidden="false" typeId="cede-0217-1b10-2a34" typeName="Psychic Weapon">
                       <comment>Psychic Focus: Before making any To Hit rolls with this weapon, the Psyker must make a Psychic check. If the Check is passed then the Psyker may attack as normal using the profile shown for this weapon. If the Check is failed then the Psyker suffers Perils of the Warp, and if the model is not removed as a casualty then it may attack as normal but may not use this weapon.</comment>
                       <characteristics>
-                        <characteristic name="Range" typeId="62ec-fbf5-5252-0d17">24&quot;</characteristic>
+                        <characteristic name="Range" typeId="62ec-fbf5-5252-0d17">24"</characteristic>
                         <characteristic name="Strength" typeId="17ff-12e7-77d3-2fbe">1</characteristic>
                         <characteristic name="AP" typeId="f431-a7b9-d9d0-36c9">4</characteristic>
-                        <characteristic name="Type" typeId="2159-62b6-4337-d516">Assault 1, Large Blast (5&quot;), Fleshbane, Pinning, Psychic Focus</characteristic>
+                        <characteristic name="Type" typeId="2159-62b6-4337-d516">Assault 1, Large Blast (5"), Fleshbane, Pinning, Psychic Focus</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink id="0bf0-66bd-f147-6697" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
-                    <infoLink id="db05-e595-8bd5-e117" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
-                    <infoLink id="239c-affa-db28-97a9" name="Psychic Focus (?? Where is this?)" hidden="false" targetId="bff3-3548-b2b8-72f1" type="rule"/>
+                    <infoLink id="0bf0-66bd-f147-6697" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule" />
+                    <infoLink id="db05-e595-8bd5-e117" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule" />
+                    <infoLink id="239c-affa-db28-97a9" name="Psychic Focus (?? Where is this?)" hidden="false" targetId="bff3-3548-b2b8-72f1" type="rule" />
                   </infoLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4fd1-5f3d-038f-be02" name="Witchblood" hidden="true" collective="false" import="true" type="upgrade">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7427-bdfa-c359-ebb8" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7427-bdfa-c359-ebb8" type="equalTo" />
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1219,7 +1218,7 @@
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -1228,67 +1227,67 @@
           <entryLinks>
             <entryLink id="f40c-7314-8386-5153" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3474-64b3-db1b-05d4" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="edce-2c24-5f56-dd2a" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3474-64b3-db1b-05d4" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="edce-2c24-5f56-dd2a" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="2781-3425-b173-618e" name="Alchem Pistol" hidden="false" collective="false" import="true" targetId="1899-9e9e-76dd-a7ba" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a5c-827b-c395-cf48" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b00-8b9c-e255-ed60" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a5c-827b-c395-cf48" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b00-8b9c-e255-ed60" type="max" />
               </constraints>
             </entryLink>
-            <entryLink id="649d-6401-9904-d426" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry"/>
+            <entryLink id="649d-6401-9904-d426" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry" />
             <entryLink id="7b96-46de-f821-91b7" name="Death Cloud Projector" hidden="false" collective="false" import="true" targetId="57fc-83ef-cf41-a68f" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03ea-98c8-b1e4-f132" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb19-f87e-037c-d0be" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03ea-98c8-b1e4-f132" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb19-f87e-037c-d0be" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="b93b-4130-6efb-0afe" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1e8-8d91-3daa-96ae" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70ac-0692-a071-56a9" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1e8-8d91-3daa-96ae" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70ac-0692-a071-56a9" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="7df1-81bc-3316-a26c" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d84-43c4-da7e-4f01" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d84-43c4-da7e-4f01" type="max" />
           </constraints>
           <profiles>
             <profile id="65f7-a587-2fbf-bdd2" name="Comes the Reaper" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When making attacks as part of a Shooting Attack or during an Assault with any weapon that has the Poison (X) special rule, Calas Typhon and any unit with the Legiones Astartes (Death Guard) and at least one model within 12” of Calas Typhon, increase the value of the Poison Special rule by 1 (I.e, from 3+ to 2+) and may reroll failed To Wound rolls for weapons with the Fleshbane special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction in the Movement phase as long as Typhon has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When making attacks as part of a Shooting Attack or during an Assault with any weapon that has the Poison (X) special rule, Calas Typhon and any unit with the Legiones Astartes (Death Guard) and at least one model within 12&#8221; of Calas Typhon, increase the value of the Poison Special rule by 1 (I.e, from 3+ to 2+) and may reroll failed To Wound rolls for weapons with the Fleshbane special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction in the Movement phase as long as Typhon has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
-        <entryLink id="76ec-91ce-1e3b-fc50" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup"/>
+        <entryLink id="76ec-91ce-1e3b-fc50" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup" />
         <entryLink id="2495-f058-c049-5675" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e093-57dc-8b0f-afcb" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84e1-82bc-f67a-bec8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e093-57dc-8b0f-afcb" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84e1-82bc-f67a-bec8" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="7427-bdfa-c359-ebb8" name="Mortarion" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="031f-3c06-53e7-0ee3" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="031f-3c06-53e7-0ee3" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="b149-05d4-2f7b-a3bd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="4055-f3db-da41-c441" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="b149-05d4-2f7b-a3bd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="4055-f3db-da41-c441" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4106-fc7b-3756-ae9a" name="Mortarion" hidden="false" collective="false" import="true" type="model">
@@ -1296,7 +1295,7 @@
             <profile id="b27d-c9d8-fa58-207a" name="Mortarion" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Primarch (Unique)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">7</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">6</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
@@ -1311,43 +1310,43 @@
           </profiles>
           <rules>
             <rule id="b29b-79a3-7a3b-efe8" name="Shadow of the Reaper" hidden="false">
-              <description>So long as Mortarion is not Embarked on any model, in Reserves, locked in combat or part of a unit with the Retinue or Deathshroud Retinue special rules, in the player&apos;s Shooting phase in lieu of making a Shooting Attack, Mortarion may be redeployed by his controlling player, this counts as an alternative form of Movement and cancels the benefits of the Legiones Astartes (Death Guard) special rule when used.
+              <description>So long as Mortarion is not Embarked on any model, in Reserves, locked in combat or part of a unit with the Retinue or Deathshroud Retinue special rules, in the player's Shooting phase in lieu of making a Shooting Attack, Mortarion may be redeployed by his controlling player, this counts as an alternative form of Movement and cancels the benefits of the Legiones Astartes (Death Guard) special rule when used.
 
-If this option is used then Mortarion is removed from the battlefield, leaving any unit that he was part of. The controlling player must then redeploy Mortarion to any point on the battlefield that is within 10&quot; of his original position, as long as there is space for his model and the chosen position is not within 3&quot; of an enemy model. He may not be placed within Impassable Terrain or inside a Vehicle or Building. This is not counted as a move as such, and the intervening terrain does not affect him in any way. Mortarion may Charge normally in a turn that he is redeployed in this way, but counts as making a Disordered Charge if doing so.</description>
+If this option is used then Mortarion is removed from the battlefield, leaving any unit that he was part of. The controlling player must then redeploy Mortarion to any point on the battlefield that is within 10" of his original position, as long as there is space for his model and the chosen position is not within 3" of an enemy model. He may not be placed within Impassable Terrain or inside a Vehicle or Building. This is not counted as a move as such, and the intervening terrain does not affect him in any way. Mortarion may Charge normally in a turn that he is redeployed in this way, but counts as making a Disordered Charge if doing so.</description>
             </rule>
             <rule id="6363-8841-1d61-e78a" name="Prenatural Resilience" hidden="false">
               <description>Any Hits allocated to Mortarion with the Poisoned (X), Rending (X), or Fleshbane special rules only affect Mortarion on a D6 roll of a 6 instead of their usual effect.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="bec8-13ea-971a-7514" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule"/>
+            <infoLink id="bec8-13ea-971a-7514" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule" />
             <infoLink id="db78-46f8-faf7-adf8" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Hatred (Psykers)"/>
+                <modifier type="set" field="name" value="Hatred (Psykers)" />
               </modifiers>
             </infoLink>
-            <infoLink id="66bb-eddf-416b-fbee" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule"/>
+            <infoLink id="66bb-eddf-416b-fbee" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule" />
             <infoLink id="40f6-ba7c-cc2b-8fce" name="Fear (X)" hidden="false" targetId="21f6-7842-df5c-d2e7" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Fear (2)"/>
+                <modifier type="set" field="name" value="Fear (2)" />
               </modifiers>
             </infoLink>
             <infoLink id="591e-2e96-ef7f-e714" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="It Will Not Die (4+)"/>
+                <modifier type="set" field="name" value="It Will Not Die (4+)" />
               </modifiers>
             </infoLink>
             <infoLink id="3735-149b-ec53-4faf" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Bulky (6)"/>
+                <modifier type="set" field="name" value="Bulky (6)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="42ad-a253-7a63-f86f" name="Silence" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="734d-1adc-9847-77ce" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="13af-8276-99e5-41e9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="734d-1adc-9847-77ce" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="13af-8276-99e5-41e9" type="max" />
               </constraints>
               <profiles>
                 <profile id="95b6-ef9b-d09c-3e26" name="Silence" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1360,28 +1359,28 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="8870-0505-2c44-0b61" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
-                <infoLink id="9b44-565b-bcfe-1248" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
-                <infoLink id="aef3-0dd2-e221-c59e" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+                <infoLink id="8870-0505-2c44-0b61" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule" />
+                <infoLink id="9b44-565b-bcfe-1248" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule" />
+                <infoLink id="aef3-0dd2-e221-c59e" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
                 <infoLink id="ecc3-b478-c1f3-5303" name="Reaping Blow (X)" hidden="false" targetId="bd8c-4f52-d682-1b40" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Reaping Blow (2)"/>
+                    <modifier type="set" field="name" value="Reaping Blow (2)" />
                   </modifiers>
                 </infoLink>
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="7d9f-0cea-7243-dbe3" name="The Lantern" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c522-fcc7-db67-e979" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="abef-cd4b-abc5-4a3d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c522-fcc7-db67-e979" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="abef-cd4b-abc5-4a3d" type="max" />
               </constraints>
               <profiles>
                 <profile id="cd5e-466a-8e36-a743" name="The Lantern" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">18"</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
                     <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Sunder</characteristic>
@@ -1389,16 +1388,16 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="d9cb-608a-2855-518d" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+                <infoLink id="d9cb-608a-2855-518d" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="5d32-6cfe-58e7-3931" name="The Barbaran Plate" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fb62-f9a0-5d1f-c50d" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7201-bd60-95ce-765d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fb62-f9a0-5d1f-c50d" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7201-bd60-95ce-765d" type="max" />
               </constraints>
               <profiles>
                 <profile id="9cc5-317a-dae5-3c01" name="The Barbaran Plate" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
@@ -1408,81 +1407,81 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="ab65-06b4-3938-47e7" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b529-18d9-662c-a97d" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fcc3-2cdd-fc00-0ebc" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b529-18d9-662c-a97d" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fcc3-2cdd-fc00-0ebc" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="33f0-90c6-b638-ec5e" name="Phosphex Bomb" hidden="false" collective="false" import="true" targetId="4188-13ff-cb03-109e" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c311-fe6b-6aa8-6b01" type="min"/>
-                <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d5e3-a3e5-de90-65c0" type="max"/>
+                <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c311-fe6b-6aa8-6b01" type="min" />
+                <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d5e3-a3e5-de90-65c0" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="8aa8-5aa2-84ed-cd21" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7187-6dc3-592a-18b8" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01cb-07f7-b45b-7819" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7187-6dc3-592a-18b8" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01cb-07f7-b45b-7819" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="f100-5ea6-0653-7bb7" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a5b-701f-bf05-2c14" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2c2-191a-1362-b9a4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a5b-701f-bf05-2c14" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2c2-191a-1362-b9a4" type="min" />
           </constraints>
           <profiles>
             <profile id="4f47-b860-15fb-4ff7" name="Sire of the Death Guard" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All friendly units composed entirely of models with the Legiones Astartes (Death Guard) in the same army as Mortarion, including Mortarion himself, ignore all penalties to their Leadership caused by the Fear and Shell Shock (X) special rules and when locked in combat suffer no penaltry to their Leadership Characteristics due to casualties suffered during an assault. In addition, an army with Mortarion as its Warlord may take an additional Reaction in the opposing player&apos;s Assault phase as long as Mortarion has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All friendly units composed entirely of models with the Legiones Astartes (Death Guard) in the same army as Mortarion, including Mortarion himself, ignore all penalties to their Leadership caused by the Fear and Shell Shock (X) special rules and when locked in combat suffer no penaltry to their Leadership Characteristics due to casualties suffered during an assault. In addition, an army with Mortarion as its Warlord may take an additional Reaction in the opposing player's Assault phase as long as Mortarion has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="425.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="425.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="dd7b-fe21-cf53-0ebc" name="Mortus Poisoner Squad" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="f06e-03a0-e37f-8366" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
+        <infoLink id="f06e-03a0-e37f-8366" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule" />
         <infoLink id="0adb-ba42-2559-cac3" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Counter-Attack (1)"/>
+            <modifier type="set" field="name" value="Counter-Attack (1)" />
           </modifiers>
         </infoLink>
-        <infoLink id="4f41-d770-ace8-28d9" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
-        <infoLink id="4a9d-1f85-27d1-18c0" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule"/>
+        <infoLink id="4f41-d770-ace8-28d9" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
+        <infoLink id="4a9d-1f85-27d1-18c0" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8781-fa3a-a2f2-bfea" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="dfa4-63db-3a8e-a198" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="4ee0-168f-36f7-496d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="8781-fa3a-a2f2-bfea" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="dfa4-63db-3a8e-a198" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="4ee0-168f-36f7-496d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="277b-5aad-6264-93e1" name="Mortus Poisoner" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6dde-f234-db06-1ada" type="min"/>
-            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f390-efb2-81f3-b2cf" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6dde-f234-db06-1ada" type="min" />
+            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f390-efb2-81f3-b2cf" type="max" />
           </constraints>
           <profiles>
             <profile id="02a9-59ef-1da4-2f90" name="Mortus Poisoner" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1496,26 +1495,26 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="ee15-87c8-0df5-5c2a" name=" Poison-master" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3286-13f9-dcfc-f6c3" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d70e-45fd-ef9e-3bc0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3286-13f9-dcfc-f6c3" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d70e-45fd-ef9e-3bc0" type="max" />
           </constraints>
           <profiles>
             <profile id="50b3-6803-e865-8605" name="Poison-master" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="dd7b-fe21-cf53-0ebc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f20a-d85b-c0b3-47f8" type="equalTo"/>
+                    <condition field="selections" scope="dd7b-fe21-cf53-0ebc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f20a-d85b-c0b3-47f8" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Heavy)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1529,37 +1528,37 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="ef26-2042-3bc7-5552" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="ef26-2042-3bc7-5552" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="180c-30bb-612c-106e" name="May take one:" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8aa5-f0c4-e7c4-40d8" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8aa5-f0c4-e7c4-40d8" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="e226-2dc1-6a93-47b1" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="1a8a-da85-9346-0c49" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="18b8-13d6-9666-a561" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="5e7b-154b-5cf7-c947" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="74a6-dbb2-4ff9-58c5" name="Power Scythe" hidden="false" collective="false" import="true" targetId="2166-369e-0757-6f98" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1568,41 +1567,41 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
               <entryLinks>
                 <entryLink id="f20a-d85b-c0b3-47f8" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dbc6-c546-f2cf-e381" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dbc6-c546-f2cf-e381" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="b8fc-02bb-d0ec-9139" name="Phosphex Bomb" hidden="false" collective="false" import="true" targetId="4188-13ff-cb03-109e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0538-e933-7e47-1766" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0538-e933-7e47-1766" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="eb00-e531-fda7-b74d" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b8a2-5de1-9b88-01e5" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b8a2-5de1-9b88-01e5" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="5476-79ac-556b-aa05" name="Toxin Bombs" hidden="false" collective="false" import="true" targetId="987b-9177-dde0-bf9b" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fbf-562c-c5ff-4316" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fbf-562c-c5ff-4316" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1611,28 +1610,28 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           <modifiers>
             <modifier type="increment" field="26b4-40b7-b21d-9d9d" value="1.0">
               <repeats>
-                <repeat field="selections" scope="dd7b-fe21-cf53-0ebc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1ade-0c02-5612-252b" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="dd7b-fe21-cf53-0ebc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1ade-0c02-5612-252b" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26b4-40b7-b21d-9d9d" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26b4-40b7-b21d-9d9d" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="cece-deef-1278-1a2f" name="Bayonet" hidden="false" collective="false" import="true" targetId="6904-6936-d6ca-a0eb" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b4c-fd73-0b14-9e1f" type="max"/>
+                <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b4c-fd73-0b14-9e1f" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0" />
               </costs>
             </entryLink>
             <entryLink id="19f6-9bdc-073a-4aac" name="Chain Bayonet" hidden="false" collective="false" import="true" targetId="bd82-cef6-67f8-19b5" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9504-0ee6-4e95-7485" type="max"/>
+                <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9504-0ee6-4e95-7485" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -1641,39 +1640,39 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           <modifiers>
             <modifier type="increment" field="66c5-3474-81aa-b109" value="1.0">
               <repeats>
-                <repeat field="selections" scope="dd7b-fe21-cf53-0ebc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="dd7b-fe21-cf53-0ebc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
             <modifier type="increment" field="7ba6-239e-5538-a33b" value="1.0">
               <repeats>
-                <repeat field="selections" scope="dd7b-fe21-cf53-0ebc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="dd7b-fe21-cf53-0ebc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
-            <modifier type="decrement" field="7ba6-239e-5538-a33b" value="5.0"/>
+            <modifier type="decrement" field="7ba6-239e-5538-a33b" value="5.0" />
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66c5-3474-81aa-b109" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ba6-239e-5538-a33b" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66c5-3474-81aa-b109" type="max" />
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ba6-239e-5538-a33b" type="min" />
           </constraints>
           <selectionEntryGroups>
             <selectionEntryGroup id="2a3f-3caf-a1a9-8357" name="One in every five may exchange its bolter for:" hidden="false" collective="false" import="true">
               <modifiers>
                 <modifier type="increment" field="8db1-9be4-f0f9-037b" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="dd7b-fe21-cf53-0ebc" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="dd7b-fe21-cf53-0ebc" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8db1-9be4-f0f9-037b" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8db1-9be4-f0f9-037b" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="890c-7f35-bc61-64c2" name="Heavy Alchem Flamer" hidden="false" collective="false" import="true" targetId="2a3d-a4bb-5326-a16a" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c674-d17c-e67c-ecd8" type="max"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c674-d17c-e67c-ecd8" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1682,12 +1681,12 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           <entryLinks>
             <entryLink id="5adf-e2c2-73b6-cf87" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4dc-06ef-bb69-ac1b" type="max"/>
+                <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4dc-06ef-bb69-ac1b" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="8c1d-2658-3db4-806b" name="Alchem Flamer" hidden="false" collective="false" import="true" targetId="0d08-eaaf-3793-0a70" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a796-24da-509d-3dda" type="max"/>
+                <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a796-24da-509d-3dda" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
@@ -1696,17 +1695,17 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           <modifiers>
             <modifier type="increment" field="66d1-3a38-70ba-c843" value="1.0">
               <repeats>
-                <repeat field="selections" scope="dd7b-fe21-cf53-0ebc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="dd7b-fe21-cf53-0ebc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="66d1-3a38-70ba-c843" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="66d1-3a38-70ba-c843" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="9c01-9d75-f00b-903e" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -1715,26 +1714,26 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           <entryLinks>
             <entryLink id="d06c-fbd7-412c-25e4" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbf0-10c5-1590-48ae" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbf0-10c5-1590-48ae" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="1d6f-369d-8821-aa1c" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ad7-3da9-eee2-1a4d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ad7-3da9-eee2-1a4d" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="bb97-29b8-1fc0-9aa1" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7720-d996-8e5d-71f1" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7720-d996-8e5d-71f1" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -1743,19 +1742,19 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="dd7b-fe21-cf53-0ebc" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                <condition field="selections" scope="dd7b-fe21-cf53-0ebc" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d18e-60b4-dca9-0707" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d18e-60b4-dca9-0707" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="586e-e624-2a3f-d751" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1764,7 +1763,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1773,7 +1772,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1782,7 +1781,7 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1791,48 +1790,48 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="be32-77c9-fe55-7dc0" name="Grave Warden Terminator Squad" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="5fba-df58-112a-a0e5" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule"/>
-        <infoLink id="4c64-5d01-c3f5-0d4c" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="5fba-df58-112a-a0e5" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule" />
+        <infoLink id="4c64-5d01-c3f5-0d4c" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="6fd5-bf0f-cee7-c955" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
         <infoLink id="d7eb-89ad-0644-6006" name="Firing Protocols (X)" hidden="false" targetId="32a3-f599-5c92-2945" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Firing Protocols (2)"/>
+            <modifier type="set" field="name" value="Firing Protocols (2)" />
           </modifiers>
         </infoLink>
         <infoLink id="900e-dfbd-1914-65d9" name="Shrouded (X)" hidden="false" targetId="10c3-fdb0-089f-ca65" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Shrouded (6+)"/>
+            <modifier type="set" field="name" value="Shrouded (6+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="e506-3257-a236-b033" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
-        <infoLink id="05c4-1c08-0950-b643" name="Shrouded in Death" hidden="false" targetId="2a8e-65b7-11c5-f84a" type="rule"/>
+        <infoLink id="e506-3257-a236-b033" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
+        <infoLink id="05c4-1c08-0950-b643" name="Shrouded in Death" hidden="false" targetId="2a8e-65b7-11c5-f84a" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ca31-c0b0-1723-d85a" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="4b86-b5c5-f3e9-3f35" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="0fe4-702f-0f7f-805c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="51c7-b78d-5c3b-7ebd" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="ca31-c0b0-1723-d85a" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="4b86-b5c5-f3e9-3f35" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="0fe4-702f-0f7f-805c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="51c7-b78d-5c3b-7ebd" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ef11-6c72-ed0c-3518" name="Chem-master" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afcf-73d2-9187-3d15" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1a5-ed23-c039-0954" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afcf-73d2-9187-3d15" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1a5-ed23-c039-0954" type="max" />
           </constraints>
           <profiles>
             <profile id="04f4-5254-1797-cff3" name="Chem-master" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1846,116 +1845,116 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="b08c-77b8-5038-a9cc" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="b08c-77b8-5038-a9cc" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="79e4-c3dc-af82-c169" name="2) Ranged Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5f54-71b6-2b16-551c">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4037-d1a2-ccae-a0a5" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9422-7b1d-5e1c-53b0" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4037-d1a2-ccae-a0a5" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9422-7b1d-5e1c-53b0" type="min" />
               </constraints>
               <selectionEntryGroups>
                 <selectionEntryGroup id="0760-1e8d-5f9e-84b8" name="1 in every 5 models may may exchange his assault grenade launcher for:" hidden="false" collective="false" import="true">
                   <modifiers>
                     <modifier type="increment" field="84ef-3f75-ca59-8554" value="1.0">
                       <repeats>
-                        <repeat field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                        <repeat field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                       </repeats>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="be32-77c9-fe55-7dc0" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="84ef-3f75-ca59-8554" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c9f9-f10e-43bc-7da5" type="max"/>
+                    <constraint field="selections" scope="be32-77c9-fe55-7dc0" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="84ef-3f75-ca59-8554" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c9f9-f10e-43bc-7da5" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="3010-ed9a-4d06-2387" name="Heavy Alchem Flamer" hidden="false" collective="false" import="true" targetId="2a3d-a4bb-5326-a16a" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="24c6-a213-c8b4-74ef" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="24c6-a213-c8b4-74ef" type="max" />
                       </constraints>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="118c-3f39-bb68-71c0" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                <entryLink id="118c-3f39-bb68-71c0" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry" />
                 <entryLink id="377a-0feb-7451-7e5b" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="586c-07f3-b4d9-072d" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="be2c-e6fd-0f32-917d" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="e904-c468-108c-37f2" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="5fdb-621d-4621-6daf" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="5f54-71b6-2b16-551c" name="Assault Grenade Launcher" hidden="false" collective="false" import="true" targetId="804c-f802-8c3f-8885" type="selectionEntry"/>
+                <entryLink id="5f54-71b6-2b16-551c" name="Assault Grenade Launcher" hidden="false" collective="false" import="true" targetId="804c-f802-8c3f-8885" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="f6ef-eab6-5dbf-2568" name="3) May take:" hidden="false" collective="false" import="true">
               <entryLinks>
                 <entryLink id="4151-cc08-f06e-0797" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcde-5a07-8075-d1ae" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcde-5a07-8075-d1ae" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="82a7-93e3-ce49-9dfd" name="Toxin Bombs" hidden="false" collective="false" import="true" targetId="987b-9177-dde0-bf9b" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9265-57d6-55b6-e1e6" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9265-57d6-55b6-e1e6" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="de7f-2043-d161-681f" name="1) Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="860d-6fe3-84b4-4aab">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fddf-0b43-99a6-9bf2" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1740-ce16-d7c3-0e51" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fddf-0b43-99a6-9bf2" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1740-ce16-d7c3-0e51" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="6c30-f8f4-ab5e-ad8d" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="df90-d8e3-be60-2b95" name="Power Scythe" hidden="false" collective="false" import="true" targetId="2166-369e-0757-6f98" type="selectionEntry"/>
-                <entryLink id="860d-6fe3-84b4-4aab" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry"/>
+                <entryLink id="df90-d8e3-be60-2b95" name="Power Scythe" hidden="false" collective="false" import="true" targetId="2166-369e-0757-6f98" type="selectionEntry" />
+                <entryLink id="860d-6fe3-84b4-4aab" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="f793-f94b-e1af-33c4" name="Grave Wardens" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de04-30ac-4390-02bc" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e5e-8e3e-fc6d-d924" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de04-30ac-4390-02bc" type="min" />
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e5e-8e3e-fc6d-d924" type="max" />
           </constraints>
           <profiles>
             <profile id="3bd5-9c83-fb86-f6a7" name="Grave Warden" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1971,16 +1970,16 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           <selectionEntryGroups>
             <selectionEntryGroup id="83c6-26e8-bdde-3739" name="Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="563b-58cf-cb5e-a3c4">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="32ec-8ae2-8857-dfd2" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c1d5-2cbd-a5b5-2720" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="32ec-8ae2-8857-dfd2" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c1d5-2cbd-a5b5-2720" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="85c4-7532-de53-be7c" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="563b-58cf-cb5e-a3c4" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry"/>
+                <entryLink id="563b-58cf-cb5e-a3c4" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="ef2d-14c6-26da-7b86" name="Ranged Option:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4ca1-5aab-a261-6d65">
@@ -1989,30 +1988,30 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
                   <modifiers>
                     <modifier type="increment" field="c751-3b0d-42a7-052d" value="1.0">
                       <repeats>
-                        <repeat field="selections" scope="be32-77c9-fe55-7dc0" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                        <repeat field="selections" scope="be32-77c9-fe55-7dc0" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                       </repeats>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c751-3b0d-42a7-052d" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="79a1-aaf6-8cf6-da2f" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c751-3b0d-42a7-052d" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="79a1-aaf6-8cf6-da2f" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="0095-2173-d42f-690a" name="Heavy Alchem Flamer" hidden="false" collective="false" import="true" targetId="2a3d-a4bb-5326-a16a" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3c64-f269-dbe2-fbd1" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3c64-f269-dbe2-fbd1" type="max" />
                       </constraints>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="4ca1-5aab-a261-6d65" name="Assault Grenade Launcher" hidden="false" collective="false" import="true" targetId="804c-f802-8c3f-8885" type="selectionEntry"/>
+                <entryLink id="4ca1-5aab-a261-6d65" name="Assault Grenade Launcher" hidden="false" collective="false" import="true" targetId="804c-f802-8c3f-8885" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2021,17 +2020,17 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="be32-77c9-fe55-7dc0" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+                <condition field="selections" scope="be32-77c9-fe55-7dc0" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24c7-d615-4141-2228" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24c7-d615-4141-2228" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="2028-2a00-715c-909b" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d230-5938-5cd2-f065" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d230-5938-5cd2-f065" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
@@ -2040,36 +2039,36 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
       <entryLinks>
         <entryLink id="0c3f-4b30-04d7-7685" name="Assault Grenade Launcher" hidden="false" collective="false" import="true" targetId="804c-f802-8c3f-8885" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e5de-09f0-2692-af6f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9134-9e0b-3599-0591" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e5de-09f0-2692-af6f" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9134-9e0b-3599-0591" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="7ac0-3a5b-73e1-17d4" name="Death Cloud Projector" hidden="false" collective="false" import="true" targetId="57fc-83ef-cf41-a68f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0bc2-ce74-eab0-910f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f847-c755-3021-ac83" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0bc2-ce74-eab0-910f" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f847-c755-3021-ac83" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="d41a-3251-5760-560e" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d23-c9f3-2c9c-1d5a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a8c-ddd0-3f0f-ba93" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d23-c9f3-2c9c-1d5a" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a8c-ddd0-3f0f-ba93" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="56d5-bad2-14e6-2277" name="Crysos Morturg" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f47c-aed4-2beb-6417" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f47c-aed4-2beb-6417" type="max" />
       </constraints>
       <profiles>
         <profile id="dd5e-f503-609a-2353" name="Crysos Morturg" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique, Psyker, Heavy)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2088,63 +2087,63 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="168b-60a0-6b52-6fe4" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="b7a1-da87-790d-6539" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
-        <infoLink id="94d9-eb6b-7f51-6fcd" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule"/>
+        <infoLink id="168b-60a0-6b52-6fe4" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="b7a1-da87-790d-6539" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
+        <infoLink id="94d9-eb6b-7f51-6fcd" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule" />
         <infoLink id="300d-658c-8402-f2dd" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Counter-Attack (1)"/>
+            <modifier type="set" field="name" value="Counter-Attack (1)" />
           </modifiers>
         </infoLink>
-        <infoLink id="355a-310f-4c86-d4dd" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
+        <infoLink id="355a-310f-4c86-d4dd" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="d376-a6bd-3afa-18db" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="09dd-97f2-3578-0b77" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="c14e-e1ca-7d1e-8ba9" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
-        <categoryLink id="3ab9-09ca-d35c-7778" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="d376-a6bd-3afa-18db" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="09dd-97f2-3578-0b77" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="c14e-e1ca-7d1e-8ba9" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false" />
+        <categoryLink id="3ab9-09ca-d35c-7778" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="82e1-3fe4-d8a1-63c5" name="The Revenant&apos;s Aegis" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="82e1-3fe4-d8a1-63c5" name="The Revenant's Aegis" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0478-ce64-6188-f5ec" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dd0f-fda6-abed-95b8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0478-ce64-6188-f5ec" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dd0f-fda6-abed-95b8" type="max" />
           </constraints>
           <profiles>
-            <profile id="2108-5bcb-681d-87e7" name="The Revenant&apos;s Aegis" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+            <profile id="2108-5bcb-681d-87e7" name="The Revenant's Aegis" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
               <characteristics>
-                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">The Revenant’s Aegis grants a 2+ Armour Save, a 4+ Invulnerable Save and a 6+ Shrouded Damage Mitigation roll.</characteristic>
+                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">The Revenant&#8217;s Aegis grants a 2+ Armour Save, a 4+ Invulnerable Save and a 6+ Shrouded Damage Mitigation roll.</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="a672-b0b3-8247-552c" name="Two Disintegrator pistols" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cf28-1ca4-90b6-6a95" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a65e-8770-72e9-bffb" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cf28-1ca4-90b6-6a95" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a65e-8770-72e9-bffb" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="f33a-0636-d712-4b2d" name="Disintegrator Pistol" hidden="false" collective="false" import="true" targetId="980e-b1e7-a4a4-407f" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c33d-cbf0-5204-4da8" type="max"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="31b2-0fc1-df54-f23b" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c33d-cbf0-5204-4da8" type="max" />
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="31b2-0fc1-df54-f23b" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
-        <selectionEntry id="1678-5bf3-402d-5a2f" name="Death&apos;s Tally" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="1678-5bf3-402d-5a2f" name="Death's Tally" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e35a-7d87-fdbc-2c95" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7527-defd-3be9-20ac" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e35a-7d87-fdbc-2c95" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7527-defd-3be9-20ac" type="max" />
           </constraints>
           <profiles>
-            <profile id="79ff-4d42-e93b-63cd" name="Death&apos;s Tally" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="79ff-4d42-e93b-63cd" name="Death's Tally" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+1</characteristic>
@@ -2155,85 +2154,85 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           </profiles>
           <rules>
             <rule id="5a33-d42e-c49a-56b7" name="Overcharged" hidden="false">
-              <description>After a combat in which a model whose weapon has this special rule has made at least one Attack has been resolved, roll a dice. On the roll of a ‘1’ that model suffers a Wound against which only Invulnerable Saves may be taken.</description>
+              <description>After a combat in which a model whose weapon has this special rule has made at least one Attack has been resolved, roll a dice. On the roll of a &#8216;1&#8217; that model suffers a Wound against which only Invulnerable Saves may be taken.</description>
             </rule>
           </rules>
           <infoLinks>
             <infoLink id="31d2-a4a7-b0a6-0318" name="Reaping Blow (X)" hidden="false" targetId="bd8c-4f52-d682-1b40" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Reaping Blow (2)"/>
+                <modifier type="set" field="name" value="Reaping Blow (2)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="57b3-7198-991b-138f" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="78f5-c6ff-f990-a402" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="56af-f73b-bfc7-308c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="78f5-c6ff-f990-a402" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="56af-f73b-bfc7-308c" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="6be2-02f6-a717-645e" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f594-87e9-50d0-da65" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="22b2-3e13-c62d-b538" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f594-87e9-50d0-da65" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="22b2-3e13-c62d-b538" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="46fb-d2a6-ef11-9d2f" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="507e-3f9e-0429-68d5" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0b9c-d762-76be-cf4a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="507e-3f9e-0429-68d5" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0b9c-d762-76be-cf4a" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="e34b-a0ca-03ab-c3f8" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4388-da0c-2caa-e17d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4388-da0c-2caa-e17d" type="max" />
           </constraints>
           <profiles>
             <profile id="e842-546a-9b15-dceb" name="The Shadow of Death" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">During deployment, if any enemy unit is deployed within 18&quot; of Crysos Morturg, or any model in a unit he has joined, then once all Infiltrators and Scouts have been deployed (both friendly and enemy) Crysos Morturg and all models in any unit he has joined may be moved up to 7&quot; in any direction, but must end the move in Unit Coherency. In addition, Crysos Morturg and any unit he has joined may make a Reaction of any kind normally allowed to them at no cost to the controlling player’s Reaction Allotment, when Reacting to an enemy unit entering play from Reserves (including as part of a Deep Strike Assault).</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">During deployment, if any enemy unit is deployed within 18" of Crysos Morturg, or any model in a unit he has joined, then once all Infiltrators and Scouts have been deployed (both friendly and enemy) Crysos Morturg and all models in any unit he has joined may be moved up to 7" in any direction, but must end the move in Unit Coherency. In addition, Crysos Morturg and any unit he has joined may make a Reaction of any kind normally allowed to them at no cost to the controlling player&#8217;s Reaction Allotment, when Reacting to an enemy unit entering play from Reserves (including as part of a Deep Strike Assault).</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
         <entryLink id="9bfb-275f-a3ff-c508" name="Aetheric Lightning" hidden="false" collective="false" import="true" targetId="b477-d985-8b95-69de" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f52d-0c9d-6731-a123" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d072-a6f8-a396-4a6d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f52d-0c9d-6731-a123" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d072-a6f8-a396-4a6d" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="9870-c296-2d55-a2af" name="Minor Combi-Weapon - Alchem Flamer" hidden="false" collective="false" import="true" targetId="b941-687c-c95e-31a6" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3667-553f-b69a-b0fb" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0148-491b-ef64-3a31" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3667-553f-b69a-b0fb" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0148-491b-ef64-3a31" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="bd75-611c-23bb-7064" name="Marshal Durak Rask" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8ecc-5681-8f65-1628" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8ecc-5681-8f65-1628" type="max" />
       </constraints>
       <profiles>
         <profile id="460f-7d2b-eaef-5abf" name="Marshal Durak Rask" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique, Heavy)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2248,23 +2247,23 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
       </profiles>
       <rules>
         <rule id="cf9d-b20b-3d98-8aaf" name="Protocols of Destruction" hidden="false">
-          <description>The controlling player of a model with Protocols of Destruction may activate them at the start of any of their own turns, or, if the controlling player is not taking the first turn of the battle, at the start of the battle, before the beginning of the opposing player’s first turn. Once Protocols of Destruction are activated, any Penetrating Hits caused by a model with Protocols of Destruction and any unit that they have joined, gain +1 to any rolls on the Vehicle Damage chart until the beginning of the controlling player’s next turn. In addition, any Legion Rapier Carriers with quad launchers in the same Detachment as Marshal Durak Rask may be upgraded to have phosphex canister shot for +20 points per model, and any Legion Arquitor Squadrons with Morbus bombards in the same Detachment may be upgraded with phosphex shells for +20 points per model.</description>
+          <description>The controlling player of a model with Protocols of Destruction may activate them at the start of any of their own turns, or, if the controlling player is not taking the first turn of the battle, at the start of the battle, before the beginning of the opposing player&#8217;s first turn. Once Protocols of Destruction are activated, any Penetrating Hits caused by a model with Protocols of Destruction and any unit that they have joined, gain +1 to any rolls on the Vehicle Damage chart until the beginning of the controlling player&#8217;s next turn. In addition, any Legion Rapier Carriers with quad launchers in the same Detachment as Marshal Durak Rask may be upgraded to have phosphex canister shot for +20 points per model, and any Legion Arquitor Squadrons with Morbus bombards in the same Detachment may be upgraded with phosphex shells for +20 points per model.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="6127-484d-d453-b4e0" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule"/>
+        <infoLink id="6127-484d-d453-b4e0" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="58d0-40f3-bf65-136f" name="Siege Breaker:" hidden="false" targetId="8247-54dc-9194-948f" primary="false"/>
-        <categoryLink id="0a04-abf8-2e59-99ae" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="076e-8fde-df99-a46e" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="9919-bd28-8a44-115d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="58d0-40f3-bf65-136f" name="Siege Breaker:" hidden="false" targetId="8247-54dc-9194-948f" primary="false" />
+        <categoryLink id="0a04-abf8-2e59-99ae" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="076e-8fde-df99-a46e" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="9919-bd28-8a44-115d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="dd03-bdde-aa4c-d15d" name="Defiant" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b76e-713c-6a4e-e46b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="73a5-de63-b01b-fe2c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b76e-713c-6a4e-e46b" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="73a5-de63-b01b-fe2c" type="max" />
           </constraints>
           <profiles>
             <profile id="aa58-7ece-155b-fc7b" name="Defiant" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2277,126 +2276,126 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="82a4-eae4-c6d2-245d" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+            <infoLink id="82a4-eae4-c6d2-245d" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
             <infoLink id="c7ae-0ebf-ead4-0070" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Brutal (2)"/>
+                <modifier type="set" field="name" value="Brutal (2)" />
               </modifiers>
             </infoLink>
-            <infoLink id="10a6-f048-cd0b-1472" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
-            <infoLink id="5c43-b68d-44b2-6999" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+            <infoLink id="10a6-f048-cd0b-1472" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule" />
+            <infoLink id="5c43-b68d-44b2-6999" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="b552-e90d-0c8f-661b" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f0bd-8ed8-26bb-da80" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e7d0-481c-fca2-62fb" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f0bd-8ed8-26bb-da80" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e7d0-481c-fca2-62fb" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="20aa-4dff-bcee-c0cd" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1c32-944b-c0b9-6161" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="495b-fae6-2e40-0512" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1c32-944b-c0b9-6161" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="495b-fae6-2e40-0512" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="4ad7-7a90-0527-205e" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0348-ad10-95e0-cdef" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0624-ad47-a6c4-c0d3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0348-ad10-95e0-cdef" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0624-ad47-a6c4-c0d3" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="35e8-8396-34a3-ca65" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b433-9f1b-85a7-0961" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b433-9f1b-85a7-0961" type="max" />
           </constraints>
           <profiles>
             <profile id="db48-f88f-d34e-6d4a" name="Merciless Doctrine" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any Feel No Pain Damage Mitigation rolls taken against Wounds inflicted by Shooting Attacks made by Marshal Durak Rask and any unit that he has joined are reduced by -1, to a minimum of 6+ (for example, a model with a Feel No Pain (4+) requires a roll of 5+ against the attack). In addition, an army whose Warlord is Durak Rask may make an additional Reaction in the opposing player’s Shooting phase, as long as Marshal Durak Rask has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any Feel No Pain Damage Mitigation rolls taken against Wounds inflicted by Shooting Attacks made by Marshal Durak Rask and any unit that he has joined are reduced by -1, to a minimum of 6+ (for example, a model with a Feel No Pain (4+) requires a roll of 5+ against the attack). In addition, an army whose Warlord is Durak Rask may make an additional Reaction in the opposing player&#8217;s Shooting phase, as long as Marshal Durak Rask has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
         <entryLink id="db4a-a856-fe6c-bd53" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="35cd-faf5-ddd8-0226" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b135-6dbb-c89c-f0f1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="35cd-faf5-ddd8-0226" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b135-6dbb-c89c-f0f1" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="4fde-c529-f6e1-89f9" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="46e9-7036-643b-6fcc" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1a7b-3a8a-a1f4-dcb6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="46e9-7036-643b-6fcc" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1a7b-3a8a-a1f4-dcb6" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="baf0-84f0-d38b-7bfd" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="64e7-b2de-2a4c-a260" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d69c-9598-1983-675c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="64e7-b2de-2a4c-a260" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d69c-9598-1983-675c" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="34f6-7e6b-1b45-5520" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5af5-7104-d896-ca33" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bca4-1a03-769c-a3cd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5af5-7104-d896-ca33" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bca4-1a03-769c-a3cd" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="0bdb-a45f-78c2-64e9" name="Phosphex Bomb" hidden="false" collective="false" import="true" targetId="4188-13ff-cb03-109e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="46fd-fe67-5427-3aa5" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="38e4-4d93-6eff-0ca8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="46fd-fe67-5427-3aa5" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="38e4-4d93-6eff-0ca8" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="165.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="165.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="7669-a6c0-7f86-e641" name="Deathshroud Terminator Squad" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <infoLinks>
-        <infoLink id="e615-02b3-1a1f-3951" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="3114-9158-4c3c-f342" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="e615-02b3-1a1f-3951" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="3114-9158-4c3c-f342" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
         <infoLink id="3ef2-0381-e92c-2e9d" name="Battle-Hardened (X)" hidden="false" targetId="5c3b-ed0b-4ad0-d547" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Battle-hardened (1)"/>
+            <modifier type="set" field="name" value="Battle-hardened (1)" />
           </modifiers>
         </infoLink>
         <infoLink id="db76-58b0-1c94-23a4" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="e88f-fb18-7c1d-6db6" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule"/>
-        <infoLink id="0325-99f5-52bf-4a56" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
+        <infoLink id="e88f-fb18-7c1d-6db6" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule" />
+        <infoLink id="0325-99f5-52bf-4a56" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="d4f9-501e-a4fa-3f6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="63ee-4b93-4160-2bd7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="9aa5-47d6-a6d0-cc9a" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="d4f9-501e-a4fa-3f6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="63ee-4b93-4160-2bd7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="9aa5-47d6-a6d0-cc9a" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1dce-0343-5e1c-eac8" name="Deathshroud" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5e27-aac6-259f-2166" type="min"/>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e7c-0d36-b8ef-9b30" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5e27-aac6-259f-2166" type="min" />
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e7c-0d36-b8ef-9b30" type="max" />
           </constraints>
           <profiles>
             <profile id="25f9-7e83-0a6d-51d1" name="Deathshroud" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2412,25 +2411,25 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           <entryLinks>
             <entryLink id="39d5-70c6-b0e7-637f" name="Alchem Pistol" hidden="false" collective="false" import="true" targetId="1899-9e9e-76dd-a7ba" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5248-d181-b3d5-4a4e" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a87-a45c-1583-dc95" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5248-d181-b3d5-4a4e" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a87-a45c-1583-dc95" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="b42e-9f98-3096-41a4" name="Power Scythe" hidden="false" collective="false" import="true" targetId="2166-369e-0757-6f98" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6047-cfa7-3112-59fc" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7afc-6eac-161b-1637" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6047-cfa7-3112-59fc" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7afc-6eac-161b-1637" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="3f0e-6253-c7c8-04c1" name="Tartaros Terminator Armour" hidden="false" collective="false" import="true" targetId="f850-d0af-8663-ccac" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbed-a11c-0da7-79c2" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7081-f75f-2516-2f8a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbed-a11c-0da7-79c2" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7081-f75f-2516-2f8a" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2441,30 +2440,30 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
               <modifiers>
                 <modifier type="increment" field="2df8-6292-fd6a-2079" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="7669-a6c0-7f86-e641" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="7669-a6c0-7f86-e641" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2df8-6292-fd6a-2079" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2df8-6292-fd6a-2079" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
             <entryLink id="9f9f-c6ac-3f5a-b810" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="be0d-ef79-1753-75c9" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="7669-a6c0-7f86-e641" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="7669-a6c0-7f86-e641" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="be0d-ef79-1753-75c9" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="be0d-ef79-1753-75c9" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -2473,167 +2472,167 @@ If this option is used then Mortarion is removed from the battlefield, leaving a
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3682-d7d8-c0a4-586b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3682-d7d8-c0a4-586b" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="3e33-cab3-8ed7-0970" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry"/>
+            <entryLink id="3e33-cab3-8ed7-0970" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="7ed3-014d-514c-6425" name="2) May exchange power scythe for:" hidden="true" collective="false" import="true">
           <modifiers>
-            <modifier type="set" field="hidden" value="false"/>
+            <modifier type="set" field="hidden" value="false" />
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6d38-e7a4-ee96-b391" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6d38-e7a4-ee96-b391" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="b8cb-c751-b91b-1b15" name="Legion standard &amp; power weapon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="88f7-2ed4-1c5f-24c0" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="88f7-2ed4-1c5f-24c0" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="0675-3390-a5ae-b335" name="Legion Standard" hidden="false" collective="false" import="true" targetId="7e13-cc1f-6bd7-7ac6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4f9b-aed6-0a18-cd61" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="667c-b28a-7100-04e8" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4f9b-aed6-0a18-cd61" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="667c-b28a-7100-04e8" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="4d80-8a32-a584-964d" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7a97-8583-537b-f8bf" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="673c-4874-750e-9c9f" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7a97-8583-537b-f8bf" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="673c-4874-750e-9c9f" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="2bcb-6e52-0eb9-9ffe" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="6c01-5ff0-262c-697c" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="6c01-5ff0-262c-697c" type="max" />
       </constraints>
       <entryLinks>
         <entryLink id="0897-7492-0847-588c" name="Command Squad, Cataphractii" hidden="false" collective="false" import="true" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="fb88-e88e-d8d2-180f" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
-        <entryLink id="e962-2f46-9618-fa58" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
-        <entryLink id="c083-d710-edfa-5fc2" name="Deathshroud Terminator Squad" hidden="false" collective="false" import="true" targetId="7669-a6c0-7f86-e641" type="selectionEntry"/>
+        <entryLink id="fb88-e88e-d8d2-180f" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
+        <entryLink id="e962-2f46-9618-fa58" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
+        <entryLink id="c083-d710-edfa-5fc2" name="Deathshroud Terminator Squad" hidden="false" collective="false" import="true" targetId="7669-a6c0-7f86-e641" type="selectionEntry" />
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="7f03-6720-21ba-0d7b" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="6088-2073-3138-1861" value="1.0">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dfb2-b0f6-107f-1159" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6088-2073-3138-1861" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dfb2-b0f6-107f-1159" type="max" />
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6088-2073-3138-1861" type="min" />
       </constraints>
       <selectionEntryGroups>
         <selectionEntryGroup id="9207-442b-b932-4e2f" name=" XIV: Death Guard" publicationId="09c5-eeae-f398-b653" page="234" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="57b4-dc58-2717-a7ee" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5b92-9836-7b04-3648" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="57b4-dc58-2717-a7ee" type="max" />
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5b92-9836-7b04-3648" type="max" />
           </constraints>
           <selectionEntries>
-            <selectionEntry id="4b55-f3ef-3b53-9a94" name="The Reaper’s Visage (Traitor only)" publicationId="09c5-eeae-f398-b653" page="234" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="4b55-f3ef-3b53-9a94" name="The Reaper&#8217;s Visage (Traitor only)" publicationId="09c5-eeae-f398-b653" page="234" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8c20-39e6-19a2-2c94" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d25c-ebf4-cde8-bc35" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8c20-39e6-19a2-2c94" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d25c-ebf4-cde8-bc35" type="max" />
               </constraints>
               <profiles>
-                <profile id="18b4-cdf2-ca1f-e585" name="The Reaper’s Visage" publicationId="09c5-eeae-f398-b653" page="234" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="18b4-cdf2-ca1f-e585" name="The Reaper&#8217;s Visage" publicationId="09c5-eeae-f398-b653" page="234" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Traitor Allegiance.
-Any enemy unit with at least one model within 12&quot; of a Warlord with this Trait must reduce the Leadership of all models in that unit by -2 whenever making a Leadership test, a Morale check, or attempting to Regroup – unless that unit also includes at least one model with the Independent Character special rule or the Primarch Unit Type. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty. </characteristic>
+Any enemy unit with at least one model within 12" of a Warlord with this Trait must reduce the Leadership of all models in that unit by -2 whenever making a Leadership test, a Morale check, or attempting to Regroup &#8211; unless that unit also includes at least one model with the Independent Character special rule or the Primarch Unit Type. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Assault phase as long as the Warlord has not been removed as a casualty. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="0a4e-17cd-dc1d-7c26" name="Witch Hunter" publicationId="09c5-eeae-f398-b653" page="234" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f0c9-7e88-1b3b-d384" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="de1a-1259-9945-460a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f0c9-7e88-1b3b-d384" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="de1a-1259-9945-460a" type="max" />
               </constraints>
               <profiles>
                 <profile id="e60a-01cb-37ec-da49" name="Witch Hunter" publicationId="09c5-eeae-f398-b653" page="234" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait gains +1 to his Toughness and Weapon Skill when locked in combat with any unit that includes at least one model with the Psyker Sub-type. All friendly units composed entirely of models with the Legiones Astartes (Death Guard) special rule, and with at least one model within 12&quot; of the Warlord gain a 6+ Invulnerable Save against any Hits inflicted by a Psychic Weapon, Psychic Power or Perils of the Warp. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait gains +1 to his Toughness and Weapon Skill when locked in combat with any unit that includes at least one model with the Psyker Sub-type. All friendly units composed entirely of models with the Legiones Astartes (Death Guard) special rule, and with at least one model within 12" of the Warlord gain a 6+ Invulnerable Save against any Hits inflicted by a Psychic Weapon, Psychic Power or Perils of the Warp. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="3c86-60af-86ba-b10d" name="The Blood of Barbarus" publicationId="09c5-eeae-f398-b653" page="234" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6f8a-d0f7-ce85-007b" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ba47-aa0c-ac89-c842" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6f8a-d0f7-ce85-007b" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ba47-aa0c-ac89-c842" type="max" />
               </constraints>
               <profiles>
                 <profile id="a27a-fca3-bb71-f679" name="The Blood of Barbarus" publicationId="09c5-eeae-f398-b653" page="234" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any Hits with the Rending (X), Murderous Strike (X), Poisoned (X) or Fleshbane special rule allocated to a Warlord with this Trait, or any model with the Legiones Astartes (Death Guard) special rule in a unit he joins, only gain the benefit of those special rules on a D6 roll of a 6 instead of the value listed as part of that special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any Hits with the Rending (X), Murderous Strike (X), Poisoned (X) or Fleshbane special rule allocated to a Warlord with this Trait, or any model with the Legiones Astartes (Death Guard) special rule in a unit he joins, only gain the benefit of those special rules on a D6 roll of a 6 instead of the value listed as part of that special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="7890-e1c6-2bc7-dfdf" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+        <entryLink id="7890-e1c6-2bc7-dfdf" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
@@ -2643,6 +2642,6 @@ Any enemy unit with at least one model within 12&quot; of a Warlord with this Tr
     </rule>
   </sharedRules>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Death Guard.cat
+++ b/2022 - LA - Death Guard.cat
@@ -1,6 +1,5 @@
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="d228-55e8-b58c-1b77" name="LA -  XIV: Death Guard" revision="14" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="28">
-  <entryLinks>
-    <entryLink id="fb89-32c1-bdc5-2e3d" name="Mortarion" hidden="false" collective="false" import="false" targetId="7427-bdfa-c359-ebb8" type="selectionEntry">
+  <entryLinks><entryLink id="fb89-32c1-bdc5-2e3d" name="Mortarion" hidden="false" collective="false" import="false" targetId="7427-bdfa-c359-ebb8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -119,930 +118,1681 @@
         <categoryLink id="1e82-64bc-993b-72e3" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="f353-7810-9fd4-e0f2" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a7cd-b983-ad18-df82" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="eef5-e492-2d90-196e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <entryLink id="f353-7810-9fd4-e0f2" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="46b6-d928-42c7-8a07" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6d4-581f-4746-bec3</comment></categoryLink>
+        <categoryLink id="b26d-c902-427b-834e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_2489-ee2a-45dd-b384</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
-    <entryLink id="d329-7f73-114a-7ec6" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9e83-a3bf-2884-1293" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8970-b123-afdc-56df" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
-    <entryLink id="7dd0-94d5-4727-58ee" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink><entryLink id="d329-7f73-114a-7ec6" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b02f-e65f-4a88-a175</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_b87b-bf35-4238-b7c6</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1aff-27af-435e-8102</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_fdf9-4906-4180-a39d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3ba4-6f75-b11f-5ac3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="4746-1ae6-ff31-80e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7e80-ec37-5a82-64e0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="5efa-646d-48cb-b8a1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8378-ede4-476d-b657</comment></categoryLink>
+        <categoryLink id="5f04-9b94-4cc4-a6ae" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_d64f-ad19-426c-adf7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
-    <entryLink id="a631-793e-4efd-16e7" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="5d31-4a18-d9f2-e89e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="8fdc-4b16-e930-5a29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
-    <entryLink id="3986-d74e-fc23-0d92" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e639-48f5-49aa-ff9a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="e870-5e18-c785-c323" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
-    <entryLink id="e814-78ae-e106-ac52" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink><entryLink id="7dd0-94d5-4727-58ee" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_7fd1-8ce8-4d10-82e7</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_eaae-8c43-4d30-898c</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_f67d-8cf3-424f-b491</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_b949-6414-4f3d-b268</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="777e-d175-06f6-89bf" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="d303-2916-45fd-fba5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="85f9-5904-d2a9-c9a7" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="f733-1a6f-4dc0-827a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_ac26-e639-4d53-9b8b</comment></categoryLink>
+        <categoryLink id="28f0-7c49-49b0-ada1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_49af-0d08-4c7e-8ce6</comment></categoryLink>
+        <categoryLink id="0931-75e2-4b14-b025" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_b606-de16-4659-95cd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
-    <entryLink id="8878-8104-48e2-ce7b" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink><entryLink id="a631-793e-4efd-16e7" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d88e-aa77-dc43-334a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="b49b-40c0-1ac0-b3a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
-    <entryLink id="1da5-7f9a-9878-5879" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7583-6fa0-4089-a19e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_0e5c-99ab-41d3-a42e</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c296-e8e8-4a7a-989a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_8868-5bcb-4604-ba8e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c3ee-8129-42df-9a8d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a009-a597-4b51-b228</comment></categoryLink>
+        <categoryLink id="6807-b5e5-45a3-a224" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_24f4-9145-4016-80d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink><entryLink id="3986-d74e-fc23-0d92" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_e732-7499-47bf-9748</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_81a5-a959-46b7-baa4</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7ec3-447a-4644-b012</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_71e2-c430-4c99-a559</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_df7b-3fb9-4f65-9165</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cb52-c11b-4bb6-ba2b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c165-3906-463a-9c73</comment></categoryLink>
+        <categoryLink id="7094-e5b5-465f-b1ea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6d1-d14c-473f-be09</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink><entryLink id="e814-78ae-e106-ac52" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_27a3-1e4c-4b76-a594</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_d59a-dcd0-44fd-b866</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_0c8b-2b92-49ed-98c7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_bafe-f799-41d9-ac85</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_6369-288c-4fec-a640</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_fe53-8858-41dc-8ec4</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="482b-2f8d-9d72-50a8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="0481-65eb-da3b-aba7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3d3c-79e0-4df6-8929" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_3a22-caae-4eea-9bc5</comment></categoryLink>
+        <categoryLink id="0cfd-0928-4022-b814" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f759-f33e-4698-9f8a</comment></categoryLink>
+        <categoryLink id="4056-f91e-42e5-a38d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_c624-3ae0-46c0-9b06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
-    <entryLink id="d511-e33b-0116-f0ec" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8dc6-70c4-8d3f-2988" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="a40a-ceb0-ca7e-8b85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3ec5-5fa2-83ac-c298" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="7556-f64a-fd29-5959" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup" />
-        <entryLink id="00d1-3087-3a68-1b6a" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink><entryLink id="8878-8104-48e2-ce7b" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_13b3-ce1e-4f9d-8319</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d681-9d81-4abd-b11b</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a57-e48b-4534-bca5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_1859-5641-4674-9097</comment>
+                </condition>
               </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
-    <entryLink id="11e9-7781-707f-d4a5" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
-      <modifiers>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8385-ea9e-4d88-abf3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_251a-df5b-4bfd-ad63</comment></categoryLink>
+        <categoryLink id="a2c8-84fe-480b-8a8b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4644-98ab-4e3f-b1fd</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink><entryLink id="1da5-7f9a-9878-5879" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_591d-d028-4663-918d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_0482-c5f9-4c95-9597</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_75a7-971d-4978-a83f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_a7d5-2bfe-4621-ac0c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9f13-b460-4f27-b0cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_31fc-e265-45a7-bb5b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dd47-b153-40f0-f377" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="434d-ce12-d83b-9d38" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="9dd7-ac13-2a00-3c24" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="0924-60ad-4e5e-9be1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_67c2-df43-44fc-92d1</comment></categoryLink>
+        <categoryLink id="08a3-7000-4804-a4f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4136-bb4e-4dd4-99f9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink><entryLink id="d511-e33b-0116-f0ec" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry"><categoryLinks>
+        <categoryLink id="c807-e1e8-488f-bccd" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_2599-24e3-44e5-9568</comment></categoryLink>
+        <categoryLink id="6365-1466-4eab-b00a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_285f-6e56-473b-b2fe</comment></categoryLink>
+        <categoryLink id="3c44-b95f-4d8f-b4ec" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_685e-022f-4e2f-a568</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="a708-88f7-eb16-6a78" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup" />
-        <entryLink id="ac33-6b79-25bf-9e5c" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup">
+        <entryLink id="dd0e-b783-45dd-80f9" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup"><comment>    template_id_2a38-6544-4267-b584    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="f7c6-3900-4607-ab73" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_8287-16ff-46ba-9838</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_81c1-fca9-44dc-ba4c</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_6e59-4592-47ef-b76d    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
-    <entryLink id="85dc-e6e8-1ad3-d878" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3a9c-99ea-897d-4f7a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c64a-bf11-2916-1c5c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="3d5d-57c4-648a-e586" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="d508-0870-5048-998b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup" />
-        <entryLink id="8e62-f926-f4c0-5a70" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
-    <entryLink id="5ad7-48c5-141b-5727" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e33f-dd24-3350-148d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="01f5-b8c3-fbe0-c192" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
-    <entryLink id="6542-9165-2e72-f5e6" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5d42-eff6-e751-ca46" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1cad-1ae8-08f0-24f6" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
-    <entryLink id="6124-e860-1360-d4a4" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink><entryLink id="11e9-7781-707f-d4a5" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ad5d-3c79-4239-9116</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_60b1-049b-4a5f-85c2</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="eed2-d3a4-9c47-57ee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2985-3f6c-9903-2a0e" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="de0d-e76f-474d-aab2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bd6a-0cda-4e0f-80ae</comment></categoryLink>
+        <categoryLink id="df44-7b07-4b98-9bb9" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_ae75-7cca-4701-9d56</comment></categoryLink>
+        <categoryLink id="7d0d-c0ca-4ed1-90ab" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_e517-62d4-48f7-8174</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
-    <entryLink id="a7e8-35f5-42bf-eb25" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
+      <entryLinks>
+        <entryLink id="baec-66fc-4cb9-a289" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup"><comment>    template_id_fafb-6414-474a-8a09    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="3780-9c8f-4238-acc3" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_1e43-c980-4508-8ec2</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_4140-36a7-4203-b5e9</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_a6a6-9bc7-4d4e-86a7    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink><entryLink id="85dc-e6e8-1ad3-d878" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry"><categoryLinks>
+        <categoryLink id="3669-1d61-43ca-bbd6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fc9d-03d1-4bbd-a1c4</comment></categoryLink>
+        <categoryLink id="7507-76ab-4735-a305" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_f51c-73d7-4f29-be1c</comment></categoryLink>
+        <categoryLink id="6902-34e5-47c8-959d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_257d-78c0-4bab-ba65</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="b283-4872-4d04-88e2" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup"><comment>    template_id_ac26-33db-40a7-bdba    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="a56e-dd01-44cc-8427" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_189b-db75-4db6-9fe9</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_cbdb-2500-4e13-876a</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_dc8e-2801-46d6-84f8    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink><entryLink id="5ad7-48c5-141b-5727" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b43b-547f-472e-9076</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8ff9-0498-4540-8552</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fbfe-931a-489b-a589</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f4c3-5aa6-4caa-abf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_17f8-f055-4c9c-b757</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="64a1-531b-a449-6a3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="70e1-63ab-5a36-b928" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="bd09-1025-4f06-85e8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f1c8-27fd-4f98-8527</comment></categoryLink>
+        <categoryLink id="a612-c826-40aa-aeea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2b20-1a8b-4753-b657</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
-    <entryLink id="df48-72df-2033-e20a" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink><entryLink id="6542-9165-2e72-f5e6" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry"><categoryLinks>
+        <categoryLink id="3c2e-2fcb-4960-8822" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4207-8d8f-4b1a-836b</comment></categoryLink>
+        <categoryLink id="8e62-a341-4670-be46" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_2b34-077f-4279-86fb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink><entryLink id="6124-e860-1360-d4a4" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="bc07-161b-073b-fe51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b08a-5031-8104-4556" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="43a8-467a-4822-a9ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6577-e0fb-4fda-834e</comment></categoryLink>
+        <categoryLink id="ae85-c823-4a29-bf11" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_5d59-09bf-4566-b7e1</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
-    <entryLink id="7194-5a5e-656b-17ff" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink><entryLink id="a7e8-35f5-42bf-eb25" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"><categoryLinks>
+        <categoryLink id="795c-30c1-42a6-9768" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_aa93-057d-42f6-82d7</comment></categoryLink>
+        <categoryLink id="8415-7326-49f2-8b63" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_403c-4e9c-4af5-84ec</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink><entryLink id="df48-72df-2033-e20a" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_23fa-06dd-49f9-a7db</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5b26-059e-40b3-9d93</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f7bf-3a1c-4103-aed8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="edb5-a892-57aa-baf5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="4d1c-5482-4ab8-89d2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5974-e109-4641-b6bc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dd44-e0a8-42a8-bdcc</comment></categoryLink>
+        <categoryLink id="e5d9-e459-4301-b639" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_c5b0-f9ae-468d-924a</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
-    <entryLink id="ac38-5436-73dc-d4bb" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink><entryLink id="7194-5a5e-656b-17ff" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8396-e51c-4e2b-bada</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_13bb-9fb5-4580-92cf</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_bfb8-8125-4548-92f5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25e3-b8f5-4448-a7c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f104-6054-49b7-afd3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_f926-27fd-4a92-97a1</comment></categoryLink>
+        <categoryLink id="8e59-0f70-4a33-9615" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_82e3-36e1-4e85-8fcb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink><entryLink id="ac38-5436-73dc-d4bb" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c888-75ff-1ced-e0fa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
         <categoryLink id="ad57-d4e3-1730-d0e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="5127-a941-5fe2-155b" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
-      <modifiers>
+    <entryLink id="5127-a941-5fe2-155b" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_658f-b1ad-4347-a998</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_12bc-3db2-4d28-abce</comment>
+            </condition>
           </conditions>
         </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6aa1-eea8-9b20-39a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0a5e-e4a6-8c88-8dc7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
-    <entryLink id="938a-6fc6-b597-2112" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_9d83-7691-41d6-8dad</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_add7-ba48-46d4-8a02</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_1fb0-2421-40a4-9e49</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5a74-10d2-56b2-767b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="1483-ddc4-dd74-487d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4c53-b957-b735-9e5b" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="bd52-b295-4f77-bb5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7004-b00d-481f-b740</comment></categoryLink>
+        <categoryLink id="1e65-de11-4777-a7d3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4f88-2fc3-491c-bfb7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
-    <entryLink id="a7f0-3ea5-1465-bcc6" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="31b9-3567-565d-1194" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3769-5c27-37d3-e2df" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
-    <entryLink id="31a6-4f5c-b6b9-1e82" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8229-ea7a-f6fa-54ee" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="5aa1-1743-6028-ca5b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
-    <entryLink id="85a0-ff11-6e9a-c5cd" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ded9-d2d7-03f4-e8a6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="e350-66f1-029c-72cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
-    <entryLink id="f598-6f7d-54d2-5dd4" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0d4c-07fb-8ff6-6b48" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="301c-3185-56ef-dd73" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
-    <entryLink id="a968-0378-9216-a941" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c561-0f53-9f05-16f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a52a-182e-48b4-551f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
-    <entryLink id="8569-3903-fbf1-b0d9" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="eccf-478b-daa1-42c1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="db42-0b07-fe22-0866" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
-    <entryLink id="a260-1302-3355-5a51" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1eb9-469a-22d2-1d92" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="bb6b-f003-c684-9a90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
-    <entryLink id="2285-cb66-db81-cf76" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0766-380d-ab3f-14a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="dca5-8ba9-e888-f006" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
-    <entryLink id="9255-8f5e-ff11-5896" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b8e8-4124-1cfe-bd91" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="7f33-a86b-d196-fc0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
-    <entryLink id="7a57-45f5-cdbb-a03e" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9469-b766-13de-0333" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="bf1b-d6bf-8bcf-c322" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
-    <entryLink id="7abc-67a6-7626-c9a6" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0b5a-37ab-0025-305a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="7ecc-16b1-3f2f-4fc0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
-    <entryLink id="da40-d086-07e1-a697" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d566-23bc-72e5-ee98" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="28af-d396-df27-0fa5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
-    <entryLink id="5b4f-55db-f031-f9b4" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2933-29df-5e64-18cf" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="894b-b641-8821-c302" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
-    <entryLink id="553c-2ee8-0c44-ef3a" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="dd78-bf40-72b9-caca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="dbd4-3d4f-0ced-8b8c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
-    <entryLink id="4b4f-6bef-f01f-a292" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="822c-2cae-c534-4980" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5bd8-87a7-56f6-2f34" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
-    <entryLink id="66d0-a8a4-5ec7-c138" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="87ee-97b2-4b16-839b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="112d-983a-9242-0823" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
-    <entryLink id="fe98-dcea-59fc-82e3" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7cef-e262-b55d-12f8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="f754-036a-01ff-b739" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
-    <entryLink id="4bcd-21dd-c6ab-7eca" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="fc5a-1f81-d036-84e9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="36e3-3558-0cd4-aa19" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
-    <entryLink id="5339-a665-932e-b58c" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="ce16-f7c5-5da4-cbe4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="fe4f-ec17-d2c3-9de8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
-    <entryLink id="12a0-1772-0dc0-29cd" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="b2fd-bdaf-33d3-c0a5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="14da-e7fd-6506-ba97" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
-    <entryLink id="049b-d9fd-b0a9-e697" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="b335-10b9-3cff-8641" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="de8d-ba01-0131-19e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
-    <entryLink id="d147-888b-e699-84cb" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="63f9-13a1-64fc-1b60" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="d47f-030d-7433-7049" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
-    <entryLink id="7987-d97a-08b6-680c" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="5592-15ea-e76f-ddea" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="5609-eb08-b5ae-2252" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
-    <entryLink id="d35e-0701-4192-aab3" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="b428-9b1a-3de9-dd66" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="c0a9-71fd-f964-6050" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
-    <entryLink id="d27d-e3be-c85a-467b" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8c74-5498-d6d3-7e28" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2976-edf4-6d1a-94f4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
-    <entryLink id="cedf-4f4f-8ec1-9097" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="328a-99f2-094c-b390" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="c760-bd0b-3cdc-6f46" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
-    <entryLink id="50b4-e9f5-dcf5-80bc" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="032b-5892-7749-6517" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="0eac-7019-e1a1-938f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
-    <entryLink id="4280-e7f6-3922-360f" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="51a4-3c5f-5ad7-f06d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ab07-1c6e-f28c-a715" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
-    <entryLink id="ba4f-ee9d-8991-9f71" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6b40-d7e9-7cec-0d0e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="f0e8-1d96-4203-0e9a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
-    <entryLink id="0cd9-5f8a-0da5-5223" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7846-f1cc-c0e4-1b5f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="3ada-4ff8-c523-2054" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
-    <entryLink id="3e5a-0eea-259c-c4e7" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="df61-6eea-0717-7d5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="32a9-161e-907b-306c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
-    <entryLink id="0fac-cfce-3ed8-0bda" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0d80-eba7-777d-70bd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="a157-f083-513f-06a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9fec-6b2d-04f8-1d85" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="abbe-707f-33d6-9c4f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup" />
-        <entryLink id="78b4-4a4f-8442-d4e1" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
-    <entryLink id="f009-4a6f-2372-d502" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="34d9-41e4-9dd5-e46b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="4f04-5391-4c61-c6c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="83d6-d890-ff34-c332" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="d795-2643-a8dd-2513" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup" />
-        <entryLink id="9d85-e6e0-126b-712e" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
-    <entryLink id="de3a-123d-3cfd-21eb" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7664-92e2-bda2-8759" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="feed-359b-e963-2b2b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="88cf-2cd2-5242-84fa" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="0208-3392-8cb4-4409" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup" />
-        <entryLink id="6bf7-6af2-6258-07e4" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
-    <entryLink id="7003-1c3a-438a-3d28" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="dff2-a9e0-4c87-33d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2e77-5129-a623-52d1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
-    <entryLink id="4570-1d63-b161-86da" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="92b0-cf7b-a4c1-a2be" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="1c36-8e5f-0b0a-5f7b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
-    <entryLink id="c793-cb2f-9479-0aad" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0757-5c73-2ec4-73cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a49e-d5cb-868c-1379" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
-    <entryLink id="6d99-d6e2-4836-5b15" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="286a-f434-5cd4-471b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="3c3e-29cd-4c48-3a61" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
-    <entryLink id="4d50-a28a-15f0-6b9d" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="4bdc-6119-8f9e-b739" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="b61a-d21e-6d85-f70f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
-    <entryLink id="925e-039d-df0e-6c82" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="bd02-a4b5-72ff-b9de" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="dd71-b488-22c7-1a57" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
-    <entryLink id="c362-07c0-c7a6-4e21" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2906-5c2f-46f0-2f22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3cc6-592f-cafb-53b9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
-    <entryLink id="c59d-949c-def6-156e" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d466-ef14-1aab-e266" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="6a89-799f-bae4-e727" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
-    <entryLink id="381d-b233-7191-e417" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0063-8735-7060-c44f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="886a-fb2d-1f8f-3b25" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
-    <entryLink id="685e-e480-ab3f-104f" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="291c-88fe-0a3e-b147" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c52a-54ab-f3c0-4674" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
-    <entryLink id="b29b-b6d8-64b0-ad57" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d296-0a74-7adc-eb37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a92f-c63a-674d-5d6b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
-    <entryLink id="6acd-f4f9-fb46-a306" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e382-f9ba-1025-ef6d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5faa-7160-603e-7392" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
-    <entryLink id="7ab5-27ee-8c1c-bddb" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1f52-0793-b77f-aa71" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="86a8-2a5a-5e1d-febe" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
-    <entryLink id="8dfd-52fe-18de-e010" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f0bf-128a-f446-ea18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d21e-0c3f-4cb3-15ca" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
-    <entryLink id="800b-aaa3-22ee-521e" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7500-4599-5f05-5d29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e0c9-cf19-0ba4-d686" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
-    <entryLink id="30bd-085b-0e7c-39a9" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="12ca-5aa1-a90d-9538" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="0f02-6375-6c11-8faf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
-    <entryLink id="5aef-8d2d-c34d-25d0" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9d14-54f7-f4d0-4702" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="cd2a-7548-6447-1afd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
-    <entryLink id="aa0c-2200-bdf0-90bd" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7c72-0819-aaaa-1f8d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="76a1-db25-00dd-0ea7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
-    <entryLink id="9fb8-08f8-9024-1015" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink><entryLink id="938a-6fc6-b597-2112" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_8ed4-376d-4030-9439</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_8a11-c2a0-4335-99ef</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_fa8e-1af7-4d41-ac8c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_94bd-c771-4a85-8581</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="eee7-ecc7-788c-23d2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="75b4-c3de-bc9b-f5a7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="19f0-bad2-aeef-3a93" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="2e28-b3d4-4664-8080" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_361e-fb90-4b0e-ac3d</comment></categoryLink>
+        <categoryLink id="00ad-90c4-4628-9129" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d4ef-1074-45a9-959e</comment></categoryLink>
+        <categoryLink id="7cf1-a4ed-4854-af26" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_febb-f536-4d25-a8ab</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
-    <entryLink id="b2b5-234c-2ba8-c05b" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink><entryLink id="a7f0-3ea5-1465-bcc6" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="8185-8a16-4725-b5aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_473b-e812-4158-9416</comment></categoryLink>
+        <categoryLink id="61b7-8b45-4430-87c1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_00a2-63ff-4698-a35b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink><entryLink id="31a6-4f5c-b6b9-1e82" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7cf3-8a72-4f82-8cdc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_228c-5681-4ce8-b726</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_01bb-8abd-4253-9a4d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="8c9f-e2a5-47d6-d8aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5f28-fcba-9bdb-2a9e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="9de5-0da9-4f87-b25e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2a08-4432-42ad-bfdb</comment></categoryLink>
+        <categoryLink id="05fa-97d6-4592-90e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_422e-0808-4897-8630</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
-    <entryLink id="af58-68f6-b173-4756" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink><entryLink id="85a0-ff11-6e9a-c5cd" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1af8-4459-4717-8e3b</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_06b4-92b9-438c-b1a5</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6c8d-8b28-417b-9a7c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_715d-8186-4aa6-b40c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_390e-358c-4f8e-ade8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="df93-4faf-4c0a-a0b6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f4c0-4396-4f39-a34f</comment></categoryLink>
+        <categoryLink id="cf44-f0d1-4410-917d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1301-8415-490e-8f06</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink><entryLink id="f598-6f7d-54d2-5dd4" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d0c9-9a26-4324-b030</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4e9e-a61d-42f2-bacb</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ed9e-b634-4bec-9eb0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4614-ad0f-4fba-adaf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_8d08-24f6-41be-8931</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="84b3-11d1-4102-963b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_caf6-5548-4b89-8102</comment></categoryLink>
+        <categoryLink id="a91c-d4bd-49ce-a7de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_63a3-be61-428d-ab29</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink><entryLink id="a968-0378-9216-a941" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f318-4b03-4767-8c7f</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b8ef-7245-4df8-a8c4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_6bce-ec44-48cb-873a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="73b1-e2ad-42dc-b12e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0678-4fdd-48e6-8f61</comment></categoryLink>
+        <categoryLink id="e6ca-9cce-4d9a-a8db" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0d82-10a9-4de2-8ad7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink><entryLink id="8569-3903-fbf1-b0d9" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ada1-1e18-4cbc-9598</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b1d1-ac44-47dd-9159</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5d64-f00c-4464-891b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25f0-f825-4a83-8f0d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_64b1-9e36-44da-b36a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2b8d-d168-462a-b97f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_d53e-113f-4a40-a3d5</comment></categoryLink>
+        <categoryLink id="03dd-220d-4bfc-a032" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1939-76b5-4279-9f8c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink><entryLink id="a260-1302-3355-5a51" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d765-3bb2-4b48-bd12</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_0ca1-cfb4-4a56-ab3b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c86f-456b-ea6d-1574" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="f21a-83be-767a-b735" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b1db-24e6-44b8-bef1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e6f7-a6ca-4825-bfc5</comment></categoryLink>
+        <categoryLink id="38ed-5caa-41f7-b089" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dbec-e027-4ec1-8514</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
-    <entryLink id="a47c-06f3-bc77-fca0" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="dab8-c369-2729-1174" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d5cf-2bc2-e065-a6a2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
-    <entryLink id="2e04-1055-0e5f-c413" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink><entryLink id="2285-cb66-db81-cf76" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d8ee-81ed-45f9-8b79</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_8f4e-e8cb-4ac9-a415</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="afec-53ef-a706-ba32" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="a690-ec72-c6e7-2fae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5072-6f29-403e-8d58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_cefb-cfd7-4dc8-99c4</comment></categoryLink>
+        <categoryLink id="5fbb-9dfc-48de-9db9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a9fd-9d16-4a5e-855c</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
-    <entryLink id="1043-8d0f-2838-9f79" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink><entryLink id="9255-8f5e-ff11-5896" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e76b-46ca-4ab8-a93d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8035-75b8-43bb-97c9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_71a4-31e7-4927-a0ab</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ffa4-dd0f-435f-a02e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_a56d-347b-4b09-a918</comment></categoryLink>
+        <categoryLink id="2f3e-ccb6-47ad-be57" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_96e5-4531-4213-903e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink><entryLink id="7a57-45f5-cdbb-a03e" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1fb5-2375-4c22-b41e</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7d7c-255d-49b6-96b9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5321-254b-4890-9bf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ddf8-b8b7-4afb-b6dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a78d-9ec9-4736-b598" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9441-d79b-4720-9667</comment></categoryLink>
+        <categoryLink id="a47a-6dd7-420b-8e38" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7d7e-32d3-4692-b401</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink><entryLink id="7abc-67a6-7626-c9a6" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_99fc-5fe7-4b37-a62f</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_25f4-f6b8-4b44-8350</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_81f7-2311-4cce-95bc</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_09aa-af2a-4012-91d1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_00ae-fad3-4df6-9cb9</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="379f-423c-1b26-4af6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="3992-b442-e809-5dde" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="905a-411e-4f36-a1b6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f65b-8958-49b3-92a5</comment></categoryLink>
+        <categoryLink id="b4f3-26f9-4dee-afbf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0451-1929-4942-8c3f</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
-    <entryLink id="83ae-538e-57d9-ce01" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6ac3-58f6-2662-ac7d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="659b-6e8c-97c7-1bfc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
-    <entryLink id="6c25-69a3-62eb-3f42" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink><entryLink id="da40-d086-07e1-a697" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d803-e5ae-434c-877f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="0376-967e-1f15-9eb6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
-    <entryLink id="2792-ab38-fd66-fe12" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="964b-f758-9f21-90d9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="51b0-bdd5-5105-8150" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
-    <entryLink id="a70f-fc8b-42cd-5f02" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_edc4-4915-40ba-bbf0</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_105f-ba26-4146-bc54</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7a2c-a76c-421c-a8a2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_05c9-0543-47ee-ba81</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e6ad-f0d7-4627-921b</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="69cd-7a55-451d-c920" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="0767-f8eb-83c2-1ef0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2834-0439-44c1-a6e2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c6a8-22a8-4d41-b969</comment></categoryLink>
+        <categoryLink id="fd73-4941-4646-99e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03ca-12cc-4e0a-b628</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
-    <entryLink id="c92c-4514-d7bb-0cd9" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink><entryLink id="5b4f-55db-f031-f9b4" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ae67-ef52-4cac-958c</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fc61-7306-4d99-acde</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1be0-67e7-45a1-bdbb</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_42a8-7fda-4e05-af0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="16dc-aa80-44ee-dbb6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="f718-09c7-8831-44ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9ea7-442f-492a-96cc" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_565a-1592-491f-8b9b</comment></categoryLink>
+        <categoryLink id="fb74-5aa6-477b-972c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_81d5-c14a-42ab-bdde</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
-    <entryLink id="8883-a80c-8cd9-bb29" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink><entryLink id="553c-2ee8-0c44-ef3a" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1ae7-c41b-4818-be71</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_08a5-b1bb-4ba1-ba42</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d677-b5ad-4838-8746</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_537f-bc1f-4aaa-b0dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="a756-512d-3bbb-0e21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a2a2-f888-8129-cd0c" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
-        <categoryLink id="148d-b489-c8ae-b615" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="d517-2af4-4fd0-86d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bc67-ce1f-4004-aeb7</comment></categoryLink>
+        <categoryLink id="03bb-f9fb-40cd-8fb6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_9a45-9699-4475-aeef</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
-    <entryLink id="b9bd-df3d-1321-f365" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink><entryLink id="4b4f-6bef-f01f-a292" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_c28f-4109-44c4-ab64</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fdc1-a894-48bc-9e7c</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_4936-a68c-4524-9088</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb37-ac0c-49ae-9d6f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="7f28-a1c8-2801-aec7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8f35-a0cd-5dd6-6281" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="535c-7dab-4e80-bc59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3afe-cfc0-4da6-a985</comment></categoryLink>
+        <categoryLink id="4a83-19f5-413b-92f3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_04a8-6aae-45ae-bd4c</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
-    <entryLink id="a225-e55e-9b3d-960b" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink><entryLink id="66d0-a8a4-5ec7-c138" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ae19-30c0-43c5-920e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_6ebe-1bf3-4d78-9dd0</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1887-152d-48b7-b13f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_a7c4-ee6a-4f0b-8ab0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bd85-fa90-47ff-9f84</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_7bd6-9043-4d7e-ba37</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d9e-2334-4a7a-9591" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3610-c975-4d55-bdfe</comment></categoryLink>
+        <categoryLink id="675a-335b-43dc-b590" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2fc2-f636-4c80-9608</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink><entryLink id="fe98-dcea-59fc-82e3" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_85c5-d4d9-4b23-9e4d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_80e8-d50b-4906-8153</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_b93b-d4f1-45eb-8a69</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e183-f183-4db7-83b5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0f39-204a-4217-b896</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_eee9-7bfd-4fea-a1bd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ea9a-b188-435c-93e0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f81d-9435-4f11-99c1</comment></categoryLink>
+        <categoryLink id="0c43-adee-4b29-99c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9568-6142-4fdd-be3a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink><entryLink id="4bcd-21dd-c6ab-7eca" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_005e-6607-4e2c-8dd2</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_7745-260c-4c36-b719</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_ba25-a4b2-4ba9-b023</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ddeb-f4c8-4091-9153</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4904-fd2f-429f-9cf7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_faea-b21b-43c5-b918</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9bd4-5c39-401e-8d79" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_b24f-3ae0-4cbb-b016</comment></categoryLink>
+        <categoryLink id="507d-2175-483a-892a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fd26-8e6b-4521-92b9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink><entryLink id="5339-a665-932e-b58c" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6ecb-28e2-43ed-a6a0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_c067-1118-4d96-b28b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_250e-23c0-4e43-bf74</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1553-a6e6-4291-853f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_aab6-797b-427a-9fd8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="852a-56ed-4ea1-819f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c77f-0819-473b-a8a2</comment></categoryLink>
+        <categoryLink id="3743-e821-47e9-b98d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_89fb-c924-4daf-923d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink><entryLink id="12a0-1772-0dc0-29cd" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d72c-519a-451f-81b6</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_3d16-444c-42c9-aad1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_f4b2-6371-494b-863a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_797f-a84b-42f6-8e66</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0d78-fe38-4829-9b12</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6483-faea-483b-8239" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0397-c837-4fea-a527</comment></categoryLink>
+        <categoryLink id="ba72-0d70-4ef2-9b4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_060b-bccb-4776-bd83</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink><entryLink id="049b-d9fd-b0a9-e697" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3c84-6d74-4c42-b38d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_5b15-7aa4-4897-aaf1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_3326-31ed-4151-9b37</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6a0e-1b65-4057-ba5d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f8c7-abc9-45ec-955f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_2538-8dc5-446c-8344</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="818b-4694-4948-898b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_c1cf-cea4-4278-8f27</comment></categoryLink>
+        <categoryLink id="3304-7478-4088-873b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5f51-2734-4a46-9f72</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink><entryLink id="d147-888b-e699-84cb" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af71-f3ff-49b1-83e9</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_1c9e-b3bf-4e88-a43f</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_6d0d-1b1d-4065-89cf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d0b7-8686-491e-9d33</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_7db8-0874-487a-be6f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1034-29a0-44b1-a85f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="04b4-c493-4d15-aca8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_0c16-6841-42b2-b02d</comment></categoryLink>
+        <categoryLink id="57e1-c0be-444b-b88a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_602d-2d2d-4ff4-a82a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink><entryLink id="7987-d97a-08b6-680c" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_22bd-baae-45f9-b366</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_52bd-55de-4d53-ba55</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_df1b-7476-4ab8-8d2f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_49fa-0dcf-4a61-a5b1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0ea-1443-4993-86e7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2a8-3fbe-448c-9902</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e036-eadf-47a4-902c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3632-0b5d-4622-ae33</comment></categoryLink>
+        <categoryLink id="9551-b11e-4dd6-a233" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_da44-7815-4fdd-981c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink><entryLink id="d35e-0701-4192-aab3" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2bfa-b203-47e2-a828</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a39b-8a3c-49cf-bf62</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2a05-07b3-49c5-8145</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f730-87fb-44bd-b68e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_2d0e-6c49-4493-a022</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2e2-50c1-40c3-b4dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f6b0-d166-4a6a-86c7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_5ad5-8701-42cd-b2b6</comment></categoryLink>
+        <categoryLink id="2ad9-3225-4ed8-8854" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_20a4-4346-4a3b-a7d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink><entryLink id="d27d-e3be-c85a-467b" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_773a-1ea4-41a0-b766</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_9d4d-6fb8-4131-a5a3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e3bc-02f8-4ece-a5ea</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c371-76d9-4a4d-bc00</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b4c6-d4ba-4b2e-9b99</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="132c-5924-4391-b3c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6ea9-a7e5-437d-9e35</comment></categoryLink>
+        <categoryLink id="7036-b56d-4544-87cb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_3cec-f053-42ab-a6eb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink><entryLink id="cedf-4f4f-8ec1-9097" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1e60-42ba-4c8b-9077</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9860-f593-425e-b89b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_c842-10e8-4509-8eda</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ea52-ff41-40f6-8cf3</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_51e6-c5e1-4003-96bc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b165-c8b8-47b8-be0f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4d7c-201f-4c99-b89a</comment></categoryLink>
+        <categoryLink id="331f-1193-4fe8-961e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_10f9-4718-4e07-bb32</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink><entryLink id="50b4-e9f5-dcf5-80bc" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1b64-4b12-4e73-b8db" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4e52-ad1b-48d4-8eed</comment></categoryLink>
+        <categoryLink id="aaf8-a762-4e0c-8dc4" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_6979-1ed3-4f1f-a025</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink><entryLink id="4280-e7f6-3922-360f" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry"><categoryLinks>
+        <categoryLink id="f7d9-258b-484f-b8d0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6140-2404-46f9-bd42</comment></categoryLink>
+        <categoryLink id="4460-1f6c-47ff-a393" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_1c86-fad8-46ec-a0b0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink><entryLink id="ba4f-ee9d-8991-9f71" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4dce-8632-4f7c-813e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_8a71-3995-4155-ac33</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d206-f2ce-41b8-945a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan">
+                  <comment>    node_id_2e02-cf1c-4a71-861c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ec81-bd33-45a8-8550</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_3344-743c-45d3-b930</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1ae1-84be-5e69-aba1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="21d0-7c77-561c-58f8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="25c9-24cb-422d-beab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4272-9b9d-4c59-95f0</comment></categoryLink>
+        <categoryLink id="b61d-c7c5-40a3-b97d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_d85b-1ae7-40d5-9341</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
-    <entryLink id="85f4-6e9a-4797-7534" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink><entryLink id="0cd9-5f8a-0da5-5223" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4729-bc86-456b-b73d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_cf0f-e3f4-4fb4-989d</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1cc8-5611-4d9a-9218</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_2e32-ca02-48f0-a8dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="76aa-6ce8-d11e-cd51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e9e9-1b4e-334a-ac0f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="3d8a-95ce-4eef-a40f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_0af1-d052-4bd7-aab6</comment></categoryLink>
+        <categoryLink id="a788-fd60-458e-8322" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_45ce-e338-43c9-b63e</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
-    <entryLink id="9d6f-9f11-1095-5ab8" name="Deathshroud Terminator Squad" hidden="false" collective="false" import="false" targetId="7669-a6c0-7f86-e641" type="selectionEntry">
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink><entryLink id="3e5a-0eea-259c-c4e7" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry"><categoryLinks>
+        <categoryLink id="1b39-81de-4719-ab2b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ff9f-01cb-41b9-800e</comment></categoryLink>
+        <categoryLink id="4fe3-ac45-409a-b4ff" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_1315-6051-4a46-b070</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink><entryLink id="0fac-cfce-3ed8-0bda" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry"><categoryLinks>
+        <categoryLink id="a004-475c-417b-bc39" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_b084-df23-4f99-812f</comment></categoryLink>
+        <categoryLink id="d48e-553b-4eef-8120" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_84fc-9304-4e9e-ab78</comment></categoryLink>
+        <categoryLink id="9678-c5ec-4eea-8418" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d06a-7939-4691-9aed</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="c31e-d513-4f5b-945a" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup"><comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+        <entryLink id="d930-b09c-454e-b57f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup"><comment>    template_id_741d-8c09-4211-ada6    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink><entryLink id="f009-4a6f-2372-d502" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_54a4-6ec8-4c61-9c3e</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_f7fd-2d16-4603-a065</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d12f-0a47-47ad-b6d9" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_c0ac-4b8c-421c-a21b</comment></categoryLink>
+        <categoryLink id="604f-47e0-4efa-9ede" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8db9-079e-4482-b200</comment></categoryLink>
+        <categoryLink id="8956-6aee-4633-833f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_413c-9273-4308-b546</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="371d-753d-40fa-8ea5" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup"><comment>    template_id_bbc4-33fc-4664-a18e    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="a4d6-8419-4ce8-a381" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup"><comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink><entryLink id="de3a-123d-3cfd-21eb" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry"><categoryLinks>
+        <categoryLink id="6312-161a-4117-9c14" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_4c8d-96f6-48f9-9590</comment></categoryLink>
+        <categoryLink id="76af-0725-4c59-b7f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_049c-0fa5-4575-8fa8</comment></categoryLink>
+        <categoryLink id="838f-722d-4679-979a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_7358-52d7-4aae-8e07</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="faed-730c-44cb-8820" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7f03-6720-21ba-0d7b" type="selectionEntryGroup"><comment>    template_id_4784-b370-444b-93ae    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="7df2-7db7-4685-b45d" name="Retinue" hidden="false" collective="false" import="true" targetId="2bcb-6e52-0eb9-9ffe" type="selectionEntryGroup"><comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink><entryLink id="7003-1c3a-438a-3d28" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_3c03-a823-4466-9bd6</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8bbb-f95b-413f-b6f4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_41b0-6b0a-482a-919e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e1f7-3cc6-4794-8b6d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c593-c715-4611-bbcf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_05ce-cc31-40ad-9320</comment></categoryLink>
+        <categoryLink id="459c-5a3f-4366-905c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f13c-f8e1-4a50-bfe3</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink><entryLink id="4570-1d63-b161-86da" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_db78-4d49-42ab-954a</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_f14d-9943-47b6-866c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a95-938f-4a07-9727</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_7775-78e1-44cc-87c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a64a-38ee-41c1-afea" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_b822-3417-4613-be37</comment></categoryLink>
+        <categoryLink id="a35e-75d0-4f5a-84ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_25db-b03f-4881-b310</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink><entryLink id="c793-cb2f-9479-0aad" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry"><categoryLinks>
+        <categoryLink id="dd6b-09eb-441a-8509" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_75a7-dc06-445b-b2dc</comment></categoryLink>
+        <categoryLink id="2b8e-3d9b-42f1-95ef" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_e21a-c03b-4885-ac46</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink><entryLink id="6d99-d6e2-4836-5b15" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9a08-5fe6-4010-bbc3</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_72cf-cfce-4e02-b379</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2b3d-ba26-45c4-b64a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_f55b-7555-444b-beee</comment></categoryLink>
+        <categoryLink id="ae40-88ba-4359-b6e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3386-c9ad-4d74-9474</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink><entryLink id="4d50-a28a-15f0-6b9d" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_a0f6-9606-4b75-a2f8</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_94b3-1331-474b-885b</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0640-14ee-48de-98f5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_79fa-3370-4ae0-9e12</comment></categoryLink>
+        <categoryLink id="2cdd-cc84-4f55-b795" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bb53-4e65-4fb6-9dd7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink><entryLink id="925e-039d-df0e-6c82" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f8cc-833a-4ac1-bf89</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+              <comment>    node_id_5988-c012-4dad-9a66</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6794-0f2a-4ffb-ac55" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_8d82-3279-4481-84bb</comment></categoryLink>
+        <categoryLink id="ca45-e8f1-4d80-9fdb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e25c-925e-4b96-8bb3</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink><entryLink id="c362-07c0-c7a6-4e21" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6b73-b21c-4e2b-9d14</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_a7fe-cc62-4a6f-a781</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5be1-1937-4964-a455</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_da1d-b2bc-4117-82a4</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6bd5-77bd-4d48-a4b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7010-be56-4709-b058</comment></categoryLink>
+        <categoryLink id="eecf-f85a-47c4-82ea" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7379-a740-47ba-a054</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink><entryLink id="c59d-949c-def6-156e" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_dd34-83cf-47d7-b557</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_be88-afef-49b3-bd1e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4521-e07b-4a95-94f7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_944f-7420-4982-8ea9</comment></categoryLink>
+        <categoryLink id="6818-1549-4d10-80fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ea80-0efe-457d-a450</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink><entryLink id="381d-b233-7191-e417" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><categoryLinks>
+        <categoryLink id="7850-713c-42ad-b4c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9a36-f261-43cc-9bd1</comment></categoryLink>
+        <categoryLink id="0493-4a69-4c98-85d5" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a648-8396-442a-af59</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink><entryLink id="685e-e480-ab3f-104f" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_cb81-0303-4b88-ae53</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9648-31e3-43aa-8cf3</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_0507-da81-4023-bfcf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0e84-54ff-488d-b066</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8188-729a-42b3-8f1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6ff-0977-4c92-bb28</comment></categoryLink>
+        <categoryLink id="0d9c-3be4-4996-8717" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f555-7d39-458f-84c9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink><entryLink id="b29b-b6d8-64b0-ad57" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8203-5b00-497b-b939</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_40ee-3e71-4978-b1e4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f6a8-f660-46dc-b3c5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_d988-3af6-48bf-b0a8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5377-9ea5-4082-b355" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_39e5-eda5-45d1-a643</comment></categoryLink>
+        <categoryLink id="c779-2731-4673-872a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_6416-21bb-4df4-9de8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink><entryLink id="6acd-f4f9-fb46-a306" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b03e-5d91-4be3-8adc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_0443-29c0-46e9-ad1d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f2c9-7356-4c27-a22f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0e9-4a9e-4b2b-a9d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="38ff-e429-4607-a40e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5528-2dac-4be5-900c</comment></categoryLink>
+        <categoryLink id="67ea-5c5d-46f5-9ac0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_dc8f-d888-4585-991d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink><entryLink id="7ab5-27ee-8c1c-bddb" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1d3c-8e17-489f-9002</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5725-8bee-4bcc-878d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_be47-0d6f-49f2-9f4b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_863c-f3a4-4802-b80c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8e89-4e0b-4a2a-9c32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_899e-b052-4d5b-8c18</comment></categoryLink>
+        <categoryLink id="cde1-b7b7-407e-9266" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f5e9-cff6-41d2-a016</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink><entryLink id="8dfd-52fe-18de-e010" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_72da-1513-4e02-b595</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7a48-a3b0-4a26-849b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e232-25f3-4cb7-8ab2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_9aa4-5660-4697-8ab2</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="96bf-c342-44dd-b255" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_09cd-2176-40af-bba6</comment></categoryLink>
+        <categoryLink id="0bf9-bd36-4c2e-b15f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_05e6-7c63-4a35-9ba0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink><entryLink id="800b-aaa3-22ee-521e" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry"><categoryLinks>
+        <categoryLink id="2695-d088-457c-813d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0dfa-4004-4751-8022</comment></categoryLink>
+        <categoryLink id="4820-4785-49c3-a885" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a669-0f5d-4fd3-811b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink><entryLink id="30bd-085b-0e7c-39a9" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_09b5-4e3b-4c84-a574</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_32e5-ebba-41fb-9ff2</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_838e-0ccf-4d3a-aabd</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_dfef-0ec2-49fb-a534</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d5f0-53ce-47e3-bf16" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4f60-472b-45a9-ab9e</comment></categoryLink>
+        <categoryLink id="2e43-304b-4f5f-b582" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e2e3-af36-45a6-a955</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink><entryLink id="5aef-8d2d-c34d-25d0" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_936f-1ef7-472e-840e</comment>
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+              <comment>    node_id_d73d-d52e-4c75-8ac0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="79ce-09f3-467f-b74b" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_7a55-ecb4-4e5d-b955</comment></categoryLink>
+        <categoryLink id="48c5-8426-4d79-848a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f28c-710e-4ff8-9810</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink><entryLink id="aa0c-2200-bdf0-90bd" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_a743-0cc2-45ae-a7eb</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2721-e88d-41f7-bedc</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_e10f-1390-4b33-8fcc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c56e-2345-4ba3-bd2b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2008-f1c4-4285-a14f</comment></categoryLink>
+        <categoryLink id="fe22-62c6-4c43-be1f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e88b-a95a-4647-af3b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink><entryLink id="9fb8-08f8-9024-1015" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_25d8-330b-4574-b515</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7836-6878-47a8-8827</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_5ea9-46dd-4a11-9410</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_ab5d-961b-4924-a705</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6b53-b81e-4b74-b93c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9189-836c-475d-a52e</comment></categoryLink>
+        <categoryLink id="426b-bffd-4189-b09e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_e1fa-b7d8-47b0-a88a</comment></categoryLink>
+        <categoryLink id="aa21-79e3-4716-8e19" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_a137-e3c0-4d63-a48c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink><entryLink id="b2b5-234c-2ba8-c05b" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry"><categoryLinks>
+        <categoryLink id="40d6-ca4e-4a61-b01a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b1d5-fd75-4f17-bbf4</comment></categoryLink>
+        <categoryLink id="9392-8a53-4659-86bc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_f221-bf81-4045-849b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink><entryLink id="af58-68f6-b173-4756" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_b743-7a00-43e4-beb8</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d12f-2c98-4e62-a716</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d4d7-ba67-47aa-962f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+                  <comment>    node_id_1637-edee-457a-bb0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2b9d-b4cc-4f14-b3fc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_f203-bc26-421f-b79e</comment></categoryLink>
+        <categoryLink id="cae8-a86b-433c-9333" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_a53e-59d9-4ac2-a21f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink><entryLink id="a47c-06f3-bc77-fca0" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry"><categoryLinks>
+        <categoryLink id="ac1b-2192-4a06-b831" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_51af-a137-4a1c-97a4</comment></categoryLink>
+        <categoryLink id="e374-97a8-4bca-b72b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ec1f-c326-40a8-9d1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink><entryLink id="2e04-1055-0e5f-c413" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_c111-feb0-4012-98cd</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_63d7-8427-431d-9ae6</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="69f5-1c69-4eb9-b2fb" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_e707-fde1-457f-91c4</comment></categoryLink>
+        <categoryLink id="b366-4a47-4236-95f9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ec67-8573-4460-89db</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink><entryLink id="1043-8d0f-2838-9f79" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3348-16e4-4a9a-a549</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_bea4-c4a8-4843-b9fe</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2970-17ff-4be1-91e5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_503a-46e7-40e7-bd07</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_4555-15e1-43ff-80a0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f779-b2b2-41ca-9796" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_fce3-801c-49c8-85d4</comment></categoryLink>
+        <categoryLink id="5162-3b45-451a-9e78" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0c2d-2349-44b6-9831</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink><entryLink id="83ae-538e-57d9-ce01" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry"><categoryLinks>
+        <categoryLink id="233b-a0bf-4f84-9f9c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ac1c-b3bf-4011-918a</comment></categoryLink>
+        <categoryLink id="7855-2f84-4e78-b724" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_589c-1d0e-4b7d-be6b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink><entryLink id="6c25-69a3-62eb-3f42" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2f46-a0b6-48a5-a0ee</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_636f-0f8a-43f1-910b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c883-39c8-4a74-aeaa</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_0796-e467-4438-89b3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7a9a-6f08-4d18-b9f9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_5a04-9847-4c91-a49a</comment></categoryLink>
+        <categoryLink id="63c5-a5f1-478e-9ad0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b4b4-daeb-483c-a306</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink><entryLink id="2792-ab38-fd66-fe12" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6087-a5e5-4d3c-9ebd</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c7e1-5f42-4528-bf07</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1950-08dc-4544-ab01</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_daf3-31ed-42c0-85dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cfb6-cb0c-4987-a18d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_7d4f-547c-43ed-a520</comment></categoryLink>
+        <categoryLink id="6bb6-7a3f-47d0-ac20" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f04e-04e8-4891-9b1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink><entryLink id="a70f-fc8b-42cd-5f02" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_dfdc-f6f6-49d2-a7b3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_354c-c71f-472f-b268</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1127-c974-4663-874d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_0843-bef2-4767-8307</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3cf0-353f-459b-9bbd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_28e0-91e7-4ada-9fac</comment></categoryLink>
+        <categoryLink id="84de-f66c-477e-91b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4448-a712-4dd7-bf6d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink><entryLink id="c92c-4514-d7bb-0cd9" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d512-fd07-4a29-863a</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_55c6-a35f-485a-9f0d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d89e-cf1f-4ceb-b3de</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e2c9-0d01-403c-900e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_a7b8-c835-4cb2-b3d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="88a5-d0e3-41d8-a088" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_e22a-c5f8-4825-a45f</comment></categoryLink>
+        <categoryLink id="9590-0364-4da1-850f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03fc-6a7f-45a5-bcb8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink><entryLink id="8883-a80c-8cd9-bb29" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry"><categoryLinks>
+        <categoryLink id="351c-cc8c-460a-82d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0aff-4f6e-4b03-a23c</comment></categoryLink>
+        <categoryLink id="7ff2-7fdf-401b-914e" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"><comment>    template_id_7d5a-62e7-43ee-b79b</comment></categoryLink>
+        <categoryLink id="01af-6f73-48ee-8e70" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_4986-9157-49f2-b670</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink><entryLink id="b9bd-df3d-1321-f365" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_319e-90d4-44a3-8e83</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_28db-d943-4099-9abd</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1a45-a592-49df-9465</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb31-d0b2-4677-928e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b3f4-5765-4650-8865" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1b86-0977-4a8b-adac</comment></categoryLink>
+        <categoryLink id="f8e0-af16-4725-89e2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_b449-403a-4e42-9239</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink><entryLink id="a225-e55e-9b3d-960b" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafa-470f-4c2c-8be3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_e2ba-a855-4de2-9f46</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_0171-b30d-44ee-9389</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fdfb-119b-4774-934a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_3891-9a00-4f8f-b95f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a0e6-964b-46e0-82d0" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e5df-17d4-4521-9d5b</comment></categoryLink>
+        <categoryLink id="d7db-457a-40a8-ae84" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"><comment>    template_id_0ecd-4873-4d3a-b28b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink><entryLink id="85f4-6e9a-4797-7534" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_fbfa-8d78-4d6d-8a05</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_21f2-0916-46bf-b75a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_4fbd-633b-4dd6-9fdd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f664-1acd-4d89-b3bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4f71-446f-4cff-afda</comment></categoryLink>
+        <categoryLink id="55ec-b4db-4c6a-9a8a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_3f44-8647-43a4-ac22</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink><entryLink id="9d6f-9f11-1095-5ab8" name="Deathshroud Terminator Squad" hidden="false" collective="false" import="false" targetId="7669-a6c0-7f86-e641" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="de3d-153c-8b6a-ee1b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="c965-8eea-54a5-dbbe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -1054,24 +1804,283 @@
         <categoryLink id="9101-b7e1-a69a-8690" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="1f21-083f-ed75-5d38" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <modifiers>
+    <entryLink id="1f21-083f-ed75-5d38" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af15-2c71-4f8b-833e</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_d95a-80b9-4463-af55</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
-      <infoLinks>
-        <infoLink id="bfa3-df31-9e63-694f" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule" />
-      </infoLinks>
       <categoryLinks>
-        <categoryLink id="3756-dc59-4b6f-1d17" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6628-588b-3f5f-005f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="22ac-2a06-4b14-80e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6b1-886e-4194-8bcd</comment></categoryLink>
+        <categoryLink id="bc56-8ed2-4040-9d2e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_51b5-f9c1-4587-8fc7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
-  </entryLinks>
-  <sharedSelectionEntries>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink><entryLink id="10d0-eea4-4e82-bf81" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
+    <entryLink id="51db-cd5f-4c46-8484" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
+    <entryLink id="4228-b1d8-497a-a7ca" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
+    <entryLink id="8290-f31c-411d-b4a9" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <entryLink id="a1f4-33fb-480b-a02d" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3531-57d1-4081-882d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_f233-2361-4177-8ba7</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b932-667a-4b43-8331</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <entryLink id="d3cf-12f9-4548-81e1" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <entryLink id="3bdb-7e8a-4455-8f3d" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3129-6f59-4365-906b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2bcb-0af1-4aea-9191" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <entryLink id="9a3a-72d6-4b1b-984f" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ede2-d453-4e34-8cda</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2907-3215-4b01-96ff</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_c90c-959f-40fb-a4cb</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ba2d-50ad-45f1-91c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0e88-485e-43c2-8bef" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <entryLink id="1356-08db-4850-8183" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_409c-0a5d-4ef8-a871</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7078-c1c7-4af2-b43d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_9a69-0fdc-4957-8982</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1a4c-69b5-4219-8502" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fba0-3ea7-4eaf-b33a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <entryLink id="5d1d-d466-4856-9dc9" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
+    <entryLink id="d580-e36e-43c9-86bb" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
+    <entryLink id="ff49-3945-43fb-8762" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
+    <entryLink id="cc35-e2d4-4601-aa38" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+  </entryLinks><sharedSelectionEntries>
     <selectionEntry id="e830-3788-1a0d-0c02" name="Calas Typhon" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d78-9648-8e21-ec44" type="max" />

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -3042,12 +3042,12 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
           <modifiers>
             <modifier type="decrement" field="6d70-c466-3e6d-51e4" value="1.0">
               <conditions>
-                <condition field="selections" scope="5b08-65c1-cc45-1b91" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8299-7028-93bc-0355" type="greaterThan"/>
+                <condition field="selections" scope="5b08-65c1-cc45-1b91" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8299-7028-93bc-0355" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="b79e-330d-7d05-1fce" value="1.0">
               <conditions>
-                <condition field="selections" scope="5b08-65c1-cc45-1b91" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8299-7028-93bc-0355" type="greaterThan"/>
+                <condition field="selections" scope="5b08-65c1-cc45-1b91" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8299-7028-93bc-0355" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -1,6 +1,5 @@
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="72ba-61c2-37ad-c785" name="LA -   III: Emperor's Children" revision="12" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="29">
-  <entryLinks>
-    <entryLink id="b36e-8c73-fe83-f087" name="   III: Emperor's Children" hidden="false" collective="false" import="false" targetId="3edc-a1b9-6dc6-b1ea" type="selectionEntry">
+  <entryLinks><entryLink id="b36e-8c73-fe83-f087" name="   III: Emperor's Children" hidden="false" collective="false" import="false" targetId="3edc-a1b9-6dc6-b1ea" type="selectionEntry">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb97-3eea-07d6-0aed" type="min" />
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2fd-9199-56bc-916b" type="max" />
@@ -134,940 +133,1670 @@
         <categoryLink id="806c-e31c-d83d-3c70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="ecec-6831-34d9-b21b" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ef81-793b-e735-16c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="285f-334a-ad39-dcb2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <entryLink id="ecec-6831-34d9-b21b" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="7dab-58e7-4980-b89b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6d4-581f-4746-bec3</comment></categoryLink>
+        <categoryLink id="6acc-0dc6-4995-bbb1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_2489-ee2a-45dd-b384</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
-    <entryLink id="12c2-c644-0a3b-8912" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2156-43cd-491c-4d48" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="906a-1e2f-1a4f-7ed4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
-    <entryLink id="bc27-da9a-8975-4051" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink><entryLink id="12c2-c644-0a3b-8912" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b02f-e65f-4a88-a175</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_b87b-bf35-4238-b7c6</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1aff-27af-435e-8102</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_fdf9-4906-4180-a39d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e265-dc69-cf9e-dfd1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="a097-5047-4d84-c63c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ace9-ab50-850d-0e7c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="a57c-a26d-46f4-b597" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8378-ede4-476d-b657</comment></categoryLink>
+        <categoryLink id="4672-121b-44c3-b0ac" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_d64f-ad19-426c-adf7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
-    <entryLink id="5665-bf93-acdc-1f4c" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9ebc-db59-ca20-286a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="21ef-bee6-9654-b960" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
-    <entryLink id="201b-dc33-b6a9-edff" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="a369-b028-93d3-eb98" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="cf5e-6ae2-11e7-6095" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
-    <entryLink id="df1d-3151-9c34-afe5" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink><entryLink id="bc27-da9a-8975-4051" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_7fd1-8ce8-4d10-82e7</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_eaae-8c43-4d30-898c</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_f67d-8cf3-424f-b491</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_b949-6414-4f3d-b268</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e909-39c8-2194-b6c4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="f4a3-a75b-4b04-f430" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4a91-2a23-ab6b-f2ed" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="f7bf-22b0-427d-bcd0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_ac26-e639-4d53-9b8b</comment></categoryLink>
+        <categoryLink id="6b8f-306f-4a23-8ed0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_49af-0d08-4c7e-8ce6</comment></categoryLink>
+        <categoryLink id="550d-b667-4202-a6f9" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_b606-de16-4659-95cd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
-    <entryLink id="8c16-7bee-f0a4-9cc2" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink><entryLink id="5665-bf93-acdc-1f4c" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0c3f-e9af-478a-c2d6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="391a-d304-0901-60b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
-    <entryLink id="9d88-65f7-6a42-b710" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7583-6fa0-4089-a19e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_0e5c-99ab-41d3-a42e</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c296-e8e8-4a7a-989a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_8868-5bcb-4604-ba8e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="15a9-ed79-4cb6-863c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a009-a597-4b51-b228</comment></categoryLink>
+        <categoryLink id="7334-9c6c-4bfc-bbdc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_24f4-9145-4016-80d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink><entryLink id="201b-dc33-b6a9-edff" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_e732-7499-47bf-9748</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_81a5-a959-46b7-baa4</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7ec3-447a-4644-b012</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_71e2-c430-4c99-a559</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_df7b-3fb9-4f65-9165</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6f6c-cae3-43bc-ba12" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c165-3906-463a-9c73</comment></categoryLink>
+        <categoryLink id="1b58-be6a-4c76-9321" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6d1-d14c-473f-be09</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink><entryLink id="df1d-3151-9c34-afe5" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_27a3-1e4c-4b76-a594</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_d59a-dcd0-44fd-b866</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_0c8b-2b92-49ed-98c7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_bafe-f799-41d9-ac85</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_6369-288c-4fec-a640</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_fe53-8858-41dc-8ec4</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1136-6bae-1e96-b9cc" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="3b27-7d3c-88a6-a809" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b388-a51e-4b48-b8b5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_3a22-caae-4eea-9bc5</comment></categoryLink>
+        <categoryLink id="b9e4-1b17-441b-bcb7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f759-f33e-4698-9f8a</comment></categoryLink>
+        <categoryLink id="cdbc-4fcc-49a2-bb8b" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_c624-3ae0-46c0-9b06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
-    <entryLink id="3862-7519-db07-7636" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2412-a539-157c-c6c1" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="4cca-f2e2-44a5-e746" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="fc2c-daf1-8e8c-db02" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="6630-6ef3-a443-b62b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup" />
-        <entryLink id="6bfc-d444-1fbd-5b93" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink><entryLink id="8c16-7bee-f0a4-9cc2" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_13b3-ce1e-4f9d-8319</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d681-9d81-4abd-b11b</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a57-e48b-4534-bca5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_1859-5641-4674-9097</comment>
+                </condition>
               </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
-    <entryLink id="06e0-e2f5-0e4d-3189" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
-      <modifiers>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e6f5-b8b2-4e13-bdb7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_251a-df5b-4bfd-ad63</comment></categoryLink>
+        <categoryLink id="be77-eee8-465e-b9b7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4644-98ab-4e3f-b1fd</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink><entryLink id="9d88-65f7-6a42-b710" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_591d-d028-4663-918d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_0482-c5f9-4c95-9597</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_75a7-971d-4978-a83f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_a7d5-2bfe-4621-ac0c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9f13-b460-4f27-b0cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_31fc-e265-45a7-bb5b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9300-a869-15e6-df14" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1746-968c-4d71-b3c7" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="fd1e-007e-250a-6e27" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="497a-ef76-422e-8b70" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_67c2-df43-44fc-92d1</comment></categoryLink>
+        <categoryLink id="f4fc-f1f6-4a48-9538" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4136-bb4e-4dd4-99f9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink><entryLink id="3862-7519-db07-7636" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry"><categoryLinks>
+        <categoryLink id="c9fd-a1b6-4df6-9e42" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_2599-24e3-44e5-9568</comment></categoryLink>
+        <categoryLink id="bde7-eefa-43ca-99c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_285f-6e56-473b-b2fe</comment></categoryLink>
+        <categoryLink id="dee2-2f1c-4a31-af0b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_685e-022f-4e2f-a568</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="e709-3e87-d4d0-607b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup" />
-        <entryLink id="a7d2-892b-1495-3b47" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup">
+        <entryLink id="663a-03c6-4088-b20e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup"><comment>    template_id_2a38-6544-4267-b584    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="4963-1dc0-49fa-ba0c" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_8287-16ff-46ba-9838</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_81c1-fca9-44dc-ba4c</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_6e59-4592-47ef-b76d    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
-    <entryLink id="4838-9716-e041-d3d4" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6eeb-cc3d-020a-27ef" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2c5d-ff0d-4c45-c147" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="8fed-486d-c112-412c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="4c60-51aa-7ba1-f63a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup" />
-        <entryLink id="ef10-cfb8-a3de-e69c" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
-    <entryLink id="314a-6609-e3d9-e76b" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0df4-bd27-c6f4-f60d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="c012-5e94-8f5c-d90e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
-    <entryLink id="c8dc-8233-18d7-0b6e" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c6c2-2b7e-8939-6b3d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7486-84ef-9385-893b" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
-    <entryLink id="8d5d-ed86-9d48-de73" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink><entryLink id="06e0-e2f5-0e4d-3189" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ad5d-3c79-4239-9116</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_60b1-049b-4a5f-85c2</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3417-3927-99f9-f950" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="176d-4a27-f6e5-9dab" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="f1b2-f13e-4773-9693" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bd6a-0cda-4e0f-80ae</comment></categoryLink>
+        <categoryLink id="647e-d098-404f-99e0" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_ae75-7cca-4701-9d56</comment></categoryLink>
+        <categoryLink id="e0af-0b61-4a3e-bd4c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_e517-62d4-48f7-8174</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
-    <entryLink id="0b7d-e2ff-4475-489c" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
+      <entryLinks>
+        <entryLink id="bfc7-3002-404a-a77b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup"><comment>    template_id_fafb-6414-474a-8a09    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="4fa2-969e-4491-a1af" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_1e43-c980-4508-8ec2</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_4140-36a7-4203-b5e9</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_a6a6-9bc7-4d4e-86a7    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink><entryLink id="4838-9716-e041-d3d4" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry"><categoryLinks>
+        <categoryLink id="64da-1b72-4b97-9bf3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fc9d-03d1-4bbd-a1c4</comment></categoryLink>
+        <categoryLink id="0fea-0015-494c-96ee" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_f51c-73d7-4f29-be1c</comment></categoryLink>
+        <categoryLink id="9027-ddc1-4d66-8902" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_257d-78c0-4bab-ba65</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="f5bf-d827-4fd9-9cb9" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup"><comment>    template_id_ac26-33db-40a7-bdba    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="e476-aed3-4264-81eb" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_189b-db75-4db6-9fe9</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_cbdb-2500-4e13-876a</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_dc8e-2801-46d6-84f8    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink><entryLink id="314a-6609-e3d9-e76b" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b43b-547f-472e-9076</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8ff9-0498-4540-8552</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fbfe-931a-489b-a589</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f4c3-5aa6-4caa-abf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_17f8-f055-4c9c-b757</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="f2e6-d9bf-0368-baac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2d3e-32d1-fc8d-d5a6" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="fd55-e5b9-492f-8f91" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f1c8-27fd-4f98-8527</comment></categoryLink>
+        <categoryLink id="e148-4310-47b0-b49b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2b20-1a8b-4753-b657</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
-    <entryLink id="3625-2600-c8d5-3980" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink><entryLink id="c8dc-8233-18d7-0b6e" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry"><categoryLinks>
+        <categoryLink id="6267-635f-497a-b7e4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4207-8d8f-4b1a-836b</comment></categoryLink>
+        <categoryLink id="d770-d464-4b60-96c8" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_2b34-077f-4279-86fb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink><entryLink id="8d5d-ed86-9d48-de73" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="6884-c61a-1ab7-8692" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1a3c-5073-4c14-9817" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="7c0c-dd2a-4f86-a073" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6577-e0fb-4fda-834e</comment></categoryLink>
+        <categoryLink id="faab-941e-4727-8896" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_5d59-09bf-4566-b7e1</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
-    <entryLink id="99df-a04f-4d15-5a7e" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink><entryLink id="0b7d-e2ff-4475-489c" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"><categoryLinks>
+        <categoryLink id="afe1-a3ac-4f1e-a6de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_aa93-057d-42f6-82d7</comment></categoryLink>
+        <categoryLink id="d677-2de9-460a-8c81" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_403c-4e9c-4af5-84ec</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink><entryLink id="3625-2600-c8d5-3980" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_23fa-06dd-49f9-a7db</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5b26-059e-40b3-9d93</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f7bf-3a1c-4103-aed8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="fd0b-4621-f89d-45d8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="9620-d2d4-92c5-d07c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="64f4-cb2e-490a-aceb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dd44-e0a8-42a8-bdcc</comment></categoryLink>
+        <categoryLink id="9353-de16-405a-a1e6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_c5b0-f9ae-468d-924a</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
-    <entryLink id="bf3f-371b-357e-fe0f" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink><entryLink id="99df-a04f-4d15-5a7e" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8396-e51c-4e2b-bada</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_13bb-9fb5-4580-92cf</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_bfb8-8125-4548-92f5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25e3-b8f5-4448-a7c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="50e5-38d1-440a-80d7" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_f926-27fd-4a92-97a1</comment></categoryLink>
+        <categoryLink id="63d7-7c31-4be0-b35b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_82e3-36e1-4e85-8fcb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink><entryLink id="bf3f-371b-357e-fe0f" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b421-52fe-eae9-c778" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
         <categoryLink id="6d11-28dd-b5d0-ffb0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="c5e5-5a6a-7520-11fc" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
-      <modifiers>
+    <entryLink id="c5e5-5a6a-7520-11fc" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_658f-b1ad-4347-a998</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_12bc-3db2-4d28-abce</comment>
+            </condition>
           </conditions>
         </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="4265-6026-884e-ccda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3a73-cdac-9e0b-806f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
-    <entryLink id="5ea2-d146-b89a-1217" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_9d83-7691-41d6-8dad</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_add7-ba48-46d4-8a02</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_1fb0-2421-40a4-9e49</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1b95-ff6c-67b0-c7ad" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="c262-93f6-ca05-c025" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="66bb-9dfe-937a-e17c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="c408-eef9-4aff-b971" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7004-b00d-481f-b740</comment></categoryLink>
+        <categoryLink id="fbfc-9a89-403f-993c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4f88-2fc3-491c-bfb7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
-    <entryLink id="bcb4-7834-f574-96e8" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9050-a0f4-60c4-02f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a473-929d-10d7-5127" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
-    <entryLink id="4dc9-f18b-b18b-f6d3" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2d13-ffdb-29f7-e4a7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="9a18-8c66-d7de-ad37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
-    <entryLink id="62a4-c5e2-9494-6380" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2fac-3433-337f-4d72" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="d6f6-a4ff-3034-b9ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
-    <entryLink id="5cee-0919-6a27-0ccf" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="222d-9743-0408-bb10" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="29f5-d0f2-8a8a-0fe3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
-    <entryLink id="05f1-c29f-3faf-0409" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="44a5-670e-0902-1e0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a254-25c1-de02-297a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
-    <entryLink id="c956-e907-5831-6800" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0137-4a40-f60d-2eea" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="800f-0df2-6922-604b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
-    <entryLink id="b5a8-92bf-83fe-fb3c" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="f0b1-e8fd-f025-8394" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="07aa-5b8b-cf91-d04f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
-    <entryLink id="d421-82ca-76cd-d9ad" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0034-d4cb-5590-e831" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="fcc7-b449-7121-bd7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
-    <entryLink id="ba87-1175-ffaa-aba9" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3cb8-bac5-8489-f87a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="230f-ac88-2d92-9ccb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
-    <entryLink id="6c22-a2ef-6eb2-3f48" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8bf5-3ec3-e641-d8eb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="5ecd-78c4-475a-7b3f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
-    <entryLink id="df27-654e-5a7d-4163" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="fb94-593e-764a-2e01" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="9de7-fcf4-240f-0ff5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
-    <entryLink id="5503-5a35-dd0c-057f" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0e42-40e2-f73d-b8b2" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="969a-bbe2-620d-67f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
-    <entryLink id="eee7-af09-ce7c-80a5" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d662-fedf-4138-58cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ca4d-ef9c-f265-1dcb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
-    <entryLink id="5ebb-48a6-444b-9865" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8a23-8042-a268-09f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d0a5-f7dd-4b67-4a3b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
-    <entryLink id="3c67-8ef9-8cc9-efa9" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="92f0-68f1-5c99-bdf0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="fdd2-07fd-90c5-c24f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
-    <entryLink id="5efd-b2d6-c765-311b" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8cb5-b39f-f07c-774b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="4f51-ed25-7d81-08de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
-    <entryLink id="4a59-da44-7080-da44" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="4664-d65c-78a9-cc1b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="abf6-43db-c130-3569" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
-    <entryLink id="e34c-4e68-da27-f688" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="5708-8290-b73b-b213" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="6068-c48e-19f2-d9ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
-    <entryLink id="efe3-2793-c6f8-64be" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e783-726f-59ca-adb0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="044f-ba25-ae60-1bf0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
-    <entryLink id="9d87-38df-a9f6-e0bb" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="bb49-12a1-1479-dde0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="26de-308d-01f5-22e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
-    <entryLink id="3596-92a3-70fc-6b1f" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8805-361f-9647-e6d4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="bc51-0762-b627-0d4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
-    <entryLink id="1933-c2cc-0886-f7e2" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="37c3-a142-92f4-1170" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="3c1c-b046-f211-4c53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
-    <entryLink id="002d-a997-d2a0-cf6d" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9890-d166-91b2-8bed" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="0799-5eb4-c25a-5a2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
-    <entryLink id="abc6-e8e1-4066-68e1" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="427b-6cec-4837-2b2a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e4b9-e529-4498-d23c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
-    <entryLink id="cebd-8215-51aa-f6a2" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8f51-adaf-bf3f-4e0e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="7906-9273-349e-89ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
-    <entryLink id="5079-8467-4b74-5a1c" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7868-8b04-94ef-2461" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="0ba1-8d30-54d6-3cb1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
-    <entryLink id="59f3-7771-84d0-8948" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1552-917e-7aad-0450" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="bee0-1c1b-7917-d7c1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
-    <entryLink id="2615-14fc-e1c3-032f" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7b98-1b44-a37a-33dd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="3bbd-b9e9-70f2-a7f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
-    <entryLink id="c289-0e8a-b032-1a0e" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="82e5-dcc5-a590-7a1b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="f572-a27a-7f3f-1e17" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
-    <entryLink id="630f-14e1-14c5-1ae2" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="bbbd-94c4-4a97-6d62" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="005b-9862-dbe9-7223" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
-    <entryLink id="3524-ef12-bdd1-19c0" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="efe8-bc8e-ad17-23cf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="f845-6b9b-b63a-16c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f56a-e824-7aec-617c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="6822-03c3-ac10-8fd0" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup" />
-        <entryLink id="f3aa-e76a-f630-a79f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
-    <entryLink id="2ced-abe5-9c73-213b" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0509-7ccc-64b8-0d46" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="7a26-cd56-8af0-7d6b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="70a5-13ef-aaa0-ec5c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="b62e-86f9-6448-d4ad" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup" />
-        <entryLink id="8b8e-65f0-7cf0-ef7b" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
-    <entryLink id="b070-f292-bf0e-962d" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1bf6-ea75-1f72-58c8" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="109f-8bb3-248e-0c03" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="cf42-7e43-c438-7b58" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="b336-b028-c4c3-7f6e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup" />
-        <entryLink id="c4b9-582e-7d51-9446" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
-    <entryLink id="d03c-82e0-25a4-b0b0" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4494-2f6c-f7b8-97b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="047e-f5df-4bf3-4112" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
-    <entryLink id="57a1-2e7c-ea7a-5e10" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6d1f-d08d-a926-6c22" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="d4d9-204e-d603-86fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
-    <entryLink id="b0af-6f67-6ff2-db71" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c050-a744-cc4f-3735" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7c32-6c97-a0b8-7e82" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
-    <entryLink id="916f-70e6-d2d1-caaa" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="a00e-dd17-2f20-4fd1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="cc9f-7e37-626e-aeda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
-    <entryLink id="b4b5-8ef8-904c-2768" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9869-1c47-5445-e654" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="0981-4cd0-3389-f45b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
-    <entryLink id="67ae-69c3-b933-a825" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a0a8-c5d7-01a7-e388" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="96f5-55a5-186d-4f3e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
-    <entryLink id="c353-7d50-a146-8f63" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e702-ba2f-1797-774a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4928-0f27-e8d0-51d0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
-    <entryLink id="1314-96d9-9d30-b56c" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="06d9-2af2-98f7-362c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="5da1-72e3-144b-d4e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
-    <entryLink id="f794-e1c0-34d6-d71a" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d255-a1a2-96d7-e07d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9d52-465c-8f24-a8c0" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
-    <entryLink id="28af-78d9-69f9-8b87" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c472-eaee-6e07-cd6d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a692-8891-6640-bd5c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
-    <entryLink id="4f12-7a28-7980-97e4" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1e8d-8b50-9ba7-1ce2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="29bb-14af-bfb8-79c4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
-    <entryLink id="adec-a47a-130f-8214" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0982-fb9f-ba42-dae6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2924-2ed2-2229-d3cb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
-    <entryLink id="3194-1cd7-f371-ca9a" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="93e6-2990-b830-1499" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="789c-808f-4b13-7144" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
-    <entryLink id="0489-a3c0-88a0-ba18" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ef2b-443f-9b90-3db7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="23c1-8766-188a-2482" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
-    <entryLink id="23f8-712f-e735-1a30" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9879-d1be-1c43-9ad1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b446-b96e-54f8-5ce8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
-    <entryLink id="1019-efcf-1548-2a00" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e6d0-e337-9c95-5aaf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="23de-4dec-ea47-3059" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
-    <entryLink id="6488-1f35-b482-fc83" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0f9a-937d-0b09-3e2e" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="818b-ca1c-7c1b-00dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
-    <entryLink id="7e61-c663-30d1-9acb" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8efd-44c6-f9bd-bfc1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="72bf-4dae-911f-bb8d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
-    <entryLink id="3e94-aa5e-e44b-1dc1" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink><entryLink id="5ea2-d146-b89a-1217" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_8ed4-376d-4030-9439</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_8a11-c2a0-4335-99ef</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_fa8e-1af7-4d41-ac8c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_94bd-c771-4a85-8581</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="14cd-5061-2107-8ac5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8017-c625-0639-a56d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="3d93-ff34-5055-af1e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="f753-33fe-441f-b3ba" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_361e-fb90-4b0e-ac3d</comment></categoryLink>
+        <categoryLink id="b020-96d3-44ea-adf5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d4ef-1074-45a9-959e</comment></categoryLink>
+        <categoryLink id="625b-1d97-4e2a-91d8" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_febb-f536-4d25-a8ab</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
-    <entryLink id="8b4a-cd3f-042a-c06c" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4221-11f9-4f2e-82fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="22f0-2caf-bd70-f70f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink><entryLink id="bcb4-7834-f574-96e8" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d2e5-d918-45f8-8546" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_473b-e812-4158-9416</comment></categoryLink>
+        <categoryLink id="aa9a-09ae-45ad-8aa2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_00a2-63ff-4698-a35b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
-    <entryLink id="6760-ab00-bae3-2a6d" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink><entryLink id="4dc9-f18b-b18b-f6d3" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7cf3-8a72-4f82-8cdc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_228c-5681-4ce8-b726</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_01bb-8abd-4253-9a4d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9c21-edaf-e5c3-e45d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="5d5f-46a8-dc0b-24f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3b2d-7bc2-4c3e-85c7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2a08-4432-42ad-bfdb</comment></categoryLink>
+        <categoryLink id="2370-ecab-4dea-bf9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_422e-0808-4897-8630</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
-    <entryLink id="0390-6e73-f86a-134a" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink><entryLink id="62a4-c5e2-9494-6380" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1af8-4459-4717-8e3b</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_06b4-92b9-438c-b1a5</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6c8d-8b28-417b-9a7c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_715d-8186-4aa6-b40c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_390e-358c-4f8e-ade8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="1728-f568-c1a1-9f44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0dd6-34d3-d2e8-c67c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="31b1-0d93-4c07-a659" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f4c0-4396-4f39-a34f</comment></categoryLink>
+        <categoryLink id="3b5f-22ba-4a1f-b070" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1301-8415-490e-8f06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
-    <entryLink id="87e1-003b-3176-7728" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink><entryLink id="5cee-0919-6a27-0ccf" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d0c9-9a26-4324-b030</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4e9e-a61d-42f2-bacb</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ed9e-b634-4bec-9eb0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4614-ad0f-4fba-adaf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_8d08-24f6-41be-8931</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d748-2ffd-4baa-981c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_caf6-5548-4b89-8102</comment></categoryLink>
+        <categoryLink id="952b-d5b2-4208-8600" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_63a3-be61-428d-ab29</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink><entryLink id="05f1-c29f-3faf-0409" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f318-4b03-4767-8c7f</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b8ef-7245-4df8-a8c4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_6bce-ec44-48cb-873a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="745b-938f-4871-b1e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0678-4fdd-48e6-8f61</comment></categoryLink>
+        <categoryLink id="7164-e814-4647-ada8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0d82-10a9-4de2-8ad7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink><entryLink id="c956-e907-5831-6800" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d765-3bb2-4b48-bd12</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_0ca1-cfb4-4a56-ab3b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3866-5ed0-de9b-9fe6" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="5e61-a899-1b61-6d4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d69b-1a33-4fbb-9abf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e6f7-a6ca-4825-bfc5</comment></categoryLink>
+        <categoryLink id="3307-ef10-42b2-8dac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dbec-e027-4ec1-8514</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
-    <entryLink id="6fe0-700b-7bdf-802b" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink><entryLink id="b5a8-92bf-83fe-fb3c" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d8ee-81ed-45f9-8b79</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_8f4e-e8cb-4ac9-a415</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1ae1-1dba-41bb-ad56" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_cefb-cfd7-4dc8-99c4</comment></categoryLink>
+        <categoryLink id="1b2e-1a4e-4a74-a265" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a9fd-9d16-4a5e-855c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink><entryLink id="d421-82ca-76cd-d9ad" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e76b-46ca-4ab8-a93d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8035-75b8-43bb-97c9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_71a4-31e7-4927-a0ab</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6c81-342d-49f5-9bda" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_a56d-347b-4b09-a918</comment></categoryLink>
+        <categoryLink id="be94-2d0e-4efc-9ab1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_96e5-4531-4213-903e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink><entryLink id="ba87-1175-ffaa-aba9" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1fb5-2375-4c22-b41e</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7d7c-255d-49b6-96b9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5321-254b-4890-9bf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ddf8-b8b7-4afb-b6dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a96a-0c0f-453e-bf98" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9441-d79b-4720-9667</comment></categoryLink>
+        <categoryLink id="0c29-d985-4e08-bc86" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7d7e-32d3-4692-b401</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink><entryLink id="6c22-a2ef-6eb2-3f48" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_99fc-5fe7-4b37-a62f</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_25f4-f6b8-4b44-8350</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_81f7-2311-4cce-95bc</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_09aa-af2a-4012-91d1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_00ae-fad3-4df6-9cb9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9bdc-bfc8-49f3-8482" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f65b-8958-49b3-92a5</comment></categoryLink>
+        <categoryLink id="be99-5768-433b-bf2b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0451-1929-4942-8c3f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink><entryLink id="df27-654e-5a7d-4163" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_edc4-4915-40ba-bbf0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_105f-ba26-4146-bc54</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7a2c-a76c-421c-a8a2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_05c9-0543-47ee-ba81</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e6ad-f0d7-4627-921b</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d5c3-7134-438b-9d23" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c6a8-22a8-4d41-b969</comment></categoryLink>
+        <categoryLink id="37da-f5d9-421f-8056" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03ca-12cc-4e0a-b628</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink><entryLink id="5503-5a35-dd0c-057f" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ae67-ef52-4cac-958c</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fc61-7306-4d99-acde</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1be0-67e7-45a1-bdbb</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_42a8-7fda-4e05-af0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1347-7d12-4cad-8c3a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_565a-1592-491f-8b9b</comment></categoryLink>
+        <categoryLink id="bc4d-7da8-4a6f-8f09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_81d5-c14a-42ab-bdde</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink><entryLink id="eee7-af09-ce7c-80a5" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1ae7-c41b-4818-be71</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_08a5-b1bb-4ba1-ba42</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d677-b5ad-4838-8746</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_537f-bc1f-4aaa-b0dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="36ba-8d9f-44da-9224" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bc67-ce1f-4004-aeb7</comment></categoryLink>
+        <categoryLink id="7703-f41c-4c29-beb7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_9a45-9699-4475-aeef</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink><entryLink id="5ebb-48a6-444b-9865" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_c28f-4109-44c4-ab64</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fdc1-a894-48bc-9e7c</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_4936-a68c-4524-9088</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb37-ac0c-49ae-9d6f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5799-2b00-4655-87c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3afe-cfc0-4da6-a985</comment></categoryLink>
+        <categoryLink id="2bec-ab4f-493d-a20f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_04a8-6aae-45ae-bd4c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink><entryLink id="3c67-8ef9-8cc9-efa9" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ae19-30c0-43c5-920e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_6ebe-1bf3-4d78-9dd0</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1887-152d-48b7-b13f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_a7c4-ee6a-4f0b-8ab0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bd85-fa90-47ff-9f84</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_7bd6-9043-4d7e-ba37</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dea0-5d32-4cdd-8fcd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3610-c975-4d55-bdfe</comment></categoryLink>
+        <categoryLink id="c084-f252-4245-8686" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2fc2-f636-4c80-9608</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink><entryLink id="5efd-b2d6-c765-311b" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_85c5-d4d9-4b23-9e4d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_80e8-d50b-4906-8153</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_b93b-d4f1-45eb-8a69</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e183-f183-4db7-83b5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0f39-204a-4217-b896</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_eee9-7bfd-4fea-a1bd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1594-0ccb-43e6-a0ea" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f81d-9435-4f11-99c1</comment></categoryLink>
+        <categoryLink id="923e-a209-4617-9c41" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9568-6142-4fdd-be3a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink><entryLink id="4a59-da44-7080-da44" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_005e-6607-4e2c-8dd2</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_7745-260c-4c36-b719</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_ba25-a4b2-4ba9-b023</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ddeb-f4c8-4091-9153</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4904-fd2f-429f-9cf7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_faea-b21b-43c5-b918</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6bb0-90ba-4237-be04" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_b24f-3ae0-4cbb-b016</comment></categoryLink>
+        <categoryLink id="08e2-3af5-4784-ad0c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fd26-8e6b-4521-92b9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink><entryLink id="e34c-4e68-da27-f688" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6ecb-28e2-43ed-a6a0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_c067-1118-4d96-b28b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_250e-23c0-4e43-bf74</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1553-a6e6-4291-853f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_aab6-797b-427a-9fd8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1b1d-ae25-4ab2-aaf7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c77f-0819-473b-a8a2</comment></categoryLink>
+        <categoryLink id="55f5-ff59-4f11-9fcc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_89fb-c924-4daf-923d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink><entryLink id="efe3-2793-c6f8-64be" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d72c-519a-451f-81b6</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_3d16-444c-42c9-aad1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_f4b2-6371-494b-863a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_797f-a84b-42f6-8e66</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0d78-fe38-4829-9b12</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="06e6-7a72-4868-ae2a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0397-c837-4fea-a527</comment></categoryLink>
+        <categoryLink id="7cca-b682-4c6f-a701" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_060b-bccb-4776-bd83</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink><entryLink id="9d87-38df-a9f6-e0bb" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3c84-6d74-4c42-b38d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_5b15-7aa4-4897-aaf1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_3326-31ed-4151-9b37</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6a0e-1b65-4057-ba5d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f8c7-abc9-45ec-955f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_2538-8dc5-446c-8344</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="41d5-b878-4f1a-8755" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_c1cf-cea4-4278-8f27</comment></categoryLink>
+        <categoryLink id="ba3f-a258-46d6-8f0a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5f51-2734-4a46-9f72</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink><entryLink id="3596-92a3-70fc-6b1f" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af71-f3ff-49b1-83e9</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_1c9e-b3bf-4e88-a43f</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_6d0d-1b1d-4065-89cf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d0b7-8686-491e-9d33</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_7db8-0874-487a-be6f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1034-29a0-44b1-a85f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b511-c07e-47ec-bb28" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_0c16-6841-42b2-b02d</comment></categoryLink>
+        <categoryLink id="048c-8fe1-4e30-947e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_602d-2d2d-4ff4-a82a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink><entryLink id="1933-c2cc-0886-f7e2" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_22bd-baae-45f9-b366</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_52bd-55de-4d53-ba55</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_df1b-7476-4ab8-8d2f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_49fa-0dcf-4a61-a5b1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0ea-1443-4993-86e7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2a8-3fbe-448c-9902</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a89b-f377-4a3c-b5e3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3632-0b5d-4622-ae33</comment></categoryLink>
+        <categoryLink id="9fdb-dd82-4897-8507" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_da44-7815-4fdd-981c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink><entryLink id="002d-a997-d2a0-cf6d" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2bfa-b203-47e2-a828</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a39b-8a3c-49cf-bf62</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2a05-07b3-49c5-8145</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f730-87fb-44bd-b68e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_2d0e-6c49-4493-a022</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2e2-50c1-40c3-b4dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="02c9-4761-4b98-a4cd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_5ad5-8701-42cd-b2b6</comment></categoryLink>
+        <categoryLink id="5767-9d0e-4815-85fc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_20a4-4346-4a3b-a7d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink><entryLink id="abc6-e8e1-4066-68e1" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_773a-1ea4-41a0-b766</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_9d4d-6fb8-4131-a5a3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e3bc-02f8-4ece-a5ea</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c371-76d9-4a4d-bc00</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b4c6-d4ba-4b2e-9b99</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d65a-0de1-45e8-97e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6ea9-a7e5-437d-9e35</comment></categoryLink>
+        <categoryLink id="1ba2-729b-4ec3-b914" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_3cec-f053-42ab-a6eb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink><entryLink id="cebd-8215-51aa-f6a2" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1e60-42ba-4c8b-9077</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9860-f593-425e-b89b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_c842-10e8-4509-8eda</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ea52-ff41-40f6-8cf3</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_51e6-c5e1-4003-96bc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="968a-6e1f-4aec-a4d8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4d7c-201f-4c99-b89a</comment></categoryLink>
+        <categoryLink id="57e7-71c7-4d10-86ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_10f9-4718-4e07-bb32</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink><entryLink id="5079-8467-4b74-5a1c" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3fbf-91e2-4620-a44c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4e52-ad1b-48d4-8eed</comment></categoryLink>
+        <categoryLink id="94f9-a70f-43df-bb67" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_6979-1ed3-4f1f-a025</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink><entryLink id="59f3-7771-84d0-8948" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry"><categoryLinks>
+        <categoryLink id="0993-0623-4fcf-aa21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6140-2404-46f9-bd42</comment></categoryLink>
+        <categoryLink id="c249-cd83-4389-a409" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_1c86-fad8-46ec-a0b0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink><entryLink id="2615-14fc-e1c3-032f" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4729-bc86-456b-b73d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_cf0f-e3f4-4fb4-989d</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1cc8-5611-4d9a-9218</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_2e32-ca02-48f0-a8dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="13e8-7122-4221-b315" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_0af1-d052-4bd7-aab6</comment></categoryLink>
+        <categoryLink id="7e7d-1007-47e6-95f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_45ce-e338-43c9-b63e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink><entryLink id="c289-0e8a-b032-1a0e" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4dce-8632-4f7c-813e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_8a71-3995-4155-ac33</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d206-f2ce-41b8-945a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan">
+                  <comment>    node_id_2e02-cf1c-4a71-861c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ec81-bd33-45a8-8550</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_3344-743c-45d3-b930</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ee85-ab1f-b425-2e48" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="b582-7a4b-38fc-578b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3cc4-870e-4655-9d2d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4272-9b9d-4c59-95f0</comment></categoryLink>
+        <categoryLink id="bde3-0e8e-4d78-8ef8" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_d85b-1ae7-40d5-9341</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
-    <entryLink id="1a8f-9850-89eb-d7ad" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a3d8-c9fd-6174-b118" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="5c34-a726-4adb-8777" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink><entryLink id="630f-14e1-14c5-1ae2" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry"><categoryLinks>
+        <categoryLink id="0098-9f2d-47ee-afd3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ff9f-01cb-41b9-800e</comment></categoryLink>
+        <categoryLink id="462a-6786-46c1-bb17" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_1315-6051-4a46-b070</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
-    <entryLink id="6aba-c558-f194-e782" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink><entryLink id="3524-ef12-bdd1-19c0" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry"><categoryLinks>
+        <categoryLink id="1d7d-9bc2-47a1-a654" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_b084-df23-4f99-812f</comment></categoryLink>
+        <categoryLink id="fddb-52bd-4823-a24c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_84fc-9304-4e9e-ab78</comment></categoryLink>
+        <categoryLink id="aff0-27eb-4df2-9cec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d06a-7939-4691-9aed</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="7255-1e04-4f3a-a56c" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup"><comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+        <entryLink id="f4e4-4b7f-4d9a-a42a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup"><comment>    template_id_741d-8c09-4211-ada6    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink><entryLink id="2ced-abe5-9c73-213b" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_54a4-6ec8-4c61-9c3e</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_f7fd-2d16-4603-a065</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2edc-b480-1a28-a405" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="ef1e-e2b2-f420-eacd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74e2-7282-4099-9d1a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_c0ac-4b8c-421c-a21b</comment></categoryLink>
+        <categoryLink id="2c2d-796d-457d-9605" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8db9-079e-4482-b200</comment></categoryLink>
+        <categoryLink id="25d8-0f3e-4741-8fc9" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_413c-9273-4308-b546</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
-    <entryLink id="764c-66f2-5272-cd99" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7260-967c-9552-04c0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="bd6c-21dd-9930-6294" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      <entryLinks>
+        <entryLink id="5f22-b8d5-489d-9c5e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup"><comment>    template_id_bbc4-33fc-4664-a18e    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="2322-1e01-4a7a-bc5d" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup"><comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink><entryLink id="b070-f292-bf0e-962d" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry"><categoryLinks>
+        <categoryLink id="2898-af70-475b-9199" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_4c8d-96f6-48f9-9590</comment></categoryLink>
+        <categoryLink id="5107-2e33-4ddd-b8d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_049c-0fa5-4575-8fa8</comment></categoryLink>
+        <categoryLink id="936b-27bf-4779-bda7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_7358-52d7-4aae-8e07</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
-    <entryLink id="dcff-a922-ec9f-0762" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+      <entryLinks>
+        <entryLink id="4e73-a2f4-4816-9678" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup"><comment>    template_id_4784-b370-444b-93ae    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="520e-19c7-4ef9-b73e" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup"><comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink><entryLink id="d03c-82e0-25a4-b0b0" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_3c03-a823-4466-9bd6</comment>
           <conditionGroups>
-            <conditionGroup type="and">
+            <conditionGroup type="or">
+              <comment>    node_id_8bbb-f95b-413f-b6f4</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_41b0-6b0a-482a-919e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e1f7-3cc6-4794-8b6d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2211-8554-fa12-729f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="a570-7a90-d7b6-73f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bab3-010a-4e14-9cd0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_05ce-cc31-40ad-9320</comment></categoryLink>
+        <categoryLink id="4483-218d-4eb3-9242" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f13c-f8e1-4a50-bfe3</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
-    <entryLink id="4e08-db14-2499-3405" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c116-21a1-7d9d-b98d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="9845-aca4-b259-fc4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
-    <entryLink id="a333-c071-34ec-5b04" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="739d-f2e6-95e9-a58f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d7ed-3f38-184a-f9fa" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
-        <categoryLink id="a85c-7f38-80bd-f9db" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
-    <entryLink id="f666-bb54-a364-fa48" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1dba-4764-c1c5-e952" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b1e3-0209-ed88-946a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
-    <entryLink id="8e78-637e-7185-c961" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink><entryLink id="57a1-2e7c-ea7a-5e10" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_db78-4d49-42ab-954a</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_f14d-9943-47b6-866c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a95-938f-4a07-9727</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_7775-78e1-44cc-87c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cf8d-5f5a-44cf-9ee7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_b822-3417-4613-be37</comment></categoryLink>
+        <categoryLink id="0142-e23c-47c9-9549" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_25db-b03f-4881-b310</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink><entryLink id="b0af-6f67-6ff2-db71" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d352-2095-4201-90ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_75a7-dc06-445b-b2dc</comment></categoryLink>
+        <categoryLink id="e58b-b2dc-456c-93fd" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_e21a-c03b-4885-ac46</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink><entryLink id="916f-70e6-d2d1-caaa" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9a08-5fe6-4010-bbc3</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_72cf-cfce-4e02-b379</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3bf8-f40b-a517-f72b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="b244-00bc-1a32-581d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8a14-97b4-42a6-89b7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_f55b-7555-444b-beee</comment></categoryLink>
+        <categoryLink id="b87f-5474-4902-baea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3386-c9ad-4d74-9474</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
-    <entryLink id="5980-4afe-fe25-4687" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3b8e-c92f-dcca-d33b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d698-5c0f-4ee6-b3f7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
-    <entryLink id="b6d1-068e-7afa-6204" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink><entryLink id="b4b5-8ef8-904c-2768" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_a0f6-9606-4b75-a2f8</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_94b3-1331-474b-885b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
-      <infoLinks>
-        <infoLink id="c06e-df8f-83fe-158d" name="Legiones Astartes (Emperor's Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule" />
-      </infoLinks>
       <categoryLinks>
-        <categoryLink id="77d3-cc99-0a9a-f5c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ed4a-30c1-c4d7-221b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="3cc6-466a-470d-b6b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_79fa-3370-4ae0-9e12</comment></categoryLink>
+        <categoryLink id="214a-b294-4985-9231" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bb53-4e65-4fb6-9dd7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
-    <entryLink id="7cde-45f7-46fc-321c" name="Phoenix Terminator Squad" hidden="false" collective="false" import="false" targetId="5b08-65c1-cc45-1b91" type="selectionEntry">
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink><entryLink id="67ae-69c3-b933-a825" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f8cc-833a-4ac1-bf89</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+              <comment>    node_id_5988-c012-4dad-9a66</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="985b-5024-423a-b3ba" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_8d82-3279-4481-84bb</comment></categoryLink>
+        <categoryLink id="e9c7-23cd-43d6-9339" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e25c-925e-4b96-8bb3</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink><entryLink id="c353-7d50-a146-8f63" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6b73-b21c-4e2b-9d14</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_a7fe-cc62-4a6f-a781</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5be1-1937-4964-a455</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_da1d-b2bc-4117-82a4</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b922-036a-43bc-b014" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7010-be56-4709-b058</comment></categoryLink>
+        <categoryLink id="8f51-ece7-4f66-b2bf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7379-a740-47ba-a054</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink><entryLink id="1314-96d9-9d30-b56c" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_dd34-83cf-47d7-b557</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_be88-afef-49b3-bd1e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="164d-e57f-4355-9bce" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_944f-7420-4982-8ea9</comment></categoryLink>
+        <categoryLink id="0318-cead-4713-ad15" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ea80-0efe-457d-a450</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink><entryLink id="f794-e1c0-34d6-d71a" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><categoryLinks>
+        <categoryLink id="2886-9fa8-4e45-b9cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9a36-f261-43cc-9bd1</comment></categoryLink>
+        <categoryLink id="bb98-986b-438f-b1bd" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a648-8396-442a-af59</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink><entryLink id="28af-78d9-69f9-8b87" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_cb81-0303-4b88-ae53</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9648-31e3-43aa-8cf3</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_0507-da81-4023-bfcf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0e84-54ff-488d-b066</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ccd9-e335-40e9-8a0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6ff-0977-4c92-bb28</comment></categoryLink>
+        <categoryLink id="fb8b-3788-4a73-a328" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f555-7d39-458f-84c9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink><entryLink id="4f12-7a28-7980-97e4" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8203-5b00-497b-b939</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_40ee-3e71-4978-b1e4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f6a8-f660-46dc-b3c5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_d988-3af6-48bf-b0a8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2d26-1ea9-4f1f-8a8b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_39e5-eda5-45d1-a643</comment></categoryLink>
+        <categoryLink id="9bf8-77a2-4d25-8d3a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_6416-21bb-4df4-9de8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink><entryLink id="adec-a47a-130f-8214" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b03e-5d91-4be3-8adc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_0443-29c0-46e9-ad1d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f2c9-7356-4c27-a22f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0e9-4a9e-4b2b-a9d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e1ca-3b7b-40db-bb16" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5528-2dac-4be5-900c</comment></categoryLink>
+        <categoryLink id="a2b4-6ff6-4813-afb7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_dc8f-d888-4585-991d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink><entryLink id="3194-1cd7-f371-ca9a" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1d3c-8e17-489f-9002</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5725-8bee-4bcc-878d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_be47-0d6f-49f2-9f4b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_863c-f3a4-4802-b80c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d87e-874f-4f4d-8f4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_899e-b052-4d5b-8c18</comment></categoryLink>
+        <categoryLink id="4a3a-5434-435a-829f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f5e9-cff6-41d2-a016</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink><entryLink id="0489-a3c0-88a0-ba18" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_72da-1513-4e02-b595</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7a48-a3b0-4a26-849b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e232-25f3-4cb7-8ab2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_9aa4-5660-4697-8ab2</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="233e-c2c7-4f39-a0a1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_09cd-2176-40af-bba6</comment></categoryLink>
+        <categoryLink id="b3b7-dca8-45d3-af56" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_05e6-7c63-4a35-9ba0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink><entryLink id="23f8-712f-e735-1a30" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry"><categoryLinks>
+        <categoryLink id="1f3a-8276-49e7-956b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0dfa-4004-4751-8022</comment></categoryLink>
+        <categoryLink id="0f3a-764d-429c-9ab3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a669-0f5d-4fd3-811b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink><entryLink id="1019-efcf-1548-2a00" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_09b5-4e3b-4c84-a574</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_32e5-ebba-41fb-9ff2</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_838e-0ccf-4d3a-aabd</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_dfef-0ec2-49fb-a534</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fb36-4123-4113-a476" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4f60-472b-45a9-ab9e</comment></categoryLink>
+        <categoryLink id="7787-c869-479e-bc35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e2e3-af36-45a6-a955</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink><entryLink id="6488-1f35-b482-fc83" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_936f-1ef7-472e-840e</comment>
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+              <comment>    node_id_d73d-d52e-4c75-8ac0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0e64-f0ab-40a4-b6fa" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_7a55-ecb4-4e5d-b955</comment></categoryLink>
+        <categoryLink id="dd28-14f9-4e79-9a49" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f28c-710e-4ff8-9810</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink><entryLink id="7e61-c663-30d1-9acb" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_a743-0cc2-45ae-a7eb</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2721-e88d-41f7-bedc</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_e10f-1390-4b33-8fcc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="907a-922d-4390-ac2e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2008-f1c4-4285-a14f</comment></categoryLink>
+        <categoryLink id="4a1d-1568-4472-a4cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e88b-a95a-4647-af3b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink><entryLink id="3e94-aa5e-e44b-1dc1" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_25d8-330b-4574-b515</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7836-6878-47a8-8827</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_5ea9-46dd-4a11-9410</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_ab5d-961b-4924-a705</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b2f0-5ef0-431b-8fd1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9189-836c-475d-a52e</comment></categoryLink>
+        <categoryLink id="3d86-713b-455b-95e0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_e1fa-b7d8-47b0-a88a</comment></categoryLink>
+        <categoryLink id="b09b-5538-4245-bc72" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_a137-e3c0-4d63-a48c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink><entryLink id="8b4a-cd3f-042a-c06c" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry"><categoryLinks>
+        <categoryLink id="4a1a-042b-4489-8f1c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b1d5-fd75-4f17-bbf4</comment></categoryLink>
+        <categoryLink id="d33a-f6e1-46a7-93a0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_f221-bf81-4045-849b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink><entryLink id="6760-ab00-bae3-2a6d" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_b743-7a00-43e4-beb8</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d12f-2c98-4e62-a716</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d4d7-ba67-47aa-962f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+                  <comment>    node_id_1637-edee-457a-bb0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2c6e-4f02-4d86-a16d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_f203-bc26-421f-b79e</comment></categoryLink>
+        <categoryLink id="a269-e6d1-4837-93cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_a53e-59d9-4ac2-a21f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink><entryLink id="0390-6e73-f86a-134a" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry"><categoryLinks>
+        <categoryLink id="21cb-5c96-413a-bd4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_51af-a137-4a1c-97a4</comment></categoryLink>
+        <categoryLink id="49ac-acf3-4e78-a1ce" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ec1f-c326-40a8-9d1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink><entryLink id="87e1-003b-3176-7728" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_c111-feb0-4012-98cd</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_63d7-8427-431d-9ae6</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b79-d43e-409c-91bd" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_e707-fde1-457f-91c4</comment></categoryLink>
+        <categoryLink id="27c5-25a9-4edb-a54e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ec67-8573-4460-89db</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink><entryLink id="6fe0-700b-7bdf-802b" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3348-16e4-4a9a-a549</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_bea4-c4a8-4843-b9fe</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2970-17ff-4be1-91e5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_503a-46e7-40e7-bd07</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_4555-15e1-43ff-80a0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7dd8-d485-4732-a9e6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_fce3-801c-49c8-85d4</comment></categoryLink>
+        <categoryLink id="7957-dfb2-4a11-9799" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0c2d-2349-44b6-9831</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink><entryLink id="1a8f-9850-89eb-d7ad" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry"><categoryLinks>
+        <categoryLink id="3806-ddf2-4d4d-843e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ac1c-b3bf-4011-918a</comment></categoryLink>
+        <categoryLink id="a4b7-7402-4624-8383" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_589c-1d0e-4b7d-be6b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink><entryLink id="6aba-c558-f194-e782" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2f46-a0b6-48a5-a0ee</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_636f-0f8a-43f1-910b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c883-39c8-4a74-aeaa</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_0796-e467-4438-89b3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3677-2167-4bc2-8eb8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_5a04-9847-4c91-a49a</comment></categoryLink>
+        <categoryLink id="255f-d4eb-4a4d-a673" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b4b4-daeb-483c-a306</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink><entryLink id="764c-66f2-5272-cd99" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6087-a5e5-4d3c-9ebd</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c7e1-5f42-4528-bf07</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1950-08dc-4544-ab01</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_daf3-31ed-42c0-85dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="22f1-5faa-4bc1-a32b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_7d4f-547c-43ed-a520</comment></categoryLink>
+        <categoryLink id="8571-12b0-4a8c-bd32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f04e-04e8-4891-9b1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink><entryLink id="dcff-a922-ec9f-0762" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_dfdc-f6f6-49d2-a7b3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_354c-c71f-472f-b268</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1127-c974-4663-874d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_0843-bef2-4767-8307</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="27d4-ad63-4f46-866b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_28e0-91e7-4ada-9fac</comment></categoryLink>
+        <categoryLink id="ffab-1f3f-4133-bd72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4448-a712-4dd7-bf6d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink><entryLink id="4e08-db14-2499-3405" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d512-fd07-4a29-863a</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_55c6-a35f-485a-9f0d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d89e-cf1f-4ceb-b3de</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e2c9-0d01-403c-900e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_a7b8-c835-4cb2-b3d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="548e-c8b6-4c2a-a2ad" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_e22a-c5f8-4825-a45f</comment></categoryLink>
+        <categoryLink id="7bb0-69d8-4021-8c1b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03fc-6a7f-45a5-bcb8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink><entryLink id="a333-c071-34ec-5b04" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d237-bb45-4543-b164" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0aff-4f6e-4b03-a23c</comment></categoryLink>
+        <categoryLink id="a4b4-ef72-49c5-9728" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"><comment>    template_id_7d5a-62e7-43ee-b79b</comment></categoryLink>
+        <categoryLink id="8d83-a3f7-4348-8756" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_4986-9157-49f2-b670</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink><entryLink id="f666-bb54-a364-fa48" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_319e-90d4-44a3-8e83</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_28db-d943-4099-9abd</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1a45-a592-49df-9465</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb31-d0b2-4677-928e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8b62-3e98-48ce-aed7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1b86-0977-4a8b-adac</comment></categoryLink>
+        <categoryLink id="1993-aa80-411d-80de" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_b449-403a-4e42-9239</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink><entryLink id="8e78-637e-7185-c961" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafa-470f-4c2c-8be3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_e2ba-a855-4de2-9f46</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_0171-b30d-44ee-9389</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fdfb-119b-4774-934a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_3891-9a00-4f8f-b95f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ee6b-3460-4e87-acc4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e5df-17d4-4521-9d5b</comment></categoryLink>
+        <categoryLink id="76c3-f685-4953-ab14" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"><comment>    template_id_0ecd-4873-4d3a-b28b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink><entryLink id="5980-4afe-fe25-4687" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_fbfa-8d78-4d6d-8a05</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_21f2-0916-46bf-b75a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_4fbd-633b-4dd6-9fdd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e277-2875-4830-b55e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4f71-446f-4cff-afda</comment></categoryLink>
+        <categoryLink id="403d-07a6-4621-8a21" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_3f44-8647-43a4-ac22</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink><entryLink id="b6d1-068e-7afa-6204" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af15-2c71-4f8b-833e</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_d95a-80b9-4463-af55</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="eaf3-e9b0-4e2f-8704" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6b1-886e-4194-8bcd</comment></categoryLink>
+        <categoryLink id="d578-6cb2-43a3-92c5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_51b5-f9c1-4587-8fc7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink><entryLink id="7cde-45f7-46fc-321c" name="Phoenix Terminator Squad" hidden="false" collective="false" import="false" targetId="5b08-65c1-cc45-1b91" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="dc9b-e4a9-c20f-6787" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="eb86-4e25-643a-c52b" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
@@ -1090,8 +1819,296 @@
         <categoryLink id="d6f0-6dea-78dc-5e07" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-  </entryLinks>
-  <sharedSelectionEntries>
+  <entryLink id="3c79-b4cc-4c75-9119" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ada1-1e18-4cbc-9598</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b1d1-ac44-47dd-9159</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5d64-f00c-4464-891b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25f0-f825-4a83-8f0d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_64b1-9e36-44da-b36a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d53e-113f-4a40-a3d5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="1939-76b5-4279-9f8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
+    <entryLink id="3142-d3a4-41f7-9859" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
+    <entryLink id="9b4c-6496-4fa7-a114" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
+    <entryLink id="670f-0e9e-4181-b489" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
+    <entryLink id="d25d-427d-46e2-910a" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <entryLink id="3edc-ede4-4324-962c" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3531-57d1-4081-882d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_f233-2361-4177-8ba7</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b932-667a-4b43-8331</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <entryLink id="3900-cef4-41bd-92e1" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <entryLink id="c29d-7214-4fe0-9a09" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3129-6f59-4365-906b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2bcb-0af1-4aea-9191" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <entryLink id="6e18-86b2-4fb9-97c7" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ede2-d453-4e34-8cda</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2907-3215-4b01-96ff</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_c90c-959f-40fb-a4cb</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ba2d-50ad-45f1-91c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0e88-485e-43c2-8bef" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <entryLink id="efae-a0dd-4e37-b474" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_409c-0a5d-4ef8-a871</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7078-c1c7-4af2-b43d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_9a69-0fdc-4957-8982</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1a4c-69b5-4219-8502" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fba0-3ea7-4eaf-b33a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <entryLink id="95be-e3dd-4a63-99e9" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
+    <entryLink id="35a3-9ce1-4896-94f0" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
+    <entryLink id="d5b8-dd69-4537-abc2" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
+    <entryLink id="71e7-3330-4605-bae7" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+  </entryLinks><sharedSelectionEntries>
     <selectionEntry id="0de5-8b3c-74a0-858e" name="Fulgrim" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b7bb-0fb5-04bc-feb5" type="max" />

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -350,7 +350,7 @@
         <categoryLink id="6884-c61a-1ab7-8692" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="1a3c-5073-4c14-9817" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
     <entryLink id="99df-a04f-4d15-5a7e" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="fd0b-4621-f89d-45d8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
@@ -772,7 +772,7 @@
         <categoryLink id="c050-a744-cc4f-3735" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="7c32-6c97-a0b8-7e82" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
     <entryLink id="916f-70e6-d2d1-caaa" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
@@ -853,7 +853,7 @@
         <categoryLink id="93e6-2990-b830-1499" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="789c-808f-4b13-7144" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
     <entryLink id="0489-a3c0-88a0-ba18" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ef2b-443f-9b90-3db7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -865,7 +865,7 @@
         <categoryLink id="9879-d1be-1c43-9ad1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="b446-b96e-54f8-5ce8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
     <entryLink id="1019-efcf-1548-2a00" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e6d0-e337-9c95-5aaf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -947,7 +947,7 @@
         <categoryLink id="3866-5ed0-de9b-9fe6" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="5e61-a899-1b61-6d4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
     <entryLink id="6fe0-700b-7bdf-802b" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -975,7 +975,7 @@
         <categoryLink id="a3d8-c9fd-6174-b118" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="5c34-a726-4adb-8777" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
     <entryLink id="6aba-c558-f194-e782" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -1025,7 +1025,7 @@
         <categoryLink id="d7ed-3f38-184a-f9fa" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
         <categoryLink id="a85c-7f38-80bd-f9db" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
     <entryLink id="f666-bb54-a364-fa48" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1dba-4764-c1c5-e952" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -2983,7 +2983,7 @@ Captain Lucius is engaged in a Challenge all friendly models in the same combat 
         <entryLink id="5fb0-8333-47d9-b44a" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
         <entryLink id="37e9-0d20-1935-e0ec" name="Phoenix Terminator Squad" hidden="false" collective="false" import="true" targetId="5b08-65c1-cc45-1b91" type="selectionEntry" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_be38-a066-4f8e-ae54</comment></selectionEntryGroup>
     <selectionEntryGroup id="0cb4-896e-a455-243b" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="2eea-3d53-05e7-90cd" value="1.0">
@@ -3085,7 +3085,7 @@ A Warlord with this Trait and all models in a unit the Warlord has joined that h
       <entryLinks>
         <entryLink id="3171-5c8a-52a0-550e" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_7dee-602c-4b47-be09</comment></selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
     <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -1,54 +1,53 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="72ba-61c2-37ad-c785" name="LA -   III: Emperor&apos;s Children" revision="12" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="29" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="72ba-61c2-37ad-c785" name="LA -   III: Emperor's Children" revision="12" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="29">
   <entryLinks>
-    <entryLink id="b36e-8c73-fe83-f087" name="   III: Emperor&apos;s Children" hidden="false" collective="false" import="false" targetId="3edc-a1b9-6dc6-b1ea" type="selectionEntry">
+    <entryLink id="b36e-8c73-fe83-f087" name="   III: Emperor's Children" hidden="false" collective="false" import="false" targetId="3edc-a1b9-6dc6-b1ea" type="selectionEntry">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb97-3eea-07d6-0aed" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2fd-9199-56bc-916b" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb97-3eea-07d6-0aed" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2fd-9199-56bc-916b" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="81e6-96ee-9e60-32fa" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="81e6-96ee-9e60-32fa" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="a119-3943-4b8b-b651" name="Captain Lucius" hidden="true" collective="false" import="false" targetId="0707-1e4b-27da-9cd4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8198-4bd3-2445-7a2b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="9304-b442-49fe-fa71" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="1574-a84f-21ef-30ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8198-4bd3-2445-7a2b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="9304-b442-49fe-fa71" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="1574-a84f-21ef-30ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="31b0-fad0-cbb6-491d" name="Captain Saul Tarvitz" hidden="true" collective="false" import="false" targetId="a91c-719f-4abf-1598" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ae2e-66fe-3c38-c0c2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="c295-161b-a153-5e23" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="c818-c8fe-e1d4-843d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ae2e-66fe-3c38-c0c2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c295-161b-a153-5e23" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="c818-c8fe-e1d4-843d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="d159-e0c0-f0a4-c8c9" name="Fulgrim" hidden="true" collective="false" import="false" targetId="0de5-8b3c-74a0-858e" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d1b1-8747-b31c-93ba" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
-        <categoryLink id="d25a-accf-b6de-facb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d1b1-8747-b31c-93ba" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true" />
+        <categoryLink id="d25a-accf-b6de-facb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="3e78-22f5-fc51-3a6e" name="Kakophoni Squad" hidden="true" collective="false" import="false" targetId="8359-c463-9cde-4f21" type="selectionEntry">
@@ -57,46 +56,46 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="76ab-3f7a-43b7-7b98" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="89c1-4a2a-ad42-8b4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="76ab-3f7a-43b7-7b98" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="89c1-4a2a-ad42-8b4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="ec64-4532-a15d-ad6b" name="Lord Commander Eidolon" hidden="true" collective="false" import="false" targetId="ac90-d090-9a21-60c4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d7b4-0c11-69c4-0790" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="dafb-5fbd-1def-b788" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="92b5-0c2e-6efd-c525" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d7b4-0c11-69c4-0790" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="dafb-5fbd-1def-b788" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="92b5-0c2e-6efd-c525" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="b704-91be-c88e-763e" name="Palatine Blade Squad" hidden="false" collective="false" import="false" targetId="fa86-f7a5-0062-a205" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8bd4-b59d-9966-f4a9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="1e32-b5d5-15b6-759c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8bd4-b59d-9966-f4a9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="1e32-b5d5-15b6-759c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="d901-03b2-b27a-d793" name="Phoenix Terminator Squad" hidden="false" collective="false" import="false" targetId="5b08-65c1-cc45-1b91" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0f06-08b1-9de3-dac5" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="1823-c289-362f-ce97" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0f06-08b1-9de3-dac5" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="1823-c289-362f-ce97" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="9e33-b30a-861d-c0f8" name="Rylanor the Unyielding" hidden="true" collective="false" import="false" targetId="281b-1950-5c15-de68" type="selectionEntry">
@@ -105,973 +104,973 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f813-02a8-90f1-a6fe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="3a40-1d8f-dc1d-d52b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f813-02a8-90f1-a6fe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="3a40-1d8f-dc1d-d52b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="abb4-2af9-15c8-2c3d" name="Sun Killer Squad" hidden="true" collective="false" import="false" targetId="cce2-fd03-ac17-88e4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2a6f-aeba-536a-ffb8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="806c-e31c-d83d-3c70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2a6f-aeba-536a-ffb8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="806c-e31c-d83d-3c70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="ecec-6831-34d9-b21b" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ef81-793b-e735-16c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="285f-334a-ad39-dcb2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="ef81-793b-e735-16c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="285f-334a-ad39-dcb2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
     <entryLink id="12c2-c644-0a3b-8912" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2156-43cd-491c-4d48" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="906a-1e2f-1a4f-7ed4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="2156-43cd-491c-4d48" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="906a-1e2f-1a4f-7ed4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
     <entryLink id="bc27-da9a-8975-4051" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e265-dc69-cf9e-dfd1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="a097-5047-4d84-c63c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ace9-ab50-850d-0e7c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="e265-dc69-cf9e-dfd1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="a097-5047-4d84-c63c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ace9-ab50-850d-0e7c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="5665-bf93-acdc-1f4c" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9ebc-db59-ca20-286a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="21ef-bee6-9654-b960" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9ebc-db59-ca20-286a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="21ef-bee6-9654-b960" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
     <entryLink id="201b-dc33-b6a9-edff" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a369-b028-93d3-eb98" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="cf5e-6ae2-11e7-6095" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a369-b028-93d3-eb98" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="cf5e-6ae2-11e7-6095" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
     <entryLink id="df1d-3151-9c34-afe5" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e909-39c8-2194-b6c4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="f4a3-a75b-4b04-f430" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4a91-2a23-ab6b-f2ed" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="e909-39c8-2194-b6c4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="f4a3-a75b-4b04-f430" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4a91-2a23-ab6b-f2ed" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
     <entryLink id="8c16-7bee-f0a4-9cc2" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0c3f-e9af-478a-c2d6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="391a-d304-0901-60b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0c3f-e9af-478a-c2d6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="391a-d304-0901-60b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
     <entryLink id="9d88-65f7-6a42-b710" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1136-6bae-1e96-b9cc" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="3b27-7d3c-88a6-a809" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1136-6bae-1e96-b9cc" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="3b27-7d3c-88a6-a809" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
     <entryLink id="3862-7519-db07-7636" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2412-a539-157c-c6c1" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="4cca-f2e2-44a5-e746" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fc2c-daf1-8e8c-db02" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="2412-a539-157c-c6c1" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="4cca-f2e2-44a5-e746" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="fc2c-daf1-8e8c-db02" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="6630-6ef3-a443-b62b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup"/>
+        <entryLink id="6630-6ef3-a443-b62b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup" />
         <entryLink id="6bfc-d444-1fbd-5b93" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
     <entryLink id="06e0-e2f5-0e4d-3189" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9300-a869-15e6-df14" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1746-968c-4d71-b3c7" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="fd1e-007e-250a-6e27" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="9300-a869-15e6-df14" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1746-968c-4d71-b3c7" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="fd1e-007e-250a-6e27" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="e709-3e87-d4d0-607b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup"/>
+        <entryLink id="e709-3e87-d4d0-607b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup" />
         <entryLink id="a7d2-892b-1495-3b47" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
     <entryLink id="4838-9716-e041-d3d4" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6eeb-cc3d-020a-27ef" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c5d-ff0d-4c45-c147" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="8fed-486d-c112-412c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="6eeb-cc3d-020a-27ef" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2c5d-ff0d-4c45-c147" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="8fed-486d-c112-412c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="4c60-51aa-7ba1-f63a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup"/>
+        <entryLink id="4c60-51aa-7ba1-f63a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup" />
         <entryLink id="ef10-cfb8-a3de-e69c" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
     <entryLink id="314a-6609-e3d9-e76b" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0df4-bd27-c6f4-f60d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c012-5e94-8f5c-d90e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0df4-bd27-c6f4-f60d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="c012-5e94-8f5c-d90e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
     <entryLink id="c8dc-8233-18d7-0b6e" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c6c2-2b7e-8939-6b3d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7486-84ef-9385-893b" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="c6c2-2b7e-8939-6b3d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7486-84ef-9385-893b" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
     <entryLink id="8d5d-ed86-9d48-de73" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3417-3927-99f9-f950" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="176d-4a27-f6e5-9dab" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="3417-3927-99f9-f950" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="176d-4a27-f6e5-9dab" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
     <entryLink id="0b7d-e2ff-4475-489c" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f2e6-d9bf-0368-baac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2d3e-32d1-fc8d-d5a6" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="f2e6-d9bf-0368-baac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2d3e-32d1-fc8d-d5a6" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
     <entryLink id="3625-2600-c8d5-3980" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6884-c61a-1ab7-8692" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a3c-5073-4c14-9817" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6884-c61a-1ab7-8692" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a3c-5073-4c14-9817" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
     <entryLink id="99df-a04f-4d15-5a7e" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fd0b-4621-f89d-45d8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="9620-d2d4-92c5-d07c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fd0b-4621-f89d-45d8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="9620-d2d4-92c5-d07c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
     <entryLink id="bf3f-371b-357e-fe0f" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b421-52fe-eae9-c778" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="6d11-28dd-b5d0-ffb0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b421-52fe-eae9-c778" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="6d11-28dd-b5d0-ffb0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="c5e5-5a6a-7520-11fc" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4265-6026-884e-ccda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3a73-cdac-9e0b-806f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="4265-6026-884e-ccda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3a73-cdac-9e0b-806f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
     <entryLink id="5ea2-d146-b89a-1217" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1b95-ff6c-67b0-c7ad" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="c262-93f6-ca05-c025" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="66bb-9dfe-937a-e17c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="1b95-ff6c-67b0-c7ad" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="c262-93f6-ca05-c025" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="66bb-9dfe-937a-e17c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="bcb4-7834-f574-96e8" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9050-a0f4-60c4-02f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a473-929d-10d7-5127" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="9050-a0f4-60c4-02f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a473-929d-10d7-5127" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="4dc9-f18b-b18b-f6d3" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2d13-ffdb-29f7-e4a7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="9a18-8c66-d7de-ad37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2d13-ffdb-29f7-e4a7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="9a18-8c66-d7de-ad37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
     <entryLink id="62a4-c5e2-9494-6380" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2fac-3433-337f-4d72" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="d6f6-a4ff-3034-b9ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2fac-3433-337f-4d72" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="d6f6-a4ff-3034-b9ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
     <entryLink id="5cee-0919-6a27-0ccf" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="222d-9743-0408-bb10" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="29f5-d0f2-8a8a-0fe3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="222d-9743-0408-bb10" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="29f5-d0f2-8a8a-0fe3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
     <entryLink id="05f1-c29f-3faf-0409" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="44a5-670e-0902-1e0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a254-25c1-de02-297a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="44a5-670e-0902-1e0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a254-25c1-de02-297a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
     <entryLink id="c956-e907-5831-6800" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0137-4a40-f60d-2eea" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="800f-0df2-6922-604b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0137-4a40-f60d-2eea" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="800f-0df2-6922-604b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
     <entryLink id="b5a8-92bf-83fe-fb3c" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f0b1-e8fd-f025-8394" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="07aa-5b8b-cf91-d04f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="f0b1-e8fd-f025-8394" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="07aa-5b8b-cf91-d04f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
     <entryLink id="d421-82ca-76cd-d9ad" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0034-d4cb-5590-e831" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="fcc7-b449-7121-bd7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0034-d4cb-5590-e831" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="fcc7-b449-7121-bd7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
     <entryLink id="ba87-1175-ffaa-aba9" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3cb8-bac5-8489-f87a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="230f-ac88-2d92-9ccb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3cb8-bac5-8489-f87a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="230f-ac88-2d92-9ccb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="6c22-a2ef-6eb2-3f48" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8bf5-3ec3-e641-d8eb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="5ecd-78c4-475a-7b3f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8bf5-3ec3-e641-d8eb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="5ecd-78c4-475a-7b3f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
     <entryLink id="df27-654e-5a7d-4163" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fb94-593e-764a-2e01" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="9de7-fcf4-240f-0ff5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fb94-593e-764a-2e01" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="9de7-fcf4-240f-0ff5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
     <entryLink id="5503-5a35-dd0c-057f" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0e42-40e2-f73d-b8b2" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="969a-bbe2-620d-67f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0e42-40e2-f73d-b8b2" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="969a-bbe2-620d-67f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
     <entryLink id="eee7-af09-ce7c-80a5" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d662-fedf-4138-58cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ca4d-ef9c-f265-1dcb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="d662-fedf-4138-58cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ca4d-ef9c-f265-1dcb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
     <entryLink id="5ebb-48a6-444b-9865" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8a23-8042-a268-09f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d0a5-f7dd-4b67-4a3b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="8a23-8042-a268-09f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d0a5-f7dd-4b67-4a3b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
     <entryLink id="3c67-8ef9-8cc9-efa9" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="92f0-68f1-5c99-bdf0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="fdd2-07fd-90c5-c24f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="92f0-68f1-5c99-bdf0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="fdd2-07fd-90c5-c24f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
     <entryLink id="5efd-b2d6-c765-311b" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8cb5-b39f-f07c-774b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="4f51-ed25-7d81-08de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8cb5-b39f-f07c-774b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="4f51-ed25-7d81-08de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
     <entryLink id="4a59-da44-7080-da44" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4664-d65c-78a9-cc1b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="abf6-43db-c130-3569" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4664-d65c-78a9-cc1b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="abf6-43db-c130-3569" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
     <entryLink id="e34c-4e68-da27-f688" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5708-8290-b73b-b213" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="6068-c48e-19f2-d9ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5708-8290-b73b-b213" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="6068-c48e-19f2-d9ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
     <entryLink id="efe3-2793-c6f8-64be" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e783-726f-59ca-adb0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="044f-ba25-ae60-1bf0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e783-726f-59ca-adb0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="044f-ba25-ae60-1bf0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
     <entryLink id="9d87-38df-a9f6-e0bb" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bb49-12a1-1479-dde0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="26de-308d-01f5-22e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bb49-12a1-1479-dde0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="26de-308d-01f5-22e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
     <entryLink id="3596-92a3-70fc-6b1f" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8805-361f-9647-e6d4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="bc51-0762-b627-0d4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8805-361f-9647-e6d4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="bc51-0762-b627-0d4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
     <entryLink id="1933-c2cc-0886-f7e2" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="37c3-a142-92f4-1170" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="3c1c-b046-f211-4c53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="37c3-a142-92f4-1170" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="3c1c-b046-f211-4c53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
     <entryLink id="002d-a997-d2a0-cf6d" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9890-d166-91b2-8bed" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="0799-5eb4-c25a-5a2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9890-d166-91b2-8bed" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="0799-5eb4-c25a-5a2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
     <entryLink id="abc6-e8e1-4066-68e1" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="427b-6cec-4837-2b2a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e4b9-e529-4498-d23c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="427b-6cec-4837-2b2a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e4b9-e529-4498-d23c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
     <entryLink id="cebd-8215-51aa-f6a2" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8f51-adaf-bf3f-4e0e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="7906-9273-349e-89ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8f51-adaf-bf3f-4e0e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="7906-9273-349e-89ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
     <entryLink id="5079-8467-4b74-5a1c" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7868-8b04-94ef-2461" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="0ba1-8d30-54d6-3cb1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7868-8b04-94ef-2461" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="0ba1-8d30-54d6-3cb1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
     <entryLink id="59f3-7771-84d0-8948" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1552-917e-7aad-0450" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bee0-1c1b-7917-d7c1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1552-917e-7aad-0450" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bee0-1c1b-7917-d7c1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="2615-14fc-e1c3-032f" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7b98-1b44-a37a-33dd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="3bbd-b9e9-70f2-a7f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7b98-1b44-a37a-33dd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="3bbd-b9e9-70f2-a7f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
     <entryLink id="c289-0e8a-b032-1a0e" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="82e5-dcc5-a590-7a1b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="f572-a27a-7f3f-1e17" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="82e5-dcc5-a590-7a1b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="f572-a27a-7f3f-1e17" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="630f-14e1-14c5-1ae2" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="bbbd-94c4-4a97-6d62" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="005b-9862-dbe9-7223" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="bbbd-94c4-4a97-6d62" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="005b-9862-dbe9-7223" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="3524-ef12-bdd1-19c0" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="efe8-bc8e-ad17-23cf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="f845-6b9b-b63a-16c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f56a-e824-7aec-617c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="efe8-bc8e-ad17-23cf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="f845-6b9b-b63a-16c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f56a-e824-7aec-617c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="6822-03c3-ac10-8fd0" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup"/>
-        <entryLink id="f3aa-e76a-f630-a79f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup"/>
+        <entryLink id="6822-03c3-ac10-8fd0" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup" />
+        <entryLink id="f3aa-e76a-f630-a79f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
     <entryLink id="2ced-abe5-9c73-213b" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0509-7ccc-64b8-0d46" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="7a26-cd56-8af0-7d6b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="70a5-13ef-aaa0-ec5c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="0509-7ccc-64b8-0d46" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="7a26-cd56-8af0-7d6b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="70a5-13ef-aaa0-ec5c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="b62e-86f9-6448-d4ad" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup"/>
-        <entryLink id="8b8e-65f0-7cf0-ef7b" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup"/>
+        <entryLink id="b62e-86f9-6448-d4ad" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup" />
+        <entryLink id="8b8e-65f0-7cf0-ef7b" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
     <entryLink id="b070-f292-bf0e-962d" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1bf6-ea75-1f72-58c8" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="109f-8bb3-248e-0c03" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cf42-7e43-c438-7b58" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="1bf6-ea75-1f72-58c8" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="109f-8bb3-248e-0c03" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cf42-7e43-c438-7b58" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="b336-b028-c4c3-7f6e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup"/>
-        <entryLink id="c4b9-582e-7d51-9446" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup"/>
+        <entryLink id="b336-b028-c4c3-7f6e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="0cb4-896e-a455-243b" type="selectionEntryGroup" />
+        <entryLink id="c4b9-582e-7d51-9446" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
     <entryLink id="d03c-82e0-25a4-b0b0" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4494-2f6c-f7b8-97b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="047e-f5df-4bf3-4112" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="4494-2f6c-f7b8-97b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="047e-f5df-4bf3-4112" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="57a1-2e7c-ea7a-5e10" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6d1f-d08d-a926-6c22" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="d4d9-204e-d603-86fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6d1f-d08d-a926-6c22" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="d4d9-204e-d603-86fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
     <entryLink id="b0af-6f67-6ff2-db71" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c050-a744-cc4f-3735" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7c32-6c97-a0b8-7e82" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="c050-a744-cc4f-3735" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7c32-6c97-a0b8-7e82" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="916f-70e6-d2d1-caaa" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a00e-dd17-2f20-4fd1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="cc9f-7e37-626e-aeda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a00e-dd17-2f20-4fd1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="cc9f-7e37-626e-aeda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
     <entryLink id="b4b5-8ef8-904c-2768" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9869-1c47-5445-e654" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="0981-4cd0-3389-f45b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9869-1c47-5445-e654" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0981-4cd0-3389-f45b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
     <entryLink id="67ae-69c3-b933-a825" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a0a8-c5d7-01a7-e388" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="96f5-55a5-186d-4f3e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a0a8-c5d7-01a7-e388" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="96f5-55a5-186d-4f3e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
     <entryLink id="c353-7d50-a146-8f63" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e702-ba2f-1797-774a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4928-0f27-e8d0-51d0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="e702-ba2f-1797-774a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4928-0f27-e8d0-51d0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
     <entryLink id="1314-96d9-9d30-b56c" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="06d9-2af2-98f7-362c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="5da1-72e3-144b-d4e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="06d9-2af2-98f7-362c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="5da1-72e3-144b-d4e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
     <entryLink id="f794-e1c0-34d6-d71a" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d255-a1a2-96d7-e07d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9d52-465c-8f24-a8c0" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="d255-a1a2-96d7-e07d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9d52-465c-8f24-a8c0" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
     <entryLink id="28af-78d9-69f9-8b87" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c472-eaee-6e07-cd6d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a692-8891-6640-bd5c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="c472-eaee-6e07-cd6d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a692-8891-6640-bd5c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
     <entryLink id="4f12-7a28-7980-97e4" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1e8d-8b50-9ba7-1ce2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="29bb-14af-bfb8-79c4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="1e8d-8b50-9ba7-1ce2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="29bb-14af-bfb8-79c4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
     <entryLink id="adec-a47a-130f-8214" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0982-fb9f-ba42-dae6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2924-2ed2-2229-d3cb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="0982-fb9f-ba42-dae6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2924-2ed2-2229-d3cb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
     <entryLink id="3194-1cd7-f371-ca9a" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="93e6-2990-b830-1499" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="789c-808f-4b13-7144" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="93e6-2990-b830-1499" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="789c-808f-4b13-7144" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="0489-a3c0-88a0-ba18" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ef2b-443f-9b90-3db7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="23c1-8766-188a-2482" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="ef2b-443f-9b90-3db7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="23c1-8766-188a-2482" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
     <entryLink id="23f8-712f-e735-1a30" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9879-d1be-1c43-9ad1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b446-b96e-54f8-5ce8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="9879-d1be-1c43-9ad1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b446-b96e-54f8-5ce8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="1019-efcf-1548-2a00" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e6d0-e337-9c95-5aaf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="23de-4dec-ea47-3059" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e6d0-e337-9c95-5aaf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="23de-4dec-ea47-3059" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
     <entryLink id="6488-1f35-b482-fc83" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0f9a-937d-0b09-3e2e" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="818b-ca1c-7c1b-00dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0f9a-937d-0b09-3e2e" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="818b-ca1c-7c1b-00dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
     <entryLink id="7e61-c663-30d1-9acb" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8efd-44c6-f9bd-bfc1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="72bf-4dae-911f-bb8d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8efd-44c6-f9bd-bfc1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="72bf-4dae-911f-bb8d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
     <entryLink id="3e94-aa5e-e44b-1dc1" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="14cd-5061-2107-8ac5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8017-c625-0639-a56d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="3d93-ff34-5055-af1e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="14cd-5061-2107-8ac5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8017-c625-0639-a56d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="3d93-ff34-5055-af1e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="8b4a-cd3f-042a-c06c" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4221-11f9-4f2e-82fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="22f0-2caf-bd70-f70f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="4221-11f9-4f2e-82fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="22f0-2caf-bd70-f70f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
     <entryLink id="6760-ab00-bae3-2a6d" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9c21-edaf-e5c3-e45d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="5d5f-46a8-dc0b-24f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9c21-edaf-e5c3-e45d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="5d5f-46a8-dc0b-24f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
     <entryLink id="0390-6e73-f86a-134a" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1728-f568-c1a1-9f44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0dd6-34d3-d2e8-c67c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1728-f568-c1a1-9f44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0dd6-34d3-d2e8-c67c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
     <entryLink id="87e1-003b-3176-7728" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3866-5ed0-de9b-9fe6" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="5e61-a899-1b61-6d4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3866-5ed0-de9b-9fe6" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="5e61-a899-1b61-6d4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="6fe0-700b-7bdf-802b" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ee85-ab1f-b425-2e48" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="b582-7a4b-38fc-578b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ee85-ab1f-b425-2e48" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="b582-7a4b-38fc-578b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
     <entryLink id="1a8f-9850-89eb-d7ad" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a3d8-c9fd-6174-b118" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="5c34-a726-4adb-8777" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a3d8-c9fd-6174-b118" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="5c34-a726-4adb-8777" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="6aba-c558-f194-e782" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2edc-b480-1a28-a405" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="ef1e-e2b2-f420-eacd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2edc-b480-1a28-a405" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="ef1e-e2b2-f420-eacd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
     <entryLink id="764c-66f2-5272-cd99" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7260-967c-9552-04c0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="bd6c-21dd-9930-6294" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7260-967c-9552-04c0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="bd6c-21dd-9930-6294" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
     <entryLink id="dcff-a922-ec9f-0762" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2211-8554-fa12-729f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="a570-7a90-d7b6-73f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2211-8554-fa12-729f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="a570-7a90-d7b6-73f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
     <entryLink id="4e08-db14-2499-3405" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c116-21a1-7d9d-b98d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="9845-aca4-b259-fc4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c116-21a1-7d9d-b98d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="9845-aca4-b259-fc4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
     <entryLink id="a333-c071-34ec-5b04" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="739d-f2e6-95e9-a58f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d7ed-3f38-184a-f9fa" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="a85c-7f38-80bd-f9db" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="739d-f2e6-95e9-a58f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d7ed-3f38-184a-f9fa" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
+        <categoryLink id="a85c-7f38-80bd-f9db" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="f666-bb54-a364-fa48" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1dba-4764-c1c5-e952" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b1e3-0209-ed88-946a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="1dba-4764-c1c5-e952" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b1e3-0209-ed88-946a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
     <entryLink id="8e78-637e-7185-c961" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3bf8-f40b-a517-f72b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="b244-00bc-1a32-581d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3bf8-f40b-a517-f72b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="b244-00bc-1a32-581d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
     <entryLink id="5980-4afe-fe25-4687" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3b8e-c92f-dcca-d33b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d698-5c0f-4ee6-b3f7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="3b8e-c92f-dcca-d33b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d698-5c0f-4ee6-b3f7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
     <entryLink id="b6d1-068e-7afa-6204" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <infoLinks>
-        <infoLink id="c06e-df8f-83fe-158d" name="Legiones Astartes (Emperor&apos;s Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule"/>
+        <infoLink id="c06e-df8f-83fe-158d" name="Legiones Astartes (Emperor's Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="77d3-cc99-0a9a-f5c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ed4a-30c1-c4d7-221b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="77d3-cc99-0a9a-f5c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ed4a-30c1-c4d7-221b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
     <entryLink id="7cde-45f7-46fc-321c" name="Phoenix Terminator Squad" hidden="false" collective="false" import="false" targetId="5b08-65c1-cc45-1b91" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="dc9b-e4a9-c20f-6787" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="eb86-4e25-643a-c52b" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="dc9b-e4a9-c20f-6787" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="eb86-4e25-643a-c52b" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="8982-038e-6d9f-692d" name="Palatine Blade Aquilae Squad" hidden="true" collective="false" import="false" targetId="1d83-4f3d-4a9b-dc39" type="selectionEntry">
@@ -1080,37 +1079,37 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bb1b-2c62-f62f-a62b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="d6f0-6dea-78dc-5e07" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bb1b-2c62-f62f-a62b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="d6f0-6dea-78dc-5e07" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="0de5-8b3c-74a0-858e" name="Fulgrim" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b7bb-0fb5-04bc-feb5" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b7bb-0fb5-04bc-feb5" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="f617-3901-e330-116d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="63e2-604e-8ad8-2949" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="f617-3901-e330-116d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="63e2-604e-8ad8-2949" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7350-db6b-c492-06cf" name="Firebrand" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d482-40ef-efc9-adf1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca83-cf90-4a88-5fa7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d482-40ef-efc9-adf1" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca83-cf90-4a88-5fa7" type="min" />
           </constraints>
           <profiles>
             <profile id="2d7d-04f2-11b5-f9e9" name="Firebrand" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">15&quot;</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">15"</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 2, Deflagrate, Shred, Master-crafted</characteristic>
@@ -1118,25 +1117,25 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="d0e2-7dd8-2104-bad8" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
-            <infoLink id="fab7-a6fb-0c40-10a7" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
-            <infoLink id="cf1e-758f-b2cf-cf5c" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="d0e2-7dd8-2104-bad8" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule" />
+            <infoLink id="fab7-a6fb-0c40-10a7" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
+            <infoLink id="cf1e-758f-b2cf-cf5c" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="c90d-0136-5e3d-40a7" name="Fulgrim" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1074-b350-567a-0c29" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4620-a0f0-44bb-88f7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1074-b350-567a-0c29" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4620-a0f0-44bb-88f7" type="min" />
           </constraints>
           <profiles>
             <profile id="2b51-7904-d885-0ab1" name="Fulgrim" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Primarch (Unique)
 </characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">8</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">6</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
@@ -1150,60 +1149,60 @@
             </profile>
           </profiles>
           <rules>
-            <rule id="67e6-a878-33e1-b714" name="Warlord: Sire of the Emperor&apos;s Children" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Fulgrim automatically has the Sire of the Emperor’s Children Warlord Trait and may not select any other Warlord Trait:
+            <rule id="67e6-a878-33e1-b714" name="Warlord: Sire of the Emperor's Children" hidden="false">
+              <description>If chosen as the army's Warlord, Fulgrim automatically has the Sire of the Emperor&#8217;s Children Warlord Trait and may not select any other Warlord Trait:
 
-Sire of the Emperor’s Children - All friendly models with the Legiones Astartes (Emperor’s Children) that can draw a line of sight to Fulgrim may use Fulgrim’s Leadership Characteristic for all Morale and Pinning checks they are required to take and all friendly units with the Legiones Astartes (Emperor’s Children) special rule on the battlefield while Fulgrim is also on the battlefield gain +1 to the Wound value used to calculate if the unit has won a close combat. In addition, the first Reaction made in each Game Turn by Fulgrim and any unit he has joined does not use up a point of the controlling player’s Reaction Allotment.</description>
+Sire of the Emperor&#8217;s Children - All friendly models with the Legiones Astartes (Emperor&#8217;s Children) that can draw a line of sight to Fulgrim may use Fulgrim&#8217;s Leadership Characteristic for all Morale and Pinning checks they are required to take and all friendly units with the Legiones Astartes (Emperor&#8217;s Children) special rule on the battlefield while Fulgrim is also on the battlefield gain +1 to the Wound value used to calculate if the unit has won a close combat. In addition, the first Reaction made in each Game Turn by Fulgrim and any unit he has joined does not use up a point of the controlling player&#8217;s Reaction Allotment.</description>
             </rule>
             <rule id="fb22-25ac-6bd6-52ee" name="The Gilded Panoply" hidden="false">
               <description>The Gilded Panoply provides Fulgrim with a 2+ Armour Save, a 3+ Invulnerable Save against Melee Attacks and a 5+ Invulnerable Save against all other Wounds inflicted upon him.</description>
             </rule>
             <rule id="89df-f48f-5c11-d109" name="Sublime Swordsman" hidden="false">
-              <description>When Fulgrim makes Melee Attacks as part of a Challenge, he gains a number of additional attacks equal to the amount which his Initiative Characteristic is greater than that of his opponent. For example, if Fulgrim attacks an enemy model with an Initiative Characteristic of 5 as part of a Challenge, Fulgrim’s Initiative of 8 grants him 3 extra Attacks</description>
+              <description>When Fulgrim makes Melee Attacks as part of a Challenge, he gains a number of additional attacks equal to the amount which his Initiative Characteristic is greater than that of his opponent. For example, if Fulgrim attacks an enemy model with an Initiative Characteristic of 5 as part of a Challenge, Fulgrim&#8217;s Initiative of 8 grants him 3 extra Attacks</description>
             </rule>
             <rule id="8684-608d-8f41-b907" name="Tactical Excellence" hidden="false">
-              <description>Once per battle, at the start of any Phase, Fulgrim&apos;s controlling player may declare the use of this special rule. For the duration of that Phase any enemy units that attempt to declare a Reaction against a Move, Shooting Attack or Charge made by Fulgrim or a unit that he has joined, must first pass a Leadership test (using the highest Leadership Characteristic in the unit attempting to make a Reaction), unless the unit that is making the Reaction includes at least one model with the Primarch Unit Type, in which case the unit may declare Reactions as normal.</description>
+              <description>Once per battle, at the start of any Phase, Fulgrim's controlling player may declare the use of this special rule. For the duration of that Phase any enemy units that attempt to declare a Reaction against a Move, Shooting Attack or Charge made by Fulgrim or a unit that he has joined, must first pass a Leadership test (using the highest Leadership Characteristic in the unit attempting to make a Reaction), unless the unit that is making the Reaction includes at least one model with the Primarch Unit Type, in which case the unit may declare Reactions as normal.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="f4c9-2238-acbd-5208" name="Legiones Astartes (Emperor&apos;s Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule"/>
-            <infoLink id="7a5b-efc7-c638-daca" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
+            <infoLink id="f4c9-2238-acbd-5208" name="Legiones Astartes (Emperor's Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule" />
+            <infoLink id="7a5b-efc7-c638-daca" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule" />
             <infoLink id="46e3-19fb-c99b-a1cd" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Bulky (6)"/>
+                <modifier type="set" field="name" value="Bulky (6)" />
               </modifiers>
             </infoLink>
             <infoLink id="b781-de7c-f9dc-0989" name="Sudden Strike (X)" hidden="false" targetId="58b3-7d84-b92d-1363" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Sudden Strike (1)"/>
+                <modifier type="set" field="name" value="Sudden Strike (1)" />
               </modifiers>
             </infoLink>
-            <infoLink id="1c25-95f2-9223-197b" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule"/>
-            <infoLink id="ae09-2b00-f711-3b09" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
+            <infoLink id="1c25-95f2-9223-197b" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule" />
+            <infoLink id="ae09-2b00-f711-3b09" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule" />
           </infoLinks>
           <entryLinks>
             <entryLink id="26fd-b025-2e7c-dac9" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e64f-11bf-c540-729a" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a376-e716-1045-b8a6" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e64f-11bf-c540-729a" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a376-e716-1045-b8a6" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="2552-2dcd-80f2-7186" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="9f03-92be-e24c-8f7f">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afd2-2e85-f8e5-72c2" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f14-1451-fc72-6468" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afd2-2e85-f8e5-72c2" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f14-1451-fc72-6468" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="9f03-92be-e24c-8f7f" name="The Blade of the Laer" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06ed-c444-a80e-b128" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06ed-c444-a80e-b128" type="max" />
               </constraints>
               <profiles>
                 <profile id="ca96-ad0e-9a49-3254" name="The Blade of the Laer" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1211,28 +1210,28 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
                     <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">User</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Duellist’s Edge (1), Fleshbane, Master-crafted, Specialist Weapon
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Duellist&#8217;s Edge (1), Fleshbane, Master-crafted, Specialist Weapon
 </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="531c-4028-2ac9-ff99" name="Duellist’s Edge (X)" hidden="true" targetId="7bf3-86ce-04c2-e6ba" type="rule">
+                <infoLink id="531c-4028-2ac9-ff99" name="Duellist&#8217;s Edge (X)" hidden="true" targetId="7bf3-86ce-04c2-e6ba" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Duellist&apos;s Edge (1)"/>
+                    <modifier type="set" field="name" value="Duellist's Edge (1)" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="c2e3-a823-fbea-66a1" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
-                <infoLink id="3607-ebb5-a36b-1508" name="Fleshbane" hidden="true" targetId="40cd-9505-253c-e76f" type="rule"/>
-                <infoLink id="fda6-db70-f586-7969" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="c2e3-a823-fbea-66a1" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule" />
+                <infoLink id="3607-ebb5-a36b-1508" name="Fleshbane" hidden="true" targetId="40cd-9505-253c-e76f" type="rule" />
+                <infoLink id="fda6-db70-f586-7969" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="c4e3-d3ab-c160-2129" name="Fireblade" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c5c-14e5-f55d-2694" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c5c-14e5-f55d-2694" type="max" />
               </constraints>
               <profiles>
                 <profile id="c0c2-da3a-c3cb-a93e" name="Fireblade" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1247,14 +1246,14 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
               <infoLinks>
                 <infoLink id="74ee-8093-ea02-9091" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Murderous Strike (5+)"/>
+                    <modifier type="set" field="name" value="Murderous Strike (5+)" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="9c40-dead-f4b5-5464" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
-                <infoLink id="409b-be04-bee6-337e" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
+                <infoLink id="9c40-dead-f4b5-5464" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
+                <infoLink id="409b-be04-bee6-337e" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1263,56 +1262,56 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
       <entryLinks>
         <entryLink id="2544-5b59-654a-7a4f" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3627-1b5f-20c0-4743" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff9a-a0eb-8782-7c05" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3627-1b5f-20c0-4743" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff9a-a0eb-8782-7c05" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="fdb6-1eac-60b4-4e2d" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a57-caa1-c0ae-9c3b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="351c-bf21-323c-1ff4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a57-caa1-c0ae-9c3b" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="351c-bf21-323c-1ff4" type="min" />
           </constraints>
           <profiles>
-            <profile id="1de7-7dc4-8061-dfff" name="Sire of the Emperor&apos;s Children" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+            <profile id="1de7-7dc4-8061-dfff" name="Sire of the Emperor's Children" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All friendly models with the Legiones Astartes (Emperor’s Children) that can draw a line of sight to Fulgrim may use Fulgrim’s Leadership Characteristic for all Morale and Pinning checks they are required to take and all friendly units with the Legiones Astartes (Emperor’s Children) special rule on the battlefield while Fulgrim is also on the battlefield gain +1 to the Wound value used to calculate if the unit has won a close combat. In addition, the first Reaction made in each Turn by Fulgrim and any unit he has joined does not use up a point of the controlling player’s Reaction Allotment.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All friendly models with the Legiones Astartes (Emperor&#8217;s Children) that can draw a line of sight to Fulgrim may use Fulgrim&#8217;s Leadership Characteristic for all Morale and Pinning checks they are required to take and all friendly units with the Legiones Astartes (Emperor&#8217;s Children) special rule on the battlefield while Fulgrim is also on the battlefield gain +1 to the Wound value used to calculate if the unit has won a close combat. In addition, the first Reaction made in each Turn by Fulgrim and any unit he has joined does not use up a point of the controlling player&#8217;s Reaction Allotment.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="425.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="425.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="5b08-65c1-cc45-1b91" name="Phoenix Terminator Squad" publicationId="09c5-eeae-f398-b653" page="158" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="c8a9-354d-f168-5a37" name="Phoenix Retinue" hidden="true">
-          <description>A Phoenix Terminator Squad may be selected as a Retinue Squad in a Detachment that includes at least one model  with both the Master of the Legion and the Legiones Astartes (Emperor&apos;s Children) special rules, instead of as an Elites choice. A unit selected as a &apos;Retinue Squad&apos; must have one model with both the Master of the Legion and Legiones Astartes (Emperor&apos;s Children) special rules from the same Detachment selected by the controlling player as the Phoenix Terminator Squad&apos;s Leader for the purposes of this special rule. A Phoenix Terminator Squad selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as the model selected as its Leader. A Phoenix Terminator Squad selected as a Retinue Squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Retinue Squad during play. One Phoenix Terminator in a Phoenix Terminator Squad selected as a Retinue may exchange their Phoenix power spear for a Legion standard and a Phoenix rapier for +15 points.</description>
+          <description>A Phoenix Terminator Squad may be selected as a Retinue Squad in a Detachment that includes at least one model  with both the Master of the Legion and the Legiones Astartes (Emperor's Children) special rules, instead of as an Elites choice. A unit selected as a 'Retinue Squad' must have one model with both the Master of the Legion and Legiones Astartes (Emperor's Children) special rules from the same Detachment selected by the controlling player as the Phoenix Terminator Squad's Leader for the purposes of this special rule. A Phoenix Terminator Squad selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as the model selected as its Leader. A Phoenix Terminator Squad selected as a Retinue Squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Retinue Squad during play. One Phoenix Terminator in a Phoenix Terminator Squad selected as a Retinue may exchange their Phoenix power spear for a Legion standard and a Phoenix rapier for +15 points.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="8285-7b06-ed1f-8b59" name="Legiones Astartes (Emperor&apos;s Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule"/>
-        <infoLink id="1fb3-1321-c2fe-a956" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="d5df-4b28-0436-b394" name="Skill Unmatched" hidden="false" targetId="752f-1b0d-5888-22b5" type="rule"/>
-        <infoLink id="218d-6bee-c553-0006" name="Living Icons" hidden="false" targetId="5615-04df-fb39-aa5d" type="rule"/>
+        <infoLink id="8285-7b06-ed1f-8b59" name="Legiones Astartes (Emperor's Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule" />
+        <infoLink id="1fb3-1321-c2fe-a956" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="d5df-4b28-0436-b394" name="Skill Unmatched" hidden="false" targetId="752f-1b0d-5888-22b5" type="rule" />
+        <infoLink id="218d-6bee-c553-0006" name="Living Icons" hidden="false" targetId="5615-04df-fb39-aa5d" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="99d4-024f-39b9-f2dd" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="5042-adc1-b6a6-33c7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="f095-c7f1-6d36-0bf8" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="99d4-024f-39b9-f2dd" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="5042-adc1-b6a6-33c7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="f095-c7f1-6d36-0bf8" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8782-15de-1f8e-d858" name="Phoenix Champion" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4067-0d12-2b19-edf6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="feaf-3e7f-6e57-94e4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4067-0d12-2b19-edf6" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="feaf-3e7f-6e57-94e4" type="min" />
           </constraints>
           <profiles>
             <profile id="ea6e-bc7f-81d0-a05c" name="Phoenix Champion" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1328,39 +1327,39 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
           <entryLinks>
             <entryLink id="e184-8bcd-ed77-b6d6" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4393-d1f9-5457-e883" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4393-d1f9-5457-e883" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="f359-944c-ca5d-f245" name="Phoenix Terminators" hidden="false" collective="false" import="true" type="model">
           <modifiers>
             <modifier type="decrement" field="6d70-c466-3e6d-51e4" value="1.0">
               <conditions>
-                <condition field="selections" scope="5b08-65c1-cc45-1b91" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8299-7028-93bc-0355" type="greaterThan"/>
+                <condition field="selections" scope="5b08-65c1-cc45-1b91" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8299-7028-93bc-0355" type="greaterThan" />
               </conditions>
             </modifier>
             <modifier type="decrement" field="b79e-330d-7d05-1fce" value="1.0">
               <conditions>
-                <condition field="selections" scope="5b08-65c1-cc45-1b91" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8299-7028-93bc-0355" type="greaterThan"/>
+                <condition field="selections" scope="5b08-65c1-cc45-1b91" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8299-7028-93bc-0355" type="greaterThan" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b79e-330d-7d05-1fce" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d70-c466-3e6d-51e4" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b79e-330d-7d05-1fce" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d70-c466-3e6d-51e4" type="min" />
           </constraints>
           <profiles>
             <profile id="49f9-a644-e073-d49d" name="Phoenix Terminator" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1374,25 +1373,25 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="8299-7028-93bc-0355" name="Phoenix Terminator Standard Bearer" hidden="false" collective="false" import="true" type="model">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="primary-category" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7aee-565f-b0ae-294e" type="instanceOf"/>
+                <condition field="selections" scope="primary-category" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7aee-565f-b0ae-294e" type="instanceOf" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adf2-6e13-a3b9-8b76" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adf2-6e13-a3b9-8b76" type="max" />
           </constraints>
           <profiles>
             <profile id="c1a0-7cbc-c18e-e62d" name="Phoenix Terminator" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1408,111 +1407,111 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
           <entryLinks>
             <entryLink id="46fe-3ac4-6c77-c35e" name="Phoenix Rapier" hidden="false" collective="false" import="true" targetId="868d-b957-c9ae-d3f2" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4983-ce41-21fc-a2b7" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac1f-4891-7ad0-b170" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4983-ce41-21fc-a2b7" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac1f-4891-7ad0-b170" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="f04e-2979-636b-a6f7" name="Legion Standard" hidden="false" collective="false" import="true" targetId="7e13-cc1f-6bd7-7ac6" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74ff-2ebf-4553-f766" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebbe-b4b6-c02c-c959" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74ff-2ebf-4553-f766" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebbe-b4b6-c02c-c959" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="3db2-9797-2637-ceeb" name="All models in the unit may take a Surgical Augment:" hidden="true" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9cb-33c7-dd52-6efb" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9cb-33c7-dd52-6efb" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="0ccb-1702-17e5-f89d" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="3f61-86fe-eecf-aed7" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </entryLink>
             <entryLink id="021f-53b1-a520-5194" name="Sub-sonic Pulser" hidden="false" collective="false" import="true" targetId="ddd0-22b3-ea96-680d" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </entryLink>
             <entryLink id="ba42-5114-9a11-0653" name="Sonic Lance" hidden="false" collective="false" import="true" targetId="5007-1732-6ad5-ce36" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="ce56-222a-b516-5455" name="Dedicated Transport" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b11b-335c-e01a-c068" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b11b-335c-e01a-c068" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="f90f-1da8-0ce7-f163" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="5b08-65c1-cc45-1b91" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="selections" scope="5b08-65c1-cc45-1b91" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0" />
               </costs>
             </entryLink>
-            <entryLink id="e4de-2ddf-4f43-ffd3" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"/>
+            <entryLink id="e4de-2ddf-4f43-ffd3" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="04a1-3e86-c141-7804" name="Phoenix Power Spear" hidden="false" collective="false" import="true" targetId="356b-300e-d83d-72b8" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f554-848d-a648-87a5" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c0d-4c78-5c22-26c0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f554-848d-a648-87a5" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c0d-4c78-5c22-26c0" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="d5e1-f77b-006c-ff1a" name="Tartaros Terminator Armour" hidden="false" collective="false" import="true" targetId="f850-d0af-8663-ccac" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4516-8970-c0fe-f871" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec4d-5515-966a-cfae" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4516-8970-c0fe-f871" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec4d-5515-966a-cfae" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="fa86-f7a5-0062-a205" name="Palatine Blade Squad" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="0fc4-9034-cfce-a4ab" name="Legiones Astartes (Emperor&apos;s Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule"/>
-        <infoLink id="17b2-6634-186d-8d31" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="4e8a-7d8c-c029-4757" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
+        <infoLink id="0fc4-9034-cfce-a4ab" name="Legiones Astartes (Emperor's Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule" />
+        <infoLink id="17b2-6634-186d-8d31" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="4e8a-7d8c-c029-4757" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
         <infoLink id="7270-a1fc-72f7-3200" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Counter-attack (1)"/>
+            <modifier type="set" field="name" value="Counter-attack (1)" />
           </modifiers>
         </infoLink>
-        <infoLink id="013a-7f55-e385-17db" name="Skill Unmatched" hidden="false" targetId="752f-1b0d-5888-22b5" type="rule"/>
+        <infoLink id="013a-7f55-e385-17db" name="Skill Unmatched" hidden="false" targetId="752f-1b0d-5888-22b5" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ae05-6cab-8164-af90" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="f3a5-ae2d-30cf-8553" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="ae05-6cab-8164-af90" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="f3a5-ae2d-30cf-8553" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a6b3-6835-0d75-8a77" name="Palatine Prefector" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94b7-1e95-040e-119e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2f2-f918-b59b-0596" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94b7-1e95-040e-119e" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2f2-f918-b59b-0596" type="min" />
           </constraints>
           <profiles>
             <profile id="2ff2-ba96-f5a6-9fcf" name="Palatine Prefector" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1528,15 +1527,15 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
         </selectionEntry>
         <selectionEntry id="ec89-3e2f-929b-a05d" name="Palatine Warriors" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c5c-c758-6efe-0672" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80fa-a0fd-338a-e3b8" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c5c-c758-6efe-0672" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80fa-a0fd-338a-e3b8" type="min" />
           </constraints>
           <profiles>
             <profile id="2dff-96cd-b045-20ed" name="Palatine Warrior" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry
 </characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1550,114 +1549,114 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="28.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="28.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="be00-2da7-f469-cd38" name="All models must choose from:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c046-15b5-062d-e5b4" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec22-d602-32f6-d62a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c046-15b5-062d-e5b4" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec22-d602-32f6-d62a" type="min" />
           </constraints>
           <entryLinks>
-            <entryLink id="e0e6-de8b-21d8-592b" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry"/>
-            <entryLink id="8e82-ff7f-0c67-caa5" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry"/>
-            <entryLink id="5c1f-3a42-e055-8f52" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry"/>
+            <entryLink id="e0e6-de8b-21d8-592b" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry" />
+            <entryLink id="8e82-ff7f-0c67-caa5" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry" />
+            <entryLink id="5c1f-3a42-e055-8f52" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry" />
             <entryLink id="0c6e-3fd0-1e36-62d6" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
             <entryLink id="6c6f-ffc4-5259-50aa" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
             <entryLink id="1e76-f883-3b26-d6fc" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
             <entryLink id="7917-93a3-8027-60e5" name="Phoenix Rapier" hidden="false" collective="false" import="true" targetId="868d-b957-c9ae-d3f2" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
             <entryLink id="f5e7-9602-252d-74f1" name="Phoenix Power Spear" hidden="false" collective="false" import="true" targetId="356b-300e-d83d-72b8" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
             <entryLink id="2009-617a-38be-d855" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="3afd-92b1-23f1-941f" name="All models in the unit may choose to take the same Surgical Augment:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f11d-08da-36d1-7b2d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f11d-08da-36d1-7b2d" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="8b3e-030a-bef5-2342" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="3f61-86fe-eecf-aed7" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </entryLink>
             <entryLink id="619a-1fd1-0918-7bf7" name="Sub-sonic Pulser" hidden="false" collective="false" import="true" targetId="ddd0-22b3-ea96-680d" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </entryLink>
             <entryLink id="16b4-5c05-f9b5-7169" name="Sonic Lance" hidden="false" collective="false" import="true" targetId="5007-1732-6ad5-ce36" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="887f-dd60-76fa-a0f4" name="The Palatine Prefector may exchange his bolt pistol for:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5801-5921-2f40-c1fb" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5801-5921-2f40-c1fb" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="251b-366a-8dab-5627" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a894-63d1-121a-b1c2" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a894-63d1-121a-b1c2" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="4ace-f7fe-1d31-d051" name="The Palatine Prefector may take:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f60-a23e-646c-7144" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f60-a23e-646c-7144" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="ce11-31fc-2ff6-0722" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bde8-df8a-b3d1-5eda" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bde8-df8a-b3d1-5eda" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="3820-d56f-f2d0-f754" name="Dedicated Transport" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec8a-d40b-c34a-9964" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec8a-d40b-c34a-9964" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="97d4-c235-96af-4f89" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1666,17 +1665,17 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="ffa0-9fbb-f052-6510" name="Drop Pod" hidden="false" collective="false" import="true" targetId="83ac-f9cf-cc29-00a3" type="selectionEntry"/>
+            <entryLink id="ffa0-9fbb-f052-6510" name="Drop Pod" hidden="false" collective="false" import="true" targetId="83ac-f9cf-cc29-00a3" type="selectionEntry" />
             <entryLink id="8310-c39c-42b5-32cf" name="Storm Eagle Gunship" hidden="true" collective="false" import="true" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1687,48 +1686,48 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
       <entryLinks>
         <entryLink id="b19d-b0e0-b59c-0590" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1ab-c4e2-fdb7-0ffa" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0cc-b104-bf6d-ff23" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1ab-c4e2-fdb7-0ffa" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0cc-b104-bf6d-ff23" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="c47b-2367-0424-d80d" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c22a-1ec6-1045-8e5b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbbf-a354-acff-ae97" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c22a-1ec6-1045-8e5b" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbbf-a354-acff-ae97" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="4911-f930-cd7d-807d" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a14-9b58-62db-4b1e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b64e-7d76-a62f-84ce" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a14-9b58-62db-4b1e" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b64e-7d76-a62f-84ce" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="51de-1b0e-335e-236f" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93a1-7869-b83f-7d52" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2495-8c87-a5f0-e199" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93a1-7869-b83f-7d52" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2495-8c87-a5f0-e199" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="53.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="53.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="8359-c463-9cde-4f21" name="Kakophoni Squad" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="1114-cab4-4a62-2cc3" name="Legiones Astartes (Emperor&apos;s Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule"/>
-        <infoLink id="0435-1879-2846-3361" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
+        <infoLink id="1114-cab4-4a62-2cc3" name="Legiones Astartes (Emperor's Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule" />
+        <infoLink id="0435-1879-2846-3361" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4ad3-2a6e-3de4-93f5" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="d713-71c8-57c2-e819" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="a519-1c43-8810-6c3b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="4ad3-2a6e-3de4-93f5" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="d713-71c8-57c2-e819" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="a519-1c43-8810-6c3b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3923-cc29-8049-0671" name="Chora" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a685-fd45-fcd9-7dc8" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="028f-93b1-0f34-320b" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a685-fd45-fcd9-7dc8" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="028f-93b1-0f34-320b" type="min" />
           </constraints>
           <profiles>
             <profile id="aa90-6586-439a-6df4" name="Chora" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -1748,20 +1747,20 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="fee0-34ad-15de-cb8a" name="Orchestrator" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fce-c2f6-bea5-ee33" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8191-7415-682d-4e80" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fce-c2f6-bea5-ee33" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8191-7415-682d-4e80" type="min" />
           </constraints>
           <profiles>
             <profile id="331f-57d4-5205-da7c" name="Orchestrator" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)
 </characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1775,18 +1774,18 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="4e8a-c69f-4d65-8947" name="The Cacophony" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e11a-c3e2-7353-9ba3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b88-b0eb-a1ac-6b83" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e11a-c3e2-7353-9ba3" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b88-b0eb-a1ac-6b83" type="min" />
           </constraints>
           <profiles>
             <profile id="7853-1812-7fcc-54a9" name="The Cacophony" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">36"</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 3, Gets Hot, Pinning, Shell Shock (1), Deflagrate</characteristic>
@@ -1794,13 +1793,13 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="5495-5775-ce2e-3e57" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
-            <infoLink id="d054-145e-111b-9c04" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
-            <infoLink id="5b25-c944-2cd2-b78a" name="Shell Shock (X)" hidden="false" targetId="46b7-63a1-941c-96a5" type="rule"/>
-            <infoLink id="5a62-97f5-ec6d-c45b" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
+            <infoLink id="5495-5775-ce2e-3e57" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule" />
+            <infoLink id="d054-145e-111b-9c04" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule" />
+            <infoLink id="5b25-c944-2cd2-b78a" name="Shell Shock (X)" hidden="false" targetId="46b7-63a1-941c-96a5" type="rule" />
+            <infoLink id="5a62-97f5-ec6d-c45b" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1809,48 +1808,48 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
           <entryLinks>
             <entryLink id="7a6b-7bfd-32cf-024d" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9977-686e-c4b3-6d0e" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9977-686e-c4b3-6d0e" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="47b6-098b-acef-0f1e" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ea4-6470-61a7-fb6a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ea4-6470-61a7-fb6a" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
             <entryLink id="4e2d-fb98-67b6-427b" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99a6-f815-5ade-26b9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99a6-f815-5ade-26b9" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="6a59-860a-5a5c-7fae" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d19-1453-1da9-3d78" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d19-1453-1da9-3d78" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="4376-2b20-79e4-bce5" name="Dedicated Transport" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1242-426c-6d8e-ed49" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1242-426c-6d8e-ed49" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="3827-40dd-712f-5d69" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1859,7 +1858,7 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1870,53 +1869,53 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
       <entryLinks>
         <entryLink id="7ca8-3126-5746-32e5" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbb3-e82e-3000-11fa" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="411b-2d55-9c9d-b008" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbb3-e82e-3000-11fa" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="411b-2d55-9c9d-b008" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="c2df-dffc-a6b3-7497" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66d5-3edb-5f92-50ea" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28ba-0e5a-4f7b-1f67" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66d5-3edb-5f92-50ea" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28ba-0e5a-4f7b-1f67" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="26bd-d797-9221-18f0" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6502-d281-995c-90a1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81ff-7df4-17a4-64af" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6502-d281-995c-90a1" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81ff-7df4-17a4-64af" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="66f0-3254-e448-c793" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="3f61-86fe-eecf-aed7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c673-a10d-93be-ed71" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a889-be89-810c-2927" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c673-a10d-93be-ed71" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a889-be89-810c-2927" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="ac90-d090-9a21-60c4" name="Lord Commander Eidolon" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="77cf-98c8-12f6-e491" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="77cf-98c8-12f6-e491" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="b7e4-e6dd-51b7-6cdb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="846d-5f51-c454-c2fc" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="abb6-d43c-caa7-4751" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="b7e4-e6dd-51b7-6cdb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="846d-5f51-c454-c2fc" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="abb6-d43c-caa7-4751" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e845-5008-a4fe-b8b9" name="Lord Commander Eidolon" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29b2-e1fa-fa4d-0767" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9743-7cb7-c89e-5d6c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29b2-e1fa-fa4d-0767" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9743-7cb7-c89e-5d6c" type="min" />
           </constraints>
           <profiles>
             <profile id="4e02-6c9a-97a3-c603" name="Lord Commander Eidolon" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1930,26 +1929,26 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="9284-bc0d-3879-1be1" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-            <infoLink id="fa02-232f-6959-e4c3" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
-            <infoLink id="2113-2c11-4ad1-b903" name="Legiones Astartes (Emperor&apos;s Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule"/>
+            <infoLink id="9284-bc0d-3879-1be1" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+            <infoLink id="fa02-232f-6959-e4c3" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule" />
+            <infoLink id="2113-2c11-4ad1-b903" name="Legiones Astartes (Emperor's Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule" />
           </infoLinks>
           <entryLinks>
             <entryLink id="fb2e-6455-0b6b-c8f4" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6ce-2c48-2040-a038" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="feaa-66db-6ee8-900c" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6ce-2c48-2040-a038" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="feaa-66db-6ee8-900c" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="067e-c26e-0693-2a74" name="Glory Aeterna" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9266-4f8e-2e3d-9402" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b83e-ad83-5bd0-ae67" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9266-4f8e-2e3d-9402" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b83e-ad83-5bd0-ae67" type="max" />
           </constraints>
           <profiles>
             <profile id="63ed-cc8a-077b-e5df" name="Master-crafted Thunder Hammer" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1963,22 +1962,22 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
           </profiles>
           <rules>
             <rule id="c742-77a2-9ded-cc84" name="Thunderous Charge" hidden="false">
-              <description>On any turn in which Lord Commander Eidolon makes a Successful charge, the model&apos;s attack ignore the Unwieldy special rule on Glory Aeterna.</description>
+              <description>On any turn in which Lord Commander Eidolon makes a Successful charge, the model's attack ignore the Unwieldy special rule on Glory Aeterna.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="e58b-db9b-27d4-5b66" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
-            <infoLink id="8f21-b34d-9b0b-3ff1" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
-            <infoLink id="3b83-c195-6eb2-c6eb" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule"/>
+            <infoLink id="e58b-db9b-27d4-5b66" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
+            <infoLink id="8f21-b34d-9b0b-3ff1" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
+            <infoLink id="3b83-c195-6eb2-c6eb" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="1e30-b521-a535-db87" name="Death Scream" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f497-6093-7217-f2d0" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="979c-872d-43f8-4085" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f497-6093-7217-f2d0" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="979c-872d-43f8-4085" type="min" />
           </constraints>
           <profiles>
             <profile id="9a14-0b99-d926-0430" name="Death Scream" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1991,94 +1990,94 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="cd3f-874c-1d51-4a9f" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule"/>
-            <infoLink id="951d-ae05-950f-fab7" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+            <infoLink id="cd3f-874c-1d51-4a9f" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule" />
+            <infoLink id="951d-ae05-950f-fab7" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="8e6e-1e4f-b6c4-2372" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ffe-9db4-9bb6-1da7" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d636-41c6-3ea9-6da6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ffe-9db4-9bb6-1da7" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d636-41c6-3ea9-6da6" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="3b9f-b6f4-0ace-4892" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18c1-febe-c4eb-fe3b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a7a-717c-054b-3448" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18c1-febe-c4eb-fe3b" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a7a-717c-054b-3448" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="6ce6-1fcb-29d3-28b8" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03b2-761a-3050-0af3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="340e-1d1b-909c-b959" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03b2-761a-3050-0af3" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="340e-1d1b-909c-b959" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="aa0a-dcca-7011-d079" name="Warhawk Jump Pack" hidden="false" collective="false" import="true" targetId="a298-8584-70ed-18ce" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ffb-e989-52ea-565e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5401-a36a-6847-6a86" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ffb-e989-52ea-565e" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5401-a36a-6847-6a86" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="ab17-dbd8-4952-2817" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b42-1d3c-4f23-5de1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="755d-e788-bca4-5561" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b42-1d3c-4f23-5de1" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="755d-e788-bca4-5561" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="bb1d-13dc-d4e8-a8f3" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcf8-9501-7a9a-1897" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ee0-127f-3da5-7d99" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcf8-9501-7a9a-1897" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ee0-127f-3da5-7d99" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="b72e-ad01-5813-ef41" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="3f61-86fe-eecf-aed7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e21d-dc75-4d9d-fea7" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6343-5779-e214-acfa" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e21d-dc75-4d9d-fea7" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6343-5779-e214-acfa" type="min" />
           </constraints>
         </entryLink>
-        <entryLink id="ae41-6060-5460-8fc5" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup"/>
+        <entryLink id="ae41-6060-5460-8fc5" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup" />
         <entryLink id="6e4e-8252-1e1d-0851" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b21b-9199-75b5-b87c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b21b-9199-75b5-b87c" type="max" />
           </constraints>
           <rules>
             <rule id="e43c-c0cb-01a4-8ead" name="Warlord: Prideful Onslaught" hidden="false">
-              <description>If Lord Commander Eidolon is the Army&apos;s Warlord, then at the beginning of the battle, once all of the opposing player&apos;s models have been deployed, but before the first turn has begun, Lord Commander Eidolon&apos;s controlling player must select one enemy HQ or Primarch choice as Lord Commander Eidolon&apos;s &quot;Rival&quot;. Lord Commander Eidolon and any unit he has joined gain a bonus of +1 to all To Hit rolls made against the &quot;Rival&quot; unit - and if the &quot;Rival&quot; unit is part of any enemy Shooting Attack or Combat that results in a friendly unit being removed entirely as casualties or Falling Back, then Lord Commander Eidolon and any unit he has joined also gains a bonus of +1 to all To Wound rolls made against the &quot;Rival&quot; unit for the remainder of the battle after that Shooting Attack or Combat has been fully resolved. In addition Lord Commander Eidolon and any unit he has joined may only declare Reactions against the Rival unit, but the first such Reaction each turn is free and does not reduce the Player&apos;s Reaction Allotment for that Phase.</description>
+              <description>If Lord Commander Eidolon is the Army's Warlord, then at the beginning of the battle, once all of the opposing player's models have been deployed, but before the first turn has begun, Lord Commander Eidolon's controlling player must select one enemy HQ or Primarch choice as Lord Commander Eidolon's "Rival". Lord Commander Eidolon and any unit he has joined gain a bonus of +1 to all To Hit rolls made against the "Rival" unit - and if the "Rival" unit is part of any enemy Shooting Attack or Combat that results in a friendly unit being removed entirely as casualties or Falling Back, then Lord Commander Eidolon and any unit he has joined also gains a bonus of +1 to all To Wound rolls made against the "Rival" unit for the remainder of the battle after that Shooting Attack or Combat has been fully resolved. In addition Lord Commander Eidolon and any unit he has joined may only declare Reactions against the Rival unit, but the first such Reaction each turn is free and does not reduce the Player's Reaction Allotment for that Phase.</description>
             </rule>
           </rules>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="215.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="215.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="a91c-719f-4abf-1598" name="Captain Saul Tarvitz" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e781-7860-b7ab-ca6f" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e781-7860-b7ab-ca6f" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="097f-3ba4-1906-564b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="d99b-5d8e-d60b-0feb" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="5ce7-8211-fce9-9cc1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="097f-3ba4-1906-564b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="d99b-5d8e-d60b-0feb" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="5ce7-8211-fce9-9cc1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b99f-1483-2853-ccaa" name="Captain Saul Tarvitz" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e01f-6e0c-c985-3b6e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e23-d9bb-3382-ab5f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e01f-6e0c-c985-3b6e" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e23-d9bb-3382-ab5f" type="max" />
           </constraints>
           <profiles>
             <profile id="b881-31aa-c089-76f2" name="Captain Saul Tarvitz " hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)
 </characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2093,35 +2092,35 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
           </profiles>
           <rules>
             <rule id="abd6-aa34-8bbe-a4c8" name="A Brother Betrayed" hidden="false">
-              <description>Captain Saul Tarvitz gains +1 Weapon Skill, +1 Strength and +1 Toughness while locked in combat with any enemy model that has both the Independent Character and Legiones Astartes (Emperor’s Children) special rules or any unit that such a model has joined. If an enemy model that has both the Independent Character and Legiones Astartes (Emperor’s Children) special rules is removed as a casualty whilst locked in combat with Captain Saul Tarvitz or any unit he has joined then Saul Tarvitz controlling player gains +1 bonus Victory point in addition to any others that might be gained from this, this bonus is increased to +2 bonus Victory points if Captain Lucius is removed as a casualty while engaged in a Challenge with Captain Saul Tarvitz.</description>
+              <description>Captain Saul Tarvitz gains +1 Weapon Skill, +1 Strength and +1 Toughness while locked in combat with any enemy model that has both the Independent Character and Legiones Astartes (Emperor&#8217;s Children) special rules or any unit that such a model has joined. If an enemy model that has both the Independent Character and Legiones Astartes (Emperor&#8217;s Children) special rules is removed as a casualty whilst locked in combat with Captain Saul Tarvitz or any unit he has joined then Saul Tarvitz controlling player gains +1 bonus Victory point in addition to any others that might be gained from this, this bonus is increased to +2 bonus Victory points if Captain Lucius is removed as a casualty while engaged in a Challenge with Captain Saul Tarvitz.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="f75e-90a6-38ec-7014" name="Legiones Astartes (Emperor&apos;s Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule"/>
-            <infoLink id="e943-8bee-48c1-41cb" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
-            <infoLink id="a8bb-68cf-8b9c-447a" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+            <infoLink id="f75e-90a6-38ec-7014" name="Legiones Astartes (Emperor's Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule" />
+            <infoLink id="e943-8bee-48c1-41cb" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule" />
+            <infoLink id="a8bb-68cf-8b9c-447a" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
             <infoLink id="756d-21de-cc17-f116" name="Preferred Enemy (X)" hidden="false" targetId="37ab-d4db-891a-de8c" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Preferred Enemy (Emperor&apos;s Children)"/>
+                <modifier type="set" field="name" value="Preferred Enemy (Emperor's Children)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <entryLinks>
             <entryLink id="412d-2060-fddc-cccc" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a48-bd99-f07c-81a2" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b678-312b-8010-dad4" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a48-bd99-f07c-81a2" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b678-312b-8010-dad4" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="6abf-3890-79c3-759d" name="Charnabal broadsword" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87a5-81d2-580f-04ed" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d67-e903-bcff-5d1d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87a5-81d2-580f-04ed" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d67-e903-bcff-5d1d" type="max" />
           </constraints>
           <profiles>
             <profile id="ed4c-d05a-3f2f-8244" name="Charnabal broadsword" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2129,29 +2128,29 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+2</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Rending (4+), Duellist&apos;s Edge (2), Two-handed, Master-crafted</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Rending (4+), Duellist's Edge (2), Two-handed, Master-crafted</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="1e40-b6e3-03bd-3240" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule"/>
-            <infoLink id="0809-e571-7ba6-c9b0" name="Duellist’s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule"/>
-            <infoLink id="030e-cd4d-e092-829a" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
-            <infoLink id="e85d-0429-23fa-5b1a" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="1e40-b6e3-03bd-3240" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule" />
+            <infoLink id="0809-e571-7ba6-c9b0" name="Duellist&#8217;s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule" />
+            <infoLink id="030e-cd4d-e092-829a" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
+            <infoLink id="e85d-0429-23fa-5b1a" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="2737-a564-8659-0c0d" name="Master-crafted Nemesis bolter" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b864-0e17-0a95-59c6" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="152c-2f9b-36cd-5580" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b864-0e17-0a95-59c6" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="152c-2f9b-36cd-5580" type="max" />
           </constraints>
           <profiles>
             <profile id="252e-1ffe-c6c6-63f2" name="Master-crafted Nemesis bolter" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">72&quot;</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">72"</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Rending (5+), Sniper, Pinning, Master-crafted</characteristic>
@@ -2159,90 +2158,90 @@ Sire of the Emperor’s Children - All friendly models with the Legiones Astarte
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="4ccc-b0c7-0873-b5f7" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
-            <infoLink id="62ad-ff8a-efb5-6290" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule"/>
-            <infoLink id="e746-8085-96e8-2f12" name="Sniper" hidden="false" targetId="9cd8-e726-5dbe-b106" type="rule"/>
-            <infoLink id="ca6c-8ebe-e511-e226" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+            <infoLink id="4ccc-b0c7-0873-b5f7" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
+            <infoLink id="62ad-ff8a-efb5-6290" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule" />
+            <infoLink id="e746-8085-96e8-2f12" name="Sniper" hidden="false" targetId="9cd8-e726-5dbe-b106" type="rule" />
+            <infoLink id="ca6c-8ebe-e511-e226" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="d26a-36d1-ac1b-79f4" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2290-9e09-7093-e400" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce6a-fecc-93fd-a815" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2290-9e09-7093-e400" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce6a-fecc-93fd-a815" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="0fde-e23e-2285-fd5a" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e27b-b519-97ae-c37d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12b9-87d7-8af1-0818" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e27b-b519-97ae-c37d" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12b9-87d7-8af1-0818" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="6de8-3053-103a-ec6b" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b45d-d934-5832-9f35" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="546a-9279-9c64-8c74" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b45d-d934-5832-9f35" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="546a-9279-9c64-8c74" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="36c2-b1d4-f2f8-1f12" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05ed-ca59-4810-5986" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2eee-04aa-6703-e834" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05ed-ca59-4810-5986" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2eee-04aa-6703-e834" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="4b0b-7c52-df56-0d6d" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eeac-9010-4724-312a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0ea-61fe-3a4a-e8c1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eeac-9010-4724-312a" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0ea-61fe-3a4a-e8c1" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="87df-f5fa-c255-caa7" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup"/>
+        <entryLink id="87df-f5fa-c255-caa7" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup" />
         <entryLink id="6847-d090-09f4-5259" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80ef-d36a-4edc-d709" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80ef-d36a-4edc-d709" type="max" />
           </constraints>
           <rules>
             <rule id="ccd0-7e04-9222-26a6" name="Warlord: Defiant unto Death" hidden="false">
-              <description>If an army’s Warlord has this trait, then check at the start of each of the controlling player’s turns to see if any of the following is true:
-● The army that includes Captain Saul Tarvitz has accrued fewer Victory points than any enemy army.
-● The army including Captain Saul Tarvitz has less units on the battlefield than all enemy armies combined.
-● Captain Saul Tarvitz is within 6” of an objective
-● Captain Saul Tarvitz and any unit he has joined is locked in combat with more than one enemy unit, or a single enemy unit that outnumbers Captain Saul Tarvitz’s unit
+              <description>If an army&#8217;s Warlord has this trait, then check at the start of each of the controlling player&#8217;s turns to see if any of the following is true:
+&#9679; The army that includes Captain Saul Tarvitz has accrued fewer Victory points than any enemy army.
+&#9679; The army including Captain Saul Tarvitz has less units on the battlefield than all enemy armies combined.
+&#9679; Captain Saul Tarvitz is within 6&#8221; of an objective
+&#9679; Captain Saul Tarvitz and any unit he has joined is locked in combat with more than one enemy unit, or a single enemy unit that outnumbers Captain Saul Tarvitz&#8217;s unit
 
-If any of these are true then Captain Saul Tarvitz and any friendly units with at least one model within 12” of Captain Saul Tarvitz gain the Fearless special rule. In addition, as long as Saul Tarvitz has not been removed as a casualty the army gains an additional Reaction in the Shooting Phase.</description>
+If any of these are true then Captain Saul Tarvitz and any friendly units with at least one model within 12&#8221; of Captain Saul Tarvitz gain the Fearless special rule. In addition, as long as Saul Tarvitz has not been removed as a casualty the army gains an additional Reaction in the Shooting Phase.</description>
             </rule>
           </rules>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="155.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="155.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="0707-1e4b-27da-9cd4" name="Captain Lucius" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9326-cd69-c6f1-949b" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9326-cd69-c6f1-949b" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="881f-052e-58c5-49de" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="8d21-e2d9-7847-b808" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="3c42-b8b4-f9e4-1f13" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="881f-052e-58c5-49de" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="8d21-e2d9-7847-b808" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="3c42-b8b4-f9e4-1f13" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="240f-c893-3999-b339" name="Captain Lucius" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d2a-7ff2-909f-7b7a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5121-89b8-0dc6-dc0c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d2a-7ff2-909f-7b7a" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5121-89b8-0dc6-dc0c" type="max" />
           </constraints>
           <profiles>
             <profile id="f2d4-31e3-efd3-ae13" name="Captain Lucius" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)
 </characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">7</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2257,7 +2256,7 @@ If any of these are true then Captain Saul Tarvitz and any friendly units with a
           </profiles>
           <rules>
             <rule id="65da-d71b-ef30-53f3" name="Supreme Duellist" hidden="false">
-              <description>While fighting in a challenge, if Captain Lucius’ Initiative Characteristic is higher than his opponents
+              <description>While fighting in a challenge, if Captain Lucius&#8217; Initiative Characteristic is higher than his opponents
 then he gains +1 to his Attacks Characteristic.</description>
             </rule>
             <rule id="d3fc-aa62-15c9-a3fa" name="Blade of the Laer" hidden="false">
@@ -2265,37 +2264,37 @@ then he gains +1 to his Attacks Characteristic.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="76fd-d31e-4dbf-4b8a" name="Legiones Astartes (Emperor&apos;s Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule"/>
-            <infoLink id="e712-3511-a43a-2a32" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
-            <infoLink id="1df6-2d8a-134a-944c" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+            <infoLink id="76fd-d31e-4dbf-4b8a" name="Legiones Astartes (Emperor's Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule" />
+            <infoLink id="e712-3511-a43a-2a32" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule" />
+            <infoLink id="1df6-2d8a-134a-944c" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
             <infoLink id="8c6f-1b31-b9f2-111a" name="Preferred Enemy (X)" hidden="false" targetId="37ab-d4db-891a-de8c" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Preferred Enemy (Independent Characters)"/>
+                <modifier type="set" field="name" value="Preferred Enemy (Independent Characters)" />
               </modifiers>
             </infoLink>
             <infoLink id="4935-ccd7-eaf7-9ede" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Precision Strikes (3+)"/>
+                <modifier type="set" field="name" value="Precision Strikes (3+)" />
               </modifiers>
             </infoLink>
-            <infoLink id="75bd-6faf-4d2e-12dc" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+            <infoLink id="75bd-6faf-4d2e-12dc" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
           </infoLinks>
           <entryLinks>
             <entryLink id="2d24-f072-423f-f16b" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73db-2de2-f618-6577" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9c0-c971-593b-7dbf" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73db-2de2-f618-6577" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9c0-c971-593b-7dbf" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="e4d4-cd80-0d70-da4e" name="Nineteen" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3dfe-0363-1ef2-b526" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14c0-6ea9-9edf-074e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3dfe-0363-1ef2-b526" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14c0-6ea9-9edf-074e" type="min" />
           </constraints>
           <profiles>
             <profile id="4f8e-7b3d-a5b5-365d" name="Nineteen" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2303,38 +2302,38 @@ then he gains +1 to his Attacks Characteristic.</description>
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">User</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Rending (3+), Duellist’s Aegis (1), Murderous Strike (6+), Master-crafted
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Rending (3+), Duellist&#8217;s Aegis (1), Murderous Strike (6+), Master-crafted
 </characteristic>
               </characteristics>
             </profile>
           </profiles>
           <rules>
-            <rule id="a5a9-8917-719a-981c" name="Duellist&apos;s Aegis (x)" hidden="false">
+            <rule id="a5a9-8917-719a-981c" name="Duellist's Aegis (x)" hidden="false">
               <description>A model with this special rule gains a bonus to their Weapon Skill equal to the value in brackets listed as part of the special rule whenever it is engaged in a Challenge with an enemy model.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="229f-6e7d-b2df-77fe" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule"/>
-            <infoLink id="bbce-99c0-5535-8fe4" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule"/>
-            <infoLink id="1aa8-c10e-4c6f-e04a" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="229f-6e7d-b2df-77fe" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule" />
+            <infoLink id="bbce-99c0-5535-8fe4" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule" />
+            <infoLink id="1aa8-c10e-4c6f-e04a" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="3ce5-a27e-f3df-f6ae" name="Melee" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4271-948d-2e5c-5136" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea2e-6f91-a669-2758" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4271-948d-2e5c-5136" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea2e-6f91-a669-2758" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="66d9-4fef-c096-4e09" name="Blade of the Laer" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0de5-8b3c-74a0-858e" type="atLeast"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0de5-8b3c-74a0-858e" type="atLeast" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -2344,18 +2343,18 @@ then he gains +1 to his Attacks Characteristic.</description>
                     <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">User</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Duellist&apos;s Edge (1), Fleshbane, Specialist Weapon, Master-crafted</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Duellist's Edge (1), Fleshbane, Specialist Weapon, Master-crafted</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="4502-62aa-7e12-8616" name="Duellist’s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule"/>
-                <infoLink id="4232-1698-a0b8-add1" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
-                <infoLink id="c9f8-82e6-bc63-be3d" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
-                <infoLink id="ba06-8bb5-0098-c204" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="4502-62aa-7e12-8616" name="Duellist&#8217;s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule" />
+                <infoLink id="4232-1698-a0b8-add1" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule" />
+                <infoLink id="c9f8-82e6-bc63-be3d" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule" />
+                <infoLink id="ba06-8bb5-0098-c204" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="66f2-e255-6aa3-c94f" name="Close combat weapon" hidden="false" collective="false" import="true" type="upgrade">
@@ -2370,7 +2369,7 @@ then he gains +1 to his Attacks Characteristic.</description>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2379,62 +2378,62 @@ then he gains +1 to his Attacks Characteristic.</description>
       <entryLinks>
         <entryLink id="eabc-d9b5-adc5-7d83" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5eb-fa32-ae66-258b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25f7-d720-378c-5b85" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5eb-fa32-ae66-258b" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25f7-d720-378c-5b85" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="aa53-a45d-60a9-7d74" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd2c-efa4-d4b9-e9e8" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9415-f2f3-3b2a-4d8a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd2c-efa4-d4b9-e9e8" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9415-f2f3-3b2a-4d8a" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="30f2-50d6-f638-9df4" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b40-3c48-82a2-2146" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b199-f34b-e853-890e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b40-3c48-82a2-2146" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b199-f34b-e853-890e" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="ff73-d3f3-c880-6af3" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c918-5b2c-0241-e84a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3906-bbea-2ea7-e989" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c918-5b2c-0241-e84a" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3906-bbea-2ea7-e989" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="0337-e861-5781-21e3" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="3f61-86fe-eecf-aed7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3de5-55f9-fc0e-ec1e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3de5-55f9-fc0e-ec1e" type="max" />
           </constraints>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
           </costs>
         </entryLink>
-        <entryLink id="0131-33ef-5bef-b292" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup"/>
+        <entryLink id="0131-33ef-5bef-b292" name="Retinue" hidden="false" collective="false" import="true" targetId="30af-29e4-7637-73ea" type="selectionEntryGroup" />
         <entryLink id="60f2-7c70-f59b-d319" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9342-3c92-7a7c-0b13" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0415-b111-31f1-5188" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9342-3c92-7a7c-0b13" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0415-b111-31f1-5188" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="87e8-b0b8-d5e7-6453" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be40-2194-8a16-1b35" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be40-2194-8a16-1b35" type="max" />
           </constraints>
           <rules>
             <rule id="3dbb-7853-49f6-1f0a" name="Warlord: The Blade Alone" hidden="false">
-              <description>If an army’s Warlord has this Trait, then no other models or units may use its Leadership regardless of any other rules or Wargear that a unit may have, however, whenever
-Captain Lucius is engaged in a Challenge all friendly models in the same combat gain the Fearless special rule. In addition, an army with Captain Lucius as its Warlord may make one additional Reaction each turn in any one Phase without using up a point of the army’s Reaction Allotment – but this additional Reaction must be made by Lucius and any unit he has joined.</description>
+              <description>If an army&#8217;s Warlord has this Trait, then no other models or units may use its Leadership regardless of any other rules or Wargear that a unit may have, however, whenever
+Captain Lucius is engaged in a Challenge all friendly models in the same combat gain the Fearless special rule. In addition, an army with Captain Lucius as its Warlord may make one additional Reaction each turn in any one Phase without using up a point of the army&#8217;s Reaction Allotment &#8211; but this additional Reaction must be made by Lucius and any unit he has joined.</description>
             </rule>
           </rules>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="281b-1950-5c15-de68" name="Rylanor the Unyielding" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea33-bd2e-4b08-59c6" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea33-bd2e-4b08-59c6" type="max" />
       </constraints>
       <profiles>
         <profile id="eb12-17e2-1019-a269" name="Rylanor the Unyielding" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2454,81 +2453,81 @@ Captain Lucius is engaged in a Challenge all friendly models in the same combat 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="d4b7-14c2-70f2-06a4" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule"/>
-        <infoLink id="8fff-2cd7-b38c-e631" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
+        <infoLink id="d4b7-14c2-70f2-06a4" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule" />
+        <infoLink id="8fff-2cd7-b38c-e631" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="7acc-1ab8-5189-f03c" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
-        <categoryLink id="0a18-eece-0831-f72d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="7acc-1ab8-5189-f03c" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false" />
+        <categoryLink id="0a18-eece-0831-f72d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <entryLinks>
         <entryLink id="53b4-68bd-0941-24e4" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af44-bf82-ce54-cb81" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f906-2c1b-a0cc-b7f8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af44-bf82-ce54-cb81" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f906-2c1b-a0cc-b7f8" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="4bbd-cac9-203a-aa9d" name="Kheres Assault Cannon" hidden="false" collective="false" import="true" targetId="fe77-2e74-160d-c7af" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2939-dd2c-e260-692c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8de-959f-bb28-e2fa" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2939-dd2c-e260-692c" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8de-959f-bb28-e2fa" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="74d9-1572-7ff3-68b4" name="Gravis Power Fist" hidden="false" collective="false" import="true" targetId="08be-6994-6a63-6279" type="selectionEntry">
           <modifiers>
-            <modifier type="append" field="name" value=" with in-built heavy flamer"/>
+            <modifier type="append" field="name" value=" with in-built heavy flamer" />
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e706-cc9f-9b0a-bf14" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7069-a866-6790-c633" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e706-cc9f-9b0a-bf14" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7069-a866-6790-c633" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="0e7f-1e78-aa98-22b9" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b97b-fce5-25ea-fd6f" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b34e-178e-bbb8-9ed7" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b97b-fce5-25ea-fd6f" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b34e-178e-bbb8-9ed7" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
         </entryLink>
         <entryLink id="ea04-1325-a3be-a1d8" name="Dreadnought Drop Pod" hidden="false" collective="false" import="true" targetId="1ffe-82e4-12db-538d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="763c-0fa7-f89a-4ffb" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="763c-0fa7-f89a-4ffb" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="250.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="250.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="cce2-fd03-ac17-88e4" name="Sun Killer Squad" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef7e-6bfd-8a32-f184" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef7e-6bfd-8a32-f184" type="max" />
       </constraints>
       <rules>
         <rule id="7323-707b-b5fb-ba70" name="Precision Fire" publicationId="09b3-d525-cdea-260c" page="14" hidden="false">
           <description>Enemy models may not make Cover saves or Damage Mitigation rolls against a wound caused by a Shooting Attack made by a model with this special rule, unless that Shooting Attack was made as a Snap Shot, in which case Cover Saves and Damage Mitigation rolls are made as normal.</description>
         </rule>
         <rule id="cb68-f549-a3ba-85bf" name="Fortified Position" publicationId="09b3-d525-cdea-260c" page="14" hidden="false">
-          <description>In games that allow the use of Fortifications, an Emperor&apos;s Children Sun Killer Squad that has not selected a Dedicated Transport may instead select a Defence Line without occupying a Fortification Force Organisation slot, but the cost in points must be counted towards the army total.</description>
+          <description>In games that allow the use of Fortifications, an Emperor's Children Sun Killer Squad that has not selected a Dedicated Transport may instead select a Defence Line without occupying a Fortification Force Organisation slot, but the cost in points must be counted towards the army total.</description>
         </rule>
         <rule id="4ddb-6ad8-15eb-a95f" name="Designated Quarry" publicationId="09b3-d525-cdea-260c" page="14" hidden="false">
-          <description>At the start of the battle, once both armies have set up all their models, including any units with the Infiltrator special rule, a single enemy unit with the Gargantuan, Super-heavy, Knight or Titan Unit Sub-type may be chosen by the player that controls any models with this special rule - this enemy unit is considered the &apos;Designated Quarry&apos;. When any friendly models with this special rule are used to make a Shooting Attack against the enemy unit their controlling player has selected as the Designated Quarry, all failed To Wound rolls of &apos;1&apos; may be re-rolled. If the enemy unit selected as the Designated Quarry has an Armour Value, add +1 to any results rolled on the Vehicle Damage chart as a result of Shooting Attacks made by models with this special rule.</description>
+          <description>At the start of the battle, once both armies have set up all their models, including any units with the Infiltrator special rule, a single enemy unit with the Gargantuan, Super-heavy, Knight or Titan Unit Sub-type may be chosen by the player that controls any models with this special rule - this enemy unit is considered the 'Designated Quarry'. When any friendly models with this special rule are used to make a Shooting Attack against the enemy unit their controlling player has selected as the Designated Quarry, all failed To Wound rolls of '1' may be re-rolled. If the enemy unit selected as the Designated Quarry has an Armour Value, add +1 to any results rolled on the Vehicle Damage chart as a result of Shooting Attacks made by models with this special rule.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="006a-76d7-f6d2-f760" name="Legiones Astartes (Emperor&apos;s Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule"/>
+        <infoLink id="006a-76d7-f6d2-f760" name="Legiones Astartes (Emperor's Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9ffc-7328-547c-da5c" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="3590-8673-cb28-8ec9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="4c73-6800-a149-a8a9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="9ffc-7328-547c-da5c" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="3590-8673-cb28-8ec9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="4c73-6800-a149-a8a9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6ea9-ad2c-0c87-7343" name="Sun Killer" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b349-523f-101f-9150" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4825-5f6e-ef78-0ecb" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b349-523f-101f-9150" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4825-5f6e-ef78-0ecb" type="min" />
           </constraints>
           <profiles>
             <profile id="3a50-7f25-9b91-7d9c" name="Sun Killer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2548,13 +2547,13 @@ Captain Lucius is engaged in a Challenge all friendly models in the same combat 
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="c2a0-d12a-e397-daca" name="Novaetor" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d220-906f-a09e-ade2" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8ec-6432-ee58-df80" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d220-906f-a09e-ade2" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8ec-6432-ee58-df80" type="min" />
           </constraints>
           <profiles>
             <profile id="5e59-aa3d-a72a-2122" name="Novaetor" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2576,34 +2575,34 @@ Captain Lucius is engaged in a Challenge all friendly models in the same combat 
           <selectionEntryGroups>
             <selectionEntryGroup id="d5c7-3c55-6d1c-df1c" name="Melee Option:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b9c3-1fa4-74c0-c00e">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0683-47eb-3366-b91b" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9102-f557-b250-b806" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0683-47eb-3366-b91b" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9102-f557-b250-b806" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="a099-b9e8-69db-7ce4" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="1af5-8a2f-0c6e-e5bc" name="Charnabal Weapon" hidden="false" collective="false" import="true" targetId="2376-af96-e101-e712" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="b9c3-1fa4-74c0-c00e" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+                <entryLink id="b9c3-1fa4-74c0-c00e" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
             <entryLink id="02da-38c2-21c6-afdd" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6794-0218-dcc0-5621" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa0f-76d6-199c-77d7" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6794-0218-dcc0-5621" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa0f-76d6-199c-77d7" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2612,34 +2611,34 @@ Captain Lucius is engaged in a Challenge all friendly models in the same combat 
           <entryLinks>
             <entryLink id="987e-3d1e-50c5-c0a0" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2e7-d14f-7fd2-1d2e" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2e7-d14f-7fd2-1d2e" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
               </costs>
             </entryLink>
             <entryLink id="847e-dc0b-4570-a334" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35bc-e337-c049-d1e1" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35bc-e337-c049-d1e1" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
             <entryLink id="a7f6-3e12-4b08-5227" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92e1-3e05-ed75-bbbb" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92e1-3e05-ed75-bbbb" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
-            <entryLink id="a8e9-7f70-fdcb-6e33" name="Surgical Augment" hidden="false" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup"/>
+            <entryLink id="a8e9-7f70-fdcb-6e33" name="Surgical Augment" hidden="false" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="f88c-b549-4371-b615" name="Dedicated Transport/Fortified Position" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c390-a765-a780-e981" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c390-a765-a780-e981" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="24e1-30bb-c65b-367c" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry">
@@ -2648,8 +2647,8 @@ Captain Lucius is engaged in a Challenge all friendly models in the same combat 
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                        <condition field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                        <condition field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan" />
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -2662,23 +2661,23 @@ Captain Lucius is engaged in a Challenge all friendly models in the same combat 
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
-                        <condition field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
+                        <condition field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan" />
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
               </modifiers>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0" />
               </costs>
             </entryLink>
-            <entryLink id="161d-ca3a-b732-bed4" name="Defence Line" hidden="false" collective="false" import="true" targetId="ea91-0572-393c-e925" type="selectionEntry"/>
+            <entryLink id="161d-ca3a-b732-bed4" name="Defence Line" hidden="false" collective="false" import="true" targetId="ea91-0572-393c-e925" type="selectionEntry" />
             <entryLink id="1759-8125-6a16-ce9b" name="Storm Eagle Gunship" hidden="true" collective="false" import="true" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -2689,109 +2688,109 @@ Captain Lucius is engaged in a Challenge all friendly models in the same combat 
           <modifiers>
             <modifier type="increment" field="91e9-5742-ec20-2ce3" value="1.0">
               <repeats>
-                <repeat field="selections" scope="cce2-fd03-ac17-88e4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cce2-fd03-ac17-88e4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
             <modifier type="increment" field="a783-04ab-4ee6-ed2f" value="1.0">
               <repeats>
-                <repeat field="selections" scope="cce2-fd03-ac17-88e4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cce2-fd03-ac17-88e4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
-            <modifier type="set" field="a783-04ab-4ee6-ed2f" value="0.0"/>
+            <modifier type="set" field="a783-04ab-4ee6-ed2f" value="0.0" />
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a783-04ab-4ee6-ed2f" type="min"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91e9-5742-ec20-2ce3" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a783-04ab-4ee6-ed2f" type="min" />
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91e9-5742-ec20-2ce3" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="ad69-0b98-edca-c09b" name="Lascannon" hidden="false" collective="false" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry"/>
-            <entryLink id="8c7a-8058-58c4-6c1b" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="170d-44e0-455c-8207" type="selectionEntry"/>
-            <entryLink id="1d05-685e-c1de-8976" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry"/>
-            <entryLink id="1f60-49ed-d204-5df6" name="Plasma Cannon" hidden="false" collective="false" import="true" targetId="43f5-3815-6b3a-a363" type="selectionEntry"/>
+            <entryLink id="ad69-0b98-edca-c09b" name="Lascannon" hidden="false" collective="false" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry" />
+            <entryLink id="8c7a-8058-58c4-6c1b" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="170d-44e0-455c-8207" type="selectionEntry" />
+            <entryLink id="1d05-685e-c1de-8976" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry" />
+            <entryLink id="1f60-49ed-d204-5df6" name="Plasma Cannon" hidden="false" collective="false" import="true" targetId="43f5-3815-6b3a-a363" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="fee5-7f48-029f-8311" name=" Novaetor Weapon Choice:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b217-7867-e795-aeb3">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e13-c8dc-febb-0a3c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e13-c8dc-febb-0a3c" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="252c-73fd-4551-43ae" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry"/>
-            <entryLink id="bda9-54a4-b7ab-de16" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry"/>
-            <entryLink id="e0fb-c9fe-18f7-071d" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry"/>
-            <entryLink id="43fc-45c5-1983-15d4" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry"/>
-            <entryLink id="3c9e-3336-0d6b-5786" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry"/>
-            <entryLink id="12c1-14a9-9bd3-c8d6" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry"/>
-            <entryLink id="9271-83cc-853e-bf30" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry"/>
+            <entryLink id="252c-73fd-4551-43ae" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry" />
+            <entryLink id="bda9-54a4-b7ab-de16" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry" />
+            <entryLink id="e0fb-c9fe-18f7-071d" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry" />
+            <entryLink id="43fc-45c5-1983-15d4" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry" />
+            <entryLink id="3c9e-3336-0d6b-5786" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry" />
+            <entryLink id="12c1-14a9-9bd3-c8d6" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry" />
+            <entryLink id="9271-83cc-853e-bf30" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry" />
             <entryLink id="1299-c9e5-95bb-e507" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
-            <entryLink id="b217-7867-e795-aeb3" name="Lascannon" hidden="false" collective="false" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry"/>
-            <entryLink id="a169-51e6-7195-ecf8" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry"/>
-            <entryLink id="5b85-7594-7fa7-3766" name="Plasma Cannon" hidden="false" collective="false" import="true" targetId="43f5-3815-6b3a-a363" type="selectionEntry"/>
-            <entryLink id="3ed5-ded1-534e-d846" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="170d-44e0-455c-8207" type="selectionEntry"/>
+            <entryLink id="b217-7867-e795-aeb3" name="Lascannon" hidden="false" collective="false" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry" />
+            <entryLink id="a169-51e6-7195-ecf8" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry" />
+            <entryLink id="5b85-7594-7fa7-3766" name="Plasma Cannon" hidden="false" collective="false" import="true" targetId="43f5-3815-6b3a-a363" type="selectionEntry" />
+            <entryLink id="3ed5-ded1-534e-d846" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="170d-44e0-455c-8207" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="b28f-afb5-3661-fd3e" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c058-31eb-2178-ea9a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bb0-0bc3-09c5-aec2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c058-31eb-2178-ea9a" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bb0-0bc3-09c5-aec2" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="a509-af92-a00d-e3ec" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5e1-c92a-1e54-7c9e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f6d-da02-36a6-e8bd" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5e1-c92a-1e54-7c9e" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f6d-da02-36a6-e8bd" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="2fec-c7aa-1012-a607" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bf8-4be6-7f85-771a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a9c-67ef-483d-2eab" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bf8-4be6-7f85-771a" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a9c-67ef-483d-2eab" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="768e-2afb-5089-0fba" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff37-fcc6-07ac-0ed4" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e787-f856-e9a2-cea0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff37-fcc6-07ac-0ed4" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e787-f856-e9a2-cea0" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="1d83-4f3d-4a9b-dc39" name="Palatine Blade Aquilae Squad" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="6c36-73b4-d013-2f61" name="Legiones Astartes (Emperor&apos;s Children)" hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule"/>
-        <infoLink id="4125-5e87-323d-cc0e" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="ee8a-ad82-d5fd-481e" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
+        <infoLink id="6c36-73b4-d013-2f61" name="Legiones Astartes (Emperor's Children)" hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule" />
+        <infoLink id="4125-5e87-323d-cc0e" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="ee8a-ad82-d5fd-481e" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
         <infoLink id="db96-be3e-168e-b9b1" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Counter-attack (1)"/>
+            <modifier type="set" field="name" value="Counter-attack (1)" />
           </modifiers>
         </infoLink>
-        <infoLink id="b772-ca8c-be1c-21e5" name="Skill Unmatched" hidden="false" targetId="752f-1b0d-5888-22b5" type="rule"/>
+        <infoLink id="b772-ca8c-be1c-21e5" name="Skill Unmatched" hidden="false" targetId="752f-1b0d-5888-22b5" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9d48-00b2-f037-c189" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="1cd7-f1fc-ce5b-71b9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="746b-9b15-ae4d-a2e2" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
+        <categoryLink id="9d48-00b2-f037-c189" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="1cd7-f1fc-ce5b-71b9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="746b-9b15-ae4d-a2e2" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="aea4-53ae-9aba-8608" name="Palatine Prefector" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67c4-a98f-3e4e-3692" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9789-31ca-c734-535d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67c4-a98f-3e4e-3692" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9789-31ca-c734-535d" type="min" />
           </constraints>
           <profiles>
             <profile id="ed82-eec4-01b1-e111" name="Palatine Prefector" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2807,15 +2806,15 @@ Captain Lucius is engaged in a Challenge all friendly models in the same combat 
         </selectionEntry>
         <selectionEntry id="7083-4849-ab3b-de85" name="Palatine Warriors" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbab-b8db-c1d5-8c2c" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a56d-d1e2-1509-2f3a" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbab-b8db-c1d5-8c2c" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a56d-d1e2-1509-2f3a" type="min" />
           </constraints>
           <profiles>
             <profile id="fa4b-80ad-df3f-13ea" name="Palatine Warrior" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry
 </characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2829,100 +2828,100 @@ Captain Lucius is engaged in a Challenge all friendly models in the same combat 
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="f9a8-8a16-d04d-f96b" name="All models must choose from:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="131d-42a8-7af6-a07c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae27-6812-914c-c846" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="131d-42a8-7af6-a07c" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae27-6812-914c-c846" type="min" />
           </constraints>
           <entryLinks>
-            <entryLink id="216c-ee76-354a-ed63" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry"/>
-            <entryLink id="a1f0-8331-ee2c-e208" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry"/>
-            <entryLink id="0a49-5f1a-860f-2d6b" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry"/>
+            <entryLink id="216c-ee76-354a-ed63" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry" />
+            <entryLink id="a1f0-8331-ee2c-e208" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry" />
+            <entryLink id="0a49-5f1a-860f-2d6b" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry" />
             <entryLink id="05db-de94-488d-b90d" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
             <entryLink id="a0f8-c591-5090-ed99" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
             <entryLink id="c4a7-5c7e-ebdb-13d9" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
             <entryLink id="47de-e73a-9bc1-c270" name="Phoenix Rapier" hidden="false" collective="false" import="true" targetId="868d-b957-c9ae-d3f2" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
             <entryLink id="10b1-c551-0eea-d315" name="Phoenix Power Spear" hidden="false" collective="false" import="true" targetId="356b-300e-d83d-72b8" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
             <entryLink id="1247-b097-2566-dc1b" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="a0e1-a15e-d9d0-61bd" name="All models in the unit may choose to take the same Surgical Augment:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7d3-6429-dd3f-d757" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7d3-6429-dd3f-d757" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="06a7-9ff2-0b11-68f5" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="3f61-86fe-eecf-aed7" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </entryLink>
             <entryLink id="4e60-1c77-3371-423f" name="Sub-sonic Pulser" hidden="false" collective="false" import="true" targetId="ddd0-22b3-ea96-680d" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </entryLink>
             <entryLink id="2f09-694a-5986-5640" name="Sonic Lance" hidden="false" collective="false" import="true" targetId="5007-1732-6ad5-ce36" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="abb7-6f87-8bb8-5550" name="The Palatine Prefector may exchange his bolt pistol for:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9127-0455-3aa0-a012" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9127-0455-3aa0-a012" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="8467-c154-150e-523b" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4ba-6c6d-46e9-79fb" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4ba-6c6d-46e9-79fb" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="d97e-3a0d-bbf0-d363" name="The Palatine Prefector may take:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b62-8e7d-10e5-d6e0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b62-8e7d-10e5-d6e0" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="0b14-641e-eb54-1821" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fdd-a829-e4b3-2d00" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fdd-a829-e4b3-2d00" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -2931,164 +2930,164 @@ Captain Lucius is engaged in a Challenge all friendly models in the same combat 
       <entryLinks>
         <entryLink id="b8e3-f587-f478-89a9" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="452c-4bfa-24a8-bce3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd6f-c2a6-7f79-c9c6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="452c-4bfa-24a8-bce3" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd6f-c2a6-7f79-c9c6" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="2bde-d349-afd1-3a0d" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e96-fa02-7c59-54d9" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5266-551d-d9c9-8370" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e96-fa02-7c59-54d9" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5266-551d-d9c9-8370" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="3df7-657f-56fc-43f9" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93b3-36bd-22fe-55b2" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2211-0839-136f-cbc1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93b3-36bd-22fe-55b2" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2211-0839-136f-cbc1" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="a447-e1b7-e22c-b517" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4ff-04ec-dacc-b259" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19d5-d5b3-0d4b-2399" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4ff-04ec-dacc-b259" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19d5-d5b3-0d4b-2399" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="ed36-fb56-e13f-2000" name="Warhawk Jump Pack" hidden="false" collective="false" import="true" targetId="a298-8584-70ed-18ce" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d32-39af-46cb-8ec3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4fb-d847-5628-f404" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d32-39af-46cb-8ec3" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4fb-d847-5628-f404" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="30af-29e4-7637-73ea" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="2a9c-85d8-0cc3-536c" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="2a9c-85d8-0cc3-536c" type="max" />
       </constraints>
       <entryLinks>
         <entryLink id="64ae-669e-eb78-d00c" name="Command Squad, Cataphractii" hidden="false" collective="false" import="true" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="5b52-604a-eea2-f0f2" name="Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
-        <entryLink id="5fb0-8333-47d9-b44a" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
-        <entryLink id="37e9-0d20-1935-e0ec" name="Phoenix Terminator Squad" hidden="false" collective="false" import="true" targetId="5b08-65c1-cc45-1b91" type="selectionEntry"/>
+        <entryLink id="5b52-604a-eea2-f0f2" name="Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
+        <entryLink id="5fb0-8333-47d9-b44a" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
+        <entryLink id="37e9-0d20-1935-e0ec" name="Phoenix Terminator Squad" hidden="false" collective="false" import="true" targetId="5b08-65c1-cc45-1b91" type="selectionEntry" />
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="0cb4-896e-a455-243b" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="2eea-3d53-05e7-90cd" value="1.0">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3b1c-6110-d10c-e91f" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2eea-3d53-05e7-90cd" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3b1c-6110-d10c-e91f" type="max" />
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2eea-3d53-05e7-90cd" type="min" />
       </constraints>
       <selectionEntryGroups>
-        <selectionEntryGroup id="82e0-3f1f-c4cc-15d6" name="  III: Emperor&apos;s Children" publicationId="09c5-eeae-f398-b653" page="152" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="82e0-3f1f-c4cc-15d6" name="  III: Emperor's Children" publicationId="09c5-eeae-f398-b653" page="152" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5e59-3378-fadb-9de7" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b95b-0247-1a89-8377" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5e59-3378-fadb-9de7" type="max" />
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b95b-0247-1a89-8377" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="a843-14b9-97c5-07f5" name="The Broken Mirror (Traitor only)" publicationId="09c5-eeae-f398-b653" page="152" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ece7-8a88-474b-dd0b" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="39f1-727a-61ee-e77a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ece7-8a88-474b-dd0b" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="39f1-727a-61ee-e77a" type="max" />
               </constraints>
               <profiles>
                 <profile id="cd44-278f-9152-d88f" name="The Broken Mirror" publicationId="09c5-eeae-f398-b653" page="152" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Traitor Allegiance.
-When a friendly unit comprised of more than one model and within 12&quot; of a Warlord with this Trait, including the Warlord and any unit it has joined, fails a Morale check, instead of Falling Back it must instead suffer one Wound that cannot be negated by any Armour Saves or Damage Mitigation rolls (this Wound is allocated by the unit’s controlling player). Once this Wound has been resolved, the unit is considered to have passed the Morale check and play continues as normal. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
+When a friendly unit comprised of more than one model and within 12" of a Warlord with this Trait, including the Warlord and any unit it has joined, fails a Morale check, instead of Falling Back it must instead suffer one Wound that cannot be negated by any Armour Saves or Damage Mitigation rolls (this Wound is allocated by the unit&#8217;s controlling player). Once this Wound has been resolved, the unit is considered to have passed the Morale check and play continues as normal. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="1b99-f912-ba66-9528" name="Paragon of Excellence" publicationId="09c5-eeae-f398-b653" page="152" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f3ae-bbec-d9ab-851f" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="260d-6779-9884-debd" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f3ae-bbec-d9ab-851f" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="260d-6779-9884-debd" type="max" />
               </constraints>
               <profiles>
                 <profile id="7ad9-f6f4-600a-c882" name="Paragon of Excellence" publicationId="09c5-eeae-f398-b653" page="152" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When any friendly unit within 12&quot; of a Warlord with this Trait, including the Warlord and any unit it has joined, passes a Morale check it gains +1 Weapon Skill until the end of the controlling player’s next turn (this benefit can only be applied once per Game Turn to any single unit). In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When any friendly unit within 12" of a Warlord with this Trait, including the Warlord and any unit it has joined, passes a Morale check it gains +1 Weapon Skill until the end of the controlling player&#8217;s next turn (this benefit can only be applied once per Game Turn to any single unit). In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="3281-2d9e-cf03-0dbb" name="Martyrs of Isstvan (Loyalist only)" publicationId="09c5-eeae-f398-b653" page="152" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dbf0-be4b-3c70-011d" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5bf8-9a19-9862-b901" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dbf0-be4b-3c70-011d" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5bf8-9a19-9862-b901" type="max" />
               </constraints>
               <profiles>
                 <profile id="41d9-a562-b004-dc98" name="Martyrs of Isstvan" publicationId="09c5-eeae-f398-b653" page="152" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Loyalist Allegiance.
-A Warlord with this Trait and all models in a unit the Warlord has joined that have the Legiones Astartes (Emperor’s Children) special rule gain a bonus of +1 to all To Hit rolls made while locked in combat with an enemy unit that has any version of the Legiones Astartes (X) special rule and the Traitor Allegiance. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+A Warlord with this Trait and all models in a unit the Warlord has joined that have the Legiones Astartes (Emperor&#8217;s Children) special rule gain a bonus of +1 to all To Hit rolls made while locked in combat with an enemy unit that has any version of the Legiones Astartes (X) special rule and the Traitor Allegiance. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="3171-5c8a-52a0-550e" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+        <entryLink id="3171-5c8a-52a0-550e" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Imperial Fists.cat
+++ b/2022 - LA - Imperial Fists.cat
@@ -2842,7 +2842,7 @@ A model with a Vigil storm shield gains a 3+ Invulnerable Save &#8211; Invulnera
         </entryLink>
         <entryLink id="6c7f-c156-bba1-86da" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_be38-a066-4f8e-ae54</comment></selectionEntryGroup>
     <selectionEntryGroup id="164e-db98-d506-d2d9" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="650b-6ccb-78d6-32d9" value="1.0">
@@ -2936,7 +2936,7 @@ A Warlord with this Trait and all models in any friendly unit that Warlord joins
       <entryLinks>
         <entryLink id="2809-4aa4-99ce-fffe" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_7dee-602c-4b47-be09</comment></selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
     <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />

--- a/2022 - LA - Imperial Fists.cat
+++ b/2022 - LA - Imperial Fists.cat
@@ -1,6 +1,5 @@
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="8866-00ec-715f-f21a" name="LA -   VII: Imperial Fists" revision="13" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26">
-  <entryLinks>
-    <entryLink id="b3e4-1487-4ab7-7515" name="Alexis Polux " hidden="false" collective="false" import="false" targetId="9229-b4f9-2213-9672" type="selectionEntry">
+  <entryLinks><entryLink id="b3e4-1487-4ab7-7515" name="Alexis Polux " hidden="false" collective="false" import="false" targetId="9229-b4f9-2213-9672" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -141,945 +140,1957 @@
         <categoryLink id="9994-ceb4-762d-8d57" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="9586-4b82-f199-8c7c" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="47ef-fb83-f80f-d54b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="59a4-7980-22c4-f717" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <entryLink id="9586-4b82-f199-8c7c" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d3f0-cb9d-4c8e-9469" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6d4-581f-4746-bec3</comment></categoryLink>
+        <categoryLink id="c68f-1df1-4084-ad7e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_2489-ee2a-45dd-b384</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
-    <entryLink id="a840-8a82-55c3-5045" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e23e-9540-7514-16a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e19c-7caf-ff85-b0ed" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
-    <entryLink id="6445-0f74-57d7-7267" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink><entryLink id="a840-8a82-55c3-5045" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b02f-e65f-4a88-a175</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_b87b-bf35-4238-b7c6</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1aff-27af-435e-8102</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_fdf9-4906-4180-a39d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b5bd-4049-731e-cc49" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="ad85-f23a-72a7-0218" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c25d-266e-495d-d157" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="4cab-5ce5-4225-b7fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8378-ede4-476d-b657</comment></categoryLink>
+        <categoryLink id="6e8b-ecc5-4ce2-add4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_d64f-ad19-426c-adf7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
-    <entryLink id="9fc4-d7aa-eeb0-0a56" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="717c-8cb4-6dca-6561" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="046f-5dda-dd4f-9604" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
-    <entryLink id="7d74-be12-a4c7-bae9" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3662-1e31-c505-a363" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="30ec-959e-9485-83a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
-    <entryLink id="16b5-ada1-0377-a933" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink><entryLink id="6445-0f74-57d7-7267" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_7fd1-8ce8-4d10-82e7</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_eaae-8c43-4d30-898c</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_f67d-8cf3-424f-b491</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_b949-6414-4f3d-b268</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d622-65cd-95c1-3848" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="5cfe-9890-b315-b4b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d3e8-e10a-c484-4f8e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="15cf-00fb-4b4c-a4e9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_ac26-e639-4d53-9b8b</comment></categoryLink>
+        <categoryLink id="46e5-40ff-47a1-be46" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_49af-0d08-4c7e-8ce6</comment></categoryLink>
+        <categoryLink id="a7d9-5f40-4c09-a796" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_b606-de16-4659-95cd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
-    <entryLink id="5144-4cee-e424-9c49" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink><entryLink id="9fc4-d7aa-eeb0-0a56" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="dcde-9335-bea9-54b4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="9481-8835-60d7-4466" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
-    <entryLink id="75de-7301-dc98-3a8b" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7583-6fa0-4089-a19e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_0e5c-99ab-41d3-a42e</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c296-e8e8-4a7a-989a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_8868-5bcb-4604-ba8e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ffdb-4282-40c8-83d7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a009-a597-4b51-b228</comment></categoryLink>
+        <categoryLink id="c386-b366-4f72-9623" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_24f4-9145-4016-80d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink><entryLink id="7d74-be12-a4c7-bae9" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_e732-7499-47bf-9748</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_81a5-a959-46b7-baa4</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7ec3-447a-4644-b012</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_71e2-c430-4c99-a559</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_df7b-3fb9-4f65-9165</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3604-c11e-4414-867b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c165-3906-463a-9c73</comment></categoryLink>
+        <categoryLink id="bcf6-2cdf-4323-8306" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6d1-d14c-473f-be09</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink><entryLink id="16b5-ada1-0377-a933" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_27a3-1e4c-4b76-a594</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_d59a-dcd0-44fd-b866</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_0c8b-2b92-49ed-98c7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_bafe-f799-41d9-ac85</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_6369-288c-4fec-a640</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_fe53-8858-41dc-8ec4</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="590a-e828-9f6f-a2a9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="6258-dd8a-0e5d-05e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bf6e-1cdb-4409-a50e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_3a22-caae-4eea-9bc5</comment></categoryLink>
+        <categoryLink id="a0f2-3814-4bf4-9ee2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f759-f33e-4698-9f8a</comment></categoryLink>
+        <categoryLink id="41c1-2932-4dd2-80f2" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_c624-3ae0-46c0-9b06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
-    <entryLink id="aafa-cd47-643c-0b12" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="61a9-ea18-ad59-7d2d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="fff6-c8dd-f828-acbb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="fa0c-191c-bd37-f71b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="5c8e-5590-884d-692f" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink><entryLink id="5144-4cee-e424-9c49" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_13b3-ce1e-4f9d-8319</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d681-9d81-4abd-b11b</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a57-e48b-4534-bca5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_1859-5641-4674-9097</comment>
+                </condition>
               </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-        <entryLink id="e2e7-e179-8fd3-28b7" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
-    <entryLink id="1dd5-63c7-0a9e-0832" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
-      <modifiers>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c2dd-1bff-46bc-b48f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_251a-df5b-4bfd-ad63</comment></categoryLink>
+        <categoryLink id="f5be-a57a-4f5b-aed1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4644-98ab-4e3f-b1fd</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink><entryLink id="75de-7301-dc98-3a8b" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_591d-d028-4663-918d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_0482-c5f9-4c95-9597</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_75a7-971d-4978-a83f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_a7d5-2bfe-4621-ac0c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9f13-b460-4f27-b0cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_31fc-e265-45a7-bb5b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="87d1-9445-fef7-3ce4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0800-c673-9000-76dd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="2bc9-64a8-d780-5482" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="af81-64d7-4d46-8868" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_67c2-df43-44fc-92d1</comment></categoryLink>
+        <categoryLink id="9a52-0a67-4363-933d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4136-bb4e-4dd4-99f9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink><entryLink id="aafa-cd47-643c-0b12" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry"><categoryLinks>
+        <categoryLink id="05fd-250f-4662-ac8c" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_2599-24e3-44e5-9568</comment></categoryLink>
+        <categoryLink id="e34f-fa33-4831-86f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_285f-6e56-473b-b2fe</comment></categoryLink>
+        <categoryLink id="48f9-5a8b-46cd-a5b6" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_685e-022f-4e2f-a568</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="1ffd-7b54-7c94-a086" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup">
+        <entryLink id="dce5-c4c9-4327-a2b7" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup"><comment>    template_id_2a38-6544-4267-b584    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="0662-bde0-48c2-93c9" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_8287-16ff-46ba-9838</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_81c1-fca9-44dc-ba4c</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
-        <entryLink id="2731-87d3-87b4-179d" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup" />
+        <comment>    template_id_6e59-4592-47ef-b76d    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
-    <entryLink id="0ba2-ada6-3003-9042" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e02b-db4d-3114-d1bd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="32ef-2312-2197-5708" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="ef48-e7aa-2d83-fd67" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="457a-ee7f-fc9c-bf4a" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-        <entryLink id="9aa8-f04e-f8a5-877a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
-    <entryLink id="601e-a3c7-a43f-9d13" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="43db-3ecf-b50d-bbc0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="10e3-ba04-a0f2-fb0a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
-    <entryLink id="c6a4-c488-a354-644d" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b9ed-997b-8fd1-c04f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="95fa-49ee-039b-bf41" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
-    <entryLink id="c0b1-dd05-761b-b6bc" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink><entryLink id="1dd5-63c7-0a9e-0832" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ad5d-3c79-4239-9116</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_60b1-049b-4a5f-85c2</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2e77-4c9a-32fc-724b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a82a-112b-573c-6c31" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="71f2-1921-49f2-9a43" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bd6a-0cda-4e0f-80ae</comment></categoryLink>
+        <categoryLink id="4657-9be9-4ab2-804d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_ae75-7cca-4701-9d56</comment></categoryLink>
+        <categoryLink id="7ca9-7333-460d-ae89" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_e517-62d4-48f7-8174</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
-    <entryLink id="be42-e556-3b98-ac06" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
+      <entryLinks>
+        <entryLink id="76db-ca18-4db8-ae99" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup"><comment>    template_id_fafb-6414-474a-8a09    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="8638-4be6-4536-934a" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_1e43-c980-4508-8ec2</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_4140-36a7-4203-b5e9</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_a6a6-9bc7-4d4e-86a7    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink><entryLink id="0ba2-ada6-3003-9042" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry"><categoryLinks>
+        <categoryLink id="4ad7-f5e3-4ece-bf93" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fc9d-03d1-4bbd-a1c4</comment></categoryLink>
+        <categoryLink id="7247-1037-41d1-9fff" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_f51c-73d7-4f29-be1c</comment></categoryLink>
+        <categoryLink id="28e4-09a3-41fc-b85e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_257d-78c0-4bab-ba65</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="b401-a2e8-46f3-8b78" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup"><comment>    template_id_ac26-33db-40a7-bdba    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="429e-a0f0-4052-aebe" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_189b-db75-4db6-9fe9</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_cbdb-2500-4e13-876a</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_dc8e-2801-46d6-84f8    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink><entryLink id="601e-a3c7-a43f-9d13" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b43b-547f-472e-9076</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8ff9-0498-4540-8552</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fbfe-931a-489b-a589</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f4c3-5aa6-4caa-abf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_17f8-f055-4c9c-b757</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="962d-ff5d-a589-37f8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5160-5ed6-d275-fddd" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="8822-0d15-462c-aff4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f1c8-27fd-4f98-8527</comment></categoryLink>
+        <categoryLink id="ac8f-1e05-4ff4-8738" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2b20-1a8b-4753-b657</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
-    <entryLink id="52a6-f923-f1a7-f203" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink><entryLink id="c6a4-c488-a354-644d" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry"><categoryLinks>
+        <categoryLink id="93ff-519d-4b8a-b0f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4207-8d8f-4b1a-836b</comment></categoryLink>
+        <categoryLink id="9d10-3bdc-44e1-a20b" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_2b34-077f-4279-86fb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink><entryLink id="c0b1-dd05-761b-b6bc" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="e3c7-c7ff-5c11-ea26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b4ce-bc5a-34b7-cd74" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="a16b-c834-45bd-ad7e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6577-e0fb-4fda-834e</comment></categoryLink>
+        <categoryLink id="fd15-a95a-4c48-b7f9" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_5d59-09bf-4566-b7e1</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
-    <entryLink id="eb10-8d4b-c2c7-17d4" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink><entryLink id="be42-e556-3b98-ac06" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"><categoryLinks>
+        <categoryLink id="8367-cdd9-43a6-894e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_aa93-057d-42f6-82d7</comment></categoryLink>
+        <categoryLink id="b8c6-34da-4eb1-845f" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_403c-4e9c-4af5-84ec</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink><entryLink id="52a6-f923-f1a7-f203" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_23fa-06dd-49f9-a7db</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5b26-059e-40b3-9d93</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f7bf-3a1c-4103-aed8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="f81e-a92f-6c7e-0980" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="d6da-13e2-7a4d-60b7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cfd9-f24f-421c-be2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dd44-e0a8-42a8-bdcc</comment></categoryLink>
+        <categoryLink id="2cc5-1efd-4a9d-a19f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_c5b0-f9ae-468d-924a</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
-    <entryLink id="aaf0-88c6-bdc4-e474" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink><entryLink id="eb10-8d4b-c2c7-17d4" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8396-e51c-4e2b-bada</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_13bb-9fb5-4580-92cf</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_bfb8-8125-4548-92f5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25e3-b8f5-4448-a7c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="faa1-5455-4c28-9c87" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_f926-27fd-4a92-97a1</comment></categoryLink>
+        <categoryLink id="2731-9e48-40fb-b32f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_82e3-36e1-4e85-8fcb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink><entryLink id="aaf0-88c6-bdc4-e474" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0443-96ce-bcb4-0051" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
         <categoryLink id="6489-c04e-5c52-779e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="01c3-2504-e80d-f951" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
-      <modifiers>
+    <entryLink id="01c3-2504-e80d-f951" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_658f-b1ad-4347-a998</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_12bc-3db2-4d28-abce</comment>
+            </condition>
           </conditions>
         </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="212d-5ae8-377b-4e83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="cac6-7437-cdd7-e86b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
-    <entryLink id="5a18-11c5-5201-77d0" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_9d83-7691-41d6-8dad</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_add7-ba48-46d4-8a02</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_1fb0-2421-40a4-9e49</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d73b-a407-0131-92bc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="1262-cf57-7c1b-575d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="40e5-fffe-0ce8-1eb2" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="659a-24fb-4820-8634" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7004-b00d-481f-b740</comment></categoryLink>
+        <categoryLink id="9e73-29b0-4e5a-88ba" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4f88-2fc3-491c-bfb7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
-    <entryLink id="e4d2-83cf-ee27-ab46" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6bf6-58bc-3de6-61bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8946-5d4e-d6f8-6709" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
-    <entryLink id="6f9b-b823-db02-749d" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e78a-5a31-04d0-9a38" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="9caf-b166-6e85-3fa0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
-    <entryLink id="f5a3-cf20-d280-0d62" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="034a-b657-4331-482a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="9694-8b06-6b72-c761" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
-    <entryLink id="8fec-45d2-8c3b-1d40" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3def-9e3f-93ca-c5b9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="2a23-c511-c2b3-e449" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
-    <entryLink id="318d-0ca8-920b-a155" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="61eb-6a78-045e-c729" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="74ec-ad61-504f-2e4d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
-    <entryLink id="85df-adb9-8692-6b35" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f0c9-2840-406c-dade" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="7f9a-3d07-b4b1-0118" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
-    <entryLink id="d49d-b769-a7a1-105f" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6456-977b-7984-ba1f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="06fc-3975-ff4c-471c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
-    <entryLink id="72b6-bd25-6175-78f0" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="f9cf-9666-e965-e4d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d437-76e4-63e3-557a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
-    <entryLink id="e2d1-37a3-572a-ec6b" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a7c9-8373-0627-56b2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="e8b7-3893-52b9-405d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
-    <entryLink id="58a1-1b58-e82a-e16a" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7923-78f2-c03d-4753" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="97a1-a791-0647-3bbc" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
-    <entryLink id="e569-03b6-aee1-0753" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6c8e-b039-4e50-10df" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="5716-3b33-edfc-9178" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
-    <entryLink id="2f2b-9484-e05f-70dc" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7daa-e663-050d-5519" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="4ccb-bc87-221c-18a1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
-    <entryLink id="6f01-0e86-1f6d-16a7" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1aea-bca1-2183-0859" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="1444-977a-f6db-d3aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
-    <entryLink id="9be0-518e-a269-8f24" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="257f-a07b-4a39-d2a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="06c4-336e-9847-fc86" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
-    <entryLink id="2619-062d-f834-7acf" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1803-7d45-bc05-1924" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0cce-d229-679a-54fc" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
-    <entryLink id="ac56-cdc4-63cf-61b1" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="4200-ff67-8196-c3eb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="3a2d-e60e-f5a7-1c72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
-    <entryLink id="6764-be36-2434-9807" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="58c8-bd18-3008-2861" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="5f81-3d66-2dbe-752a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
-    <entryLink id="6460-302a-4edf-0f8f" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="cad5-93d3-73d0-b7e1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="d327-daff-3007-2ce7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
-    <entryLink id="e7a9-d890-739a-b83d" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1106-dfdb-1061-5622" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="7bf4-6bb0-c9fe-b689" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
-    <entryLink id="cc42-19e4-a783-9145" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9a49-8843-adf4-d448" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="9d8f-05f0-52f5-a78f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
-    <entryLink id="5d3e-7bdf-f892-ba0e" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="410c-cff2-1480-9e6b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="8bc8-f311-e10d-5b90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
-    <entryLink id="e823-d2fc-99d4-7c6c" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8887-4fb0-f50f-71d1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="a13c-a5f2-c61b-37cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
-    <entryLink id="3161-18f3-4ff5-565e" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="208a-c842-a3e5-0cbf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="3200-21ec-16c3-05fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
-    <entryLink id="8612-8de9-0d49-bc1c" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8375-b2bc-b21f-6d62" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="76a9-9067-c558-8050" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
-    <entryLink id="89f4-ec64-18e3-834a" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="798e-a9ff-0549-f6ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="14c5-d9b9-da62-b98b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
-    <entryLink id="2c48-417f-2d9f-607f" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2134-480f-42c0-e0c3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="4da0-e85b-d624-c95e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
-    <entryLink id="a598-c2dd-0f71-f45b" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="f2be-a5a7-541e-bc2d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="76de-e849-aa9e-2613" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
-    <entryLink id="a59b-5848-48be-a140" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6396-d7a3-ad58-ba44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="136d-5187-426c-24d0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
-    <entryLink id="7adb-70a6-609d-c5cd" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0c42-0d87-5d42-4a2b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="6816-a248-0d38-3e72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
-    <entryLink id="b631-2b65-2745-d79c" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="f307-1415-e1ad-a802" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="e378-b7ba-eec5-dc84" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
-    <entryLink id="0494-6bf7-a54d-33b6" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2f00-2f8a-19eb-1c2e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7fbf-f45e-492a-8d14" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
-    <entryLink id="66e7-ee64-2389-9645" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ffaa-7844-7127-00da" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="5116-89cd-9757-e6f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="13a6-ada3-716a-ff96" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="a08c-011b-657c-2b29" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup" />
-        <entryLink id="911e-408a-54b9-0665" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
-    <entryLink id="a201-1329-ae33-a22b" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e2aa-3263-a6f5-bb01" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="1218-58c8-f917-1e6a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="37be-f2ca-8423-c23f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="6b3a-20f7-081c-6e0a" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup" />
-        <entryLink id="f61f-c8ac-4596-a30d" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
-    <entryLink id="da86-05c2-dfd5-5d37" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d933-cbf0-2445-0e88" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="8641-efc7-96cc-e018" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b4b4-5fdc-bbbc-e6f8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="e154-0c29-2540-5af1" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup" />
-        <entryLink id="b483-76d5-7c21-2559" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
-    <entryLink id="f093-f91f-9522-4287" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="da86-5c27-c422-5f76" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7e92-ac64-8348-6282" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
-    <entryLink id="7a81-e760-5681-fbf6" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1d36-1ec7-0fbc-ba7d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="15a3-8494-bf9a-2e88" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
-    <entryLink id="5205-b4e0-165a-50d9" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="df40-7f9f-fcb9-fbf0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b87f-1d62-0cb2-4a42" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
-    <entryLink id="d927-e039-79a6-0fc9" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9ac4-3429-b432-bd7f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="8e52-f4e4-1aa0-ee60" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
-    <entryLink id="f01d-877f-a918-e097" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6fec-c224-577a-bfc7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="f065-e895-8376-0868" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
-    <entryLink id="c0c1-05ae-ef48-64e1" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9779-c785-e5ca-3cfc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="ab72-0878-8634-2452" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
-    <entryLink id="e829-1a56-02ec-5649" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="97eb-2dd1-515d-429b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7a5a-35e3-db4e-ae29" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
-    <entryLink id="1509-08ef-cef0-45d5" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e443-4e9a-afd7-75a1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="b36a-c596-6ac7-7ac4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
-    <entryLink id="db09-4e6b-eedc-a4e1" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="fec1-dbcd-da44-8e43" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7b1a-4c68-2dee-4e89" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
-    <entryLink id="5b49-59c1-ec3b-b338" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="04fd-39e5-998c-d810" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ed18-8a46-841b-da96" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
-    <entryLink id="7f98-4826-a1f8-3a6b" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d776-6199-79a7-f820" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1277-e55b-20f5-2be4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
-    <entryLink id="f37a-4ae1-3013-e07b" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="cd7e-b7da-5084-edb3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="97f8-fc78-6e0f-2880" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
-    <entryLink id="d567-0a28-d590-0504" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6ca1-2a3b-ce97-7411" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="00f5-daec-ffef-ce45" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
-    <entryLink id="9a93-d8a8-61ed-c1cc" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b66c-a617-dea0-71cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f783-3e36-9368-b8ee" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
-    <entryLink id="f810-cb9a-1661-531b" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4b88-e1ec-00bf-74e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b813-80f4-3b3c-389a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
-    <entryLink id="a1da-a30a-5185-b804" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9296-e8c7-5a57-f74e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="7990-cb8e-74c7-972b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
-    <entryLink id="533f-92c6-3c3c-191c" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e905-a7fb-b03f-1b78" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="aa0b-d64e-6f23-e0aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
-    <entryLink id="85ce-3361-689f-de0b" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0962-9fe8-d952-237b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="c8f8-89e0-e77a-aa29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
-    <entryLink id="b8ca-7fc3-9885-442f" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink><entryLink id="5a18-11c5-5201-77d0" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_8ed4-376d-4030-9439</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_8a11-c2a0-4335-99ef</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_fa8e-1af7-4d41-ac8c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_94bd-c771-4a85-8581</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c53e-35fb-7409-d6cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c562-f87b-3a3f-c2b7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="abfc-aae3-2d06-2698" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="3fd4-8208-4615-9b90" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_361e-fb90-4b0e-ac3d</comment></categoryLink>
+        <categoryLink id="7156-fd7d-4a2c-833f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d4ef-1074-45a9-959e</comment></categoryLink>
+        <categoryLink id="085c-cf44-44a1-8a06" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_febb-f536-4d25-a8ab</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
-    <entryLink id="8253-1664-7120-6604" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7d73-a401-01b6-a020" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1244-c41f-d990-595b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink><entryLink id="e4d2-83cf-ee27-ab46" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="8db6-6588-4d5d-bace" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_473b-e812-4158-9416</comment></categoryLink>
+        <categoryLink id="9a7f-d63d-43a7-9667" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_00a2-63ff-4698-a35b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
-    <entryLink id="4d8c-dee2-eca3-f946" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink><entryLink id="6f9b-b823-db02-749d" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7cf3-8a72-4f82-8cdc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_228c-5681-4ce8-b726</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_01bb-8abd-4253-9a4d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9454-6a20-9086-a0ba" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="bc38-316f-be80-ff7e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7cba-9999-4b44-b796" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2a08-4432-42ad-bfdb</comment></categoryLink>
+        <categoryLink id="56c1-61a3-44c0-b363" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_422e-0808-4897-8630</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
-    <entryLink id="185a-9d55-8778-fe4a" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink><entryLink id="f5a3-cf20-d280-0d62" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1af8-4459-4717-8e3b</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_06b4-92b9-438c-b1a5</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6c8d-8b28-417b-9a7c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_715d-8186-4aa6-b40c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_390e-358c-4f8e-ade8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="bff4-f7ed-e114-74eb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="17eb-e4da-3cab-53e4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="bd6c-63c4-42f4-a9d5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f4c0-4396-4f39-a34f</comment></categoryLink>
+        <categoryLink id="e85e-8b1f-4cbf-bcf1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1301-8415-490e-8f06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
-    <entryLink id="b0f6-19e9-0bc0-1908" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink><entryLink id="8fec-45d2-8c3b-1d40" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d0c9-9a26-4324-b030</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4e9e-a61d-42f2-bacb</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ed9e-b634-4bec-9eb0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4614-ad0f-4fba-adaf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_8d08-24f6-41be-8931</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="118a-1582-46ba-9b34" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_caf6-5548-4b89-8102</comment></categoryLink>
+        <categoryLink id="d18e-94ee-4588-b975" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_63a3-be61-428d-ab29</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink><entryLink id="318d-0ca8-920b-a155" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f318-4b03-4767-8c7f</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b8ef-7245-4df8-a8c4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_6bce-ec44-48cb-873a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9462-b72f-4cec-ba88" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0678-4fdd-48e6-8f61</comment></categoryLink>
+        <categoryLink id="3b02-69ab-463d-8406" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0d82-10a9-4de2-8ad7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink><entryLink id="85df-adb9-8692-6b35" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ada1-1e18-4cbc-9598</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b1d1-ac44-47dd-9159</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5d64-f00c-4464-891b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25f0-f825-4a83-8f0d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_64b1-9e36-44da-b36a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2c78-1607-49cc-9d34" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_d53e-113f-4a40-a3d5</comment></categoryLink>
+        <categoryLink id="52f5-995e-4bb1-ad12" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1939-76b5-4279-9f8c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink><entryLink id="d49d-b769-a7a1-105f" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d765-3bb2-4b48-bd12</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_0ca1-cfb4-4a56-ab3b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0715-6555-04ea-4b57" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="68a1-1f57-31d4-e18e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="115e-8282-4a91-ac40" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e6f7-a6ca-4825-bfc5</comment></categoryLink>
+        <categoryLink id="32e2-fc40-40dc-acdb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dbec-e027-4ec1-8514</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
-    <entryLink id="44c2-325e-b064-e639" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink><entryLink id="72b6-bd25-6175-78f0" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d8ee-81ed-45f9-8b79</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_8f4e-e8cb-4ac9-a415</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7219-11d9-4bb1-b496" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_cefb-cfd7-4dc8-99c4</comment></categoryLink>
+        <categoryLink id="4dcc-9f39-48ba-b49d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a9fd-9d16-4a5e-855c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink><entryLink id="e2d1-37a3-572a-ec6b" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e76b-46ca-4ab8-a93d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8035-75b8-43bb-97c9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_71a4-31e7-4927-a0ab</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2714-6823-42c1-b7ef" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_a56d-347b-4b09-a918</comment></categoryLink>
+        <categoryLink id="8486-76ad-42a9-b86f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_96e5-4531-4213-903e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink><entryLink id="58a1-1b58-e82a-e16a" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1fb5-2375-4c22-b41e</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7d7c-255d-49b6-96b9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5321-254b-4890-9bf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ddf8-b8b7-4afb-b6dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1d21-49a1-476c-b1e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9441-d79b-4720-9667</comment></categoryLink>
+        <categoryLink id="cff9-fac2-4e13-8da3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7d7e-32d3-4692-b401</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink><entryLink id="e569-03b6-aee1-0753" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_99fc-5fe7-4b37-a62f</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_25f4-f6b8-4b44-8350</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_81f7-2311-4cce-95bc</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_09aa-af2a-4012-91d1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_00ae-fad3-4df6-9cb9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="efb5-0e81-4e99-b0ce" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f65b-8958-49b3-92a5</comment></categoryLink>
+        <categoryLink id="6b51-55dd-4027-b339" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0451-1929-4942-8c3f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink><entryLink id="2f2b-9484-e05f-70dc" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_edc4-4915-40ba-bbf0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_105f-ba26-4146-bc54</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7a2c-a76c-421c-a8a2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_05c9-0543-47ee-ba81</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e6ad-f0d7-4627-921b</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6aa9-25df-4591-8b12" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c6a8-22a8-4d41-b969</comment></categoryLink>
+        <categoryLink id="1032-6393-4c43-a4c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03ca-12cc-4e0a-b628</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink><entryLink id="6f01-0e86-1f6d-16a7" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ae67-ef52-4cac-958c</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fc61-7306-4d99-acde</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1be0-67e7-45a1-bdbb</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_42a8-7fda-4e05-af0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b242-61ea-49a9-9d69" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_565a-1592-491f-8b9b</comment></categoryLink>
+        <categoryLink id="3c2c-8f70-4e43-9e76" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_81d5-c14a-42ab-bdde</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink><entryLink id="9be0-518e-a269-8f24" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1ae7-c41b-4818-be71</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_08a5-b1bb-4ba1-ba42</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d677-b5ad-4838-8746</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_537f-bc1f-4aaa-b0dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1c87-7072-489d-a0e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bc67-ce1f-4004-aeb7</comment></categoryLink>
+        <categoryLink id="2311-66b8-40e9-a5e4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_9a45-9699-4475-aeef</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink><entryLink id="2619-062d-f834-7acf" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_c28f-4109-44c4-ab64</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fdc1-a894-48bc-9e7c</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_4936-a68c-4524-9088</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb37-ac0c-49ae-9d6f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f78d-9a3d-4f08-8482" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3afe-cfc0-4da6-a985</comment></categoryLink>
+        <categoryLink id="f8a8-7aef-4467-a3d7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_04a8-6aae-45ae-bd4c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink><entryLink id="ac56-cdc4-63cf-61b1" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ae19-30c0-43c5-920e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_6ebe-1bf3-4d78-9dd0</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1887-152d-48b7-b13f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_a7c4-ee6a-4f0b-8ab0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bd85-fa90-47ff-9f84</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_7bd6-9043-4d7e-ba37</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3948-2fee-4005-a3fa" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3610-c975-4d55-bdfe</comment></categoryLink>
+        <categoryLink id="b320-7acf-4b48-8b5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2fc2-f636-4c80-9608</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink><entryLink id="6764-be36-2434-9807" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_85c5-d4d9-4b23-9e4d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_80e8-d50b-4906-8153</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_b93b-d4f1-45eb-8a69</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e183-f183-4db7-83b5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0f39-204a-4217-b896</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_eee9-7bfd-4fea-a1bd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="438e-8823-4e7d-b2c5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f81d-9435-4f11-99c1</comment></categoryLink>
+        <categoryLink id="0a5b-203b-4d18-8d87" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9568-6142-4fdd-be3a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink><entryLink id="6460-302a-4edf-0f8f" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_005e-6607-4e2c-8dd2</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_7745-260c-4c36-b719</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_ba25-a4b2-4ba9-b023</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ddeb-f4c8-4091-9153</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4904-fd2f-429f-9cf7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_faea-b21b-43c5-b918</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b341-096b-44a3-9aa1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_b24f-3ae0-4cbb-b016</comment></categoryLink>
+        <categoryLink id="4e82-d681-4227-8060" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fd26-8e6b-4521-92b9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink><entryLink id="e7a9-d890-739a-b83d" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6ecb-28e2-43ed-a6a0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_c067-1118-4d96-b28b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_250e-23c0-4e43-bf74</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1553-a6e6-4291-853f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_aab6-797b-427a-9fd8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="847e-b454-4aa3-b86a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c77f-0819-473b-a8a2</comment></categoryLink>
+        <categoryLink id="e8c3-b480-40ca-b10f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_89fb-c924-4daf-923d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink><entryLink id="cc42-19e4-a783-9145" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d72c-519a-451f-81b6</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_3d16-444c-42c9-aad1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_f4b2-6371-494b-863a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_797f-a84b-42f6-8e66</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0d78-fe38-4829-9b12</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d99d-45fc-48d4-9648" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0397-c837-4fea-a527</comment></categoryLink>
+        <categoryLink id="82a2-7c36-46dd-b65e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_060b-bccb-4776-bd83</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink><entryLink id="5d3e-7bdf-f892-ba0e" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3c84-6d74-4c42-b38d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_5b15-7aa4-4897-aaf1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_3326-31ed-4151-9b37</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6a0e-1b65-4057-ba5d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f8c7-abc9-45ec-955f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_2538-8dc5-446c-8344</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9264-e03b-46ea-a2d9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_c1cf-cea4-4278-8f27</comment></categoryLink>
+        <categoryLink id="ca15-145f-4fe7-aac5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5f51-2734-4a46-9f72</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink><entryLink id="e823-d2fc-99d4-7c6c" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af71-f3ff-49b1-83e9</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_1c9e-b3bf-4e88-a43f</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_6d0d-1b1d-4065-89cf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d0b7-8686-491e-9d33</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_7db8-0874-487a-be6f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1034-29a0-44b1-a85f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ad95-f8cd-4d0a-93d1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_0c16-6841-42b2-b02d</comment></categoryLink>
+        <categoryLink id="23c8-d3d1-4065-8817" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_602d-2d2d-4ff4-a82a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink><entryLink id="3161-18f3-4ff5-565e" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_22bd-baae-45f9-b366</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_52bd-55de-4d53-ba55</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_df1b-7476-4ab8-8d2f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_49fa-0dcf-4a61-a5b1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0ea-1443-4993-86e7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2a8-3fbe-448c-9902</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a32d-8c05-4205-ae58" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3632-0b5d-4622-ae33</comment></categoryLink>
+        <categoryLink id="9f43-8675-4e4e-8451" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_da44-7815-4fdd-981c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink><entryLink id="8612-8de9-0d49-bc1c" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2bfa-b203-47e2-a828</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a39b-8a3c-49cf-bf62</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2a05-07b3-49c5-8145</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f730-87fb-44bd-b68e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_2d0e-6c49-4493-a022</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2e2-50c1-40c3-b4dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6284-bd05-45e6-9123" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_5ad5-8701-42cd-b2b6</comment></categoryLink>
+        <categoryLink id="3fb2-e9af-48fb-bed0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_20a4-4346-4a3b-a7d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink><entryLink id="89f4-ec64-18e3-834a" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_773a-1ea4-41a0-b766</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_9d4d-6fb8-4131-a5a3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e3bc-02f8-4ece-a5ea</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c371-76d9-4a4d-bc00</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b4c6-d4ba-4b2e-9b99</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d492-edc2-4076-82aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6ea9-a7e5-437d-9e35</comment></categoryLink>
+        <categoryLink id="174c-5d93-4b1e-a524" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_3cec-f053-42ab-a6eb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink><entryLink id="2c48-417f-2d9f-607f" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1e60-42ba-4c8b-9077</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9860-f593-425e-b89b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_c842-10e8-4509-8eda</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ea52-ff41-40f6-8cf3</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_51e6-c5e1-4003-96bc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cebc-a6ee-44ec-b023" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4d7c-201f-4c99-b89a</comment></categoryLink>
+        <categoryLink id="38f6-dca4-46b3-8949" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_10f9-4718-4e07-bb32</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink><entryLink id="a598-c2dd-0f71-f45b" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="35b2-7abe-410c-87c1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4e52-ad1b-48d4-8eed</comment></categoryLink>
+        <categoryLink id="277c-3bff-4990-91b6" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_6979-1ed3-4f1f-a025</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink><entryLink id="a59b-5848-48be-a140" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry"><categoryLinks>
+        <categoryLink id="f204-1c09-4da2-9685" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6140-2404-46f9-bd42</comment></categoryLink>
+        <categoryLink id="e032-55b7-48f8-b05b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_1c86-fad8-46ec-a0b0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink><entryLink id="7adb-70a6-609d-c5cd" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4729-bc86-456b-b73d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_cf0f-e3f4-4fb4-989d</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1cc8-5611-4d9a-9218</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_2e32-ca02-48f0-a8dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c05c-47cc-403f-a25e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_0af1-d052-4bd7-aab6</comment></categoryLink>
+        <categoryLink id="831d-5b82-4068-bc99" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_45ce-e338-43c9-b63e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink><entryLink id="b631-2b65-2745-d79c" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4dce-8632-4f7c-813e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_8a71-3995-4155-ac33</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d206-f2ce-41b8-945a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan">
+                  <comment>    node_id_2e02-cf1c-4a71-861c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ec81-bd33-45a8-8550</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_3344-743c-45d3-b930</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ebdb-c055-099b-4d8b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="7d34-32cf-de84-1681" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6bb9-0af9-e129-9e9d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="4f1d-b07d-4d04-8eab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4272-9b9d-4c59-95f0</comment></categoryLink>
+        <categoryLink id="7f66-32f3-44a7-8cc0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_d85b-1ae7-40d5-9341</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
-    <entryLink id="0cb9-d47f-f2d7-bfb9" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e6cc-2e9d-4c89-6eba" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="9972-607b-a844-41da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink><entryLink id="0494-6bf7-a54d-33b6" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry"><categoryLinks>
+        <categoryLink id="116b-18fb-485d-ad6d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ff9f-01cb-41b9-800e</comment></categoryLink>
+        <categoryLink id="a275-bd36-4404-9768" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_1315-6051-4a46-b070</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
-    <entryLink id="4766-17f6-e613-f831" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink><entryLink id="66e7-ee64-2389-9645" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry"><categoryLinks>
+        <categoryLink id="2b33-a9a8-49eb-8237" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_b084-df23-4f99-812f</comment></categoryLink>
+        <categoryLink id="db02-cb9d-4bb0-8bec" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_84fc-9304-4e9e-ab78</comment></categoryLink>
+        <categoryLink id="3f3b-16cf-44ee-bbb2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d06a-7939-4691-9aed</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="9a32-aba7-4507-bf00" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup"><comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+        <entryLink id="4e9c-1766-4fdc-aa2a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup"><comment>    template_id_741d-8c09-4211-ada6    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink><entryLink id="a201-1329-ae33-a22b" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_54a4-6ec8-4c61-9c3e</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_f7fd-2d16-4603-a065</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="48dc-f813-d91d-1a66" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="5e53-4193-a88c-47e4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="829e-8d80-4df0-ac7d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_c0ac-4b8c-421c-a21b</comment></categoryLink>
+        <categoryLink id="671e-88b5-4415-9775" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8db9-079e-4482-b200</comment></categoryLink>
+        <categoryLink id="d97c-dd63-462d-a43a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_413c-9273-4308-b546</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
-    <entryLink id="4f6c-a6a0-471a-d91e" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f4f2-f5c1-852f-f2f4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="43c7-06a5-8c7b-85af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      <entryLinks>
+        <entryLink id="5cf3-2c96-47b5-a979" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup"><comment>    template_id_bbc4-33fc-4664-a18e    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="0cc1-042a-44ab-8a4f" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup"><comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink><entryLink id="da86-05c2-dfd5-5d37" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry"><categoryLinks>
+        <categoryLink id="dd56-e594-4747-bb82" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_4c8d-96f6-48f9-9590</comment></categoryLink>
+        <categoryLink id="a037-2bca-4aed-9e55" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_049c-0fa5-4575-8fa8</comment></categoryLink>
+        <categoryLink id="08e2-9af8-4123-b471" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_7358-52d7-4aae-8e07</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
-    <entryLink id="cbb7-653a-6657-251a" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+      <entryLinks>
+        <entryLink id="5469-07f8-4a59-91d3" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup"><comment>    template_id_4784-b370-444b-93ae    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="d5cc-d47d-4482-908b" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup"><comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink><entryLink id="f093-f91f-9522-4287" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_3c03-a823-4466-9bd6</comment>
           <conditionGroups>
-            <conditionGroup type="and">
+            <conditionGroup type="or">
+              <comment>    node_id_8bbb-f95b-413f-b6f4</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_41b0-6b0a-482a-919e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e1f7-3cc6-4794-8b6d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="399e-c833-90bb-65d3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="52c7-e41e-e9a4-c57c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c54b-f4eb-4446-ab24" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_05ce-cc31-40ad-9320</comment></categoryLink>
+        <categoryLink id="c84b-54fc-4602-8b00" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f13c-f8e1-4a50-bfe3</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
-    <entryLink id="3c84-63cb-339a-9eea" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="90d1-4dee-1f65-1a45" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="40bf-4f06-7c14-b8b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
-    <entryLink id="b3ed-cd72-c764-20a7" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3eaa-966b-ae55-c3b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0f28-49b8-ae80-17f3" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
-        <categoryLink id="5f58-2713-85b9-5efa" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
-    <entryLink id="5134-d030-f52c-821b" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9bef-3b3f-8273-7ad3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="983a-8eee-715e-a69f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
-    <entryLink id="83eb-08b0-548d-c442" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink><entryLink id="7a81-e760-5681-fbf6" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_db78-4d49-42ab-954a</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_f14d-9943-47b6-866c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a95-938f-4a07-9727</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_7775-78e1-44cc-87c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe46-d1f9-44f3-a423" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_b822-3417-4613-be37</comment></categoryLink>
+        <categoryLink id="68c1-d0dc-4352-81f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_25db-b03f-4881-b310</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink><entryLink id="5205-b4e0-165a-50d9" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry"><categoryLinks>
+        <categoryLink id="68ae-1d35-4996-82c6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_75a7-dc06-445b-b2dc</comment></categoryLink>
+        <categoryLink id="e39a-18f6-4664-98a1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_e21a-c03b-4885-ac46</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink><entryLink id="d927-e039-79a6-0fc9" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9a08-5fe6-4010-bbc3</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_72cf-cfce-4e02-b379</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="eb54-3f93-c551-aa64" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="28f3-6735-3fe8-5daa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="feae-09be-4a36-be3a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_f55b-7555-444b-beee</comment></categoryLink>
+        <categoryLink id="05ca-a4f0-44cd-aa7f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3386-c9ad-4d74-9474</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
-    <entryLink id="4b12-b17a-86c7-960a" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0fab-a641-0aca-93c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b99b-a19a-14d8-3e9f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
-    <entryLink id="da28-3e90-f9bb-ac33" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink><entryLink id="f01d-877f-a918-e097" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_a0f6-9606-4b75-a2f8</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_94b3-1331-474b-885b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8247-71b0-fc82-30a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3c7e-b112-2089-7e60" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="c618-9c76-4138-ba0d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_79fa-3370-4ae0-9e12</comment></categoryLink>
+        <categoryLink id="8798-f85c-477c-a818" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bb53-4e65-4fb6-9dd7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
-  </entryLinks>
-  <sharedSelectionEntries>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink><entryLink id="c0c1-05ae-ef48-64e1" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f8cc-833a-4ac1-bf89</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+              <comment>    node_id_5988-c012-4dad-9a66</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5e56-8d23-488f-9b96" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_8d82-3279-4481-84bb</comment></categoryLink>
+        <categoryLink id="8e16-69fd-4d5d-82f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e25c-925e-4b96-8bb3</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink><entryLink id="e829-1a56-02ec-5649" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6b73-b21c-4e2b-9d14</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_a7fe-cc62-4a6f-a781</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5be1-1937-4964-a455</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_da1d-b2bc-4117-82a4</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="440a-f7ed-46af-9890" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7010-be56-4709-b058</comment></categoryLink>
+        <categoryLink id="a2d2-f033-4707-b3fb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7379-a740-47ba-a054</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink><entryLink id="1509-08ef-cef0-45d5" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_dd34-83cf-47d7-b557</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_be88-afef-49b3-bd1e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fd9b-be65-4c2f-be62" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_944f-7420-4982-8ea9</comment></categoryLink>
+        <categoryLink id="ccef-e1bc-4e35-9c2d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ea80-0efe-457d-a450</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink><entryLink id="db09-4e6b-eedc-a4e1" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><categoryLinks>
+        <categoryLink id="c548-a391-4819-84d6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9a36-f261-43cc-9bd1</comment></categoryLink>
+        <categoryLink id="0790-3540-4913-806f" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a648-8396-442a-af59</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink><entryLink id="5b49-59c1-ec3b-b338" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_cb81-0303-4b88-ae53</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9648-31e3-43aa-8cf3</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_0507-da81-4023-bfcf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0e84-54ff-488d-b066</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="974c-da5a-4284-9b31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6ff-0977-4c92-bb28</comment></categoryLink>
+        <categoryLink id="45af-f788-4cbd-9a7e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f555-7d39-458f-84c9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink><entryLink id="7f98-4826-a1f8-3a6b" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8203-5b00-497b-b939</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_40ee-3e71-4978-b1e4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f6a8-f660-46dc-b3c5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_d988-3af6-48bf-b0a8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c8a6-807a-4a38-9c08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_39e5-eda5-45d1-a643</comment></categoryLink>
+        <categoryLink id="3e6a-9e8e-48ad-afd1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_6416-21bb-4df4-9de8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink><entryLink id="f37a-4ae1-3013-e07b" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b03e-5d91-4be3-8adc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_0443-29c0-46e9-ad1d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f2c9-7356-4c27-a22f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0e9-4a9e-4b2b-a9d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="201a-6246-4511-bd31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5528-2dac-4be5-900c</comment></categoryLink>
+        <categoryLink id="c04e-06c6-49bf-9b41" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_dc8f-d888-4585-991d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink><entryLink id="d567-0a28-d590-0504" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1d3c-8e17-489f-9002</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5725-8bee-4bcc-878d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_be47-0d6f-49f2-9f4b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_863c-f3a4-4802-b80c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cd3a-b00b-4c54-8436" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_899e-b052-4d5b-8c18</comment></categoryLink>
+        <categoryLink id="73bf-c31b-4c39-9957" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f5e9-cff6-41d2-a016</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink><entryLink id="9a93-d8a8-61ed-c1cc" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_72da-1513-4e02-b595</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7a48-a3b0-4a26-849b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e232-25f3-4cb7-8ab2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_9aa4-5660-4697-8ab2</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2f51-de85-4639-bff2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_09cd-2176-40af-bba6</comment></categoryLink>
+        <categoryLink id="cb12-1ee6-49f4-af3d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_05e6-7c63-4a35-9ba0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink><entryLink id="f810-cb9a-1661-531b" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry"><categoryLinks>
+        <categoryLink id="a91e-dfdc-494a-92f7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0dfa-4004-4751-8022</comment></categoryLink>
+        <categoryLink id="e265-d334-4355-96e0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a669-0f5d-4fd3-811b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink><entryLink id="a1da-a30a-5185-b804" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_09b5-4e3b-4c84-a574</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_32e5-ebba-41fb-9ff2</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_838e-0ccf-4d3a-aabd</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_dfef-0ec2-49fb-a534</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="864d-1e85-4ccb-9d54" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4f60-472b-45a9-ab9e</comment></categoryLink>
+        <categoryLink id="1d1e-c958-4d22-8d77" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e2e3-af36-45a6-a955</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink><entryLink id="533f-92c6-3c3c-191c" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_936f-1ef7-472e-840e</comment>
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+              <comment>    node_id_d73d-d52e-4c75-8ac0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cea8-8b31-4e69-93b9" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_7a55-ecb4-4e5d-b955</comment></categoryLink>
+        <categoryLink id="be8a-0f31-4fd0-9f15" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f28c-710e-4ff8-9810</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink><entryLink id="85ce-3361-689f-de0b" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_a743-0cc2-45ae-a7eb</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2721-e88d-41f7-bedc</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_e10f-1390-4b33-8fcc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="469b-edc2-4cf1-8278" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2008-f1c4-4285-a14f</comment></categoryLink>
+        <categoryLink id="a5c3-1823-4c9a-8dcf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e88b-a95a-4647-af3b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink><entryLink id="b8ca-7fc3-9885-442f" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_25d8-330b-4574-b515</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7836-6878-47a8-8827</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_5ea9-46dd-4a11-9410</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_ab5d-961b-4924-a705</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d83d-1d4f-4be4-9d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9189-836c-475d-a52e</comment></categoryLink>
+        <categoryLink id="a994-cfc8-4333-b98c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_e1fa-b7d8-47b0-a88a</comment></categoryLink>
+        <categoryLink id="254e-e7e4-4cac-bd13" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_a137-e3c0-4d63-a48c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink><entryLink id="8253-1664-7120-6604" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry"><categoryLinks>
+        <categoryLink id="0fae-fa6e-46a3-90de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b1d5-fd75-4f17-bbf4</comment></categoryLink>
+        <categoryLink id="a882-55f8-423b-81e1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_f221-bf81-4045-849b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink><entryLink id="4d8c-dee2-eca3-f946" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_b743-7a00-43e4-beb8</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d12f-2c98-4e62-a716</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d4d7-ba67-47aa-962f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+                  <comment>    node_id_1637-edee-457a-bb0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3d0e-4174-428d-bcab" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_f203-bc26-421f-b79e</comment></categoryLink>
+        <categoryLink id="384f-83a1-4c68-a5fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_a53e-59d9-4ac2-a21f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink><entryLink id="185a-9d55-8778-fe4a" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry"><categoryLinks>
+        <categoryLink id="a145-37a5-42df-9dbb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_51af-a137-4a1c-97a4</comment></categoryLink>
+        <categoryLink id="8fdc-d13c-4799-b063" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ec1f-c326-40a8-9d1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink><entryLink id="b0f6-19e9-0bc0-1908" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_c111-feb0-4012-98cd</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_63d7-8427-431d-9ae6</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="15b6-41c3-4b0b-b558" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_e707-fde1-457f-91c4</comment></categoryLink>
+        <categoryLink id="40b7-bc21-4c0a-8326" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ec67-8573-4460-89db</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink><entryLink id="44c2-325e-b064-e639" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3348-16e4-4a9a-a549</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_bea4-c4a8-4843-b9fe</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2970-17ff-4be1-91e5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_503a-46e7-40e7-bd07</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_4555-15e1-43ff-80a0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b3c5-9816-4d6b-ad66" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_fce3-801c-49c8-85d4</comment></categoryLink>
+        <categoryLink id="c6e4-c714-486e-9444" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0c2d-2349-44b6-9831</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink><entryLink id="0cb9-d47f-f2d7-bfb9" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry"><categoryLinks>
+        <categoryLink id="8ccd-8bdc-49ce-a92f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ac1c-b3bf-4011-918a</comment></categoryLink>
+        <categoryLink id="6d3f-606d-4aee-89d6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_589c-1d0e-4b7d-be6b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink><entryLink id="4766-17f6-e613-f831" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2f46-a0b6-48a5-a0ee</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_636f-0f8a-43f1-910b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c883-39c8-4a74-aeaa</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_0796-e467-4438-89b3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9c9e-fe48-4e0f-9564" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_5a04-9847-4c91-a49a</comment></categoryLink>
+        <categoryLink id="04d1-0d44-490f-b30f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b4b4-daeb-483c-a306</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink><entryLink id="4f6c-a6a0-471a-d91e" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6087-a5e5-4d3c-9ebd</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c7e1-5f42-4528-bf07</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1950-08dc-4544-ab01</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_daf3-31ed-42c0-85dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e81d-262a-49a7-80af" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_7d4f-547c-43ed-a520</comment></categoryLink>
+        <categoryLink id="201e-47b6-4c26-8874" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f04e-04e8-4891-9b1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink><entryLink id="cbb7-653a-6657-251a" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_dfdc-f6f6-49d2-a7b3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_354c-c71f-472f-b268</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1127-c974-4663-874d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_0843-bef2-4767-8307</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2528-cf50-43e3-9136" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_28e0-91e7-4ada-9fac</comment></categoryLink>
+        <categoryLink id="f4f5-9c09-4885-891c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4448-a712-4dd7-bf6d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink><entryLink id="3c84-63cb-339a-9eea" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d512-fd07-4a29-863a</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_55c6-a35f-485a-9f0d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d89e-cf1f-4ceb-b3de</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e2c9-0d01-403c-900e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_a7b8-c835-4cb2-b3d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b2e0-b87b-447e-bfd5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_e22a-c5f8-4825-a45f</comment></categoryLink>
+        <categoryLink id="18cf-3981-430f-b5f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03fc-6a7f-45a5-bcb8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink><entryLink id="b3ed-cd72-c764-20a7" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry"><categoryLinks>
+        <categoryLink id="dc2d-37db-4db9-81fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0aff-4f6e-4b03-a23c</comment></categoryLink>
+        <categoryLink id="fbe4-915c-4e11-af61" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"><comment>    template_id_7d5a-62e7-43ee-b79b</comment></categoryLink>
+        <categoryLink id="c127-9d97-4023-85e1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_4986-9157-49f2-b670</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink><entryLink id="5134-d030-f52c-821b" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_319e-90d4-44a3-8e83</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_28db-d943-4099-9abd</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1a45-a592-49df-9465</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb31-d0b2-4677-928e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ac24-0350-42cd-ba0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1b86-0977-4a8b-adac</comment></categoryLink>
+        <categoryLink id="6350-053d-429d-aed0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_b449-403a-4e42-9239</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink><entryLink id="83eb-08b0-548d-c442" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafa-470f-4c2c-8be3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_e2ba-a855-4de2-9f46</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_0171-b30d-44ee-9389</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fdfb-119b-4774-934a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_3891-9a00-4f8f-b95f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="064e-83e0-4d41-bad7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e5df-17d4-4521-9d5b</comment></categoryLink>
+        <categoryLink id="3d4b-f4c1-43e8-a037" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"><comment>    template_id_0ecd-4873-4d3a-b28b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink><entryLink id="4b12-b17a-86c7-960a" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_fbfa-8d78-4d6d-8a05</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_21f2-0916-46bf-b75a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_4fbd-633b-4dd6-9fdd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3153-9bb7-4242-beb6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4f71-446f-4cff-afda</comment></categoryLink>
+        <categoryLink id="f50c-a911-496a-93d2" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_3f44-8647-43a4-ac22</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink><entryLink id="da28-3e90-f9bb-ac33" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af15-2c71-4f8b-833e</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_d95a-80b9-4463-af55</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="39a1-51e2-4764-a688" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6b1-886e-4194-8bcd</comment></categoryLink>
+        <categoryLink id="8213-afb5-44c8-8f36" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_51b5-f9c1-4587-8fc7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink><entryLink id="b931-4326-4708-aa0b" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
+    <entryLink id="e061-de24-4dc4-ac53" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
+    <entryLink id="e563-b1bf-4cb7-a08b" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
+    <entryLink id="d6f6-123b-4756-9644" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <entryLink id="5c30-161a-40da-9db5" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3531-57d1-4081-882d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_f233-2361-4177-8ba7</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b932-667a-4b43-8331</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <entryLink id="d4e4-38de-44b8-98b7" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <entryLink id="89db-e6ad-4c4c-982d" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3129-6f59-4365-906b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2bcb-0af1-4aea-9191" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <entryLink id="db97-f8e1-45e0-bbb9" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ede2-d453-4e34-8cda</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2907-3215-4b01-96ff</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_c90c-959f-40fb-a4cb</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ba2d-50ad-45f1-91c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0e88-485e-43c2-8bef" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <entryLink id="3def-78ba-4205-ab81" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_409c-0a5d-4ef8-a871</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7078-c1c7-4af2-b43d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_9a69-0fdc-4957-8982</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1a4c-69b5-4219-8502" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fba0-3ea7-4eaf-b33a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <entryLink id="ae0a-5c89-4fff-b1d4" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
+    <entryLink id="9b87-d3cb-4851-829a" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
+    <entryLink id="5190-2c0b-4bf4-9679" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
+    <entryLink id="c59c-24fc-4d50-97c9" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+  </entryLinks><sharedSelectionEntries>
     <selectionEntry id="19ce-b8dc-dd40-fee9" name="Phalanx Warder Squad" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="7d3f-816a-0e4e-60f8" name="Shield Wall" hidden="false">

--- a/2022 - LA - Imperial Fists.cat
+++ b/2022 - LA - Imperial Fists.cat
@@ -357,7 +357,7 @@
         <categoryLink id="e3c7-c7ff-5c11-ea26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="b4ce-bc5a-34b7-cd74" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
     <entryLink id="eb10-8d4b-c2c7-17d4" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f81e-a92f-6c7e-0980" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
@@ -785,7 +785,7 @@
         <categoryLink id="df40-7f9f-fcb9-fbf0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="b87f-1d62-0cb2-4a42" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
     <entryLink id="d927-e039-79a6-0fc9" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
@@ -866,7 +866,7 @@
         <categoryLink id="6ca1-2a3b-ce97-7411" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="00f5-daec-ffef-ce45" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
     <entryLink id="9a93-d8a8-61ed-c1cc" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b66c-a617-dea0-71cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -878,7 +878,7 @@
         <categoryLink id="4b88-e1ec-00bf-74e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="b813-80f4-3b3c-389a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
     <entryLink id="a1da-a30a-5185-b804" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9296-e8c7-5a57-f74e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -960,7 +960,7 @@
         <categoryLink id="0715-6555-04ea-4b57" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="68a1-1f57-31d4-e18e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
     <entryLink id="44c2-325e-b064-e639" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -989,7 +989,7 @@
         <categoryLink id="e6cc-2e9d-4c89-6eba" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="9972-607b-a844-41da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
     <entryLink id="4766-17f6-e613-f831" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -1039,7 +1039,7 @@
         <categoryLink id="0f28-49b8-ae80-17f3" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
         <categoryLink id="5f58-2713-85b9-5efa" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
     <entryLink id="5134-d030-f52c-821b" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9bef-3b3f-8273-7ad3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />

--- a/2022 - LA - Imperial Fists.cat
+++ b/2022 - LA - Imperial Fists.cat
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8866-00ec-715f-f21a" name="LA -   VII: Imperial Fists" revision="13" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="8866-00ec-715f-f21a" name="LA -   VII: Imperial Fists" revision="13" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26">
   <entryLinks>
     <entryLink id="b3e4-1487-4ab7-7515" name="Alexis Polux " hidden="false" collective="false" import="false" targetId="9229-b4f9-2213-9672" type="selectionEntry">
       <modifiers>
@@ -7,21 +6,21 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ee0f-2bd2-436f-ec16" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="2c32-d871-9f89-6b91" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8d13-d219-2715-ad2a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="ee0f-2bd2-436f-ec16" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="2c32-d871-9f89-6b91" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8d13-d219-2715-ad2a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="f3a4-1d62-0904-18c5" name="Fafnir Rann" hidden="false" collective="false" import="false" targetId="d483-8c34-3bcb-f1d5" type="selectionEntry">
@@ -30,67 +29,67 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="74f0-6109-ed78-2945" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="d3ba-a5cd-59f7-f99a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e598-efd8-ee80-b4c1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="74f0-6109-ed78-2945" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d3ba-a5cd-59f7-f99a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e598-efd8-ee80-b4c1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="a7ed-633f-9b24-83bb" name="Phalanx Warder Squad" hidden="false" collective="false" import="false" targetId="19ce-b8dc-dd40-fee9" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5d82-2938-d6b0-d460" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0a15-f02d-76e8-3f43" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="5d82-2938-d6b0-d460" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0a15-f02d-76e8-3f43" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="eb84-0ca9-ee5b-9d94" name="Sigismund" hidden="false" collective="false" import="false" targetId="f323-a02c-fa4e-b1ef" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3ef3-f102-3e71-37b5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="c59c-4b7b-a872-41e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f613-1e6d-5e72-52bb" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="3ef3-f102-3e71-37b5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c59c-4b7b-a872-41e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f613-1e6d-5e72-52bb" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="c1a0-4e23-bb48-8b6b" name="Templar Brethren" hidden="false" collective="false" import="false" targetId="6f69-665c-3199-77aa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b5a2-d4b6-25b7-29df" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="796e-07e7-3709-4854" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b5a2-d4b6-25b7-29df" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="796e-07e7-3709-4854" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="6de5-a6a9-bf25-76c8" name="Rogal Dorn" hidden="false" collective="false" import="false" targetId="6910-f5e3-01df-f3d5" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="47a6-fca8-5f4d-405a" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
-        <categoryLink id="e638-6d16-32ac-73f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="47a6-fca8-5f4d-405a" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true" />
+        <categoryLink id="e638-6d16-32ac-73f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="bf53-51f2-5ab5-fecc" name="Huscarl Squad" hidden="true" collective="false" import="false" targetId="4420-5ce0-beb7-cb5e" type="selectionEntry">
@@ -99,986 +98,986 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="16af-a65b-280b-08c7" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="cb46-df5a-b5d3-a80b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="16af-a65b-280b-08c7" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="cb46-df5a-b5d3-a80b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="60d8-c9b4-2967-a26c" name="Ætos Dios" hidden="true" collective="false" import="false" targetId="fcc2-2335-aedc-b49e" type="selectionEntry">
+    <entryLink id="60d8-c9b4-2967-a26c" name="&#198;tos Dios" hidden="true" collective="false" import="false" targetId="fcc2-2335-aedc-b49e" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6910-f5e3-01df-f3d5" type="greaterThan"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6910-f5e3-01df-f3d5" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="beb5-b21a-55d0-1402" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="03eb-1039-9034-ac08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="beb5-b21a-55d0-1402" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="03eb-1039-9034-ac08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="f1fc-d6e3-4b34-52b9" name="   VII: Imperial Fists" hidden="false" collective="false" import="false" targetId="a0e1-f2c4-8bcd-0723" type="selectionEntry">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1db-8a52-1f19-c4dc" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e48-8604-9f0e-d8c0" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1db-8a52-1f19-c4dc" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e48-8604-9f0e-d8c0" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="9994-ceb4-762d-8d57" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="9994-ceb4-762d-8d57" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="9586-4b82-f199-8c7c" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="47ef-fb83-f80f-d54b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="59a4-7980-22c4-f717" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="47ef-fb83-f80f-d54b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="59a4-7980-22c4-f717" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
     <entryLink id="a840-8a82-55c3-5045" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e23e-9540-7514-16a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e19c-7caf-ff85-b0ed" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="e23e-9540-7514-16a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e19c-7caf-ff85-b0ed" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
     <entryLink id="6445-0f74-57d7-7267" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b5bd-4049-731e-cc49" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="ad85-f23a-72a7-0218" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c25d-266e-495d-d157" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="b5bd-4049-731e-cc49" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="ad85-f23a-72a7-0218" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c25d-266e-495d-d157" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="9fc4-d7aa-eeb0-0a56" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="717c-8cb4-6dca-6561" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="046f-5dda-dd4f-9604" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="717c-8cb4-6dca-6561" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="046f-5dda-dd4f-9604" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
     <entryLink id="7d74-be12-a4c7-bae9" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3662-1e31-c505-a363" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="30ec-959e-9485-83a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3662-1e31-c505-a363" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="30ec-959e-9485-83a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
     <entryLink id="16b5-ada1-0377-a933" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d622-65cd-95c1-3848" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="5cfe-9890-b315-b4b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d3e8-e10a-c484-4f8e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="d622-65cd-95c1-3848" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="5cfe-9890-b315-b4b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d3e8-e10a-c484-4f8e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
     <entryLink id="5144-4cee-e424-9c49" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dcde-9335-bea9-54b4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="9481-8835-60d7-4466" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="dcde-9335-bea9-54b4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="9481-8835-60d7-4466" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
     <entryLink id="75de-7301-dc98-3a8b" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="590a-e828-9f6f-a2a9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="6258-dd8a-0e5d-05e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="590a-e828-9f6f-a2a9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="6258-dd8a-0e5d-05e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
     <entryLink id="aafa-cd47-643c-0b12" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="61a9-ea18-ad59-7d2d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="fff6-c8dd-f828-acbb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fa0c-191c-bd37-f71b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="61a9-ea18-ad59-7d2d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="fff6-c8dd-f828-acbb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="fa0c-191c-bd37-f71b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
         <entryLink id="5c8e-5590-884d-692f" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="e2e7-e179-8fd3-28b7" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup"/>
+        <entryLink id="e2e7-e179-8fd3-28b7" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
     <entryLink id="1dd5-63c7-0a9e-0832" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="87d1-9445-fef7-3ce4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0800-c673-9000-76dd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="2bc9-64a8-d780-5482" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="87d1-9445-fef7-3ce4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0800-c673-9000-76dd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="2bc9-64a8-d780-5482" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
         <entryLink id="1ffd-7b54-7c94-a086" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="2731-87d3-87b4-179d" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup"/>
+        <entryLink id="2731-87d3-87b4-179d" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
     <entryLink id="0ba2-ada6-3003-9042" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e02b-db4d-3114-d1bd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="32ef-2312-2197-5708" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="ef48-e7aa-2d83-fd67" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="e02b-db4d-3114-d1bd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="32ef-2312-2197-5708" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="ef48-e7aa-2d83-fd67" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
       <entryLinks>
         <entryLink id="457a-ee7f-fc9c-bf4a" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="9aa8-f04e-f8a5-877a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup"/>
+        <entryLink id="9aa8-f04e-f8a5-877a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
     <entryLink id="601e-a3c7-a43f-9d13" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="43db-3ecf-b50d-bbc0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="10e3-ba04-a0f2-fb0a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="43db-3ecf-b50d-bbc0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="10e3-ba04-a0f2-fb0a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
     <entryLink id="c6a4-c488-a354-644d" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b9ed-997b-8fd1-c04f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="95fa-49ee-039b-bf41" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="b9ed-997b-8fd1-c04f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="95fa-49ee-039b-bf41" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
     <entryLink id="c0b1-dd05-761b-b6bc" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2e77-4c9a-32fc-724b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a82a-112b-573c-6c31" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="2e77-4c9a-32fc-724b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a82a-112b-573c-6c31" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
     <entryLink id="be42-e556-3b98-ac06" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="962d-ff5d-a589-37f8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5160-5ed6-d275-fddd" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="962d-ff5d-a589-37f8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5160-5ed6-d275-fddd" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
     <entryLink id="52a6-f923-f1a7-f203" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e3c7-c7ff-5c11-ea26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b4ce-bc5a-34b7-cd74" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="e3c7-c7ff-5c11-ea26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b4ce-bc5a-34b7-cd74" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
     <entryLink id="eb10-8d4b-c2c7-17d4" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f81e-a92f-6c7e-0980" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="d6da-13e2-7a4d-60b7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f81e-a92f-6c7e-0980" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d6da-13e2-7a4d-60b7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
     <entryLink id="aaf0-88c6-bdc4-e474" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0443-96ce-bcb4-0051" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="6489-c04e-5c52-779e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0443-96ce-bcb4-0051" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="6489-c04e-5c52-779e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="01c3-2504-e80d-f951" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="212d-5ae8-377b-4e83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cac6-7437-cdd7-e86b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="212d-5ae8-377b-4e83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cac6-7437-cdd7-e86b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
     <entryLink id="5a18-11c5-5201-77d0" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d73b-a407-0131-92bc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="1262-cf57-7c1b-575d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="40e5-fffe-0ce8-1eb2" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="d73b-a407-0131-92bc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="1262-cf57-7c1b-575d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="40e5-fffe-0ce8-1eb2" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="e4d2-83cf-ee27-ab46" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6bf6-58bc-3de6-61bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8946-5d4e-d6f8-6709" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6bf6-58bc-3de6-61bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8946-5d4e-d6f8-6709" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="6f9b-b823-db02-749d" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e78a-5a31-04d0-9a38" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="9caf-b166-6e85-3fa0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e78a-5a31-04d0-9a38" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="9caf-b166-6e85-3fa0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
     <entryLink id="f5a3-cf20-d280-0d62" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="034a-b657-4331-482a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="9694-8b06-6b72-c761" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="034a-b657-4331-482a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="9694-8b06-6b72-c761" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
     <entryLink id="8fec-45d2-8c3b-1d40" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3def-9e3f-93ca-c5b9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="2a23-c511-c2b3-e449" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3def-9e3f-93ca-c5b9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="2a23-c511-c2b3-e449" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
     <entryLink id="318d-0ca8-920b-a155" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="61eb-6a78-045e-c729" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="74ec-ad61-504f-2e4d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="61eb-6a78-045e-c729" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ec-ad61-504f-2e4d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
     <entryLink id="85df-adb9-8692-6b35" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f0c9-2840-406c-dade" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="7f9a-3d07-b4b1-0118" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f0c9-2840-406c-dade" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="7f9a-3d07-b4b1-0118" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
     <entryLink id="d49d-b769-a7a1-105f" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6456-977b-7984-ba1f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="06fc-3975-ff4c-471c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6456-977b-7984-ba1f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="06fc-3975-ff4c-471c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
     <entryLink id="72b6-bd25-6175-78f0" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f9cf-9666-e965-e4d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d437-76e4-63e3-557a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="f9cf-9666-e965-e4d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d437-76e4-63e3-557a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
     <entryLink id="e2d1-37a3-572a-ec6b" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a7c9-8373-0627-56b2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="e8b7-3893-52b9-405d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a7c9-8373-0627-56b2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="e8b7-3893-52b9-405d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
     <entryLink id="58a1-1b58-e82a-e16a" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7923-78f2-c03d-4753" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="97a1-a791-0647-3bbc" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="7923-78f2-c03d-4753" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="97a1-a791-0647-3bbc" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="e569-03b6-aee1-0753" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6c8e-b039-4e50-10df" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="5716-3b33-edfc-9178" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6c8e-b039-4e50-10df" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="5716-3b33-edfc-9178" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
     <entryLink id="2f2b-9484-e05f-70dc" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7daa-e663-050d-5519" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="4ccb-bc87-221c-18a1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7daa-e663-050d-5519" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="4ccb-bc87-221c-18a1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
     <entryLink id="6f01-0e86-1f6d-16a7" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1aea-bca1-2183-0859" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="1444-977a-f6db-d3aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1aea-bca1-2183-0859" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="1444-977a-f6db-d3aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
     <entryLink id="9be0-518e-a269-8f24" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="257f-a07b-4a39-d2a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="06c4-336e-9847-fc86" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="257f-a07b-4a39-d2a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="06c4-336e-9847-fc86" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
     <entryLink id="2619-062d-f834-7acf" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1803-7d45-bc05-1924" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0cce-d229-679a-54fc" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="1803-7d45-bc05-1924" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0cce-d229-679a-54fc" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
     <entryLink id="ac56-cdc4-63cf-61b1" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4200-ff67-8196-c3eb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="3a2d-e60e-f5a7-1c72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4200-ff67-8196-c3eb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="3a2d-e60e-f5a7-1c72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
     <entryLink id="6764-be36-2434-9807" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="58c8-bd18-3008-2861" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="5f81-3d66-2dbe-752a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="58c8-bd18-3008-2861" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="5f81-3d66-2dbe-752a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
     <entryLink id="6460-302a-4edf-0f8f" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cad5-93d3-73d0-b7e1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="d327-daff-3007-2ce7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="cad5-93d3-73d0-b7e1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="d327-daff-3007-2ce7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
     <entryLink id="e7a9-d890-739a-b83d" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1106-dfdb-1061-5622" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="7bf4-6bb0-c9fe-b689" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1106-dfdb-1061-5622" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="7bf4-6bb0-c9fe-b689" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
     <entryLink id="cc42-19e4-a783-9145" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9a49-8843-adf4-d448" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="9d8f-05f0-52f5-a78f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9a49-8843-adf4-d448" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="9d8f-05f0-52f5-a78f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
     <entryLink id="5d3e-7bdf-f892-ba0e" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="410c-cff2-1480-9e6b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="8bc8-f311-e10d-5b90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="410c-cff2-1480-9e6b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="8bc8-f311-e10d-5b90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
     <entryLink id="e823-d2fc-99d4-7c6c" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8887-4fb0-f50f-71d1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="a13c-a5f2-c61b-37cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8887-4fb0-f50f-71d1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="a13c-a5f2-c61b-37cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
     <entryLink id="3161-18f3-4ff5-565e" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="208a-c842-a3e5-0cbf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="3200-21ec-16c3-05fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="208a-c842-a3e5-0cbf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="3200-21ec-16c3-05fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
     <entryLink id="8612-8de9-0d49-bc1c" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8375-b2bc-b21f-6d62" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="76a9-9067-c558-8050" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8375-b2bc-b21f-6d62" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="76a9-9067-c558-8050" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
     <entryLink id="89f4-ec64-18e3-834a" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="798e-a9ff-0549-f6ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="14c5-d9b9-da62-b98b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="798e-a9ff-0549-f6ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="14c5-d9b9-da62-b98b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
     <entryLink id="2c48-417f-2d9f-607f" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2134-480f-42c0-e0c3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="4da0-e85b-d624-c95e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2134-480f-42c0-e0c3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="4da0-e85b-d624-c95e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
     <entryLink id="a598-c2dd-0f71-f45b" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f2be-a5a7-541e-bc2d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="76de-e849-aa9e-2613" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="f2be-a5a7-541e-bc2d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="76de-e849-aa9e-2613" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
     <entryLink id="a59b-5848-48be-a140" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6396-d7a3-ad58-ba44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="136d-5187-426c-24d0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6396-d7a3-ad58-ba44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="136d-5187-426c-24d0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="7adb-70a6-609d-c5cd" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0c42-0d87-5d42-4a2b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="6816-a248-0d38-3e72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0c42-0d87-5d42-4a2b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="6816-a248-0d38-3e72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
     <entryLink id="b631-2b65-2745-d79c" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f307-1415-e1ad-a802" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="e378-b7ba-eec5-dc84" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f307-1415-e1ad-a802" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="e378-b7ba-eec5-dc84" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="0494-6bf7-a54d-33b6" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2f00-2f8a-19eb-1c2e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7fbf-f45e-492a-8d14" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="2f00-2f8a-19eb-1c2e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7fbf-f45e-492a-8d14" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="66e7-ee64-2389-9645" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ffaa-7844-7127-00da" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="5116-89cd-9757-e6f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="13a6-ada3-716a-ff96" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="ffaa-7844-7127-00da" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="5116-89cd-9757-e6f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="13a6-ada3-716a-ff96" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="a08c-011b-657c-2b29" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup"/>
-        <entryLink id="911e-408a-54b9-0665" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup"/>
+        <entryLink id="a08c-011b-657c-2b29" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup" />
+        <entryLink id="911e-408a-54b9-0665" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
     <entryLink id="a201-1329-ae33-a22b" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e2aa-3263-a6f5-bb01" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="1218-58c8-f917-1e6a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="37be-f2ca-8423-c23f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="e2aa-3263-a6f5-bb01" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="1218-58c8-f917-1e6a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="37be-f2ca-8423-c23f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="6b3a-20f7-081c-6e0a" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup"/>
-        <entryLink id="f61f-c8ac-4596-a30d" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup"/>
+        <entryLink id="6b3a-20f7-081c-6e0a" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup" />
+        <entryLink id="f61f-c8ac-4596-a30d" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
     <entryLink id="da86-05c2-dfd5-5d37" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d933-cbf0-2445-0e88" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="8641-efc7-96cc-e018" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b4b4-5fdc-bbbc-e6f8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="d933-cbf0-2445-0e88" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="8641-efc7-96cc-e018" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b4b4-5fdc-bbbc-e6f8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="e154-0c29-2540-5af1" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup"/>
-        <entryLink id="b483-76d5-7c21-2559" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup"/>
+        <entryLink id="e154-0c29-2540-5af1" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup" />
+        <entryLink id="b483-76d5-7c21-2559" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="164e-db98-d506-d2d9" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
     <entryLink id="f093-f91f-9522-4287" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="da86-5c27-c422-5f76" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7e92-ac64-8348-6282" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="da86-5c27-c422-5f76" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7e92-ac64-8348-6282" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="7a81-e760-5681-fbf6" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1d36-1ec7-0fbc-ba7d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="15a3-8494-bf9a-2e88" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1d36-1ec7-0fbc-ba7d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="15a3-8494-bf9a-2e88" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
     <entryLink id="5205-b4e0-165a-50d9" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="df40-7f9f-fcb9-fbf0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b87f-1d62-0cb2-4a42" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="df40-7f9f-fcb9-fbf0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b87f-1d62-0cb2-4a42" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="d927-e039-79a6-0fc9" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9ac4-3429-b432-bd7f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="8e52-f4e4-1aa0-ee60" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9ac4-3429-b432-bd7f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="8e52-f4e4-1aa0-ee60" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
     <entryLink id="f01d-877f-a918-e097" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6fec-c224-577a-bfc7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="f065-e895-8376-0868" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6fec-c224-577a-bfc7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="f065-e895-8376-0868" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
     <entryLink id="c0c1-05ae-ef48-64e1" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9779-c785-e5ca-3cfc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="ab72-0878-8634-2452" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9779-c785-e5ca-3cfc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="ab72-0878-8634-2452" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
     <entryLink id="e829-1a56-02ec-5649" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="97eb-2dd1-515d-429b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7a5a-35e3-db4e-ae29" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="97eb-2dd1-515d-429b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7a5a-35e3-db4e-ae29" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
     <entryLink id="1509-08ef-cef0-45d5" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e443-4e9a-afd7-75a1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="b36a-c596-6ac7-7ac4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e443-4e9a-afd7-75a1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="b36a-c596-6ac7-7ac4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
     <entryLink id="db09-4e6b-eedc-a4e1" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fec1-dbcd-da44-8e43" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7b1a-4c68-2dee-4e89" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="fec1-dbcd-da44-8e43" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7b1a-4c68-2dee-4e89" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
     <entryLink id="5b49-59c1-ec3b-b338" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="04fd-39e5-998c-d810" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ed18-8a46-841b-da96" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="04fd-39e5-998c-d810" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ed18-8a46-841b-da96" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
     <entryLink id="7f98-4826-a1f8-3a6b" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d776-6199-79a7-f820" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1277-e55b-20f5-2be4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="d776-6199-79a7-f820" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1277-e55b-20f5-2be4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
     <entryLink id="f37a-4ae1-3013-e07b" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="cd7e-b7da-5084-edb3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="97f8-fc78-6e0f-2880" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="cd7e-b7da-5084-edb3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="97f8-fc78-6e0f-2880" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
     <entryLink id="d567-0a28-d590-0504" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6ca1-2a3b-ce97-7411" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="00f5-daec-ffef-ce45" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6ca1-2a3b-ce97-7411" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="00f5-daec-ffef-ce45" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="9a93-d8a8-61ed-c1cc" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b66c-a617-dea0-71cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f783-3e36-9368-b8ee" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="b66c-a617-dea0-71cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f783-3e36-9368-b8ee" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
     <entryLink id="f810-cb9a-1661-531b" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4b88-e1ec-00bf-74e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b813-80f4-3b3c-389a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="4b88-e1ec-00bf-74e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b813-80f4-3b3c-389a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="a1da-a30a-5185-b804" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9296-e8c7-5a57-f74e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="7990-cb8e-74c7-972b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9296-e8c7-5a57-f74e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="7990-cb8e-74c7-972b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
     <entryLink id="533f-92c6-3c3c-191c" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e905-a7fb-b03f-1b78" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="aa0b-d64e-6f23-e0aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e905-a7fb-b03f-1b78" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="aa0b-d64e-6f23-e0aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
     <entryLink id="85ce-3361-689f-de0b" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0962-9fe8-d952-237b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="c8f8-89e0-e77a-aa29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0962-9fe8-d952-237b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="c8f8-89e0-e77a-aa29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
     <entryLink id="b8ca-7fc3-9885-442f" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c53e-35fb-7409-d6cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c562-f87b-3a3f-c2b7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="abfc-aae3-2d06-2698" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="c53e-35fb-7409-d6cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c562-f87b-3a3f-c2b7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="abfc-aae3-2d06-2698" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="8253-1664-7120-6604" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7d73-a401-01b6-a020" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1244-c41f-d990-595b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="7d73-a401-01b6-a020" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1244-c41f-d990-595b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
     <entryLink id="4d8c-dee2-eca3-f946" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9454-6a20-9086-a0ba" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="bc38-316f-be80-ff7e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9454-6a20-9086-a0ba" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="bc38-316f-be80-ff7e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
     <entryLink id="185a-9d55-8778-fe4a" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="bff4-f7ed-e114-74eb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="17eb-e4da-3cab-53e4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="bff4-f7ed-e114-74eb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="17eb-e4da-3cab-53e4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
     <entryLink id="b0f6-19e9-0bc0-1908" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0715-6555-04ea-4b57" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="68a1-1f57-31d4-e18e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0715-6555-04ea-4b57" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="68a1-1f57-31d4-e18e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="44c2-325e-b064-e639" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ebdb-c055-099b-4d8b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="7d34-32cf-de84-1681" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6bb9-0af9-e129-9e9d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="ebdb-c055-099b-4d8b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="7d34-32cf-de84-1681" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6bb9-0af9-e129-9e9d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
     <entryLink id="0cb9-d47f-f2d7-bfb9" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e6cc-2e9d-4c89-6eba" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="9972-607b-a844-41da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e6cc-2e9d-4c89-6eba" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="9972-607b-a844-41da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="4766-17f6-e613-f831" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="48dc-f813-d91d-1a66" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="5e53-4193-a88c-47e4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="48dc-f813-d91d-1a66" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="5e53-4193-a88c-47e4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
     <entryLink id="4f6c-a6a0-471a-d91e" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f4f2-f5c1-852f-f2f4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="43c7-06a5-8c7b-85af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f4f2-f5c1-852f-f2f4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="43c7-06a5-8c7b-85af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
     <entryLink id="cbb7-653a-6657-251a" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="399e-c833-90bb-65d3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="52c7-e41e-e9a4-c57c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="399e-c833-90bb-65d3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="52c7-e41e-e9a4-c57c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
     <entryLink id="3c84-63cb-339a-9eea" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="90d1-4dee-1f65-1a45" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="40bf-4f06-7c14-b8b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="90d1-4dee-1f65-1a45" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="40bf-4f06-7c14-b8b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
     <entryLink id="b3ed-cd72-c764-20a7" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3eaa-966b-ae55-c3b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0f28-49b8-ae80-17f3" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="5f58-2713-85b9-5efa" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="3eaa-966b-ae55-c3b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0f28-49b8-ae80-17f3" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
+        <categoryLink id="5f58-2713-85b9-5efa" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="5134-d030-f52c-821b" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9bef-3b3f-8273-7ad3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="983a-8eee-715e-a69f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="9bef-3b3f-8273-7ad3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="983a-8eee-715e-a69f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
     <entryLink id="83eb-08b0-548d-c442" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="eb54-3f93-c551-aa64" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="28f3-6735-3fe8-5daa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="eb54-3f93-c551-aa64" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="28f3-6735-3fe8-5daa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
     <entryLink id="4b12-b17a-86c7-960a" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0fab-a641-0aca-93c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b99b-a19a-14d8-3e9f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="0fab-a641-0aca-93c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b99b-a19a-14d8-3e9f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
     <entryLink id="da28-3e90-f9bb-ac33" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8247-71b0-fc82-30a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3c7e-b112-2089-7e60" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="8247-71b0-fc82-30a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3c7e-b112-2089-7e60" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="19ce-b8dc-dd40-fee9" name="Phalanx Warder Squad" hidden="false" collective="false" import="true" type="unit">
@@ -1091,31 +1090,31 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="bac0-f49c-0b38-29bc" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule"/>
+        <infoLink id="bac0-f49c-0b38-29bc" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="fdda-3efe-5d7d-bf3e" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="37c5-26ea-8f6f-cc83" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="b742-fcda-a7e3-3a0e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="fdda-3efe-5d7d-bf3e" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="37c5-26ea-8f6f-cc83" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="b742-fcda-a7e3-3a0e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="931f-3c6f-8658-fa6f" name="Warder Sergeant" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d13f-b56e-5bde-a9da" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2351-29fd-a3cc-a70c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d13f-b56e-5bde-a9da" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2351-29fd-a3cc-a70c" type="max" />
           </constraints>
           <profiles>
             <profile id="8b28-7619-9b61-72c9" name="Warder Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="19ce-b8dc-dd40-fee9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                    <condition field="selections" scope="19ce-b8dc-dd40-fee9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Heavy)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1129,73 +1128,73 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="fdf2-f339-3520-8788" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="fdf2-f339-3520-8788" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="1cc8-ac5c-b5c2-b7ad" name=" Weapon Options:" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cff9-f9b1-3fc6-515e" type="max"/>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7124-ad1d-66bc-4850" type="min"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cff9-f9b1-3fc6-515e" type="max" />
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7124-ad1d-66bc-4850" type="min" />
               </constraints>
               <selectionEntryGroups>
                 <selectionEntryGroup id="9dd9-b465-802e-c5cf" name="Default Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="47b0-6df9-2370-526c">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="6376-90ad-9d50-1acc" type="min"/>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="58b6-de5c-356d-f83f" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="6376-90ad-9d50-1acc" type="min" />
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="58b6-de5c-356d-f83f" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="47b0-6df9-2370-526c" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
                       <modifiers>
-                        <modifier type="set" field="854c-b3ad-c214-c5bb" value="0.0"/>
+                        <modifier type="set" field="854c-b3ad-c214-c5bb" value="0.0" />
                       </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="854c-b3ad-c214-c5bb" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1a6f-8a10-14d7-7090" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="854c-b3ad-c214-c5bb" type="min" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1a6f-8a10-14d7-7090" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="2722-72b1-a26c-58ba" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
                       <modifiers>
-                        <modifier type="set" field="f13f-27fa-530d-f26f" value="0.0"/>
+                        <modifier type="set" field="f13f-27fa-530d-f26f" value="0.0" />
                       </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="f13f-27fa-530d-f26f" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="aa4e-ee74-8f3c-a2d9" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="f13f-27fa-530d-f26f" type="min" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="aa4e-ee74-8f3c-a2d9" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="7457-4bc9-6d0c-ded4" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                       <modifiers>
-                        <modifier type="set" field="9eec-be0a-c0ed-209a" value="0.0"/>
+                        <modifier type="set" field="9eec-be0a-c0ed-209a" value="0.0" />
                       </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="9eec-be0a-c0ed-209a" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="955a-9208-d570-8224" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="9eec-be0a-c0ed-209a" type="min" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="955a-9208-d570-8224" type="max" />
                       </constraints>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="e0fe-d29b-b9e8-8ee5" name="May swap a default option for:" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d6ef-77fb-fc47-6414" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d6ef-77fb-fc47-6414" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="aba7-ed1b-1d97-9b83" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="614c-d450-a3f4-b7d7" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="42f1-c412-bf6b-e2db" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="b682-2c89-f979-aa74" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="cff5-cb31-92b3-24b3" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -1206,32 +1205,32 @@
               <entryLinks>
                 <entryLink id="1d4e-3be6-94b7-ca43" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e455-237f-628d-81f6" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e455-237f-628d-81f6" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="50d0-815e-9ce7-d0d1" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
                       <conditions>
-                        <condition field="selections" scope="19ce-b8dc-dd40-fee9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02ad-dc88-8eb4-81be" type="equalTo"/>
+                        <condition field="selections" scope="19ce-b8dc-dd40-fee9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02ad-dc88-8eb4-81be" type="equalTo" />
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b948-4a57-1a3e-c205" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b948-4a57-1a3e-c205" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1240,18 +1239,18 @@
           <entryLinks>
             <entryLink id="ddf4-0e88-1275-efc0" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e63-7151-bf7c-7a96" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e63-7151-bf7c-7a96" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="04d6-ba4f-715f-7d16" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94b7-7659-c67d-b598" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94b7-7659-c67d-b598" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -1260,10 +1259,10 @@
           <entryLinks>
             <entryLink id="02ad-dc88-8eb4-81be" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a66a-d989-983a-2ac4" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a66a-d989-983a-2ac4" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -1272,19 +1271,19 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e12e-d7a8-88d4-56df" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e12e-d7a8-88d4-56df" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="1e55-f0ee-cfa1-ec03" name="Termite Assault Drill" hidden="false" collective="false" import="true" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1293,7 +1292,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1302,7 +1301,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1311,7 +1310,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1320,8 +1319,8 @@
         </selectionEntryGroup>
         <selectionEntryGroup id="9cef-6264-b4bf-ab94" name="1) Phalanx Warders" hidden="false" collective="false" import="true" defaultSelectionEntryId="5491-9420-e713-30f9">
           <constraints>
-            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df58-9bb9-e816-3380" type="max"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35f3-e426-1779-44de" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df58-9bb9-e816-3380" type="max" />
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35f3-e426-1779-44de" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="5491-9420-e713-30f9" name="Phalanx Warder" hidden="false" collective="false" import="true" type="model">
@@ -1329,7 +1328,7 @@
                 <profile id="63c9-ae74-ba0a-487c" name="Phalanx Warder" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1345,88 +1344,88 @@
               <entryLinks>
                 <entryLink id="fce2-8f5a-5914-fff5" name="Power Axe" hidden="false" collective="false" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0c5c-2c05-6214-aa38" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2b85-44a6-27e6-2f35" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0c5c-2c05-6214-aa38" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2b85-44a6-27e6-2f35" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="8a74-4c93-17b5-b0b3" name="Bolter" hidden="false" collective="false" import="true" targetId="a080-c391-6083-5e5d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="70b1-3dbd-0bb1-9e7e" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aa23-0c7f-95e7-5a71" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="70b1-3dbd-0bb1-9e7e" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aa23-0c7f-95e7-5a71" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="3098-0d0b-95b7-1a52" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aee7-e715-9ee7-98e0" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="51ad-748b-0e06-1164" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aee7-e715-9ee7-98e0" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="51ad-748b-0e06-1164" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="d62c-34f4-876f-a499" name="Phalanx Warder w/Special Weapon (1 in 5)" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="db64-3a9e-d7d5-dc48" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db64-3a9e-d7d5-dc48" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db64-3a9e-d7d5-dc48" type="max" />
               </constraints>
               <selectionEntryGroups>
                 <selectionEntryGroup id="9b03-fb86-d28d-de13" name="Weapon Choice" hidden="false" collective="false" import="true" defaultSelectionEntryId="e098-09cf-b11f-0cb7">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bacc-5f82-ff1c-ec15" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8969-a2de-bd6b-c1db" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bacc-5f82-ff1c-ec15" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8969-a2de-bd6b-c1db" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="9fd4-f392-b786-8435" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="c5ae-4bee-960e-49ba" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="d029-1d8e-e205-64e6" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="e098-09cf-b11f-0cb7" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="eb17-d14f-a593-1161" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="fbb1-a9cf-1c06-db48" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="77c4-aab8-8fb4-ff28" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="971d-664c-4b65-191a" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="e59b-a520-6122-ea8f" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -1435,19 +1434,19 @@
               <entryLinks>
                 <entryLink id="859a-78bc-02fe-71c9" name="Power Axe" hidden="false" collective="false" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d311-3011-ea0b-a424" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3a58-ecf3-2a7e-7c5a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d311-3011-ea0b-a424" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3a58-ecf3-2a7e-7c5a" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="1966-14fe-c1af-2e00" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d97f-9b26-5188-9eec" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="63bd-383e-6402-0e86" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d97f-9b26-5188-9eec" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="63bd-383e-6402-0e86" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1456,60 +1455,60 @@
       <entryLinks>
         <entryLink id="7e02-6cd0-83cc-66ed" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d3c-a8b4-2f37-426b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07c9-0e9b-9aff-7ba0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d3c-a8b4-2f37-426b" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07c9-0e9b-9aff-7ba0" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="1454-22bf-8b7d-9ef5" name="Boarding Shield" hidden="false" collective="false" import="true" targetId="0c0f-f751-cc4e-4951" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f972-1ca8-471a-59a6" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06c5-9777-d437-8343" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f972-1ca8-471a-59a6" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06c5-9777-d437-8343" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="5938-50c8-36f2-f01e" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e997-b528-09a6-f79c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cdd-edbe-a0b6-892a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e997-b528-09a6-f79c" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cdd-edbe-a0b6-892a" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="df07-1a66-6c4e-0b55" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2fb-372f-794a-ad57" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d88-091d-91d5-5be0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2fb-372f-794a-ad57" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d88-091d-91d5-5be0" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="f5af-15a3-5698-f0f7" name="Breacher Charge" hidden="false" collective="false" import="true" targetId="9622-f67e-4afe-09f3" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d319-afbe-c6fd-33ba" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f31c-35f8-a226-bb31" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d319-afbe-c6fd-33ba" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f31c-35f8-a226-bb31" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="f323-a02c-fa4e-b1ef" name="Sigismund" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="34e4-4d23-aba2-6807" type="max"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="96ef-3948-ea4e-1bb0" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="34e4-4d23-aba2-6807" type="max" />
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="96ef-3948-ea4e-1bb0" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="0f9a-794e-6027-b9cf" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="e5a6-f3dc-73de-2bdb" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="8937-ca79-5a50-90fb" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="0f9a-794e-6027-b9cf" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="e5a6-f3dc-73de-2bdb" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="8937-ca79-5a50-90fb" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3825-ece6-4a69-41cb" name="Sigismund" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fc8-2292-cae4-5186" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="caa8-057b-f8bb-137f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fc8-2292-cae4-5186" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="caa8-057b-f8bb-137f" type="max" />
           </constraints>
           <profiles>
             <profile id="0d53-05a1-9d0e-a48a" name="Sigismund" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">7</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1523,38 +1522,38 @@
             </profile>
           </profiles>
           <rules>
-            <rule id="f6fc-f7e4-ccf6-1805" name="Death&apos;s Champion" hidden="false">
+            <rule id="f6fc-f7e4-ccf6-1805" name="Death's Champion" hidden="false">
               <description>Sigismund and any unit he joins gains a bonus of +2 to all Charge Distances and Sweeping Advance rolls made for the unit. In addition, if Sigismund is present in any Detachment then that Detachment may take Templar Brethren squads as Troops choices.</description>
             </rule>
             <rule id="08ae-c080-c699-d291" name="Dolorous Fighter" hidden="false">
-              <description>When a Challenge is issued in any combat that includes Sigismund, Sigismund’s controlling player must always accept that Challenge with Sigismund – if the opposing player does not issue a Challenge then Sigismund’s controlling player must do so and must nominate Sigismund to fight in that Challenge. Additionally, when fighting in a Challenge, successful Invulnerable Saves taken against Sigismund’s attacks must be re-rolled.</description>
+              <description>When a Challenge is issued in any combat that includes Sigismund, Sigismund&#8217;s controlling player must always accept that Challenge with Sigismund &#8211; if the opposing player does not issue a Challenge then Sigismund&#8217;s controlling player must do so and must nominate Sigismund to fight in that Challenge. Additionally, when fighting in a Challenge, successful Invulnerable Saves taken against Sigismund&#8217;s attacks must be re-rolled.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="2baf-299e-2999-b21d" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule"/>
-            <infoLink id="6d99-ba61-d40d-6667" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
-            <infoLink id="a322-a9c1-efe1-1702" name="Eternal Warrior" hidden="false" targetId="000b-fe96-31f8-c0ad" type="rule"/>
+            <infoLink id="2baf-299e-2999-b21d" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule" />
+            <infoLink id="6d99-ba61-d40d-6667" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule" />
+            <infoLink id="a322-a9c1-efe1-1702" name="Eternal Warrior" hidden="false" targetId="000b-fe96-31f8-c0ad" type="rule" />
             <infoLink id="7731-db8d-fa51-6eeb" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Adamantium Will (3+)"/>
+                <modifier type="set" field="name" value="Adamantium Will (3+)" />
               </modifiers>
             </infoLink>
             <infoLink id="a7a5-b98c-251a-7e68" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Precision Strikes (3+)"/>
+                <modifier type="set" field="name" value="Precision Strikes (3+)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="f52c-c884-92c0-a4cd" name="Master-crafted bolt pistol" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9abf-570d-e7f1-3072" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be7b-4184-a69a-4521" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9abf-570d-e7f1-3072" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be7b-4184-a69a-4521" type="max" />
               </constraints>
               <profiles>
                 <profile id="1e3d-08a5-f4ab-4d7d" name="Master-Crafted bolt pistol" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">12"</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
                     <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 1, Master-crafted</characteristic>
@@ -1562,16 +1561,16 @@
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="24c3-bfdd-857e-f205" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="24c3-bfdd-857e-f205" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="de58-da54-74a1-e536" name="The Black Sword" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="250e-ffea-1826-2070" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0702-8ed2-1442-6996" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="250e-ffea-1826-2070" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0702-8ed2-1442-6996" type="max" />
               </constraints>
               <profiles>
                 <profile id="b940-1db3-d2e0-c95f" name="The Black Sword" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1584,85 +1583,85 @@
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="e7cc-ccaa-fc73-30af" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
-                <infoLink id="004a-b400-6600-b4ec" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
-                <infoLink id="13f5-f576-39b1-e969" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="e7cc-ccaa-fc73-30af" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule" />
+                <infoLink id="004a-b400-6600-b4ec" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
+                <infoLink id="13f5-f576-39b1-e969" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="49f3-d1fd-8962-e42d" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85e0-d73d-b99e-f79b" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a66-6909-adc0-be8d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85e0-d73d-b99e-f79b" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a66-6909-adc0-be8d" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="0842-43ac-acef-241a" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f15-71e7-07d1-36c5" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8dc-582c-df77-f165" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f15-71e7-07d1-36c5" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8dc-582c-df77-f165" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="37d2-0c32-5e2e-cf67" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14af-d16d-1b28-854a" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e5f-d9a0-0e33-d814" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14af-d16d-1b28-854a" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e5f-d9a0-0e33-d814" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="883b-d678-74ff-a936" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8a2-c34b-4493-716b" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45ab-3781-e5b2-58aa" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8a2-c34b-4493-716b" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45ab-3781-e5b2-58aa" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="8503-81bb-4029-e749" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2079-e5a0-9436-8e1a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2079-e5a0-9436-8e1a" type="max" />
           </constraints>
           <profiles>
             <profile id="7990-89f5-0db2-3254" name="Slayer of Kings" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If Sigismund is the army’s Warlord and slays the enemy Warlord in a Challenge, Sigismund’s controlling player gains +1 Victory point and all models in the same army as Sigismund may add +1 to the total number of Wounds caused in each combat for the purposes of determining Assault results for the rest of the battle (this does not stack with any other rules that increase the Assault result). In addition, an army with Sigismund as its Warlord may make an additional Reaction during the opponent’s Movement phase as long as Sigismund has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If Sigismund is the army&#8217;s Warlord and slays the enemy Warlord in a Challenge, Sigismund&#8217;s controlling player gains +1 Victory point and all models in the same army as Sigismund may add +1 to the total number of Wounds caused in each combat for the purposes of determining Assault results for the rest of the battle (this does not stack with any other rules that increase the Assault result). In addition, an army with Sigismund as its Warlord may make an additional Reaction during the opponent&#8217;s Movement phase as long as Sigismund has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
         <entryLink id="c686-a7c2-348e-8b65" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b473-77be-818a-f915" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bae5-29f8-ae75-c5c1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b473-77be-818a-f915" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bae5-29f8-ae75-c5c1" type="min" />
           </constraints>
         </entryLink>
-        <entryLink id="9e12-d8c6-8e48-4c11" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup"/>
+        <entryLink id="9e12-d8c6-8e48-4c11" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="230.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="230.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="9229-b4f9-2213-9672" name="Alexis Polux " hidden="false" collective="false" import="true" type="unit">
       <comment>(Urgent help needed)</comment>
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7721-fdef-2fe0-7f7c" type="max"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e111-dc03-a164-6a76" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7721-fdef-2fe0-7f7c" type="max" />
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e111-dc03-a164-6a76" type="max" />
       </constraints>
       <infoLinks>
-        <infoLink id="b9f0-6dd3-7d59-aa1d" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule"/>
+        <infoLink id="b9f0-6dd3-7d59-aa1d" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="93db-ffc9-0558-73e6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="e823-f428-97c9-b5d7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="0d9a-8f4f-0ec8-6ebc" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="7668-e167-087e-ec1a" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="93db-ffc9-0558-73e6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="e823-f428-97c9-b5d7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="0d9a-8f4f-0ec8-6ebc" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="7668-e167-087e-ec1a" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="194d-69e1-55b6-8453" name="Alexis Polux" hidden="false" collective="false" import="true" type="model">
@@ -1670,7 +1669,7 @@
             <profile id="281c-8f66-fd88-399e" name="Alexis Polux" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Heavy, Unique)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">5</characteristic>
@@ -1685,102 +1684,102 @@
           </profiles>
           <rules>
             <rule id="d5ed-fb61-0ad0-3d66" name="Hammer Blow" hidden="false">
-              <description>During any Fight sub-phase, Alexis Polux’s controlling player may choose to have Alexis Polux make a single attack with the profile &quot;Hammer Blow&quot; (while using this option Alexis Polux may not gain bonus attacks for Charging, additional weapons or from any other special rule)</description>
+              <description>During any Fight sub-phase, Alexis Polux&#8217;s controlling player may choose to have Alexis Polux make a single attack with the profile "Hammer Blow" (while using this option Alexis Polux may not gain bonus attacks for Charging, additional weapons or from any other special rule)</description>
             </rule>
             <rule id="1719-25bf-e884-5928" name="Void Commander" hidden="false">
               <description>The controlling player may opt to automatically pass or fail any Pinning test made for Alexis Polux and any unit he has joined. In addition, all models in a unit that Alexis Polux joins while in Reserves (see the Combined Reserves Units rule on page 309 of the Horus Heresy: Age of Darkness rulebook) gain the Deep Strike special rule.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="e767-8faf-6d38-c1d7" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+            <infoLink id="e767-8faf-6d38-c1d7" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule" />
           </infoLinks>
           <entryLinks>
             <entryLink id="3c0a-6c75-d0e0-9bba" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d260-60a4-5c4b-1775" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd92-f07b-e14c-0891" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d260-60a4-5c4b-1775" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd92-f07b-e14c-0891" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="4687-4e8e-a6e7-5ed3" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dba9-72d8-9d2f-2958" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="452b-f63f-f6ae-e6f8" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dba9-72d8-9d2f-2958" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="452b-f63f-f6ae-e6f8" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="ccfd-c0c1-18ad-51d2" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2dfd-3326-0f13-365d" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6599-856e-3c69-5603" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2dfd-3326-0f13-365d" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6599-856e-3c69-5603" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="8317-8265-9578-a4a1" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15ac-4d9c-df5c-08b1" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f55f-6777-c9c7-24df" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15ac-4d9c-df5c-08b1" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f55f-6777-c9c7-24df" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="e7d0-0983-6b41-27ef" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="0d1c-227e-a3f8-cd63" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68c5-4fc9-4cda-9346" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4391-7912-6ca7-d189" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68c5-4fc9-4cda-9346" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4391-7912-6ca7-d189" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="ce2a-13b3-23df-237f" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="b682-2c89-f979-aa74" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d16-dd67-cde1-3a75" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8fc-d670-2a13-0297" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d16-dd67-cde1-3a75" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8fc-d670-2a13-0297" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="672b-e1e9-6253-ed91" name="Vigil Storm Shield" hidden="false" collective="false" import="true" targetId="ec3d-1f0c-d195-a006" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86e6-d20b-2c80-1c65" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5114-ee70-d5f0-4758" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86e6-d20b-2c80-1c65" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5114-ee70-d5f0-4758" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="02b9-034a-2569-5151" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3a4-3d2f-d7b9-2182" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3a4-3d2f-d7b9-2182" type="max" />
           </constraints>
           <profiles>
             <profile id="e9eb-a5a2-1f4a-d591" name="Master Tactician" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">After all models are deployed but before any rolls to Seize the Initiative are made, the controlling player of Alexis Polux may redeploy one friendly unit within the limitations of the mission being played. This may place a unit that had been deployed normally into Reserves, or bring a unit out of Reserves – but may not add or remove units that have been assigned to a Deep Strike Assault, Drop Pod Assault, Flanking Assault or Subterranean Assault. In addition, an army with Alexis Polux as its Warlord may make an additional Reaction during the opponent’s Assault phase as long as Alexis Polux has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">After all models are deployed but before any rolls to Seize the Initiative are made, the controlling player of Alexis Polux may redeploy one friendly unit within the limitations of the mission being played. This may place a unit that had been deployed normally into Reserves, or bring a unit out of Reserves &#8211; but may not add or remove units that have been assigned to a Deep Strike Assault, Drop Pod Assault, Flanking Assault or Subterranean Assault. In addition, an army with Alexis Polux as its Warlord may make an additional Reaction during the opponent&#8217;s Assault phase as long as Alexis Polux has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
         <entryLink id="1887-d97c-3c7b-23ca" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7df2-278d-0347-afb5" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8bb-a526-f80a-cbe7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7df2-278d-0347-afb5" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8bb-a526-f80a-cbe7" type="min" />
           </constraints>
         </entryLink>
-        <entryLink id="d612-4dfb-1250-9e3c" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup"/>
+        <entryLink id="d612-4dfb-1250-9e3c" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="d483-8c34-3bcb-f1d5" name="Fafnir Rann" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="37d2-c4e6-e4ec-3210" type="max"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e288-2028-da8e-3648" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="37d2-c4e6-e4ec-3210" type="max" />
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e288-2028-da8e-3648" type="max" />
       </constraints>
       <infoLinks>
-        <infoLink id="8ae1-d697-8e62-0961" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule"/>
+        <infoLink id="8ae1-d697-8e62-0961" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="7d2a-1492-8056-3083" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="f860-72fd-d93c-1290" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="7b95-8b9b-38c1-f8fb" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="1715-31a2-3ed9-4522" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="7d2a-1492-8056-3083" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="f860-72fd-d93c-1290" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="7b95-8b9b-38c1-f8fb" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="1715-31a2-3ed9-4522" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0a3e-c822-cc8c-3bef" name="Fafnir Rann" hidden="false" collective="false" import="true" type="model">
@@ -1788,7 +1787,7 @@
             <profile id="d439-67cb-cbb1-a257" name="Fafnir Rann" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Unique, Character, Heavy)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1802,7 +1801,7 @@
             </profile>
           </profiles>
           <rules>
-            <rule id="fd2e-1576-229e-204d" name="Executioner&apos;s Tax" hidden="false">
+            <rule id="fd2e-1576-229e-204d" name="Executioner's Tax" hidden="false">
               <description>When an enemy unit makes a successful Charge that places one or more enemy models in base contact with Fafnir Rann, or any model in a unit Fafnir Rann has joined, that enemy unit suffers D3+3 Str 5 AP- Hits. These attacks hit automatically and are resolved during the Fight sub-phase at Initiative Step 10, but grant no model a Pile-in move and do not benefit from any special rules that Fafnir Rann or any other model in the same unit may have. Hits inflicted by this special rule are allocated as normal for attacks made in an assault.</description>
             </rule>
             <rule id="e9b2-d9e3-c543-2145" name="Shield Master" hidden="false">
@@ -1812,15 +1811,15 @@
           <infoLinks>
             <infoLink id="1b27-b613-6482-ebd0" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+                <modifier type="set" field="name" value="Hammer of Wrath (1)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="5f0c-149f-6941-9ac9" name="The Headsman and The Hunter" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0eb8-2659-d5eb-a096" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3557-848a-4210-591d" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0eb8-2659-d5eb-a096" type="min" />
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3557-848a-4210-591d" type="max" />
               </constraints>
               <profiles>
                 <profile id="abee-6d5f-6378-ae8a" name="Single axe" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1842,118 +1841,118 @@
               </profiles>
               <rules>
                 <rule id="e8d7-00df-7197-b35c" name="Single axe*" hidden="false">
-                  <description>*All Hits inflicted by enemy models and allocated to Fafnir Rann must reduce their Strength by -1 (to a minimum of 1) – see the Shield Master special rule for more details.</description>
+                  <description>*All Hits inflicted by enemy models and allocated to Fafnir Rann must reduce their Strength by -1 (to a minimum of 1) &#8211; see the Shield Master special rule for more details.</description>
                 </rule>
                 <rule id="c731-16b4-5cc0-abdf" name="The Headsman and The Hunter" hidden="false">
-                  <description>Fafnir Rann’s power axes, The Headsman and The Hunter, are considered a single weapon with two profiles – one representing Fafnir Rann using a single axe in concert with his shield and one representing Fafnir Rann using both axes at once. In each Fight sub-phase Fafnir Rann’s controlling player must choose one of these two profiles to use for all of Fafnir Rann’s attacks. (Note that the Shield Master special rule allows Fafnir Rann make use of a weapon with the Two-handed special rule despite having a Breaching Shield). 
+                  <description>Fafnir Rann&#8217;s power axes, The Headsman and The Hunter, are considered a single weapon with two profiles &#8211; one representing Fafnir Rann using a single axe in concert with his shield and one representing Fafnir Rann using both axes at once. In each Fight sub-phase Fafnir Rann&#8217;s controlling player must choose one of these two profiles to use for all of Fafnir Rann&#8217;s attacks. (Note that the Shield Master special rule allows Fafnir Rann make use of a weapon with the Two-handed special rule despite having a Breaching Shield). 
 
-Both weapons are counted as ‘Power’ weapons for those rules that affect such weapons</description>
+Both weapons are counted as &#8216;Power&#8217; weapons for those rules that affect such weapons</description>
                 </rule>
               </rules>
               <infoLinks>
-                <infoLink id="ea33-132b-b19f-0797" name="Rampage (X)" hidden="false" targetId="3efb-2a2c-2d0b-92fc" type="rule"/>
-                <infoLink id="13dc-5a45-4519-60ac" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
-                <infoLink id="b0dd-6dc3-5fb6-21a5" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
-                <infoLink id="8244-a33b-8a47-0270" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="ea33-132b-b19f-0797" name="Rampage (X)" hidden="false" targetId="3efb-2a2c-2d0b-92fc" type="rule" />
+                <infoLink id="13dc-5a45-4519-60ac" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule" />
+                <infoLink id="b0dd-6dc3-5fb6-21a5" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
+                <infoLink id="8244-a33b-8a47-0270" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="902b-c703-37f1-b851" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9371-b57b-91d1-9df2" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a84c-671c-24e2-ef02" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9371-b57b-91d1-9df2" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a84c-671c-24e2-ef02" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="c055-6552-4203-d0a8" name="Boarding Shield" hidden="false" collective="false" import="true" targetId="0c0f-f751-cc4e-4951" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ce2-5590-8827-eefc" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea0f-a8f2-7bce-7520" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ce2-5590-8827-eefc" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea0f-a8f2-7bce-7520" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="02a0-74ae-24c9-25e3" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56c7-f9eb-6718-6e2b" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1eac-c999-9344-84ec" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56c7-f9eb-6718-6e2b" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1eac-c999-9344-84ec" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="8bdd-edb0-1d2e-dff0" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a988-438f-2fe5-75f8" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0409-2fed-716b-f19e" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a988-438f-2fe5-75f8" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0409-2fed-716b-f19e" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="733f-8442-c54e-17d8" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a4d-1136-3c95-789d" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b95c-0fbb-30ef-ac9c" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a4d-1136-3c95-789d" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b95c-0fbb-30ef-ac9c" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="cd78-54c7-ae06-c32b" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c873-fdd2-3849-3c87" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8289-b55d-0aeb-3787" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c873-fdd2-3849-3c87" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8289-b55d-0aeb-3787" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="0b19-7a4e-365d-f507" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3bb-37d2-3f79-4b5b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3bb-37d2-3f79-4b5b" type="max" />
           </constraints>
           <profiles>
             <profile id="b682-1020-3c99-382e" name="The Unbroken Wall" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Fafnir Rann, and all models in any Legion Breacher Squads or Phalanx Warder Squads in the same Detachment, gain a bonus of +1 to their Weapon Skill for the duration of any Assault phase in which they successfully Charge an enemy unit. In addition, an army with Fafnir Rann as its Warlord may make an additional Reaction in the opposing player’s Assault phase as long as Fafnir Rann has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Fafnir Rann, and all models in any Legion Breacher Squads or Phalanx Warder Squads in the same Detachment, gain a bonus of +1 to their Weapon Skill for the duration of any Assault phase in which they successfully Charge an enemy unit. In addition, an army with Fafnir Rann as its Warlord may make an additional Reaction in the opposing player&#8217;s Assault phase as long as Fafnir Rann has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
         <entryLink id="d0df-2f6d-dd75-8937" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a500-161e-a216-e8a1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cef0-422b-8e54-0568" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a500-161e-a216-e8a1" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cef0-422b-8e54-0568" type="min" />
           </constraints>
         </entryLink>
-        <entryLink id="46df-a318-ab20-f5e9" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup"/>
+        <entryLink id="46df-a318-ab20-f5e9" name="Retinue" hidden="false" collective="false" import="true" targetId="446f-102e-289b-bdc5" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="6f69-665c-3199-77aa" name="Templar Brethren" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="293e-f309-d4d3-6b07" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule"/>
-        <infoLink id="2bd3-4551-0e40-808a" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule"/>
+        <infoLink id="293e-f309-d4d3-6b07" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule" />
+        <infoLink id="2bd3-4551-0e40-808a" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule" />
         <infoLink id="db39-5374-ff6b-72c0" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Furious Charge (1)"/>
+            <modifier type="set" field="name" value="Furious Charge (1)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="cb18-a58d-6e9d-83c8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="a39f-1c2d-1a53-289b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="cb18-a58d-6e9d-83c8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="a39f-1c2d-1a53-289b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b931-6924-6d4d-b9ab" name="Champion" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="131a-ac5f-b7d1-c0db" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1b8-0476-d14f-a0fe" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="131a-ac5f-b7d1-c0db" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1b8-0476-d14f-a0fe" type="max" />
           </constraints>
           <profiles>
             <profile id="26e4-3925-936d-3419" name="Champion" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1967,92 +1966,92 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="f4ea-6f45-96bc-414b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="f4ea-6f45-96bc-414b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="c926-b781-4ed2-a1eb" name="Bolt Pistol Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="3187-e170-646a-9c41">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9244-3247-8f29-e430" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8373-2db9-a6c1-488f" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9244-3247-8f29-e430" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8373-2db9-a6c1-488f" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="3187-e170-646a-9c41" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+                <entryLink id="3187-e170-646a-9c41" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry" />
                 <entryLink id="5fe3-cc54-9bd8-3448" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="6ee6-0c08-b3ca-3949" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="1ead-6bd3-4773-b80b" name="Power Sword Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="041f-652e-9f1c-973d">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8e6-edaf-41c9-3c7f" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a99-551f-a700-43f8" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8e6-edaf-41c9-3c7f" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a99-551f-a700-43f8" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="6fe8-ceb3-5fd9-4251" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="fe8b-4204-a3de-e0c9" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="b682-2c89-f979-aa74" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="a9f8-13b5-2f46-0b01" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="041f-652e-9f1c-973d" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
+                <entryLink id="041f-652e-9f1c-973d" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="bf21-a51b-b385-2193" name="Wargear" hidden="false" collective="false" import="true">
               <selectionEntries>
                 <selectionEntry id="0465-1377-ad3b-f93e" name="Master-craft a weapon" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78f4-bb14-e935-1cfa" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78f4-bb14-e935-1cfa" type="max" />
                   </constraints>
                   <infoLinks>
-                    <infoLink id="d2aa-bc51-5817-acf1" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                    <infoLink id="d2aa-bc51-5817-acf1" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
                   </infoLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
                 <entryLink id="dc38-a979-2e11-0f46" name="Combat Shield" hidden="false" collective="false" import="true" targetId="472a-8297-2c71-3a9c" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9fb3-219f-2c4f-b84b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9fb3-219f-2c4f-b84b" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="6681-6a14-6869-3289" name="Brethren" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff00-67ac-1b42-892e" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74d2-eb75-ec6c-7772" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff00-67ac-1b42-892e" type="min" />
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74d2-eb75-ec6c-7772" type="max" />
           </constraints>
           <profiles>
             <profile id="3638-baa5-5a01-5220" name="Brethren" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2066,7 +2065,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2075,17 +2074,17 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
           <modifiers>
             <modifier type="increment" field="2ebd-bee2-e9ca-28a3" value="1.0">
               <repeats>
-                <repeat field="selections" scope="6f69-665c-3199-77aa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6681-6a14-6869-3289" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6f69-665c-3199-77aa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6681-6a14-6869-3289" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ebd-bee2-e9ca-28a3" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ebd-bee2-e9ca-28a3" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="5a46-2091-c7b5-9c75" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -2094,17 +2093,17 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
           <modifiers>
             <modifier type="increment" field="1bc2-a0df-267d-b03f" value="1.0">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6681-6a14-6869-3289" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6681-6a14-6869-3289" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1bc2-a0df-267d-b03f" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1bc2-a0df-267d-b03f" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="6bb2-f4b3-786f-2772" name="Combat Shield" hidden="false" collective="false" import="true" targetId="472a-8297-2c71-3a9c" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -2113,24 +2112,24 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
           <selectionEntries>
             <selectionEntry id="7019-4b20-0f41-2476" name="Nuncio-vox" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81aa-7bb5-f63b-2119" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81aa-7bb5-f63b-2119" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="fdbe-81ed-d918-aa78" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry"/>
+                <entryLink id="fdbe-81ed-d918-aa78" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry" />
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="b4cf-899e-c273-f453" name="Legion Vexilla" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22e6-4818-6a5b-6778" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22e6-4818-6a5b-6778" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="8205-b9fa-b5dd-dc2f" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry"/>
+                <entryLink id="8205-b9fa-b5dd-dc2f" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry" />
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2139,24 +2138,24 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
           <entryLinks>
             <entryLink id="cea3-30e9-5f65-5023" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c32b-e367-d817-1edb" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c32b-e367-d817-1edb" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="9a3e-d057-c491-a06a" name="5) Dedicated Transport" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8c09-9abc-6119-9877" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8c09-9abc-6119-9877" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="8417-c82b-411f-11df" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -2165,7 +2164,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -2174,7 +2173,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -2185,50 +2184,50 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
       <entryLinks>
         <entryLink id="cae4-3552-73e1-715a" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdf0-62e7-7122-b057" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="29d6-9c45-9948-dadb" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdf0-62e7-7122-b057" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="29d6-9c45-9948-dadb" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="4c7d-f763-7103-34c8" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fea4-0a87-0501-b812" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9749-a9c3-07c7-943a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fea4-0a87-0501-b812" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9749-a9c3-07c7-943a" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="7d74-e3c0-5d15-980f" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d13-b328-81a3-a210" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a220-ae15-0889-0b14" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d13-b328-81a3-a210" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a220-ae15-0889-0b14" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="647f-0b5d-1ac9-a505" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7087-340f-8e40-1374" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7af2-6ee9-5743-e10f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7087-340f-8e40-1374" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7af2-6ee9-5743-e10f" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="3c80-0156-2018-22a9" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98c7-f6e8-0b6a-c9f8" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4675-027f-af01-066a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98c7-f6e8-0b6a-c9f8" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4675-027f-af01-066a" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="6910-f5e3-01df-f3d5" name="Rogal Dorn" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a7f3-f43c-87a7-1a4d" type="max"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6fbe-f4fe-0e81-4211" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a7f3-f43c-87a7-1a4d" type="max" />
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6fbe-f4fe-0e81-4211" type="max" />
       </constraints>
       <infoLinks>
-        <infoLink id="7f1a-b7fb-507c-ea29" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule"/>
+        <infoLink id="7f1a-b7fb-507c-ea29" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="c043-4561-4769-2322" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="0895-b881-212f-b491" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="c043-4561-4769-2322" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="0895-b881-212f-b491" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7518-46a4-31f2-3033" name="Rogal Dorn" hidden="false" collective="false" import="true" type="model">
@@ -2236,7 +2235,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
             <profile id="351a-fc44-4bc4-81b7" name="Rogal Dorn" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Primarch (Unique)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">8</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">6</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
@@ -2255,22 +2254,22 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="ae84-4964-40c2-d157" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule"/>
+            <infoLink id="ae84-4964-40c2-d157" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule" />
             <infoLink id="9a19-9bb2-de73-61df" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Furious Charge (2)"/>
+                <modifier type="set" field="name" value="Furious Charge (2)" />
               </modifiers>
             </infoLink>
-            <infoLink id="86d5-56f7-4dd9-ebe4" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+            <infoLink id="86d5-56f7-4dd9-ebe4" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule" />
           </infoLinks>
           <selectionEntries>
-            <selectionEntry id="0d6e-97c4-159a-9d0b" name="Storm&apos;s Teeth" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="0d6e-97c4-159a-9d0b" name="Storm's Teeth" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b16-e7a6-8a55-1e39" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0435-c7ad-7401-acd0" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b16-e7a6-8a55-1e39" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0435-c7ad-7401-acd0" type="max" />
               </constraints>
               <profiles>
-                <profile id="4866-b590-5415-b04d" name="Storm&apos;s Teeth" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                <profile id="4866-b590-5415-b04d" name="Storm's Teeth" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+2</characteristic>
@@ -2280,32 +2279,32 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="c406-687b-171b-07d2" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+                <infoLink id="c406-687b-171b-07d2" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
                 <infoLink id="48ea-1ab1-45cd-fca2" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Murderous Strike (6+)"/>
+                    <modifier type="set" field="name" value="Murderous Strike (6+)" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="d9ae-a0b2-7977-ef03" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+                <infoLink id="d9ae-a0b2-7977-ef03" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
                 <infoLink id="452f-d455-e81b-576b" name="Reaping Blow (X)" hidden="false" targetId="bd8c-4f52-d682-1b40" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Reaping Blow (2)"/>
+                    <modifier type="set" field="name" value="Reaping Blow (2)" />
                   </modifiers>
                 </infoLink>
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="21f8-784b-2604-3635" name="The Voice of Terra" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8b2a-b4b8-d578-67a5" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fa61-5293-b280-8b71" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8b2a-b4b8-d578-67a5" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fa61-5293-b280-8b71" type="max" />
               </constraints>
               <profiles>
                 <profile id="8e95-59c7-552d-cb81" name="The Voice of Terra" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">24"</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
                     <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 3, Rending (5+)</characteristic>
@@ -2315,18 +2314,18 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
               <infoLinks>
                 <infoLink id="078b-3a1b-275e-f3aa" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Rending (5+)"/>
+                    <modifier type="set" field="name" value="Rending (5+)" />
                   </modifiers>
                 </infoLink>
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="5766-9e7f-fce2-c27b" name="The Auric Armour" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2cf7-21a1-3c8f-d887" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="251f-97f7-ec75-708f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2cf7-21a1-3c8f-d887" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="251f-97f7-ec75-708f" type="max" />
               </constraints>
               <profiles>
                 <profile id="3456-123b-ea89-a9e7" name="The Auric Armour" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
@@ -2336,51 +2335,51 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="c886-9952-fc5d-fe57" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bfc6-e6d9-d3a9-285d" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d8d6-f4a1-2d08-fc8c" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bfc6-e6d9-d3a9-285d" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d8d6-f4a1-2d08-fc8c" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="8d33-c123-0393-1017" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5c9c-357d-e326-4f00" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e49d-234f-1cec-f111" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5c9c-357d-e326-4f00" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e49d-234f-1cec-f111" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="eeb7-96e6-4e68-2561" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b18-37ee-d0d8-a7dc" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e51-3aa1-271a-45d0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b18-37ee-d0d8-a7dc" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e51-3aa1-271a-45d0" type="min" />
           </constraints>
           <profiles>
             <profile id="6cd0-07b0-1b44-0780" name="Sire of the Imperial Fists" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All models with both the Legiones Astartes (Imperial Fist) special rule and the Character Sub-type in the same army as Rogal Dorn may use his Leadership Characteristic instead of their own, and any unit they are part of may add +1 to the total number of successful Wounds caused  for the purposes of resolving which side has won a combat (this does not stack with any other rules that increase the Assault). In addition, the controlling player of an army with Rogal Dorn as its Warlord may select one Phase at the start of the battle, before any models are deployed onto the battlefield. During the chosen Phase of their opponent&apos;s turn, an army that includes Rogal Dorn gains an additional Reaction as long as Rogal Dorn has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All models with both the Legiones Astartes (Imperial Fist) special rule and the Character Sub-type in the same army as Rogal Dorn may use his Leadership Characteristic instead of their own, and any unit they are part of may add +1 to the total number of successful Wounds caused  for the purposes of resolving which side has won a combat (this does not stack with any other rules that increase the Assault). In addition, the controlling player of an army with Rogal Dorn as its Warlord may select one Phase at the start of the battle, before any models are deployed onto the battlefield. During the chosen Phase of their opponent's turn, an army that includes Rogal Dorn gains an additional Reaction as long as Rogal Dorn has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="435.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="435.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="4420-5ce0-beb7-cb5e" name="Huscarl Squad" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="69e1-6db6-c554-0f87" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="69e1-6db6-c554-0f87" type="max" />
       </constraints>
       <rules>
         <rule id="235c-ee1f-442b-bd63" name="Iron Bulwark" hidden="false">
@@ -2388,32 +2387,32 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="c582-d065-31ef-1b43" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
-        <infoLink id="7a6d-8af8-fd6f-6913" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="c582-d065-31ef-1b43" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
+        <infoLink id="7a6d-8af8-fd6f-6913" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="3159-8f85-e68f-c88e" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="1b54-dd41-0d20-8ea4" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+        <infoLink id="1b54-dd41-0d20-8ea4" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9c2c-a3a7-f173-2fd3" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="1611-1fbf-b28d-082b" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="7d8a-f02e-04ca-e7e6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="c04e-d6da-5531-7c3a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="9c2c-a3a7-f173-2fd3" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="1611-1fbf-b28d-082b" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
+        <categoryLink id="7d8a-f02e-04ca-e7e6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="c04e-d6da-5531-7c3a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3702-7bd5-26f0-d56e" name="Huscarl-master" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cc78-440a-70a7-60b5" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d1f-812b-206b-3533" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cc78-440a-70a7-60b5" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d1f-812b-206b-3533" type="min" />
           </constraints>
           <profiles>
             <profile id="20a2-f85a-f3ec-171b" name="Huscarl-master" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2427,34 +2426,34 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="229e-c226-4feb-c31d" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="229e-c226-4feb-c31d" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="94fa-0bcd-69d0-d2ad" name="Melee Weapon Choice:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4f2d-84c0-97b0-f8b2">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7a5b-9a0c-6c3c-8c4d" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d3e4-2232-e149-d6e1" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7a5b-9a0c-6c3c-8c4d" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d3e4-2232-e149-d6e1" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="4f2d-84c0-97b0-f8b2" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
+                <entryLink id="4f2d-84c0-97b0-f8b2" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry" />
                 <entryLink id="f1aa-abd8-5487-343b" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="b682-2c89-f979-aa74" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="dadd-8f2d-e846-6ef6" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
-                <entryLink id="3d96-21ab-a9f1-f648" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
-                <entryLink id="86c6-3842-abe0-412e" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry"/>
+                <entryLink id="dadd-8f2d-e846-6ef6" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
+                <entryLink id="3d96-21ab-a9f1-f648" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry" />
+                <entryLink id="86c6-3842-abe0-412e" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="eb98-cb77-c13a-439b" name="Wargear" hidden="false" collective="false" import="true">
               <entryLinks>
                 <entryLink id="97cb-07d6-7086-6bf6" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3786-f3a5-1e30-092b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3786-f3a5-1e30-092b" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -2463,21 +2462,21 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
           <entryLinks>
             <entryLink id="1193-a871-216e-72a1" name="Vigil Storm Shield" hidden="false" collective="false" import="true" targetId="ec3d-1f0c-d195-a006" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4c22-1a9c-4a29-6e47" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c8ec-e9f9-ead5-1ca1" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4c22-1a9c-4a29-6e47" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c8ec-e9f9-ead5-1ca1" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="3e83-dc8c-d8b3-82df" name="Huscarls" hidden="false" collective="false" import="true" defaultSelectionEntryId="8638-d404-b9d1-b4e0">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aacb-86f7-e737-9d96" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b6c3-910d-461a-268d" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aacb-86f7-e737-9d96" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b6c3-910d-461a-268d" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="8638-d404-b9d1-b4e0" name="Huscarl w/Power Sword" hidden="false" collective="false" import="true" type="model">
@@ -2485,7 +2484,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
                 <profile id="490c-e5a9-2298-9772" name="Huscarl" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2501,19 +2500,19 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
               <entryLinks>
                 <entryLink id="7bad-caa1-e545-cb5f" name="Vigil Storm Shield" hidden="false" collective="false" import="true" targetId="9036-de5a-581a-718b" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c6ec-e723-9a64-ee75" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bb25-54ac-2b17-b483" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c6ec-e723-9a64-ee75" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bb25-54ac-2b17-b483" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="aede-0b1a-f9ce-7248" name="Power Sword" hidden="false" collective="false" import="true" targetId="fa06-cac0-3d98-125e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="24e2-85d3-63d2-e656" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d8ab-cd1e-c34f-37e3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="24e2-85d3-63d2-e656" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d8ab-cd1e-c34f-37e3" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="9f54-f812-8da1-06f8" name="Huscarl w/Solarite Power Gauntlet" hidden="false" collective="false" import="true" type="model">
@@ -2521,7 +2520,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
                 <profile id="3938-5546-4320-655d" name="Huscarl" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2537,19 +2536,19 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
               <entryLinks>
                 <entryLink id="8d0c-0b43-9d47-3d3a" name="Vigil Storm Shield" hidden="false" collective="false" import="true" targetId="9036-de5a-581a-718b" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b127-ea20-fbd7-b7a4" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b7d1-6cb0-da03-8417" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b127-ea20-fbd7-b7a4" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b7d1-6cb0-da03-8417" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="d5a4-d05e-813e-34bd" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="de6c-46d1-4e1f-6803" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6eb6-0643-1148-7067" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4168-f66d-afc5-450d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6eb6-0643-1148-7067" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4168-f66d-afc5-450d" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="79c5-4c2d-9c5a-1264" name="Huscarl w/Power Maul" hidden="false" collective="false" import="true" type="model">
@@ -2557,7 +2556,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
                 <profile id="3f69-775b-8c17-1dd5" name="Huscarl" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2573,19 +2572,19 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
               <entryLinks>
                 <entryLink id="e76a-2f98-0f53-1684" name="Vigil Storm Shield" hidden="false" collective="false" import="true" targetId="9036-de5a-581a-718b" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8ca7-0ba2-931b-72d7" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="70c7-6410-724c-57c6" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8ca7-0ba2-931b-72d7" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="70c7-6410-724c-57c6" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="4812-fe9a-5da7-7f31" name="Power Maul" hidden="false" collective="false" import="true" targetId="98e8-f217-dea9-0493" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="df8a-e9b1-74b2-939b" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6890-87ba-beaf-97e0" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="df8a-e9b1-74b2-939b" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6890-87ba-beaf-97e0" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="f4df-5a23-421b-f605" name="Huscarl w/Power Lance" hidden="false" collective="false" import="true" type="model">
@@ -2593,7 +2592,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
                 <profile id="3a86-76df-edbf-a484" name="Huscarl" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2609,19 +2608,19 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
               <entryLinks>
                 <entryLink id="ce8b-4aff-7f21-c29b" name="Vigil Storm Shield" hidden="false" collective="false" import="true" targetId="9036-de5a-581a-718b" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7771-fb4c-e305-0d49" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ac6b-342f-7c03-7581" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7771-fb4c-e305-0d49" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ac6b-342f-7c03-7581" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="8381-ed14-c538-e71a" name="Power Lance" hidden="false" collective="false" import="true" targetId="fca3-4ec1-c581-1ba3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="45c3-ad4f-da2d-558b" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3e31-6914-2d23-6977" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="45c3-ad4f-da2d-558b" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3e31-6914-2d23-6977" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="9320-8138-b8d2-9717" name="Huscarl w/Power Axe" hidden="false" collective="false" import="true" type="model">
@@ -2629,7 +2628,7 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
                 <profile id="9c57-bfd1-0da3-03a3" name="Huscarl" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2645,38 +2644,38 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
               <entryLinks>
                 <entryLink id="0ece-0b2a-fc42-dd5a" name="Vigil Storm Shield" hidden="false" collective="false" import="true" targetId="9036-de5a-581a-718b" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f325-afb7-4258-b8f1" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f30e-8d42-6ab0-1e23" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f325-afb7-4258-b8f1" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f30e-8d42-6ab0-1e23" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="7512-a3a7-2264-c66c" name="Power Axe" hidden="false" collective="false" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ea89-b439-2874-aa57" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e2b2-36cf-f7ee-f62a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ea89-b439-2874-aa57" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e2b2-36cf-f7ee-f62a" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0" />
       </costs>
     </selectionEntry>
-    <selectionEntry id="fcc2-2335-aedc-b49e" name="Ætos Dios" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="fcc2-2335-aedc-b49e" name="&#198;tos Dios" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="70a5-e360-d389-e8dc" type="max"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0d75-2081-17ff-ee05" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="70a5-e360-d389-e8dc" type="max" />
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0d75-2081-17ff-ee05" type="max" />
       </constraints>
       <profiles>
-        <profile id="a9b3-4cf6-8347-5711" name="Ætos Dios" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
+        <profile id="a9b3-4cf6-8347-5711" name="&#198;tos Dios" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Flyer, Hover, Lumbering, Transport, Unique)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">18&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">18"</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">12</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
@@ -2688,37 +2687,37 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
         </profile>
       </profiles>
       <rules>
-        <rule id="83d0-7a80-1fac-af84" name="Ætos Praetoria" hidden="false">
-          <description>An army that includes Rogal Dorn may also include the Ætos Dios. If the Ætos Dios is included in an army in this way, Rogal Dorn must begin the battle Embarked upon it.</description>
+        <rule id="83d0-7a80-1fac-af84" name="&#198;tos Praetoria" hidden="false">
+          <description>An army that includes Rogal Dorn may also include the &#198;tos Dios. If the &#198;tos Dios is included in an army in this way, Rogal Dorn must begin the battle Embarked upon it.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="0c4f-4086-86d7-59a9" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule"/>
-        <infoLink id="c129-0b00-69a5-950d" name="Power of the Machine Spirit" hidden="false" targetId="5a93-13e0-809d-782a" type="rule"/>
-        <infoLink id="1bef-6d35-ea53-4ec9" name="Assault Vehicle" hidden="false" targetId="aa61-11f6-2bb5-7c0e" type="rule"/>
+        <infoLink id="0c4f-4086-86d7-59a9" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule" />
+        <infoLink id="c129-0b00-69a5-950d" name="Power of the Machine Spirit" hidden="false" targetId="5a93-13e0-809d-782a" type="rule" />
+        <infoLink id="1bef-6d35-ea53-4ec9" name="Assault Vehicle" hidden="false" targetId="aa61-11f6-2bb5-7c0e" type="rule" />
         <infoLink id="975f-d75d-9387-bee3" name="Void Shields" hidden="false" targetId="c503-f5b8-3da0-16e6" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Void Shields (1)"/>
+            <modifier type="set" field="name" value="Void Shields (1)" />
           </modifiers>
         </infoLink>
-        <infoLink id="2e8b-f617-0766-bb4e" name="Transport Bay" hidden="false" targetId="0662-8b8d-38e8-60f8" type="rule"/>
+        <infoLink id="2e8b-f617-0766-bb4e" name="Transport Bay" hidden="false" targetId="0662-8b8d-38e8-60f8" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0926-4bcb-7263-d6a1" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="9de5-657e-8970-390d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="4ee5-2ad3-9806-aa1c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="0926-4bcb-7263-d6a1" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false" />
+        <categoryLink id="9de5-657e-8970-390d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="4ee5-2ad3-9806-aa1c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="d982-313d-0d97-d831" name="Wing Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="0127-b935-d076-9419">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bb60-424d-96ca-8c3d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e2c3-757f-fcce-9f25" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bb60-424d-96ca-8c3d" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e2c3-757f-fcce-9f25" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="0127-b935-d076-9419" name="Hellstrike Missile" hidden="false" collective="false" import="true" targetId="5e24-bdca-a89c-0f40" type="selectionEntry"/>
+            <entryLink id="0127-b935-d076-9419" name="Hellstrike Missile" hidden="false" collective="false" import="true" targetId="5e24-bdca-a89c-0f40" type="selectionEntry" />
             <entryLink id="5cb9-06d8-49f4-4867" name="Macro-Bomb Cluster" hidden="false" collective="false" import="true" targetId="c3a9-3ba5-0488-0482" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -2727,44 +2726,44 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
       <entryLinks>
         <entryLink id="6d35-2371-7360-bf40" name="Lascannon" hidden="false" collective="false" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bfa3-f515-b397-b984" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6b39-c887-8b31-843b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bfa3-f515-b397-b984" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6b39-c887-8b31-843b" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="5709-f986-a21c-290d" name="Turbo-Laser Destructor" hidden="false" collective="false" import="true" targetId="5ac0-ef19-fed7-ea88" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="505a-b443-62bb-7f17" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d879-ea39-ad84-a79d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="505a-b443-62bb-7f17" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d879-ea39-ad84-a79d" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="374a-fc14-bad6-2cd6" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="07fd-c24a-9235-4206" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="16d0-47b8-4b70-95d5" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5b0d-8415-432d-d5a0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="16d0-47b8-4b70-95d5" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5b0d-8415-432d-d5a0" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="2fd1-07df-af6f-edba" name="Ramjet Diffraction Grid" hidden="false" collective="false" import="true" targetId="a884-7de7-32c4-3ef6" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="df8b-98b7-a036-ff31" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f549-72fd-8a38-7a53" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="df8b-98b7-a036-ff31" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f549-72fd-8a38-7a53" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="9baf-f820-a188-60d1" name="Flare Shield" hidden="false" collective="false" import="true" targetId="0e77-6285-22bb-1534" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a572-87b9-1a8a-6516" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fcdc-78ca-51c3-28c5" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a572-87b9-1a8a-6516" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fcdc-78ca-51c3-28c5" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="800.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="800.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="de6c-46d1-4e1f-6803" name="Solarite Power Gauntlet" hidden="false" collective="true" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
@@ -2779,17 +2778,17 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="7541-9b86-c106-2163" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+        <infoLink id="7541-9b86-c106-2163" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="9036-de5a-581a-718b" name="Vigil Storm Shield" hidden="false" collective="true" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
@@ -2798,36 +2797,36 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
           <characteristics>
             <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Any model with both the Legiones Astartes (Imperial Fists) and Independent Character special rules that does not have the Unique unit Sub-type may take a Vigil storm shield for +20 points. Additionally, any models with the Legiones Astartes (Imperial Fists) special rule in a Legion Tartaros Terminator Squad, or Legion Tartaros Command Squad may exchange a combi-bolter for a Vigil storm shield for +15 points each. Any models with the Legiones Astartes (Imperial Fists) special rule in a Legion Cataphractii Terminator Squad or Legion Cataphractii Command Squad may exchange a combi-bolter for a Vigil storm shield for +10 points each.
 
-A model with a Vigil storm shield gains a 3+ Invulnerable Save – Invulnerable Saves granted by a Vigil storm shield do not stack with other Invulnerable Saves and cannot be modified by any other special rule. If a model has another Invulnerable Save then the controlling player must choose one to use. A model with a Vigil storm shield may never gain an additional attack for being armed with two close combat weapons or make attacks using a weapon with the Two-handed special rule</characteristic>
+A model with a Vigil storm shield gains a 3+ Invulnerable Save &#8211; Invulnerable Saves granted by a Vigil storm shield do not stack with other Invulnerable Saves and cannot be modified by any other special rule. If a model has another Invulnerable Save then the controlling player must choose one to use. A model with a Vigil storm shield may never gain an additional attack for being armed with two close combat weapons or make attacks using a weapon with the Two-handed special rule</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="446f-102e-289b-bdc5" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="644e-3b1e-aafd-25e2" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="644e-3b1e-aafd-25e2" type="max" />
       </constraints>
       <entryLinks>
-        <entryLink id="c8e0-4021-0f8b-e9b9" name="Tartaros Command Squad" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
+        <entryLink id="c8e0-4021-0f8b-e9b9" name="Tartaros Command Squad" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
         <entryLink id="9db7-8776-0292-d1f5" name="Huscarl Squad" hidden="true" collective="false" import="true" targetId="4420-5ce0-beb7-cb5e" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan"/>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan" />
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -2836,110 +2835,110 @@ A model with a Vigil storm shield gains a 3+ Invulnerable Save – Invulnerable 
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="6c7f-c156-bba1-86da" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="6c7f-c156-bba1-86da" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="164e-db98-d506-d2d9" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="650b-6ccb-78d6-32d9" value="1.0">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="959b-6ea8-1ae9-909c" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="650b-6ccb-78d6-32d9" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="959b-6ea8-1ae9-909c" type="max" />
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="650b-6ccb-78d6-32d9" type="min" />
       </constraints>
       <selectionEntryGroups>
         <selectionEntryGroup id="5fcf-f980-7ec5-e745" name="  VII: Imperial Fists" publicationId="817a-6288-e016-7469" page="225" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="23c7-c4e7-3c80-eca6" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cb6e-e5de-f467-29a3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="23c7-c4e7-3c80-eca6" type="max" />
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cb6e-e5de-f467-29a3" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="2032-0319-6801-d2db" name="Solar Marshal (Loyalist only)" publicationId="817a-6288-e016-7469" page="225" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8713-686d-b6d2-7e29" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c23c-36e6-2465-a5b3" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8713-686d-b6d2-7e29" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c23c-36e6-2465-a5b3" type="max" />
               </constraints>
               <profiles>
                 <profile id="ebb6-bd09-6eca-6022" name="Solar Marshal" publicationId="817a-6288-e016-7469" page="225" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Loyalist Allegiance.
-A Warlord with this Trait and all models in any friendly unit that Warlord joins gain +1 to their Weapon Skill Characteristic when locked in combat with one or more enemy units that have the Traitor Allegiance. In addition, an army whose Warlord has this Trait may make one additional Reaction per turn in any one of the opposing player’s Phases, as long as the Warlord has not been removed as a casualty. This additional Reaction may only be made by the Warlord’s unit and does not allow any unit to make more than one Reaction per Phase.</characteristic>
+A Warlord with this Trait and all models in any friendly unit that Warlord joins gain +1 to their Weapon Skill Characteristic when locked in combat with one or more enemy units that have the Traitor Allegiance. In addition, an army whose Warlord has this Trait may make one additional Reaction per turn in any one of the opposing player&#8217;s Phases, as long as the Warlord has not been removed as a casualty. This additional Reaction may only be made by the Warlord&#8217;s unit and does not allow any unit to make more than one Reaction per Phase.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="7b12-bb04-dff6-1cf4" name="Warden of Inwit" publicationId="817a-6288-e016-7469" page="225" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b457-6103-76fe-2127" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="82aa-b23d-ba2d-7868" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b457-6103-76fe-2127" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="82aa-b23d-ba2d-7868" type="max" />
               </constraints>
               <profiles>
                 <profile id="79bf-8c69-ef27-6b5c" name="Warden of Inwit" publicationId="817a-6288-e016-7469" page="225" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When within 6&quot; of an objective, or within their own Deployment Zone, a Warlord with this Trait, and all models in any friendly unit that Warlord joins, automatically pass any Morale checks or Pinning tests they are called upon to make. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When within 6" of an objective, or within their own Deployment Zone, a Warlord with this Trait, and all models in any friendly unit that Warlord joins, automatically pass any Morale checks or Pinning tests they are called upon to make. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="0635-fcd3-b449-f8ce" name="Architect of Devastation" publicationId="817a-6288-e016-7469" page="225" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fac6-590c-c51d-8fdb" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ef23-04dd-34e7-70f7" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fac6-590c-c51d-8fdb" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ef23-04dd-34e7-70f7" type="max" />
               </constraints>
               <profiles>
                 <profile id="d94d-2096-a468-d4a8" name="Architect of Devastation" publicationId="817a-6288-e016-7469" page="225" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord, and all models with the Legiones Astartes (Imperial Fists) special rule in any unit he joins, may re-roll failed To Hit rolls of ‘1’ as long as that unit is entirely within an area of Terrain that grants a Cover Save or Embarked within a Fortification. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord, and all models with the Legiones Astartes (Imperial Fists) special rule in any unit he joins, may re-roll failed To Hit rolls of &#8216;1&#8217; as long as that unit is entirely within an area of Terrain that grants a Cover Save or Embarked within a Fortification. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="2809-4aa4-99ce-fffe" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+        <entryLink id="2809-4aa4-99ce-fffe" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Iron Hands.cat
+++ b/2022 - LA - Iron Hands.cat
@@ -314,7 +314,7 @@
         <categoryLink id="459d-41f4-7d5f-b47c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="cc50-714e-2393-65f9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
     <entryLink id="441c-ddc8-3d17-9db6" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f918-fd61-e41a-e9c0" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
@@ -742,7 +742,7 @@
         <categoryLink id="f22d-8b8d-8524-6acf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="b2c6-8c6d-0312-ce1f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
     <entryLink id="de63-6ef3-fd41-049c" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
@@ -823,7 +823,7 @@
         <categoryLink id="fc36-b4d6-0bcd-4518" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="f681-f9b9-80e8-316a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
     <entryLink id="02c1-84ae-30b9-c351" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="74ec-1179-4130-423f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -835,7 +835,7 @@
         <categoryLink id="85c9-7e62-53a1-d63e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="3b3b-b65b-529d-d328" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
     <entryLink id="4713-5110-f8f9-269e" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ee31-00d9-9130-cce6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -917,7 +917,7 @@
         <categoryLink id="532e-eb62-171f-b0e7" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="21bf-01b0-1f9b-df07" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
     <entryLink id="ef84-1b45-e4b0-fa3e" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -945,7 +945,7 @@
         <categoryLink id="fecf-acab-f5c9-18e2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="1c8a-b4be-4122-6e09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
     <entryLink id="f50d-3ded-be21-4dfd" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -994,7 +994,7 @@
         <categoryLink id="cf44-8c7b-c976-6516" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
         <categoryLink id="d5b2-facb-1613-44dc" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
     <entryLink id="96a3-8241-6955-d836" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="17f0-e211-e298-7280" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />

--- a/2022 - LA - Iron Hands.cat
+++ b/2022 - LA - Iron Hands.cat
@@ -1,6 +1,5 @@
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="b73e-125f-db29-17f2" name="LA -  X: Iron Hands" revision="13" battleScribeVersion="2.03" authorName="Figjam Bohica" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="22">
-  <entryLinks>
-    <entryLink id="6107-168e-198e-2e94" name="  X: Iron Hands" hidden="false" collective="false" import="false" targetId="bfc9-c99c-bf8a-3917" type="selectionEntry">
+  <entryLinks><entryLink id="6107-168e-198e-2e94" name="  X: Iron Hands" hidden="false" collective="false" import="false" targetId="bfc9-c99c-bf8a-3917" type="selectionEntry">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4452-bec3-6da1-2edd" type="min" />
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da6a-761c-e00e-569b" type="max" />
@@ -98,946 +97,1957 @@
         <categoryLink id="4198-15b1-372c-89c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="2dbc-c2bc-600f-0c06" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6c76-36d4-fcc2-06f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ea5a-e2c0-0687-2034" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <entryLink id="2dbc-c2bc-600f-0c06" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="7683-f549-4aeb-b17c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6d4-581f-4746-bec3</comment></categoryLink>
+        <categoryLink id="2f77-ab82-48bc-a7d0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_2489-ee2a-45dd-b384</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
-    <entryLink id="2683-1143-e3eb-16b0" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f8fb-055f-f8ba-c03d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2da4-a8af-1485-a179" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
-    <entryLink id="75b9-a14d-71c6-c1c3" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink><entryLink id="2683-1143-e3eb-16b0" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b02f-e65f-4a88-a175</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_b87b-bf35-4238-b7c6</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1aff-27af-435e-8102</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_fdf9-4906-4180-a39d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="531a-be7b-d57c-54bc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="a743-76f5-596b-b2f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="781e-381d-a6c8-ab81" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="1a12-e8a5-43d5-88dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8378-ede4-476d-b657</comment></categoryLink>
+        <categoryLink id="d616-aa3d-454d-803b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_d64f-ad19-426c-adf7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
-    <entryLink id="1f59-14e1-1648-5cb4" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9192-8658-63c7-7517" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="59cf-20e0-a0fc-4bec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
-    <entryLink id="afbe-8f22-7252-8b13" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1b48-5870-0014-271a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="b204-d1e3-78bc-448e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
-    <entryLink id="ccd5-7195-3de9-39e4" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink><entryLink id="75b9-a14d-71c6-c1c3" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_7fd1-8ce8-4d10-82e7</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_eaae-8c43-4d30-898c</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_f67d-8cf3-424f-b491</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_b949-6414-4f3d-b268</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0c09-eed2-c6ce-455f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="0116-7fce-ff42-fe7f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5a58-816b-8f96-cd03" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="4162-b432-4130-9b44" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_ac26-e639-4d53-9b8b</comment></categoryLink>
+        <categoryLink id="ab6d-5dbc-49fa-b1f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_49af-0d08-4c7e-8ce6</comment></categoryLink>
+        <categoryLink id="ff63-6ded-4135-9b31" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_b606-de16-4659-95cd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
-    <entryLink id="6f1a-6235-21d1-c5ce" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink><entryLink id="1f59-14e1-1648-5cb4" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="5e4b-7307-79cb-2aad" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="b32b-1841-a801-9fa3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
-    <entryLink id="2de1-61c4-6bf6-bced" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7583-6fa0-4089-a19e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_0e5c-99ab-41d3-a42e</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c296-e8e8-4a7a-989a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_8868-5bcb-4604-ba8e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="04a5-ffb0-41c1-9186" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a009-a597-4b51-b228</comment></categoryLink>
+        <categoryLink id="3a90-828e-43ef-bd4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_24f4-9145-4016-80d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink><entryLink id="afbe-8f22-7252-8b13" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_e732-7499-47bf-9748</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_81a5-a959-46b7-baa4</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7ec3-447a-4644-b012</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_71e2-c430-4c99-a559</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_df7b-3fb9-4f65-9165</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2000-ff0e-44b4-8bb8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c165-3906-463a-9c73</comment></categoryLink>
+        <categoryLink id="bba5-9f9e-4d9f-98eb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6d1-d14c-473f-be09</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink><entryLink id="ccd5-7195-3de9-39e4" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_27a3-1e4c-4b76-a594</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_d59a-dcd0-44fd-b866</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_0c8b-2b92-49ed-98c7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_bafe-f799-41d9-ac85</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_6369-288c-4fec-a640</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_fe53-8858-41dc-8ec4</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d4a3-f571-7ef9-181c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="56b2-bcf8-db8f-da7b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b577-1e77-448b-8832" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_3a22-caae-4eea-9bc5</comment></categoryLink>
+        <categoryLink id="d77e-ada5-4dd8-bfd1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f759-f33e-4698-9f8a</comment></categoryLink>
+        <categoryLink id="47bd-3b91-40a5-bf18" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_c624-3ae0-46c0-9b06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
-    <entryLink id="6961-b3e3-7f30-b911" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="00c4-811f-1598-2ffa" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="bde3-a6e6-54cc-60a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4b87-2885-1188-d662" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="03e8-da10-e22f-1b82" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup" />
-        <entryLink id="db2e-68e7-1c6c-1742" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink><entryLink id="6f1a-6235-21d1-c5ce" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_13b3-ce1e-4f9d-8319</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d681-9d81-4abd-b11b</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a57-e48b-4534-bca5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_1859-5641-4674-9097</comment>
+                </condition>
               </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
-    <entryLink id="951e-a5cb-a35b-c772" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
-      <modifiers>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fce5-bf28-4be8-ae84" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_251a-df5b-4bfd-ad63</comment></categoryLink>
+        <categoryLink id="2ec3-8c30-49da-ab05" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4644-98ab-4e3f-b1fd</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink><entryLink id="2de1-61c4-6bf6-bced" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_591d-d028-4663-918d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_0482-c5f9-4c95-9597</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_75a7-971d-4978-a83f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_a7d5-2bfe-4621-ac0c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9f13-b460-4f27-b0cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_31fc-e265-45a7-bb5b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3956-6385-981b-8819" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="87a6-468b-e69c-c1be" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="f601-de9b-59f5-5ff5" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="19f3-10a3-4301-9213" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_67c2-df43-44fc-92d1</comment></categoryLink>
+        <categoryLink id="002a-3d5d-46cb-966a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4136-bb4e-4dd4-99f9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink><entryLink id="6961-b3e3-7f30-b911" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry"><categoryLinks>
+        <categoryLink id="f9c2-76c7-4f9d-aa85" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_2599-24e3-44e5-9568</comment></categoryLink>
+        <categoryLink id="8e9a-7ad6-4a4f-9f29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_285f-6e56-473b-b2fe</comment></categoryLink>
+        <categoryLink id="1d19-a281-41b2-b9b1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_685e-022f-4e2f-a568</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="e86b-b26b-d8ae-5c6e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup" />
-        <entryLink id="a514-b234-827b-d1f5" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup">
+        <entryLink id="1eb7-6f5f-46e8-85e1" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup"><comment>    template_id_2a38-6544-4267-b584    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="cde6-1111-4730-8ab1" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_8287-16ff-46ba-9838</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_81c1-fca9-44dc-ba4c</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_6e59-4592-47ef-b76d    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
-    <entryLink id="c5b4-a6f8-485f-e0c3" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="853b-37a7-6c33-fa9b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0418-529a-e1bf-19fa" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="edf9-470b-834b-a7fe" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="d5e2-8f8f-0186-6f13" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup" />
-        <entryLink id="849a-6691-c91c-badb" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
-    <entryLink id="a843-ca70-a435-03e2" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c816-0c94-2ee4-97e8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="dbca-d326-7547-08c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
-    <entryLink id="7fbd-8c69-0c5d-8ae0" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9bb9-b773-6839-37de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="14f3-519d-cf5f-9323" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
-    <entryLink id="02b9-6b6a-ac24-1614" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink><entryLink id="951e-a5cb-a35b-c772" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ad5d-3c79-4239-9116</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_60b1-049b-4a5f-85c2</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fa57-3c82-abf5-7bdc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0609-db69-b708-0783" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="363d-de50-4343-80b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bd6a-0cda-4e0f-80ae</comment></categoryLink>
+        <categoryLink id="88c6-86da-4163-b575" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_ae75-7cca-4701-9d56</comment></categoryLink>
+        <categoryLink id="eab6-c4fa-4cb3-a4f9" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_e517-62d4-48f7-8174</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
-    <entryLink id="993e-8cdb-d3b7-9f4c" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
+      <entryLinks>
+        <entryLink id="a608-a116-48d8-bd81" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup"><comment>    template_id_fafb-6414-474a-8a09    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="7187-04eb-4d71-9931" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_1e43-c980-4508-8ec2</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_4140-36a7-4203-b5e9</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_a6a6-9bc7-4d4e-86a7    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink><entryLink id="c5b4-a6f8-485f-e0c3" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry"><categoryLinks>
+        <categoryLink id="67e8-8b0e-44ee-b9a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fc9d-03d1-4bbd-a1c4</comment></categoryLink>
+        <categoryLink id="da1c-db14-4133-beda" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_f51c-73d7-4f29-be1c</comment></categoryLink>
+        <categoryLink id="3ebe-6583-4dc6-9da4" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_257d-78c0-4bab-ba65</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="d7ac-eadd-4f53-98e9" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup"><comment>    template_id_ac26-33db-40a7-bdba    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="93b9-f73a-44a8-adf0" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_189b-db75-4db6-9fe9</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_cbdb-2500-4e13-876a</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_dc8e-2801-46d6-84f8    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink><entryLink id="a843-ca70-a435-03e2" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b43b-547f-472e-9076</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8ff9-0498-4540-8552</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fbfe-931a-489b-a589</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f4c3-5aa6-4caa-abf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_17f8-f055-4c9c-b757</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="4865-e18e-de2a-61ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7511-6774-9d83-64a2" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="673f-a311-4439-9ad3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f1c8-27fd-4f98-8527</comment></categoryLink>
+        <categoryLink id="2ced-12a5-4348-b66f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2b20-1a8b-4753-b657</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
-    <entryLink id="93e5-a4d1-94a2-8d1d" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink><entryLink id="7fbd-8c69-0c5d-8ae0" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry"><categoryLinks>
+        <categoryLink id="127c-2d74-47bb-8f5f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4207-8d8f-4b1a-836b</comment></categoryLink>
+        <categoryLink id="1f70-c692-4919-8175" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_2b34-077f-4279-86fb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink><entryLink id="02b9-6b6a-ac24-1614" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="459d-41f4-7d5f-b47c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="cc50-714e-2393-65f9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="1f60-a02b-458d-915b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6577-e0fb-4fda-834e</comment></categoryLink>
+        <categoryLink id="1186-f153-49c1-a39b" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_5d59-09bf-4566-b7e1</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
-    <entryLink id="441c-ddc8-3d17-9db6" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink><entryLink id="993e-8cdb-d3b7-9f4c" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"><categoryLinks>
+        <categoryLink id="70c4-0a82-45d4-a57f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_aa93-057d-42f6-82d7</comment></categoryLink>
+        <categoryLink id="5bbd-9c26-43d2-8da7" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_403c-4e9c-4af5-84ec</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink><entryLink id="93e5-a4d1-94a2-8d1d" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_23fa-06dd-49f9-a7db</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5b26-059e-40b3-9d93</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f7bf-3a1c-4103-aed8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="f918-fd61-e41a-e9c0" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="4e42-ca8c-97e0-6ea6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7274-faea-4f90-9304" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dd44-e0a8-42a8-bdcc</comment></categoryLink>
+        <categoryLink id="ece3-76a8-4e23-be5e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_c5b0-f9ae-468d-924a</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
-    <entryLink id="4b9b-0cec-f73e-8f5f" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink><entryLink id="441c-ddc8-3d17-9db6" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8396-e51c-4e2b-bada</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_13bb-9fb5-4580-92cf</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_bfb8-8125-4548-92f5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25e3-b8f5-4448-a7c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0bd-d1d4-4c20-b957" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_f926-27fd-4a92-97a1</comment></categoryLink>
+        <categoryLink id="68ee-f6a6-4d8e-9644" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_82e3-36e1-4e85-8fcb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink><entryLink id="4b9b-0cec-f73e-8f5f" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1477-4a3f-d2b5-c7bf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
         <categoryLink id="09b3-c5f5-37b7-512a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="4123-db2b-5a98-1ef1" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
-      <modifiers>
+    <entryLink id="4123-db2b-5a98-1ef1" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_658f-b1ad-4347-a998</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_12bc-3db2-4d28-abce</comment>
+            </condition>
           </conditions>
         </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e364-1ebe-d1c0-d90d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e7fc-e2f4-a4d8-839b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
-    <entryLink id="2395-c646-99b6-1777" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_9d83-7691-41d6-8dad</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_add7-ba48-46d4-8a02</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_1fb0-2421-40a4-9e49</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c780-1b7a-0929-5223" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="0366-c15a-ffdc-62de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1237-261a-bdce-25f6" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="15ac-5d7e-4103-853c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7004-b00d-481f-b740</comment></categoryLink>
+        <categoryLink id="0870-8748-4ea3-a510" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4f88-2fc3-491c-bfb7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
-    <entryLink id="fe4f-e632-67a2-3710" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3edc-9a96-323d-fca0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a5b6-d63f-a175-b375" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
-    <entryLink id="19a2-1290-e7e5-8e08" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="417b-dbb5-bec6-e1f0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="f936-0064-b47d-0555" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
-    <entryLink id="071e-77a5-ee6a-a920" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7abd-e634-26fb-60a3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="cc55-492f-0300-bd31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
-    <entryLink id="7576-7c97-0d6f-0e29" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2e4c-2f9a-b6c3-1443" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="9456-af88-1cb7-c951" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
-    <entryLink id="6f34-4910-1f0d-135d" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b1eb-06fb-765d-08d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="abec-5c83-73e2-5418" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
-    <entryLink id="68f5-4813-a2bd-e9aa" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ba17-bb90-131c-570a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="2b60-d0f8-a4ac-43ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
-    <entryLink id="ad5a-8d7b-66ac-b648" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="912b-d8a7-bbba-e232" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="94e1-9241-75a9-1cab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
-    <entryLink id="b91b-785c-33ba-8be8" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d8c9-80dd-a1d3-53a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3aa0-dd36-09dd-cbbe" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
-    <entryLink id="7d9e-d55b-a6b3-3ea5" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d2e6-c609-4e43-db8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="1791-83f0-15aa-e570" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
-    <entryLink id="4a6b-0977-b9a7-33db" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="181a-5eb1-5e75-8050" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5c6e-066e-4dc0-b68e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
-    <entryLink id="d566-4709-c68f-21b6" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3464-74db-6bc4-4038" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="d83a-feac-f872-bef4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
-    <entryLink id="e765-9cfe-5819-6569" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="2143-5b09-31fa-fb2d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="778c-9efa-24a4-96ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
-    <entryLink id="8302-359e-ff65-a0e5" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="dfa9-3f9f-0554-c3a2" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="e1c0-b29b-dec0-27c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
-    <entryLink id="5dcb-a287-24ca-d938" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="274b-5eb5-1db1-fd4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b385-74fb-293c-2768" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
-    <entryLink id="fc5f-3428-c1f6-88ed" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5ae9-503f-bc04-cc53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e5f6-ce2e-52ff-0c49" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
-    <entryLink id="bfaa-8542-9067-c2d0" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="38eb-f183-e981-92d8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="162b-4449-21f6-ff6f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
-    <entryLink id="72a7-17b3-fff3-1c5a" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="77f7-6263-51a4-0ba6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="cc9a-f0ce-ddf7-4b31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
-    <entryLink id="d710-dc61-52f2-c32e" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7601-f1f6-9915-ca32" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="85fd-4cb5-94d0-f6ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
-    <entryLink id="a26b-fdd0-67d7-d9d7" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="cfa6-2fee-3825-fa84" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="3a68-6c78-11cd-f7c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
-    <entryLink id="d646-3919-f006-1442" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8497-b22f-b83a-70c4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="fb0d-756b-9216-94cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
-    <entryLink id="4c4a-6c88-508f-ffd0" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="cd6a-3d8d-bc37-d895" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="ede8-3474-0cb0-7a40" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
-    <entryLink id="4b8b-f3bd-f072-7c97" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="f6e1-a675-3d27-e26f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="788b-d547-1eae-1d0f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
-    <entryLink id="8e2e-97f0-d89f-9855" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1fc4-e84a-3234-08b3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="80b6-4b14-2f4f-f57a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
-    <entryLink id="f78e-acbe-e0ef-3f9a" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="2fdf-1912-95e9-2a15" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="be83-2df4-f1c2-e45f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
-    <entryLink id="798e-c8c7-1a7c-795a" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8a2e-3887-8e73-1a8e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="bb8b-28fb-b2f1-d693" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
-    <entryLink id="163e-01af-2fd1-1c45" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="087c-966b-e42a-22cd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="371a-2b24-a9d6-1166" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
-    <entryLink id="1364-f4c8-53dc-2f0b" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="959d-19e4-ec90-7ec8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="8bd9-79cd-330f-49e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
-    <entryLink id="f1a5-3987-25ff-8129" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0365-fb85-70ff-72a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e6fb-affe-77d4-0fdc" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
-    <entryLink id="1e4f-08a0-3f42-5441" name="Nathaniel Garro" hidden="false" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="74de-2ade-bb53-c807" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="f47f-8df0-b88c-0896" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
-    <entryLink id="36e0-66bf-7196-6a14" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="41e8-4066-0081-1914" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="65d9-debb-4048-6268" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
-    <entryLink id="ed6a-42cb-a16d-f0b3" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a245-6239-8d27-78b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4019-9176-bc30-1fc8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
-    <entryLink id="7d73-b111-0aff-e0d8" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a88a-3efc-e35c-e466" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="4f02-9117-fcfa-8d90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9edc-bd97-9265-611d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="3449-7ebf-0229-7e05" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup" />
-        <entryLink id="c5e6-977b-629c-d1ac" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
-    <entryLink id="448a-4b83-ef67-b271" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6266-605b-9031-8d3b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="c183-23e3-a758-d7e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b646-d67b-7291-72e6" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="ed8c-fa94-6db8-aac5" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup" />
-        <entryLink id="c642-3734-7d2e-e7db" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
-    <entryLink id="15b4-257b-14c0-c12d" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7638-a22f-e65c-c09e" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="48c4-973a-24ec-a974" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d976-73f8-5630-0d19" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="ac63-f355-e855-e4b6" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup" />
-        <entryLink id="e1cd-b865-f455-a386" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
-    <entryLink id="39bc-81bd-6d7d-0acd" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7d80-e262-0816-6d73" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="998a-f5f3-ca40-366b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
-    <entryLink id="df0f-2d75-d0a1-272e" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="57dc-2e67-328f-8356" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="bb9c-9c6e-0823-587d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
-    <entryLink id="f1e3-383f-3d13-bdaf" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f22d-8b8d-8524-6acf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b2c6-8c6d-0312-ce1f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
-    <entryLink id="de63-6ef3-fd41-049c" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="5dee-e4b8-569e-4604" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="d4e8-e6e7-53fa-f8e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
-    <entryLink id="eb63-a37e-895d-9a79" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="5cc7-810b-0d3e-63dc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="f6e0-5868-53b2-5d5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
-    <entryLink id="fd4e-e93f-4fa7-bde0" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4264-476a-c67a-b0e2" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="fc75-1c4f-a0ad-2e5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
-    <entryLink id="3555-5ac4-93c0-8745" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="35f2-a5a3-cb5a-d288" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="918e-93ef-64fb-fdd3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
-    <entryLink id="477f-108c-303a-fc0b" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="afdb-e293-67c7-4748" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="aaee-7ce8-137e-a5df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
-    <entryLink id="75ca-4404-b438-2721" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="fb08-b634-5cb1-7e26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="decb-30d8-b220-f489" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
-    <entryLink id="8c72-434e-a163-ed88" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6303-a996-2cf4-78ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b7f0-a478-429b-75a7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
-    <entryLink id="be5f-a69e-5831-c359" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="afd9-5c5c-db16-996f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7e8c-7024-3a84-4378" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
-    <entryLink id="6810-facb-c707-b1ea" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d83b-c1ed-b059-47c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3e5c-692d-7275-a0d6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
-    <entryLink id="be5b-081f-76e6-2f75" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="fc36-b4d6-0bcd-4518" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f681-f9b9-80e8-316a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
-    <entryLink id="02c1-84ae-30b9-c351" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="74ec-1179-4130-423f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b927-ca6b-1eed-ee30" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
-    <entryLink id="e7b5-cf72-972f-ee5f" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="85c9-7e62-53a1-d63e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3b3b-b65b-529d-d328" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
-    <entryLink id="4713-5110-f8f9-269e" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ee31-00d9-9130-cce6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="6350-3358-7460-b373" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
-    <entryLink id="31e7-41bc-dac7-267c" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9783-d9a6-566c-c110" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="ba85-382b-c5f7-9c71" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
-    <entryLink id="5944-cb4e-8d33-7d57" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="dbbf-7484-4f53-9da7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="b3bc-a9ec-3e00-79be" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
-    <entryLink id="591d-7932-3aa6-5aaa" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink><entryLink id="2395-c646-99b6-1777" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_8ed4-376d-4030-9439</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_8a11-c2a0-4335-99ef</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_fa8e-1af7-4d41-ac8c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_94bd-c771-4a85-8581</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9f8c-79f2-ce3f-2934" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="bcf3-01d8-1987-9cee" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="39a3-c7ed-ea3e-a199" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="f5b4-a847-40bd-9fcc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_361e-fb90-4b0e-ac3d</comment></categoryLink>
+        <categoryLink id="0cc1-e21c-4567-a7d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d4ef-1074-45a9-959e</comment></categoryLink>
+        <categoryLink id="49db-b064-4a44-9f36" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_febb-f536-4d25-a8ab</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
-    <entryLink id="3f8d-3188-9f3c-3170" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c4e5-1505-2fdc-f0be" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="78ef-61eb-9587-ee0c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink><entryLink id="fe4f-e632-67a2-3710" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="a1bd-ae00-4214-a9b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_473b-e812-4158-9416</comment></categoryLink>
+        <categoryLink id="3a63-f533-43f1-a628" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_00a2-63ff-4698-a35b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
-    <entryLink id="1281-3189-bd56-de0e" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink><entryLink id="19a2-1290-e7e5-8e08" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7cf3-8a72-4f82-8cdc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_228c-5681-4ce8-b726</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_01bb-8abd-4253-9a4d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6b29-deb4-4c36-3517" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="34c0-9279-1cb8-3620" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ca0e-d305-425e-91d6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2a08-4432-42ad-bfdb</comment></categoryLink>
+        <categoryLink id="2349-394d-44c8-80d8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_422e-0808-4897-8630</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
-    <entryLink id="9718-a1aa-6d82-72bb" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink><entryLink id="071e-77a5-ee6a-a920" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1af8-4459-4717-8e3b</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_06b4-92b9-438c-b1a5</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6c8d-8b28-417b-9a7c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_715d-8186-4aa6-b40c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_390e-358c-4f8e-ade8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="90d1-4d68-bd2d-78fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c6ad-e25c-b5aa-fc06" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="31ff-2ccc-4e58-ab5c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f4c0-4396-4f39-a34f</comment></categoryLink>
+        <categoryLink id="98b5-26aa-482e-a84f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1301-8415-490e-8f06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
-    <entryLink id="8ae9-54f1-74d0-0758" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink><entryLink id="7576-7c97-0d6f-0e29" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d0c9-9a26-4324-b030</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4e9e-a61d-42f2-bacb</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ed9e-b634-4bec-9eb0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4614-ad0f-4fba-adaf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_8d08-24f6-41be-8931</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2304-3950-4554-bd93" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_caf6-5548-4b89-8102</comment></categoryLink>
+        <categoryLink id="5197-c018-4fe8-968c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_63a3-be61-428d-ab29</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink><entryLink id="6f34-4910-1f0d-135d" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f318-4b03-4767-8c7f</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b8ef-7245-4df8-a8c4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_6bce-ec44-48cb-873a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ecdd-d9e3-454a-bcb6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0678-4fdd-48e6-8f61</comment></categoryLink>
+        <categoryLink id="1f73-a1b8-45f8-81cb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0d82-10a9-4de2-8ad7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink><entryLink id="68f5-4813-a2bd-e9aa" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ada1-1e18-4cbc-9598</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b1d1-ac44-47dd-9159</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5d64-f00c-4464-891b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25f0-f825-4a83-8f0d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_64b1-9e36-44da-b36a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="95cf-b65f-4d0c-911d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_d53e-113f-4a40-a3d5</comment></categoryLink>
+        <categoryLink id="013f-17e2-468b-9899" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1939-76b5-4279-9f8c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink><entryLink id="ad5a-8d7b-66ac-b648" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d765-3bb2-4b48-bd12</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_0ca1-cfb4-4a56-ab3b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="532e-eb62-171f-b0e7" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="21bf-01b0-1f9b-df07" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7925-3317-4a88-8efa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e6f7-a6ca-4825-bfc5</comment></categoryLink>
+        <categoryLink id="c3b6-38ef-49a5-8127" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dbec-e027-4ec1-8514</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
-    <entryLink id="ef84-1b45-e4b0-fa3e" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink><entryLink id="b91b-785c-33ba-8be8" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d8ee-81ed-45f9-8b79</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_8f4e-e8cb-4ac9-a415</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2727-19fc-4baf-a661" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_cefb-cfd7-4dc8-99c4</comment></categoryLink>
+        <categoryLink id="6f64-4eb8-45d3-b8b4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a9fd-9d16-4a5e-855c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink><entryLink id="7d9e-d55b-a6b3-3ea5" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e76b-46ca-4ab8-a93d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8035-75b8-43bb-97c9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_71a4-31e7-4927-a0ab</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cc3c-4262-4895-a8bf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_a56d-347b-4b09-a918</comment></categoryLink>
+        <categoryLink id="1425-c955-4f44-836b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_96e5-4531-4213-903e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink><entryLink id="4a6b-0977-b9a7-33db" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1fb5-2375-4c22-b41e</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7d7c-255d-49b6-96b9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5321-254b-4890-9bf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ddf8-b8b7-4afb-b6dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c8e2-f86c-4958-bdd5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9441-d79b-4720-9667</comment></categoryLink>
+        <categoryLink id="ff75-dddb-4920-bb1c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7d7e-32d3-4692-b401</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink><entryLink id="d566-4709-c68f-21b6" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_99fc-5fe7-4b37-a62f</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_25f4-f6b8-4b44-8350</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_81f7-2311-4cce-95bc</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_09aa-af2a-4012-91d1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_00ae-fad3-4df6-9cb9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="191e-94f2-4152-b3ed" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f65b-8958-49b3-92a5</comment></categoryLink>
+        <categoryLink id="6a7f-8950-467d-871b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0451-1929-4942-8c3f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink><entryLink id="e765-9cfe-5819-6569" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_edc4-4915-40ba-bbf0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_105f-ba26-4146-bc54</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7a2c-a76c-421c-a8a2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_05c9-0543-47ee-ba81</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e6ad-f0d7-4627-921b</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="24ad-6999-414b-a114" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c6a8-22a8-4d41-b969</comment></categoryLink>
+        <categoryLink id="a8dc-1b96-4ecc-8b7d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03ca-12cc-4e0a-b628</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink><entryLink id="8302-359e-ff65-a0e5" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ae67-ef52-4cac-958c</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fc61-7306-4d99-acde</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1be0-67e7-45a1-bdbb</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_42a8-7fda-4e05-af0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="33d3-8f37-4bf2-bf5d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_565a-1592-491f-8b9b</comment></categoryLink>
+        <categoryLink id="23e3-c2df-430b-8c3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_81d5-c14a-42ab-bdde</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink><entryLink id="5dcb-a287-24ca-d938" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1ae7-c41b-4818-be71</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_08a5-b1bb-4ba1-ba42</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d677-b5ad-4838-8746</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_537f-bc1f-4aaa-b0dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8191-db70-4c73-a399" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bc67-ce1f-4004-aeb7</comment></categoryLink>
+        <categoryLink id="c66d-2e7e-436d-855f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_9a45-9699-4475-aeef</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink><entryLink id="fc5f-3428-c1f6-88ed" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_c28f-4109-44c4-ab64</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fdc1-a894-48bc-9e7c</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_4936-a68c-4524-9088</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb37-ac0c-49ae-9d6f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="488e-a1d7-4a84-829f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3afe-cfc0-4da6-a985</comment></categoryLink>
+        <categoryLink id="b30b-ea60-4b43-9275" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_04a8-6aae-45ae-bd4c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink><entryLink id="bfaa-8542-9067-c2d0" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ae19-30c0-43c5-920e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_6ebe-1bf3-4d78-9dd0</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1887-152d-48b7-b13f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_a7c4-ee6a-4f0b-8ab0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bd85-fa90-47ff-9f84</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_7bd6-9043-4d7e-ba37</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ac20-c01d-45b7-aa1a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3610-c975-4d55-bdfe</comment></categoryLink>
+        <categoryLink id="460e-ce32-4b4c-87f7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2fc2-f636-4c80-9608</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink><entryLink id="72a7-17b3-fff3-1c5a" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_85c5-d4d9-4b23-9e4d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_80e8-d50b-4906-8153</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_b93b-d4f1-45eb-8a69</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e183-f183-4db7-83b5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0f39-204a-4217-b896</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_eee9-7bfd-4fea-a1bd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f2fd-c8e9-4f28-9dff" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f81d-9435-4f11-99c1</comment></categoryLink>
+        <categoryLink id="787b-fa03-4c22-bee3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9568-6142-4fdd-be3a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink><entryLink id="d710-dc61-52f2-c32e" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_005e-6607-4e2c-8dd2</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_7745-260c-4c36-b719</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_ba25-a4b2-4ba9-b023</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ddeb-f4c8-4091-9153</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4904-fd2f-429f-9cf7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_faea-b21b-43c5-b918</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e69a-17f8-4243-9edb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_b24f-3ae0-4cbb-b016</comment></categoryLink>
+        <categoryLink id="fc46-c775-4230-86bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fd26-8e6b-4521-92b9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink><entryLink id="a26b-fdd0-67d7-d9d7" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6ecb-28e2-43ed-a6a0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_c067-1118-4d96-b28b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_250e-23c0-4e43-bf74</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1553-a6e6-4291-853f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_aab6-797b-427a-9fd8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0fb2-8945-4a73-8c90" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c77f-0819-473b-a8a2</comment></categoryLink>
+        <categoryLink id="be53-0ab7-470e-b19e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_89fb-c924-4daf-923d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink><entryLink id="d646-3919-f006-1442" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d72c-519a-451f-81b6</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_3d16-444c-42c9-aad1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_f4b2-6371-494b-863a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_797f-a84b-42f6-8e66</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0d78-fe38-4829-9b12</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3427-23dc-41b3-85ed" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0397-c837-4fea-a527</comment></categoryLink>
+        <categoryLink id="1762-7500-4d8c-a753" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_060b-bccb-4776-bd83</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink><entryLink id="4c4a-6c88-508f-ffd0" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3c84-6d74-4c42-b38d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_5b15-7aa4-4897-aaf1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_3326-31ed-4151-9b37</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6a0e-1b65-4057-ba5d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f8c7-abc9-45ec-955f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_2538-8dc5-446c-8344</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9e14-eb32-463e-abd8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_c1cf-cea4-4278-8f27</comment></categoryLink>
+        <categoryLink id="4b27-42a6-4c8e-8289" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5f51-2734-4a46-9f72</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink><entryLink id="4b8b-f3bd-f072-7c97" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af71-f3ff-49b1-83e9</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_1c9e-b3bf-4e88-a43f</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_6d0d-1b1d-4065-89cf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d0b7-8686-491e-9d33</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_7db8-0874-487a-be6f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1034-29a0-44b1-a85f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8e74-d116-41b0-986d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_0c16-6841-42b2-b02d</comment></categoryLink>
+        <categoryLink id="2619-d62f-42bf-939e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_602d-2d2d-4ff4-a82a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink><entryLink id="8e2e-97f0-d89f-9855" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_22bd-baae-45f9-b366</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_52bd-55de-4d53-ba55</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_df1b-7476-4ab8-8d2f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_49fa-0dcf-4a61-a5b1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0ea-1443-4993-86e7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2a8-3fbe-448c-9902</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1d0a-a03a-4378-ac2a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3632-0b5d-4622-ae33</comment></categoryLink>
+        <categoryLink id="e270-3fa9-4a07-aab7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_da44-7815-4fdd-981c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink><entryLink id="f78e-acbe-e0ef-3f9a" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2bfa-b203-47e2-a828</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a39b-8a3c-49cf-bf62</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2a05-07b3-49c5-8145</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f730-87fb-44bd-b68e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_2d0e-6c49-4493-a022</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2e2-50c1-40c3-b4dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f100-2cf0-4736-a1ca" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_5ad5-8701-42cd-b2b6</comment></categoryLink>
+        <categoryLink id="dd35-c0d7-4e7d-ae89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_20a4-4346-4a3b-a7d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink><entryLink id="798e-c8c7-1a7c-795a" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_773a-1ea4-41a0-b766</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_9d4d-6fb8-4131-a5a3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e3bc-02f8-4ece-a5ea</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c371-76d9-4a4d-bc00</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b4c6-d4ba-4b2e-9b99</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c09f-79b7-4033-bd99" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6ea9-a7e5-437d-9e35</comment></categoryLink>
+        <categoryLink id="ff61-c2d8-4d2f-8797" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_3cec-f053-42ab-a6eb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink><entryLink id="163e-01af-2fd1-1c45" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1e60-42ba-4c8b-9077</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9860-f593-425e-b89b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_c842-10e8-4509-8eda</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ea52-ff41-40f6-8cf3</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_51e6-c5e1-4003-96bc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0240-0ea7-4985-a213" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4d7c-201f-4c99-b89a</comment></categoryLink>
+        <categoryLink id="2a47-b4bb-440e-bd51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_10f9-4718-4e07-bb32</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink><entryLink id="1364-f4c8-53dc-2f0b" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2054-ee06-42b4-b03b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4e52-ad1b-48d4-8eed</comment></categoryLink>
+        <categoryLink id="0257-3836-4167-bd31" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_6979-1ed3-4f1f-a025</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink><entryLink id="f1a5-3987-25ff-8129" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry"><categoryLinks>
+        <categoryLink id="cb96-b6fe-42d8-aedd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6140-2404-46f9-bd42</comment></categoryLink>
+        <categoryLink id="17e6-3fb7-4a2d-8de2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_1c86-fad8-46ec-a0b0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink><entryLink id="1e4f-08a0-3f42-5441" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4729-bc86-456b-b73d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_cf0f-e3f4-4fb4-989d</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1cc8-5611-4d9a-9218</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_2e32-ca02-48f0-a8dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9422-e630-4369-8a9c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_0af1-d052-4bd7-aab6</comment></categoryLink>
+        <categoryLink id="4f39-1490-4048-a9b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_45ce-e338-43c9-b63e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink><entryLink id="36e0-66bf-7196-6a14" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4dce-8632-4f7c-813e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_8a71-3995-4155-ac33</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d206-f2ce-41b8-945a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan">
+                  <comment>    node_id_2e02-cf1c-4a71-861c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ec81-bd33-45a8-8550</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_3344-743c-45d3-b930</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6441-874e-5580-ee68" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="4900-7ae1-3710-27fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0ae3-249b-4f8a-8543" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4272-9b9d-4c59-95f0</comment></categoryLink>
+        <categoryLink id="8eb5-8bad-4be2-9c51" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_d85b-1ae7-40d5-9341</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
-    <entryLink id="4882-f7c6-bb2a-1149" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="fecf-acab-f5c9-18e2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="1c8a-b4be-4122-6e09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink><entryLink id="ed6a-42cb-a16d-f0b3" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d536-8dce-45b0-9ecf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ff9f-01cb-41b9-800e</comment></categoryLink>
+        <categoryLink id="0c87-9ec2-465c-b4bf" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_1315-6051-4a46-b070</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
-    <entryLink id="f50d-3ded-be21-4dfd" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink><entryLink id="7d73-b111-0aff-e0d8" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry"><categoryLinks>
+        <categoryLink id="1a55-5638-44a7-b62d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_b084-df23-4f99-812f</comment></categoryLink>
+        <categoryLink id="957d-a4cf-4b6c-a314" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_84fc-9304-4e9e-ab78</comment></categoryLink>
+        <categoryLink id="291c-515f-4a20-88a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d06a-7939-4691-9aed</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="7d07-d3f3-4b93-b5ca" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup"><comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+        <entryLink id="395e-8d55-45b9-ba97" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup"><comment>    template_id_741d-8c09-4211-ada6    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink><entryLink id="448a-4b83-ef67-b271" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_54a4-6ec8-4c61-9c3e</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_f7fd-2d16-4603-a065</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="abb2-fa85-d1ef-7154" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="e219-f12b-d557-6779" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c217-652c-4c38-8fa3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_c0ac-4b8c-421c-a21b</comment></categoryLink>
+        <categoryLink id="b977-0f04-4090-b2bd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8db9-079e-4482-b200</comment></categoryLink>
+        <categoryLink id="141f-bf9c-4e9a-9a72" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_413c-9273-4308-b546</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
-    <entryLink id="6cc4-b71c-19d3-fbf9" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="96a5-968a-66d4-b487" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="e156-5f36-9d0f-4a9a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      <entryLinks>
+        <entryLink id="39ae-444c-47df-b992" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup"><comment>    template_id_bbc4-33fc-4664-a18e    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="5374-836f-4a24-a37d" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup"><comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink><entryLink id="15b4-257b-14c0-c12d" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry"><categoryLinks>
+        <categoryLink id="5273-e5fa-4ec6-8391" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_4c8d-96f6-48f9-9590</comment></categoryLink>
+        <categoryLink id="c9a8-53eb-4d4f-aec5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_049c-0fa5-4575-8fa8</comment></categoryLink>
+        <categoryLink id="9a50-944b-4eec-a496" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_7358-52d7-4aae-8e07</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
-    <entryLink id="0d04-7fb4-1b16-4e46" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+      <entryLinks>
+        <entryLink id="e5fe-bfe3-412f-9def" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup"><comment>    template_id_4784-b370-444b-93ae    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="0422-7063-4936-993c" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup"><comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink><entryLink id="39bc-81bd-6d7d-0acd" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_3c03-a823-4466-9bd6</comment>
           <conditionGroups>
-            <conditionGroup type="and">
+            <conditionGroup type="or">
+              <comment>    node_id_8bbb-f95b-413f-b6f4</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_41b0-6b0a-482a-919e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e1f7-3cc6-4794-8b6d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e913-f827-150c-fab3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="12b6-cb33-e8f6-d088" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="449c-2b58-4150-81f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_05ce-cc31-40ad-9320</comment></categoryLink>
+        <categoryLink id="1f74-3a76-418a-a851" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f13c-f8e1-4a50-bfe3</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
-    <entryLink id="cb3c-43be-2c3d-670b" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="dcca-3a17-817e-1103" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
-    <entryLink id="2548-c7f0-25ed-f3d9" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="85e1-2ff5-4a68-513d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="cf44-8c7b-c976-6516" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
-        <categoryLink id="d5b2-facb-1613-44dc" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
-    <entryLink id="96a3-8241-6955-d836" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="17f0-e211-e298-7280" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="15ee-e7b6-98b3-91a9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
-    <entryLink id="9be7-bc70-dadc-dd58" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink><entryLink id="df0f-2d75-d0a1-272e" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_db78-4d49-42ab-954a</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_f14d-9943-47b6-866c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a95-938f-4a07-9727</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_7775-78e1-44cc-87c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dfa7-370f-4495-b71e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_b822-3417-4613-be37</comment></categoryLink>
+        <categoryLink id="1133-e98f-414e-ae55" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_25db-b03f-4881-b310</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink><entryLink id="f1e3-383f-3d13-bdaf" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry"><categoryLinks>
+        <categoryLink id="c393-8e6c-4361-8223" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_75a7-dc06-445b-b2dc</comment></categoryLink>
+        <categoryLink id="045b-ec81-4078-a0dd" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_e21a-c03b-4885-ac46</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink><entryLink id="de63-6ef3-fd41-049c" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9a08-5fe6-4010-bbc3</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_72cf-cfce-4e02-b379</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8722-856a-826c-84b3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="efaf-72c1-6376-af2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a351-1bd0-4f6e-bcdb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_f55b-7555-444b-beee</comment></categoryLink>
+        <categoryLink id="2a09-cc6f-4efb-b641" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3386-c9ad-4d74-9474</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
-    <entryLink id="52be-3800-aa3f-3077" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0ffe-2e1c-a8bc-7023" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2a69-e3df-9913-6f1b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
-    <entryLink id="bcea-53b5-c7b1-4233" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink><entryLink id="eb63-a37e-895d-9a79" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_a0f6-9606-4b75-a2f8</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_94b3-1331-474b-885b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
-      <infoLinks>
-        <infoLink id="b9e9-3d4a-f9e7-b8c6" name="Legiones Astartes (Iron Hands) " hidden="false" targetId="2e45-4b61-44fb-260b" type="rule" />
-      </infoLinks>
       <categoryLinks>
-        <categoryLink id="7df1-c6fb-ca38-bb32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="56d9-39b6-a7b5-9b38" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="9e37-3e4e-432b-8b17" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_79fa-3370-4ae0-9e12</comment></categoryLink>
+        <categoryLink id="9193-ba0c-4129-9095" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bb53-4e65-4fb6-9dd7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
-  </entryLinks>
-  <sharedSelectionEntries>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink><entryLink id="fd4e-e93f-4fa7-bde0" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f8cc-833a-4ac1-bf89</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+              <comment>    node_id_5988-c012-4dad-9a66</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4031-11fd-4b63-ae09" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_8d82-3279-4481-84bb</comment></categoryLink>
+        <categoryLink id="345d-8033-4d35-9951" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e25c-925e-4b96-8bb3</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink><entryLink id="3555-5ac4-93c0-8745" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6b73-b21c-4e2b-9d14</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_a7fe-cc62-4a6f-a781</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5be1-1937-4964-a455</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_da1d-b2bc-4117-82a4</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1d34-17cb-4d42-8e66" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7010-be56-4709-b058</comment></categoryLink>
+        <categoryLink id="cabc-b92c-4e55-9b2b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7379-a740-47ba-a054</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink><entryLink id="477f-108c-303a-fc0b" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_dd34-83cf-47d7-b557</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_be88-afef-49b3-bd1e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="074f-1376-44f5-9f80" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_944f-7420-4982-8ea9</comment></categoryLink>
+        <categoryLink id="c7bb-9159-48c4-b85c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ea80-0efe-457d-a450</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink><entryLink id="75ca-4404-b438-2721" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d3e9-8aff-437c-800f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9a36-f261-43cc-9bd1</comment></categoryLink>
+        <categoryLink id="dc18-4451-40b5-808a" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a648-8396-442a-af59</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink><entryLink id="8c72-434e-a163-ed88" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_cb81-0303-4b88-ae53</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9648-31e3-43aa-8cf3</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_0507-da81-4023-bfcf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0e84-54ff-488d-b066</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1d5f-4d33-4a11-b560" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6ff-0977-4c92-bb28</comment></categoryLink>
+        <categoryLink id="b1a5-8060-4987-b508" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f555-7d39-458f-84c9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink><entryLink id="be5f-a69e-5831-c359" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8203-5b00-497b-b939</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_40ee-3e71-4978-b1e4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f6a8-f660-46dc-b3c5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_d988-3af6-48bf-b0a8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3f99-f0cc-4aeb-8668" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_39e5-eda5-45d1-a643</comment></categoryLink>
+        <categoryLink id="ec43-c362-4142-8889" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_6416-21bb-4df4-9de8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink><entryLink id="6810-facb-c707-b1ea" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b03e-5d91-4be3-8adc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_0443-29c0-46e9-ad1d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f2c9-7356-4c27-a22f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0e9-4a9e-4b2b-a9d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e635-ab9d-4d7f-828e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5528-2dac-4be5-900c</comment></categoryLink>
+        <categoryLink id="c899-390e-47e9-af93" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_dc8f-d888-4585-991d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink><entryLink id="be5b-081f-76e6-2f75" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1d3c-8e17-489f-9002</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5725-8bee-4bcc-878d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_be47-0d6f-49f2-9f4b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_863c-f3a4-4802-b80c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="263b-340a-4aff-b94c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_899e-b052-4d5b-8c18</comment></categoryLink>
+        <categoryLink id="0550-d4b2-4249-a943" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f5e9-cff6-41d2-a016</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink><entryLink id="02c1-84ae-30b9-c351" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_72da-1513-4e02-b595</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7a48-a3b0-4a26-849b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e232-25f3-4cb7-8ab2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_9aa4-5660-4697-8ab2</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6e93-7a9b-42d1-bed1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_09cd-2176-40af-bba6</comment></categoryLink>
+        <categoryLink id="5905-e9b2-474f-87b7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_05e6-7c63-4a35-9ba0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink><entryLink id="e7b5-cf72-972f-ee5f" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry"><categoryLinks>
+        <categoryLink id="f27b-7b17-48aa-91b3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0dfa-4004-4751-8022</comment></categoryLink>
+        <categoryLink id="296e-f599-4b87-9ab8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a669-0f5d-4fd3-811b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink><entryLink id="4713-5110-f8f9-269e" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_09b5-4e3b-4c84-a574</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_32e5-ebba-41fb-9ff2</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_838e-0ccf-4d3a-aabd</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_dfef-0ec2-49fb-a534</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5534-2628-41ba-a472" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4f60-472b-45a9-ab9e</comment></categoryLink>
+        <categoryLink id="89c7-8dc9-45b3-9c81" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e2e3-af36-45a6-a955</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink><entryLink id="31e7-41bc-dac7-267c" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_936f-1ef7-472e-840e</comment>
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+              <comment>    node_id_d73d-d52e-4c75-8ac0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cf10-c8f2-4c49-86c9" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_7a55-ecb4-4e5d-b955</comment></categoryLink>
+        <categoryLink id="a8fc-287f-4fe9-a876" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f28c-710e-4ff8-9810</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink><entryLink id="5944-cb4e-8d33-7d57" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_a743-0cc2-45ae-a7eb</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2721-e88d-41f7-bedc</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_e10f-1390-4b33-8fcc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ed72-97fe-4893-88e7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2008-f1c4-4285-a14f</comment></categoryLink>
+        <categoryLink id="f579-f446-4298-84b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e88b-a95a-4647-af3b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink><entryLink id="591d-7932-3aa6-5aaa" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_25d8-330b-4574-b515</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7836-6878-47a8-8827</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_5ea9-46dd-4a11-9410</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_ab5d-961b-4924-a705</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6581-1578-4996-984c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9189-836c-475d-a52e</comment></categoryLink>
+        <categoryLink id="ba8a-99a8-4551-aaa8" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_e1fa-b7d8-47b0-a88a</comment></categoryLink>
+        <categoryLink id="e4e1-fd8a-47d1-a193" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_a137-e3c0-4d63-a48c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink><entryLink id="3f8d-3188-9f3c-3170" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry"><categoryLinks>
+        <categoryLink id="78ea-d942-460f-ae3e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b1d5-fd75-4f17-bbf4</comment></categoryLink>
+        <categoryLink id="a00a-d987-43e1-93b9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_f221-bf81-4045-849b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink><entryLink id="1281-3189-bd56-de0e" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_b743-7a00-43e4-beb8</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d12f-2c98-4e62-a716</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d4d7-ba67-47aa-962f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+                  <comment>    node_id_1637-edee-457a-bb0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cab0-268a-4cc3-86c8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_f203-bc26-421f-b79e</comment></categoryLink>
+        <categoryLink id="b66e-bba9-40a9-b44a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_a53e-59d9-4ac2-a21f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink><entryLink id="9718-a1aa-6d82-72bb" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry"><categoryLinks>
+        <categoryLink id="9f25-e473-4ae5-b0df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_51af-a137-4a1c-97a4</comment></categoryLink>
+        <categoryLink id="a19c-4128-49ae-beda" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ec1f-c326-40a8-9d1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink><entryLink id="8ae9-54f1-74d0-0758" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_c111-feb0-4012-98cd</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_63d7-8427-431d-9ae6</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a22e-b52a-4d6d-970b" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_e707-fde1-457f-91c4</comment></categoryLink>
+        <categoryLink id="efbc-5237-44ee-809d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ec67-8573-4460-89db</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink><entryLink id="ef84-1b45-e4b0-fa3e" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3348-16e4-4a9a-a549</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_bea4-c4a8-4843-b9fe</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2970-17ff-4be1-91e5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_503a-46e7-40e7-bd07</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_4555-15e1-43ff-80a0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f2ba-b747-4d1b-a869" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_fce3-801c-49c8-85d4</comment></categoryLink>
+        <categoryLink id="07a9-9284-46f4-a69b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0c2d-2349-44b6-9831</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink><entryLink id="4882-f7c6-bb2a-1149" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry"><categoryLinks>
+        <categoryLink id="2497-341f-437b-9d8b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ac1c-b3bf-4011-918a</comment></categoryLink>
+        <categoryLink id="6d11-eded-4529-b8a5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_589c-1d0e-4b7d-be6b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink><entryLink id="f50d-3ded-be21-4dfd" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2f46-a0b6-48a5-a0ee</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_636f-0f8a-43f1-910b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c883-39c8-4a74-aeaa</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_0796-e467-4438-89b3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cab8-641e-4542-8146" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_5a04-9847-4c91-a49a</comment></categoryLink>
+        <categoryLink id="59df-3334-4981-9b2a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b4b4-daeb-483c-a306</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink><entryLink id="6cc4-b71c-19d3-fbf9" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6087-a5e5-4d3c-9ebd</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c7e1-5f42-4528-bf07</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1950-08dc-4544-ab01</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_daf3-31ed-42c0-85dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4a23-5020-4bca-af53" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_7d4f-547c-43ed-a520</comment></categoryLink>
+        <categoryLink id="987a-8cc7-4528-85cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f04e-04e8-4891-9b1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink><entryLink id="0d04-7fb4-1b16-4e46" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_dfdc-f6f6-49d2-a7b3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_354c-c71f-472f-b268</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1127-c974-4663-874d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_0843-bef2-4767-8307</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d93-17f2-4ba3-a1f8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_28e0-91e7-4ada-9fac</comment></categoryLink>
+        <categoryLink id="eaf1-7c54-4def-8f33" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4448-a712-4dd7-bf6d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink><entryLink id="cb3c-43be-2c3d-670b" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d512-fd07-4a29-863a</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_55c6-a35f-485a-9f0d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d89e-cf1f-4ceb-b3de</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e2c9-0d01-403c-900e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_a7b8-c835-4cb2-b3d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="18a3-bb12-4734-8442" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_e22a-c5f8-4825-a45f</comment></categoryLink>
+        <categoryLink id="cf33-2617-4d81-8699" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03fc-6a7f-45a5-bcb8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink><entryLink id="2548-c7f0-25ed-f3d9" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry"><categoryLinks>
+        <categoryLink id="b1f9-60de-4e1b-9cb7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0aff-4f6e-4b03-a23c</comment></categoryLink>
+        <categoryLink id="e1d1-f500-419d-beef" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"><comment>    template_id_7d5a-62e7-43ee-b79b</comment></categoryLink>
+        <categoryLink id="f84d-74fd-4d11-9a56" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_4986-9157-49f2-b670</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink><entryLink id="96a3-8241-6955-d836" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_319e-90d4-44a3-8e83</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_28db-d943-4099-9abd</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1a45-a592-49df-9465</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb31-d0b2-4677-928e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2385-0bf3-446b-9124" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1b86-0977-4a8b-adac</comment></categoryLink>
+        <categoryLink id="1ad8-d351-40e1-b55c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_b449-403a-4e42-9239</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink><entryLink id="9be7-bc70-dadc-dd58" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafa-470f-4c2c-8be3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_e2ba-a855-4de2-9f46</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_0171-b30d-44ee-9389</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fdfb-119b-4774-934a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_3891-9a00-4f8f-b95f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c15d-d695-48a4-8c56" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e5df-17d4-4521-9d5b</comment></categoryLink>
+        <categoryLink id="8c80-4a45-494c-9b78" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"><comment>    template_id_0ecd-4873-4d3a-b28b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink><entryLink id="52be-3800-aa3f-3077" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_fbfa-8d78-4d6d-8a05</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_21f2-0916-46bf-b75a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_4fbd-633b-4dd6-9fdd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4c4f-780f-49bf-8537" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4f71-446f-4cff-afda</comment></categoryLink>
+        <categoryLink id="71ce-85f9-4bcb-8916" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_3f44-8647-43a4-ac22</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink><entryLink id="bcea-53b5-c7b1-4233" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af15-2c71-4f8b-833e</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_d95a-80b9-4463-af55</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="80ba-9c98-4038-bd18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6b1-886e-4194-8bcd</comment></categoryLink>
+        <categoryLink id="dca9-a2b9-47c6-8647" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_51b5-f9c1-4587-8fc7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink><entryLink id="eb49-50fe-4645-8bfd" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
+    <entryLink id="0c94-0e19-41b9-a7ec" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
+    <entryLink id="7a96-4e14-4df4-bf65" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
+    <entryLink id="b50b-f90c-4ff2-8614" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <entryLink id="9791-2c90-4894-97b2" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3531-57d1-4081-882d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_f233-2361-4177-8ba7</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b932-667a-4b43-8331</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <entryLink id="afa1-337b-47d9-aa8c" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <entryLink id="cfcd-9cae-4593-9a14" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3129-6f59-4365-906b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2bcb-0af1-4aea-9191" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <entryLink id="4add-b3b6-4e53-8945" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ede2-d453-4e34-8cda</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2907-3215-4b01-96ff</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_c90c-959f-40fb-a4cb</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ba2d-50ad-45f1-91c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0e88-485e-43c2-8bef" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <entryLink id="4077-a4e7-4143-a5d1" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_409c-0a5d-4ef8-a871</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7078-c1c7-4af2-b43d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_9a69-0fdc-4957-8982</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1a4c-69b5-4219-8502" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fba0-3ea7-4eaf-b33a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <entryLink id="8877-1b96-4317-8993" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
+    <entryLink id="c900-4b3a-4f5a-84e9" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
+    <entryLink id="ac1b-9510-4209-8ea6" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
+    <entryLink id="8191-6b96-4be1-8bbd" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+  </entryLinks><sharedSelectionEntries>
     <selectionEntry id="ea50-6315-7a52-f560" name="Gorgon Terminator Squad" publicationId="817a-6288-e016-7469" page="282" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="beee-48f0-ef0e-6867" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">

--- a/2022 - LA - Iron Hands.cat
+++ b/2022 - LA - Iron Hands.cat
@@ -2367,7 +2367,7 @@ A Warlord with this Trait, and all models in any unit he joins, gain the Fear (1
       <entryLinks>
         <entryLink id="05d9-9067-a598-766b" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_7dee-602c-4b47-be09</comment></selectionEntryGroup>
     <selectionEntryGroup id="8a62-e4e2-d57f-5c33" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="8047-f642-a311-b9b4" type="max" />
@@ -2385,7 +2385,7 @@ A Warlord with this Trait, and all models in any unit he joins, gain the Fear (1
         <entryLink id="9f8a-3c65-6a66-e294" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
         <entryLink id="92a3-5f51-0863-b6f8" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_be38-a066-4f8e-ae54</comment></selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
     <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />

--- a/2022 - LA - Iron Hands.cat
+++ b/2022 - LA - Iron Hands.cat
@@ -33,7 +33,7 @@
         <categoryLink id="1b49-70c4-2fde-68f7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="adaf-b561-c972-57ac" name="Shadrak Meduson" hidden="false" collective="false" import="false" targetId="44c8-4cd9-3121-5a52" type="selectionEntry">
+    <entryLink id="adaf-b561-c972-57ac" name="Shadrak Meduson" hidden="true" collective="false" import="false" targetId="44c8-4cd9-3121-5a52" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -2735,6 +2735,19 @@
         <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
       </categoryLinks>
     </entryLink>
+    <entryLink id="db67-3e5a-0ee9-ed74" name="Gorgon Terminator Squad" hidden="true" collective="false" import="false" targetId="ea50-6315-7a52-f560" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6f48-212c-3bcc-1075" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f587-2f63-30e0-fe1e" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="ea50-6315-7a52-f560" name="Gorgon Terminator Squad" publicationId="817a-6288-e016-7469" page="282" hidden="false" collective="false" import="true" type="unit">
@@ -3071,6 +3084,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="292a-0d1d-dfae-51db" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="e6fd-f829-f0f9-e593" name="Pride of the Legion Compulsory Troops" hidden="false" collective="false" import="true" targetId="8c3a-f99e-4226-e519" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
@@ -3093,7 +3107,7 @@
         <categoryLink id="221e-a4f5-b097-1747" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="c831-444b-9325-de3b" name="Immortal Sergeant" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="c831-444b-9325-de3b" name=" Immortal Sergeant" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0e4-057b-24d0-300f" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39e9-5f6e-e06f-12ec" type="min"/>

--- a/2022 - LA - Iron Hands.cat
+++ b/2022 - LA - Iron Hands.cat
@@ -1,13 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="b73e-125f-db29-17f2" name="LA -  X: Iron Hands" revision="13" battleScribeVersion="2.03" authorName="Figjam Bohica" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="22" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="b73e-125f-db29-17f2" name="LA -  X: Iron Hands" revision="13" battleScribeVersion="2.03" authorName="Figjam Bohica" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="22">
   <entryLinks>
     <entryLink id="6107-168e-198e-2e94" name="  X: Iron Hands" hidden="false" collective="false" import="false" targetId="bfc9-c99c-bf8a-3917" type="selectionEntry">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4452-bec3-6da1-2edd" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da6a-761c-e00e-569b" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4452-bec3-6da1-2edd" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da6a-761c-e00e-569b" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="8e8d-01b9-6875-ad9c" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="8e8d-01b9-6875-ad9c" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="2fdc-7a7e-ae85-ad77" name="Iron Father Autek Mor" hidden="true" collective="false" import="false" targetId="0283-efdd-6ee3-6741" type="selectionEntry">
@@ -16,21 +15,21 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0ea8-3c19-bd9e-00d7" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="1b49-70c4-2fde-68f7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0ea8-3c19-bd9e-00d7" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="1b49-70c4-2fde-68f7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="adaf-b561-c972-57ac" name="Shadrak Meduson" hidden="false" collective="false" import="false" targetId="44c8-4cd9-3121-5a52" type="selectionEntry">
@@ -39,42 +38,42 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4352-3cd4-e3da-54fa" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="5628-344a-7f03-95bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4352-3cd4-e3da-54fa" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="5628-344a-7f03-95bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="e1ce-d9b7-2ea1-760b" name="Medusan Immortal Squad" hidden="false" collective="false" import="false" targetId="f9e4-0da2-5049-df81" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="028c-19b9-ccdf-9229" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="3f2e-25c7-b685-51db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="028c-19b9-ccdf-9229" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="3f2e-25c7-b685-51db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="de83-37e7-9228-0b81" name="Gorgon Terminator Squad" hidden="false" collective="false" import="false" targetId="ea50-6315-7a52-f560" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="26b1-401b-c49d-a163" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="0ac3-4093-1c72-a6c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="26b1-401b-c49d-a163" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="0ac3-4093-1c72-a6c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="acbb-d53d-6be7-eef8" name="Ferrus Manus" hidden="false" collective="false" import="false" targetId="554b-1024-a345-0d14" type="selectionEntry">
@@ -83,995 +82,995 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="84ec-691d-8d75-7998" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
-        <categoryLink id="4198-15b1-372c-89c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="84ec-691d-8d75-7998" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true" />
+        <categoryLink id="4198-15b1-372c-89c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="2dbc-c2bc-600f-0c06" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6c76-36d4-fcc2-06f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ea5a-e2c0-0687-2034" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6c76-36d4-fcc2-06f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ea5a-e2c0-0687-2034" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
     <entryLink id="2683-1143-e3eb-16b0" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f8fb-055f-f8ba-c03d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2da4-a8af-1485-a179" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="f8fb-055f-f8ba-c03d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2da4-a8af-1485-a179" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
     <entryLink id="75b9-a14d-71c6-c1c3" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="531a-be7b-d57c-54bc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="a743-76f5-596b-b2f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="781e-381d-a6c8-ab81" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="531a-be7b-d57c-54bc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="a743-76f5-596b-b2f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="781e-381d-a6c8-ab81" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="1f59-14e1-1648-5cb4" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9192-8658-63c7-7517" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="59cf-20e0-a0fc-4bec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9192-8658-63c7-7517" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="59cf-20e0-a0fc-4bec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
     <entryLink id="afbe-8f22-7252-8b13" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1b48-5870-0014-271a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="b204-d1e3-78bc-448e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1b48-5870-0014-271a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="b204-d1e3-78bc-448e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
     <entryLink id="ccd5-7195-3de9-39e4" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0c09-eed2-c6ce-455f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="0116-7fce-ff42-fe7f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5a58-816b-8f96-cd03" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="0c09-eed2-c6ce-455f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0116-7fce-ff42-fe7f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5a58-816b-8f96-cd03" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
     <entryLink id="6f1a-6235-21d1-c5ce" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5e4b-7307-79cb-2aad" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="b32b-1841-a801-9fa3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5e4b-7307-79cb-2aad" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="b32b-1841-a801-9fa3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
     <entryLink id="2de1-61c4-6bf6-bced" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d4a3-f571-7ef9-181c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="56b2-bcf8-db8f-da7b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d4a3-f571-7ef9-181c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="56b2-bcf8-db8f-da7b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
     <entryLink id="6961-b3e3-7f30-b911" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="00c4-811f-1598-2ffa" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="bde3-a6e6-54cc-60a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4b87-2885-1188-d662" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="00c4-811f-1598-2ffa" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="bde3-a6e6-54cc-60a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4b87-2885-1188-d662" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="03e8-da10-e22f-1b82" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup"/>
+        <entryLink id="03e8-da10-e22f-1b82" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup" />
         <entryLink id="db2e-68e7-1c6c-1742" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
     <entryLink id="951e-a5cb-a35b-c772" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3956-6385-981b-8819" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="87a6-468b-e69c-c1be" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="f601-de9b-59f5-5ff5" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="3956-6385-981b-8819" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="87a6-468b-e69c-c1be" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="f601-de9b-59f5-5ff5" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="e86b-b26b-d8ae-5c6e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup"/>
+        <entryLink id="e86b-b26b-d8ae-5c6e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup" />
         <entryLink id="a514-b234-827b-d1f5" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
     <entryLink id="c5b4-a6f8-485f-e0c3" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="853b-37a7-6c33-fa9b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0418-529a-e1bf-19fa" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="edf9-470b-834b-a7fe" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="853b-37a7-6c33-fa9b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0418-529a-e1bf-19fa" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="edf9-470b-834b-a7fe" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="d5e2-8f8f-0186-6f13" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup"/>
+        <entryLink id="d5e2-8f8f-0186-6f13" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup" />
         <entryLink id="849a-6691-c91c-badb" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
     <entryLink id="a843-ca70-a435-03e2" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c816-0c94-2ee4-97e8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="dbca-d326-7547-08c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c816-0c94-2ee4-97e8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="dbca-d326-7547-08c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
     <entryLink id="7fbd-8c69-0c5d-8ae0" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9bb9-b773-6839-37de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="14f3-519d-cf5f-9323" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="9bb9-b773-6839-37de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="14f3-519d-cf5f-9323" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
     <entryLink id="02b9-6b6a-ac24-1614" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fa57-3c82-abf5-7bdc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0609-db69-b708-0783" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="fa57-3c82-abf5-7bdc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0609-db69-b708-0783" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
     <entryLink id="993e-8cdb-d3b7-9f4c" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4865-e18e-de2a-61ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7511-6774-9d83-64a2" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="4865-e18e-de2a-61ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7511-6774-9d83-64a2" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
     <entryLink id="93e5-a4d1-94a2-8d1d" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="459d-41f4-7d5f-b47c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cc50-714e-2393-65f9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="459d-41f4-7d5f-b47c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cc50-714e-2393-65f9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
     <entryLink id="441c-ddc8-3d17-9db6" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f918-fd61-e41a-e9c0" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="4e42-ca8c-97e0-6ea6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f918-fd61-e41a-e9c0" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="4e42-ca8c-97e0-6ea6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
     <entryLink id="4b9b-0cec-f73e-8f5f" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1477-4a3f-d2b5-c7bf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="09b3-c5f5-37b7-512a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1477-4a3f-d2b5-c7bf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="09b3-c5f5-37b7-512a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="4123-db2b-5a98-1ef1" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e364-1ebe-d1c0-d90d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e7fc-e2f4-a4d8-839b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="e364-1ebe-d1c0-d90d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e7fc-e2f4-a4d8-839b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
     <entryLink id="2395-c646-99b6-1777" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c780-1b7a-0929-5223" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="0366-c15a-ffdc-62de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1237-261a-bdce-25f6" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="c780-1b7a-0929-5223" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0366-c15a-ffdc-62de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1237-261a-bdce-25f6" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="fe4f-e632-67a2-3710" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3edc-9a96-323d-fca0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a5b6-d63f-a175-b375" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="3edc-9a96-323d-fca0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a5b6-d63f-a175-b375" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="19a2-1290-e7e5-8e08" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="417b-dbb5-bec6-e1f0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="f936-0064-b47d-0555" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="417b-dbb5-bec6-e1f0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="f936-0064-b47d-0555" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
     <entryLink id="071e-77a5-ee6a-a920" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7abd-e634-26fb-60a3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="cc55-492f-0300-bd31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7abd-e634-26fb-60a3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="cc55-492f-0300-bd31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
     <entryLink id="7576-7c97-0d6f-0e29" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2e4c-2f9a-b6c3-1443" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="9456-af88-1cb7-c951" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2e4c-2f9a-b6c3-1443" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="9456-af88-1cb7-c951" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
     <entryLink id="6f34-4910-1f0d-135d" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b1eb-06fb-765d-08d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="abec-5c83-73e2-5418" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="b1eb-06fb-765d-08d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="abec-5c83-73e2-5418" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
     <entryLink id="68f5-4813-a2bd-e9aa" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ba17-bb90-131c-570a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="2b60-d0f8-a4ac-43ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ba17-bb90-131c-570a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="2b60-d0f8-a4ac-43ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
     <entryLink id="ad5a-8d7b-66ac-b648" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="912b-d8a7-bbba-e232" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="94e1-9241-75a9-1cab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="912b-d8a7-bbba-e232" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="94e1-9241-75a9-1cab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
     <entryLink id="b91b-785c-33ba-8be8" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d8c9-80dd-a1d3-53a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3aa0-dd36-09dd-cbbe" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="d8c9-80dd-a1d3-53a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3aa0-dd36-09dd-cbbe" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
     <entryLink id="7d9e-d55b-a6b3-3ea5" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d2e6-c609-4e43-db8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="1791-83f0-15aa-e570" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d2e6-c609-4e43-db8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="1791-83f0-15aa-e570" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
     <entryLink id="4a6b-0977-b9a7-33db" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="181a-5eb1-5e75-8050" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5c6e-066e-4dc0-b68e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="181a-5eb1-5e75-8050" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5c6e-066e-4dc0-b68e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="d566-4709-c68f-21b6" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3464-74db-6bc4-4038" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="d83a-feac-f872-bef4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3464-74db-6bc4-4038" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="d83a-feac-f872-bef4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
     <entryLink id="e765-9cfe-5819-6569" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2143-5b09-31fa-fb2d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="778c-9efa-24a4-96ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2143-5b09-31fa-fb2d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="778c-9efa-24a4-96ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
     <entryLink id="8302-359e-ff65-a0e5" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="dfa9-3f9f-0554-c3a2" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="e1c0-b29b-dec0-27c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="dfa9-3f9f-0554-c3a2" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="e1c0-b29b-dec0-27c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
     <entryLink id="5dcb-a287-24ca-d938" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="274b-5eb5-1db1-fd4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b385-74fb-293c-2768" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="274b-5eb5-1db1-fd4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b385-74fb-293c-2768" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
     <entryLink id="fc5f-3428-c1f6-88ed" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5ae9-503f-bc04-cc53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e5f6-ce2e-52ff-0c49" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="5ae9-503f-bc04-cc53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e5f6-ce2e-52ff-0c49" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
     <entryLink id="bfaa-8542-9067-c2d0" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="38eb-f183-e981-92d8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="162b-4449-21f6-ff6f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="38eb-f183-e981-92d8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="162b-4449-21f6-ff6f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
     <entryLink id="72a7-17b3-fff3-1c5a" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="77f7-6263-51a4-0ba6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="cc9a-f0ce-ddf7-4b31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="77f7-6263-51a4-0ba6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="cc9a-f0ce-ddf7-4b31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
     <entryLink id="d710-dc61-52f2-c32e" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7601-f1f6-9915-ca32" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="85fd-4cb5-94d0-f6ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7601-f1f6-9915-ca32" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="85fd-4cb5-94d0-f6ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
     <entryLink id="a26b-fdd0-67d7-d9d7" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cfa6-2fee-3825-fa84" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="3a68-6c78-11cd-f7c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="cfa6-2fee-3825-fa84" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="3a68-6c78-11cd-f7c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
     <entryLink id="d646-3919-f006-1442" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8497-b22f-b83a-70c4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="fb0d-756b-9216-94cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8497-b22f-b83a-70c4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="fb0d-756b-9216-94cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
     <entryLink id="4c4a-6c88-508f-ffd0" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cd6a-3d8d-bc37-d895" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="ede8-3474-0cb0-7a40" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="cd6a-3d8d-bc37-d895" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="ede8-3474-0cb0-7a40" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
     <entryLink id="4b8b-f3bd-f072-7c97" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f6e1-a675-3d27-e26f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="788b-d547-1eae-1d0f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f6e1-a675-3d27-e26f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="788b-d547-1eae-1d0f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
     <entryLink id="8e2e-97f0-d89f-9855" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1fc4-e84a-3234-08b3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="80b6-4b14-2f4f-f57a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1fc4-e84a-3234-08b3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="80b6-4b14-2f4f-f57a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
     <entryLink id="f78e-acbe-e0ef-3f9a" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2fdf-1912-95e9-2a15" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="be83-2df4-f1c2-e45f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2fdf-1912-95e9-2a15" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="be83-2df4-f1c2-e45f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
     <entryLink id="798e-c8c7-1a7c-795a" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8a2e-3887-8e73-1a8e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bb8b-28fb-b2f1-d693" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="8a2e-3887-8e73-1a8e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bb8b-28fb-b2f1-d693" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
     <entryLink id="163e-01af-2fd1-1c45" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="087c-966b-e42a-22cd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="371a-2b24-a9d6-1166" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="087c-966b-e42a-22cd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="371a-2b24-a9d6-1166" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
     <entryLink id="1364-f4c8-53dc-2f0b" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="959d-19e4-ec90-7ec8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="8bd9-79cd-330f-49e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="959d-19e4-ec90-7ec8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="8bd9-79cd-330f-49e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
     <entryLink id="f1a5-3987-25ff-8129" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0365-fb85-70ff-72a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e6fb-affe-77d4-0fdc" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="0365-fb85-70ff-72a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e6fb-affe-77d4-0fdc" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="1e4f-08a0-3f42-5441" name="Nathaniel Garro" hidden="false" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="74de-2ade-bb53-c807" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="f47f-8df0-b88c-0896" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="74de-2ade-bb53-c807" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="f47f-8df0-b88c-0896" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
     <entryLink id="36e0-66bf-7196-6a14" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="41e8-4066-0081-1914" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="65d9-debb-4048-6268" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="41e8-4066-0081-1914" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="65d9-debb-4048-6268" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="ed6a-42cb-a16d-f0b3" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a245-6239-8d27-78b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4019-9176-bc30-1fc8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="a245-6239-8d27-78b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4019-9176-bc30-1fc8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="7d73-b111-0aff-e0d8" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a88a-3efc-e35c-e466" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="4f02-9117-fcfa-8d90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9edc-bd97-9265-611d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="a88a-3efc-e35c-e466" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="4f02-9117-fcfa-8d90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9edc-bd97-9265-611d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="3449-7ebf-0229-7e05" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup"/>
-        <entryLink id="c5e6-977b-629c-d1ac" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup"/>
+        <entryLink id="3449-7ebf-0229-7e05" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup" />
+        <entryLink id="c5e6-977b-629c-d1ac" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
     <entryLink id="448a-4b83-ef67-b271" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6266-605b-9031-8d3b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="c183-23e3-a758-d7e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b646-d67b-7291-72e6" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="6266-605b-9031-8d3b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c183-23e3-a758-d7e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b646-d67b-7291-72e6" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="ed8c-fa94-6db8-aac5" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup"/>
-        <entryLink id="c642-3734-7d2e-e7db" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup"/>
+        <entryLink id="ed8c-fa94-6db8-aac5" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup" />
+        <entryLink id="c642-3734-7d2e-e7db" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
     <entryLink id="15b4-257b-14c0-c12d" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7638-a22f-e65c-c09e" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="48c4-973a-24ec-a974" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d976-73f8-5630-0d19" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="7638-a22f-e65c-c09e" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="48c4-973a-24ec-a974" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d976-73f8-5630-0d19" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="ac63-f355-e855-e4b6" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup"/>
-        <entryLink id="e1cd-b865-f455-a386" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup"/>
+        <entryLink id="ac63-f355-e855-e4b6" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4dfa-3ccc-df19-6789" type="selectionEntryGroup" />
+        <entryLink id="e1cd-b865-f455-a386" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
     <entryLink id="39bc-81bd-6d7d-0acd" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7d80-e262-0816-6d73" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="998a-f5f3-ca40-366b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="7d80-e262-0816-6d73" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="998a-f5f3-ca40-366b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="df0f-2d75-d0a1-272e" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="57dc-2e67-328f-8356" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="bb9c-9c6e-0823-587d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="57dc-2e67-328f-8356" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="bb9c-9c6e-0823-587d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
     <entryLink id="f1e3-383f-3d13-bdaf" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f22d-8b8d-8524-6acf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b2c6-8c6d-0312-ce1f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="f22d-8b8d-8524-6acf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b2c6-8c6d-0312-ce1f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="de63-6ef3-fd41-049c" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5dee-e4b8-569e-4604" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="d4e8-e6e7-53fa-f8e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5dee-e4b8-569e-4604" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="d4e8-e6e7-53fa-f8e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
     <entryLink id="eb63-a37e-895d-9a79" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5cc7-810b-0d3e-63dc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="f6e0-5868-53b2-5d5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5cc7-810b-0d3e-63dc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="f6e0-5868-53b2-5d5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
     <entryLink id="fd4e-e93f-4fa7-bde0" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4264-476a-c67a-b0e2" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="fc75-1c4f-a0ad-2e5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4264-476a-c67a-b0e2" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="fc75-1c4f-a0ad-2e5e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
     <entryLink id="3555-5ac4-93c0-8745" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="35f2-a5a3-cb5a-d288" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="918e-93ef-64fb-fdd3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="35f2-a5a3-cb5a-d288" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="918e-93ef-64fb-fdd3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
     <entryLink id="477f-108c-303a-fc0b" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="afdb-e293-67c7-4748" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="aaee-7ce8-137e-a5df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="afdb-e293-67c7-4748" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="aaee-7ce8-137e-a5df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
     <entryLink id="75ca-4404-b438-2721" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fb08-b634-5cb1-7e26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="decb-30d8-b220-f489" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="fb08-b634-5cb1-7e26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="decb-30d8-b220-f489" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
     <entryLink id="8c72-434e-a163-ed88" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6303-a996-2cf4-78ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b7f0-a478-429b-75a7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6303-a996-2cf4-78ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b7f0-a478-429b-75a7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
     <entryLink id="be5f-a69e-5831-c359" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="afd9-5c5c-db16-996f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7e8c-7024-3a84-4378" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="afd9-5c5c-db16-996f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7e8c-7024-3a84-4378" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
     <entryLink id="6810-facb-c707-b1ea" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d83b-c1ed-b059-47c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3e5c-692d-7275-a0d6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="d83b-c1ed-b059-47c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3e5c-692d-7275-a0d6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
     <entryLink id="be5b-081f-76e6-2f75" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fc36-b4d6-0bcd-4518" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f681-f9b9-80e8-316a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="fc36-b4d6-0bcd-4518" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f681-f9b9-80e8-316a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="02c1-84ae-30b9-c351" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="74ec-1179-4130-423f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b927-ca6b-1eed-ee30" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="74ec-1179-4130-423f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b927-ca6b-1eed-ee30" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
     <entryLink id="e7b5-cf72-972f-ee5f" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="85c9-7e62-53a1-d63e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3b3b-b65b-529d-d328" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="85c9-7e62-53a1-d63e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3b3b-b65b-529d-d328" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="4713-5110-f8f9-269e" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ee31-00d9-9130-cce6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="6350-3358-7460-b373" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ee31-00d9-9130-cce6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="6350-3358-7460-b373" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
     <entryLink id="31e7-41bc-dac7-267c" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9783-d9a6-566c-c110" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="ba85-382b-c5f7-9c71" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9783-d9a6-566c-c110" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="ba85-382b-c5f7-9c71" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
     <entryLink id="5944-cb4e-8d33-7d57" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="dbbf-7484-4f53-9da7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="b3bc-a9ec-3e00-79be" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="dbbf-7484-4f53-9da7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="b3bc-a9ec-3e00-79be" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
     <entryLink id="591d-7932-3aa6-5aaa" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9f8c-79f2-ce3f-2934" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bcf3-01d8-1987-9cee" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="39a3-c7ed-ea3e-a199" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="9f8c-79f2-ce3f-2934" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bcf3-01d8-1987-9cee" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="39a3-c7ed-ea3e-a199" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="3f8d-3188-9f3c-3170" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c4e5-1505-2fdc-f0be" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="78ef-61eb-9587-ee0c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="c4e5-1505-2fdc-f0be" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="78ef-61eb-9587-ee0c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
     <entryLink id="1281-3189-bd56-de0e" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6b29-deb4-4c36-3517" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="34c0-9279-1cb8-3620" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6b29-deb4-4c36-3517" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="34c0-9279-1cb8-3620" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
     <entryLink id="9718-a1aa-6d82-72bb" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="90d1-4d68-bd2d-78fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c6ad-e25c-b5aa-fc06" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="90d1-4d68-bd2d-78fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c6ad-e25c-b5aa-fc06" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
     <entryLink id="8ae9-54f1-74d0-0758" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="532e-eb62-171f-b0e7" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="21bf-01b0-1f9b-df07" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="532e-eb62-171f-b0e7" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="21bf-01b0-1f9b-df07" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="ef84-1b45-e4b0-fa3e" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6441-874e-5580-ee68" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="4900-7ae1-3710-27fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6441-874e-5580-ee68" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="4900-7ae1-3710-27fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
     <entryLink id="4882-f7c6-bb2a-1149" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fecf-acab-f5c9-18e2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="1c8a-b4be-4122-6e09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fecf-acab-f5c9-18e2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="1c8a-b4be-4122-6e09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="f50d-3ded-be21-4dfd" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="abb2-fa85-d1ef-7154" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="e219-f12b-d557-6779" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="abb2-fa85-d1ef-7154" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="e219-f12b-d557-6779" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
     <entryLink id="6cc4-b71c-19d3-fbf9" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="96a5-968a-66d4-b487" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="e156-5f36-9d0f-4a9a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="96a5-968a-66d4-b487" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="e156-5f36-9d0f-4a9a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
     <entryLink id="0d04-7fb4-1b16-4e46" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e913-f827-150c-fab3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="12b6-cb33-e8f6-d088" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e913-f827-150c-fab3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="12b6-cb33-e8f6-d088" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
     <entryLink id="cb3c-43be-2c3d-670b" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="dcca-3a17-817e-1103" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="dcca-3a17-817e-1103" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
     <entryLink id="2548-c7f0-25ed-f3d9" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="85e1-2ff5-4a68-513d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cf44-8c7b-c976-6516" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="d5b2-facb-1613-44dc" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="85e1-2ff5-4a68-513d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cf44-8c7b-c976-6516" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
+        <categoryLink id="d5b2-facb-1613-44dc" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="96a3-8241-6955-d836" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="17f0-e211-e298-7280" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="15ee-e7b6-98b3-91a9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="17f0-e211-e298-7280" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="15ee-e7b6-98b3-91a9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
     <entryLink id="9be7-bc70-dadc-dd58" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8722-856a-826c-84b3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="efaf-72c1-6376-af2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8722-856a-826c-84b3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="efaf-72c1-6376-af2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
     <entryLink id="52be-3800-aa3f-3077" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0ffe-2e1c-a8bc-7023" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2a69-e3df-9913-6f1b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="0ffe-2e1c-a8bc-7023" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2a69-e3df-9913-6f1b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
     <entryLink id="bcea-53b5-c7b1-4233" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <infoLinks>
-        <infoLink id="b9e9-3d4a-f9e7-b8c6" name="Legiones Astartes (Iron Hands) " hidden="false" targetId="2e45-4b61-44fb-260b" type="rule"/>
+        <infoLink id="b9e9-3d4a-f9e7-b8c6" name="Legiones Astartes (Iron Hands) " hidden="false" targetId="2e45-4b61-44fb-260b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="7df1-c6fb-ca38-bb32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="56d9-39b6-a7b5-9b38" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="7df1-c6fb-ca38-bb32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="56d9-39b6-a7b5-9b38" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="ea50-6315-7a52-f560" name="Gorgon Terminator Squad" publicationId="817a-6288-e016-7469" page="282" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="beee-48f0-ef0e-6867" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+            <modifier type="set" field="name" value="Feel No Pain (5+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="2cee-c3e5-a53d-c618" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="6c67-2c26-4fce-e059" name="Legiones Astartes (Iron Hands) " hidden="false" targetId="2e45-4b61-44fb-260b" type="rule"/>
+        <infoLink id="2cee-c3e5-a53d-c618" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="6c67-2c26-4fce-e059" name="Legiones Astartes (Iron Hands) " hidden="false" targetId="2e45-4b61-44fb-260b" type="rule" />
         <infoLink id="cde0-474e-f808-02fe" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="db91-3a2e-46b5-3998" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="db91-3a2e-46b5-3998" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9593-8dda-915e-8ef4" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="0de3-d934-b836-a40c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="5df3-9231-c29a-5bf6" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="9bfa-f05f-d04f-e983" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="9593-8dda-915e-8ef4" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="0de3-d934-b836-a40c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="5df3-9231-c29a-5bf6" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
+        <categoryLink id="9bfa-f05f-d04f-e983" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="175c-be5a-9f30-7a03" name="Gorgon Hammerbearer" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc48-f096-3a2b-61d6" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c0a-b3d8-2b75-a89c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc48-f096-3a2b-61d6" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c0a-b3d8-2b75-a89c" type="max" />
           </constraints>
           <profiles>
             <profile id="4e33-1fdf-a9c0-16e0" name="Gorgon Hammerbearer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Heavy)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1087,34 +1086,34 @@
           <selectionEntryGroups>
             <selectionEntryGroup id="7470-b3a9-08e3-cb35" name="Ranged Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a76e-1c70-a447-4e6d">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="967f-d676-525f-2e31" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f13-0213-38bf-2e49" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="967f-d676-525f-2e31" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f13-0213-38bf-2e49" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="a76e-1c70-a447-4e6d" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                <entryLink id="a76e-1c70-a447-4e6d" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry" />
                 <entryLink id="ea21-e886-de41-8c4c" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="7d4f-aeef-dffd-784e" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="623a-3e67-446d-36c4" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="6290-d977-3e5d-de48" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="dc8b-eb90-0273-e62b" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1123,62 +1122,62 @@
           <entryLinks>
             <entryLink id="4a2b-086d-6484-da21" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52ac-2c80-9ca7-6364" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a989-49b5-f9e6-2ed5" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52ac-2c80-9ca7-6364" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a989-49b5-f9e6-2ed5" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="cb66-67d9-e9df-96be" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd30-c30f-9261-3bb1" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcda-d0fc-ec77-3647" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd30-c30f-9261-3bb1" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcda-d0fc-ec77-3647" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="9a68-4eef-69ba-3e68" name="3) Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c44-209d-f162-7e2f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c44-209d-f162-7e2f" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="6023-4e38-cddc-ae1b" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e04c-d5b1-9199-6640" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e04c-d5b1-9199-6640" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="740b-f90c-74bf-c44c" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="ea50-6315-7a52-f560" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="selections" scope="ea50-6315-7a52-f560" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="03dc-20de-9a36-ce49" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="03dc-20de-9a36-ce49" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="c1fd-ea03-2c5a-9ccb" name="1) Gorgon Terminators" hidden="false" collective="false" import="true" defaultSelectionEntryId="fd64-e12a-55e6-5c0a">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="821e-bff2-bd65-4b19" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68a8-8905-9f6e-000a" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="821e-bff2-bd65-4b19" type="min" />
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68a8-8905-9f6e-000a" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="fd64-e12a-55e6-5c0a" name="Gorgon Terminator" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f5b-a0cd-0015-083a" type="max"/>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f5b-a0cd-0015-083a" type="max" />
               </constraints>
               <profiles>
                 <profile id="58e9-f8f4-e13f-1586" name="Gorgon Terminator" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1194,88 +1193,88 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="34d8-cde2-7007-4029" name="1) Melee Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="0dd6-9457-a610-e14f">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="626f-baf5-90bd-f169" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f336-4767-a9d7-5a2b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="626f-baf5-90bd-f169" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f336-4767-a9d7-5a2b" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="ac2c-6972-44ee-a88a" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="72ad-4782-54f9-2ccf" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="054b-e58e-9331-866e" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
-                    <entryLink id="0dd6-9457-a610-e14f" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
+                    <entryLink id="0dd6-9457-a610-e14f" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="6a18-118d-724a-447d" name="2) Ranged Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="5718-bab6-f80e-9fd2">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2cd3-a14b-e499-3d42" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="92fd-25ac-ca59-58b8" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2cd3-a14b-e499-3d42" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="92fd-25ac-ca59-58b8" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="31d8-5e3c-1693-f298" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="6429-3149-b7bc-b64a" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
-                    <entryLink id="5718-bab6-f80e-9fd2" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                    <entryLink id="5718-bab6-f80e-9fd2" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry" />
                     <entryLink id="9d0d-093e-2d27-70b5" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="65ca-0a21-3486-0a43" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="220a-5e9d-2e5c-568e" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="9d54-5435-f913-c46a" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="c51d-6b5f-3efe-8aef" name="Gorgon Terminator w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="093c-1c9b-abc4-fd1d" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="ea50-6315-7a52-f560" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="ea50-6315-7a52-f560" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="093c-1c9b-abc4-fd1d" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="093c-1c9b-abc4-fd1d" type="max" />
               </constraints>
               <profiles>
                 <profile id="8aa5-59cd-1ca2-3b03" name="Gorgon Terminator" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1291,64 +1290,64 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="229a-009c-aa7b-dba1" name="1) Melee Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="c9b0-c9da-c945-c1e0">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7457-e1d0-fd6c-b0b4" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fc1-c7cd-572a-9569" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7457-e1d0-fd6c-b0b4" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fc1-c7cd-572a-9569" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="1abb-ef88-666e-6219" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="1c7a-50a5-2d5c-5faa" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="3e05-57ff-bfcd-6410" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
-                    <entryLink id="c9b0-c9da-c945-c1e0" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
+                    <entryLink id="c9b0-c9da-c945-c1e0" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="288e-1f59-04f6-95d2" name="2) Heavy Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="f542-c650-bdb0-afa4">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8a8c-954b-124e-6279" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9a65-f874-4bc0-4a4e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8a8c-954b-124e-6279" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9a65-f874-4bc0-4a4e" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="f542-c650-bdb0-afa4" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="6003-a852-db33-a866" name="Plasma Blaster" hidden="false" collective="false" import="true" targetId="cd52-e9e8-3ab1-995c" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="3960-4b92-ff8f-84b2" name="Reaper Autocannon" hidden="false" collective="false" import="true" targetId="b87f-48de-6ced-043b" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="5530-ac93-5efc-bc04" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="8ffb-08d9-0a5d-1eca" name="Graviton Shredder" hidden="false" collective="false" import="true" targetId="0849-b63b-0b1b-fd4f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1357,10 +1356,10 @@
           <entryLinks>
             <entryLink id="6a90-94bc-385c-1182" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fc0-965a-9acc-cdd9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fc0-965a-9acc-cdd9" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -1369,43 +1368,43 @@
       <entryLinks>
         <entryLink id="db7f-08dc-b6bc-8e4a" name="Gorgon Terminator Armour" hidden="false" collective="false" import="true" targetId="16ca-e521-1c1b-0716" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d28b-2b3d-55e8-3df4" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="292a-0d1d-dfae-51db" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d28b-2b3d-55e8-3df4" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="292a-0d1d-dfae-51db" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="f9e4-0da2-5049-df81" name="Medusan Immortal Squad" publicationId="817a-6288-e016-7469" page="283" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="f442-82de-df20-e6d1" name="Legiones Astartes (Iron Hands) " hidden="false" targetId="2e45-4b61-44fb-260b" type="rule"/>
+        <infoLink id="f442-82de-df20-e6d1" name="Legiones Astartes (Iron Hands) " hidden="false" targetId="2e45-4b61-44fb-260b" type="rule" />
         <infoLink id="abce-5f4b-1f3f-904b" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+            <modifier type="set" field="name" value="Feel No Pain (5+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="1cc4-f0ab-2ffb-ad30" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
-        <infoLink id="68c9-ea5b-8dbf-55ce" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="1cc4-f0ab-2ffb-ad30" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule" />
+        <infoLink id="68c9-ea5b-8dbf-55ce" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="922a-9c91-509f-36fd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="b0a0-c02f-f97d-8b78" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="221e-a4f5-b097-1747" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="922a-9c91-509f-36fd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="b0a0-c02f-f97d-8b78" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="221e-a4f5-b097-1747" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c831-444b-9325-de3b" name="Immortal Sergeant" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0e4-057b-24d0-300f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39e9-5f6e-e06f-12ec" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0e4-057b-24d0-300f" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39e9-5f6e-e06f-12ec" type="min" />
           </constraints>
           <profiles>
             <profile id="318f-b8ac-d79e-2c6c" name="Immortal Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="f9e4-0da2-5049-df81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                    <condition field="selections" scope="f9e4-0da2-5049-df81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1425,74 +1424,74 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="ce14-5b51-ca57-a479" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-            <categoryLink id="3981-f592-d5f7-9f94" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-            <categoryLink id="ecc9-de7f-c8ba-d75a" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="ce14-5b51-ca57-a479" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+            <categoryLink id="3981-f592-d5f7-9f94" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+            <categoryLink id="ecc9-de7f-c8ba-d75a" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="e878-6b8e-8676-4e2a" name="May exchange his Bolt Pistol/Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="19a7-5f91-e245-aea2">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea02-e503-f9ad-e6d0" type="max"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5def-984f-6321-8b71" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea02-e503-f9ad-e6d0" type="max" />
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5def-984f-6321-8b71" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="19a7-5f91-e245-aea2" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ed48-df85-ed93-36af" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ed48-df85-ed93-36af" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="2b24-679c-4f8f-f0e6" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5965-f155-7753-8601" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5965-f155-7753-8601" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="db86-5cdc-e7a2-d14c" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba27-fb9e-99fa-0aaf" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba27-fb9e-99fa-0aaf" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="1b8a-3912-d519-3d58" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7092-a7f1-8596-28cb" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7092-a7f1-8596-28cb" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="4395-92ad-42a4-9894" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a81d-4369-7030-b531" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a81d-4369-7030-b531" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="7e6d-53da-0340-b9bd" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5eb4-4db8-0759-db21" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5eb4-4db8-0759-db21" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="10b4-adce-bfc4-c4ca" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da74-ded4-1fb1-c906" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da74-ded4-1fb1-c906" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="b379-f37a-e8b5-ead4" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="a08a-116f-34bf-c1c6" value="0.0"/>
+                    <modifier type="set" field="a08a-116f-34bf-c1c6" value="0.0" />
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a879-1eb5-7ce0-fc04" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a08a-116f-34bf-c1c6" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a879-1eb5-7ce0-fc04" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a08a-116f-34bf-c1c6" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -1501,55 +1500,55 @@
               <entryLinks>
                 <entryLink id="59c7-f6a5-4e94-71fa" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7aa4-4195-9fd3-c6e3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7aa4-4195-9fd3-c6e3" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="df33-b5d3-c76b-1a04" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4aa7-e93a-ca14-c8f5" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4aa7-e93a-ca14-c8f5" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="67cb-fa53-d751-796d" name="Bayonet" hidden="false" collective="false" import="true" targetId="6904-6936-d6ca-a0eb" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
                       <conditions>
-                        <condition field="selections" scope="c831-444b-9325-de3b" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b379-f37a-e8b5-ead4" type="equalTo"/>
+                        <condition field="selections" scope="c831-444b-9325-de3b" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b379-f37a-e8b5-ead4" type="equalTo" />
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="150e-1c72-3603-d9e4" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="150e-1c72-3603-d9e4" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="1356-b4f4-a09e-d06b" name="Chain Bayonet" hidden="false" collective="false" import="true" targetId="bd82-cef6-67f8-19b5" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
                       <conditions>
-                        <condition field="selections" scope="c831-444b-9325-de3b" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b379-f37a-e8b5-ead4" type="equalTo"/>
+                        <condition field="selections" scope="c831-444b-9325-de3b" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b379-f37a-e8b5-ead4" type="equalTo" />
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f58-d544-d74f-04b2" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f58-d544-d74f-04b2" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1558,22 +1557,22 @@
           <modifiers>
             <modifier type="increment" field="0a63-eb3b-2427-4dd3" value="1.0">
               <repeats>
-                <repeat field="selections" scope="f9e4-0da2-5049-df81" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="2329-ea89-f938-82e1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9e4-0da2-5049-df81" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="2329-ea89-f938-82e1" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a63-eb3b-2427-4dd3" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a63-eb3b-2427-4dd3" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="7cfe-3f69-d5e1-a2da" name="Bayonet" hidden="false" collective="false" import="true" targetId="6904-6936-d6ca-a0eb" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0" />
               </costs>
             </entryLink>
             <entryLink id="8db1-1ee8-a4e0-988d" name="Chain Bayonet" hidden="false" collective="false" import="true" targetId="bd82-cef6-67f8-19b5" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -1582,42 +1581,42 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="11.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
+                <condition field="selections" scope="parent" value="11.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18f9-b7fe-ee4a-bcc0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18f9-b7fe-ee4a-bcc0" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="56c3-4c49-dd3a-9dc7" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="a1a3-3528-69d6-45ed" name="1) Immortals" hidden="false" collective="false" import="true" defaultSelectionEntryId="2329-ea89-f938-82e1">
           <constraints>
-            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69e7-7cd2-3ebb-9c3c" type="max"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c01-58a3-8ff7-1f5c" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69e7-7cd2-3ebb-9c3c" type="max" />
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c01-58a3-8ff7-1f5c" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="fbb8-920f-1fc0-33b7" name="Immortal w/Heavy Weapon (1 in 5)" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="b46e-80dc-b21f-7070" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="f9e4-0da2-5049-df81" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="f9e4-0da2-5049-df81" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b46e-80dc-b21f-7070" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b46e-80dc-b21f-7070" type="max" />
               </constraints>
               <profiles>
                 <profile id="aa60-7d53-32da-e32e" name="Immortal" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e"/>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e" />
                     <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
@@ -1632,46 +1631,46 @@
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="49a1-da73-5b34-36d5" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-                <categoryLink id="8046-11c0-741f-8507" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+                <categoryLink id="49a1-da73-5b34-36d5" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+                <categoryLink id="8046-11c0-741f-8507" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="5c24-cc99-00cd-564a" name="Heavy Weapon Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2fcc-c821-e9de-ad5b">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0464-2751-fd84-bae8" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af85-6fe9-c30d-5003" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0464-2751-fd84-bae8" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af85-6fe9-c30d-5003" type="min" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="24b3-a0a9-6f8f-cd8f" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="e7ca-f147-3449-1ff3" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="2fcc-c821-e9de-ad5b" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="910f-8ff2-d876-25fb" name="Lascutter" hidden="false" collective="false" import="true" targetId="6331-c1b9-bf0e-d0e5" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="b6b1-d17c-c2f5-8c2b" name="Graviton Shredder" hidden="false" collective="false" import="true" targetId="0849-b63b-0b1b-fd4f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="2329-ea89-f938-82e1" name="Immortal w/Bolter" hidden="false" collective="false" import="true" type="model">
@@ -1695,13 +1694,13 @@
               <entryLinks>
                 <entryLink id="6a5b-e18c-fc0e-db13" name="Bolter" hidden="false" collective="false" import="true" targetId="a080-c391-6083-5e5d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7df6-c238-852c-6421" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8886-c93e-d942-53d4" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7df6-c238-852c-6421" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8886-c93e-d942-53d4" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="e55b-24af-5f9c-7361" name="Immortal w/Volkite Charger" hidden="false" collective="false" import="true" type="model">
@@ -1725,13 +1724,13 @@
               <entryLinks>
                 <entryLink id="fe62-12f7-e3bb-708a" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="5c82-c306-9c5c-5908" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="747c-5b79-9c35-2438" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a0e-b974-3dc7-34fd" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="747c-5b79-9c35-2438" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a0e-b974-3dc7-34fd" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="f562-5d9a-3e00-a74d" name="Immortal w/Chainsword" hidden="false" collective="false" import="true" type="model">
@@ -1755,13 +1754,13 @@
               <entryLinks>
                 <entryLink id="ae9b-61bc-f717-dd25" name="Chainsword" hidden="false" collective="false" import="true" targetId="b5b7-b50a-ac86-9173" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf45-de9b-52f6-e606" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d5b-c05e-8e09-2bdf" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf45-de9b-52f6-e606" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d5b-c05e-8e09-2bdf" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1770,54 +1769,54 @@
       <entryLinks>
         <entryLink id="29cd-ed01-42a2-7b7e" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e859-a102-ff38-a3f6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af1e-0665-e9c4-fdc3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e859-a102-ff38-a3f6" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af1e-0665-e9c4-fdc3" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="8ccb-70e1-92aa-befe" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5c4f-663d-2432-b0e3" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="e33b-e155-13fd-22a9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5c4f-663d-2432-b0e3" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="e33b-e155-13fd-22a9" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="0864-d204-f9d4-3fe5" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4443-9d8b-ab93-53d0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2088-a800-a705-bda5" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4443-9d8b-ab93-53d0" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2088-a800-a705-bda5" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="8e83-6fc6-2e35-812f" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0f86-6040-32d4-8b04" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c1a0-062a-2e87-92fc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0f86-6040-32d4-8b04" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c1a0-062a-2e87-92fc" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="e7f7-0895-6c03-c9ad" name="Boarding Shield" hidden="false" collective="false" import="true" targetId="0c0f-f751-cc4e-4951" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6e77-fe33-4291-910d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eac2-d65d-e13d-6eeb" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6e77-fe33-4291-910d" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eac2-d65d-e13d-6eeb" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="554b-1024-a345-0d14" name="Ferrus Manus" publicationId="817a-6288-e016-7469" page="280" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5bb9-b8ff-92fb-a4d6" type="max"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bbac-3de7-7dbd-15c1" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5bb9-b8ff-92fb-a4d6" type="max" />
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bbac-3de7-7dbd-15c1" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="ea33-c875-88be-d428" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="9014-262a-9067-0e59" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="d7ac-8652-d9dd-8de6" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="ea33-c875-88be-d428" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="9014-262a-9067-0e59" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="d7ac-8652-d9dd-8de6" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6b2c-960f-6914-2c01" name="Ferrus Manus" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2015-d204-2425-4b24" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c73f-2752-ee33-ef2d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2015-d204-2425-4b24" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c73f-2752-ee33-ef2d" type="min" />
           </constraints>
           <profiles>
             <profile id="d4e7-a0b0-4338-bd56" name="Ferrus Manus" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -1839,21 +1838,21 @@
           <infoLinks>
             <infoLink id="953a-81e8-3c48-c8ec" name="Battlesmith (X)" hidden="false" targetId="5d57-4d02-1e36-4a82" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Battlesmith (2+)"/>
+                <modifier type="set" field="name" value="Battlesmith (2+)" />
               </modifiers>
             </infoLink>
             <infoLink id="105b-ec0f-fc4d-99fd" name="Firing Protocols (X)" hidden="false" targetId="32a3-f599-5c92-2945" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Firing Protocols (3)"/>
+                <modifier type="set" field="name" value="Firing Protocols (3)" />
               </modifiers>
             </infoLink>
-            <infoLink id="5395-1a9f-10c7-a5dd" name="Legiones Astartes (Iron Hands) " hidden="false" targetId="2e45-4b61-44fb-260b" type="rule"/>
+            <infoLink id="5395-1a9f-10c7-a5dd" name="Legiones Astartes (Iron Hands) " hidden="false" targetId="2e45-4b61-44fb-260b" type="rule" />
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="d8b9-24a9-2ad2-72d4" name="Forgebreaker" publicationId="817a-6288-e016-7469" page="281" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db5d-62bb-7495-5d8d" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3c5-07c8-e92b-3ade" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db5d-62bb-7495-5d8d" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3c5-07c8-e92b-3ade" type="min" />
               </constraints>
               <profiles>
                 <profile id="6444-8212-2829-0f03" name="Forgebreaker" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1866,26 +1865,26 @@
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="35b8-f9e3-cd86-d4fd" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="35b8-f9e3-cd86-d4fd" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
                 <infoLink id="6c15-3ba3-6b4a-9cea" name="Exoshock (X)" hidden="false" targetId="69ca-318a-b47a-7a3c" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Exoshock (3+)"/>
+                    <modifier type="set" field="name" value="Exoshock (3+)" />
                   </modifiers>
                 </infoLink>
                 <infoLink id="b973-54a9-26f9-6cbc" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Brutal (3)"/>
+                    <modifier type="set" field="name" value="Brutal (3)" />
                   </modifiers>
                 </infoLink>
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="9553-da46-1067-b72c" name="The Medusan Carapace" publicationId="817a-6288-e016-7469" page="281" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ec8-e96f-172f-ea78" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e460-4b82-5eec-c35c" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ec8-e96f-172f-ea78" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e460-4b82-5eec-c35c" type="min" />
               </constraints>
               <profiles>
                 <profile id="f106-46c8-97ad-e6f8" name="The Medusan Carapace" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
@@ -1895,95 +1894,95 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="2318-ef55-a30e-9a25" name="Graviton Shredder" hidden="false" collective="false" import="true" targetId="0849-b63b-0b1b-fd4f" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="name" value="Master-crafted gravitron shredder"/>
+                <modifier type="set" field="name" value="Master-crafted gravitron shredder" />
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2fc7-0b16-d667-f4a0" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="21c1-0aef-72a0-8437" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2fc7-0b16-d667-f4a0" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="21c1-0aef-72a0-8437" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="2c5f-3e0e-c1de-3696" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="2c5f-3e0e-c1de-3696" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
               </infoLinks>
             </entryLink>
             <entryLink id="d559-4570-b59a-7122" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e3c3-3760-d3e6-444f" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7ca8-a5f5-ec30-8ca5" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e3c3-3760-d3e6-444f" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7ca8-a5f5-ec30-8ca5" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="29cd-6cfa-09bc-e643" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="06a8-6294-bfaf-896e" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a01f-9f8b-7f24-4edc" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="06a8-6294-bfaf-896e" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a01f-9f8b-7f24-4edc" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="ee23-700b-a686-3259" name="Plasma Blaster" hidden="false" collective="false" import="true" targetId="cd52-e9e8-3ab1-995c" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="name" value="Master-crafted plasma blaster"/>
+                <modifier type="set" field="name" value="Master-crafted plasma blaster" />
               </modifiers>
               <infoLinks>
-                <infoLink id="4020-4046-51a9-10c5" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="4020-4046-51a9-10c5" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
               </infoLinks>
             </entryLink>
             <entryLink id="9f9e-2a43-4724-15a2" name="Servo-Arm" hidden="false" collective="false" import="true" targetId="4168-fc85-8912-7188" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="84cb-970c-4831-3a3a" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="47e8-9de1-5095-679a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="84cb-970c-4831-3a3a" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="47e8-9de1-5095-679a" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="4e33-2aa0-fd61-4a1f" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8023-5cdb-d7bc-548a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad73-f024-6bc5-ab17" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8023-5cdb-d7bc-548a" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad73-f024-6bc5-ab17" type="min" />
           </constraints>
           <profiles>
             <profile id="d201-1df0-bb07-e209" name="Sire of the Iron Hands" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All models with the infantry unit type and the Legiones Astartes  (Iron Hands) special rule in the same army as Ferrus Manus gain the Feel No Pain (+6). )This does not stack with other versions of the same special rule and models that already have a better version of the special rule may use either at the choice of the controlling player.) and all models with both the Vehicle unit type and the Legiones Astartes (Iron Hands) special rule gain the It Will Not Die (5+) special rule. In addition, an army with Ferrys Manus gains an additional Reaction in the opposing Player&apos;s Assult phase as long as Ferrus Manus has not been removed as a casualty. </characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All models with the infantry unit type and the Legiones Astartes  (Iron Hands) special rule in the same army as Ferrus Manus gain the Feel No Pain (+6). )This does not stack with other versions of the same special rule and models that already have a better version of the special rule may use either at the choice of the controlling player.) and all models with both the Vehicle unit type and the Legiones Astartes (Iron Hands) special rule gain the It Will Not Die (5+) special rule. In addition, an army with Ferrys Manus gains an additional Reaction in the opposing Player's Assult phase as long as Ferrus Manus has not been removed as a casualty. </characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
         <entryLink id="6028-f01f-0288-e01d" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="115e-61df-b95e-9c12" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f53a-fc81-6377-250a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="115e-61df-b95e-9c12" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f53a-fc81-6377-250a" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="465.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="465.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="0283-efdd-6ee3-6741" name="Iron Father Autek Mor" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6a7d-46e8-4f67-aa91" type="max"/>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9e96-f78b-5bbc-f13d" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6a7d-46e8-4f67-aa91" type="max" />
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9e96-f78b-5bbc-f13d" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="f1af-c02b-85f4-4611" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="4cb3-dd41-3d7c-685e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="d41e-871d-300d-cb4b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="f1af-c02b-85f4-4611" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="4cb3-dd41-3d7c-685e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="d41e-871d-300d-cb4b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9aef-f396-b30d-8cd0" name="Iron Father Autek Mor" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c97-08c5-f603-a33c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3394-a09e-c924-e21d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c97-08c5-f603-a33c" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3394-a09e-c924-e21d" type="max" />
           </constraints>
           <profiles>
             <profile id="6be7-eb7c-96d5-fa12" name="Iron Father Autek Mor" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2010,27 +2009,27 @@
           <infoLinks>
             <infoLink id="18e5-53a4-4720-b6b2" name="Battlesmith (X)" hidden="false" targetId="5d57-4d02-1e36-4a82" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Battlesmith (3+)"/>
+                <modifier type="set" field="name" value="Battlesmith (3+)" />
               </modifiers>
             </infoLink>
             <infoLink id="cdc8-a07c-e7b2-7541" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Bulky (2)"/>
+                <modifier type="set" field="name" value="Bulky (2)" />
               </modifiers>
             </infoLink>
             <infoLink id="4585-da80-77ac-0701" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+                <modifier type="set" field="name" value="Feel No Pain (5+)" />
               </modifiers>
             </infoLink>
-            <infoLink id="f93a-c80e-3b93-e746" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
-            <infoLink id="eb66-9d2b-3d3f-6871" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+            <infoLink id="f93a-c80e-3b93-e746" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule" />
+            <infoLink id="eb66-9d2b-3d3f-6871" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="ef4b-7287-2ab3-5886" name="Argonikos" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="188c-c870-b656-1100" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2ed7-a89e-cc98-3f0a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="188c-c870-b656-1100" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2ed7-a89e-cc98-3f0a" type="max" />
               </constraints>
               <profiles>
                 <profile id="c583-8cde-f351-cf47" name="Argonikos" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2045,19 +2044,19 @@
               <infoLinks>
                 <infoLink id="fc1c-cd7f-6582-52ba" name="Reaping Blow (X)" hidden="false" targetId="bd8c-4f52-d682-1b40" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Reaping Blow (2)"/>
+                    <modifier type="set" field="name" value="Reaping Blow (2)" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="c96e-12e5-c3de-4072" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+                <infoLink id="c96e-12e5-c3de-4072" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="1782-e1aa-a946-88d2" name="Manipulator Array" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1801-7421-2046-bf8a" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d60d-782c-90e8-d499" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1801-7421-2046-bf8a" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d60d-782c-90e8-d499" type="max" />
               </constraints>
               <profiles>
                 <profile id="4a3a-0b6b-002f-c308" name="Manipulator Array" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2070,83 +2069,83 @@
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="dfd0-a2a7-7025-0f3f" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
-                <infoLink id="8d89-5fd8-56f0-15be" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+                <infoLink id="dfd0-a2a7-7025-0f3f" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
+                <infoLink id="8d89-5fd8-56f0-15be" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
                 <infoLink id="106f-ac9c-b12c-573a" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Precision Strikes (3+)"/>
+                    <modifier type="set" field="name" value="Precision Strikes (3+)" />
                   </modifiers>
                 </infoLink>
                 <infoLink id="02cb-f9e3-4df4-578d" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Armourbane (Melee)"/>
+                    <modifier type="set" field="name" value="Armourbane (Melee)" />
                   </modifiers>
                 </infoLink>
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="93c5-b805-4b68-6460" name="Cyber-Familiar" hidden="false" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e956-c702-4c8e-2500" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="af25-6aef-68d7-04e2" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e956-c702-4c8e-2500" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="af25-6aef-68d7-04e2" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="2fa7-5eaa-4292-6e3f" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0bf9-6291-98b7-0ef2" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="efe7-524b-ecea-0505" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0bf9-6291-98b7-0ef2" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="efe7-524b-ecea-0505" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="6ea9-1d51-bd12-0eae" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1aa-05bf-dc51-e4ac" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1aa-05bf-dc51-e4ac" type="max" />
           </constraints>
           <profiles>
-            <profile id="68b9-f695-8368-7e20" name="Tyrant&apos;s Wrath" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+            <profile id="68b9-f695-8368-7e20" name="Tyrant's Wrath" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any unit made up of models with the Legiones Astartes (Iron Hands) special rule that a Warlord with this Trait has joined, may add +1 to the amount of wounds caused when calculating who has won in close combat. At the end of the combat, after Pile-in or Consolidation moves are made, a unit that has added this bonus suffers a single wound with no Armour Saves or Damage Mitigation rolls allowed. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any unit made up of models with the Legiones Astartes (Iron Hands) special rule that a Warlord with this Trait has joined, may add +1 to the amount of wounds caused when calculating who has won in close combat. At the end of the combat, after Pile-in or Consolidation moves are made, a unit that has added this bonus suffers a single wound with no Armour Saves or Damage Mitigation rolls allowed. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
         <entryLink id="bb06-7ce9-19a2-e2cf" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d1e9-ab16-4519-6bbc" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c25-3ff9-da70-cbca" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d1e9-ab16-4519-6bbc" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c25-3ff9-da70-cbca" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="3215-b221-94ce-89ce" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup"/>
+        <entryLink id="3215-b221-94ce-89ce" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="225.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="225.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="44c8-4cd9-3121-5a52" name="Shadrak Meduson" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6bfb-1f1f-67e0-0d4b" type="max"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7b9a-32a2-58e0-b6dc" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6bfb-1f1f-67e0-0d4b" type="max" />
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7b9a-32a2-58e0-b6dc" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="66f5-3b86-bd2f-710f" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="b22b-21c0-8c4b-d804" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="87be-a40d-63fe-1eed" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="66f5-3b86-bd2f-710f" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="b22b-21c0-8c4b-d804" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="87be-a40d-63fe-1eed" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="94ef-185a-f5bc-cc1c" name="Shadrak Meduson" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3187-c2a5-59ab-e77d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="869b-c5d2-e9ca-fad0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3187-c2a5-59ab-e77d" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="869b-c5d2-e9ca-fad0" type="max" />
           </constraints>
           <profiles>
             <profile id="aa84-8156-adf8-6d51" name="Shadrak Meduson" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2166,13 +2165,13 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="03df-cf4e-8145-84cf" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+            <infoLink id="03df-cf4e-8145-84cf" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="09cb-065d-9ee0-ac34" name="Albian power gladius" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8323-2174-4b9d-5ab7" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bd0d-8574-2858-535f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8323-2174-4b9d-5ab7" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bd0d-8574-2858-535f" type="max" />
               </constraints>
               <profiles>
                 <profile id="8396-f6d5-3317-df44" name="Albian power gladius" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2187,82 +2186,82 @@
               <infoLinks>
                 <infoLink id="8c57-32cb-7956-b6fb" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Breaching (5+)"/>
+                    <modifier type="set" field="name" value="Breaching (5+)" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="a96f-cef1-3a9c-6aa5" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="a96f-cef1-3a9c-6aa5" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="50a4-48ab-7521-2710" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8cc2-0df9-4e2e-f265" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4553-ed2c-754d-cfbf" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8cc2-0df9-4e2e-f265" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4553-ed2c-754d-cfbf" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="10db-a1a9-318c-4417" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1266-a91b-53ed-5bcb" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2322-26b3-54d3-fc5f" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1266-a91b-53ed-5bcb" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2322-26b3-54d3-fc5f" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="52c0-57aa-6dc4-d949" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c6b8-37df-e747-0674" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c5f6-3819-76c9-65db" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c6b8-37df-e747-0674" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c5f6-3819-76c9-65db" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="d75b-eb77-7186-6868" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ea6c-d5d7-a228-6e22" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fe1d-a670-0be4-d20b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ea6c-d5d7-a228-6e22" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fe1d-a670-0be4-d20b" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="1a34-fb33-5155-2d55" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="25fa-02b8-c2ce-aee2" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="781f-f01c-2dc5-7cec" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="25fa-02b8-c2ce-aee2" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="781f-f01c-2dc5-7cec" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="40d3-b640-81bf-11f0" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d583-2a9e-ccaa-e17c" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aede-cbde-3573-6fac" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d583-2a9e-ccaa-e17c" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aede-cbde-3573-6fac" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="061b-8551-7b4b-31d3" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb22-361d-a505-a593" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb22-361d-a505-a593" type="max" />
           </constraints>
           <profiles>
             <profile id="1c4a-b0ba-900c-cc16" name="Storm Bringer" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Shadrak Meduson and any friendly models with the Legiones Astartes (Iron Hands) special rule in a unit he has joined gain the Furious Charge (1) Special Rule. Note that if the unit already has a version of the Furious Charge special rule then this does not stack or increase that rule, and the controlling player may choose to use any one of the Furious Charge rules available to them. In addition, an army whose Warlord is Shadrak Meduson may make an additional Reaction in the opposing player’s Assault phase, as long as Shadrak Meduson has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Shadrak Meduson and any friendly models with the Legiones Astartes (Iron Hands) special rule in a unit he has joined gain the Furious Charge (1) Special Rule. Note that if the unit already has a version of the Furious Charge special rule then this does not stack or increase that rule, and the controlling player may choose to use any one of the Furious Charge rules available to them. In addition, an army whose Warlord is Shadrak Meduson may make an additional Reaction in the opposing player&#8217;s Assault phase, as long as Shadrak Meduson has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
         <entryLink id="35ad-5d30-9ad4-43d6" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="047c-939c-4487-2462" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7f30-df9f-ff46-9763" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="047c-939c-4487-2462" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7f30-df9f-ff46-9763" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="c2f7-bcb4-705f-cb0a" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup"/>
+        <entryLink id="c2f7-bcb4-705f-cb0a" name="Retinue" hidden="false" collective="false" import="true" targetId="8a62-e4e2-d57f-5c33" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -2271,124 +2270,124 @@
       <modifiers>
         <modifier type="set" field="fd1f-23dc-7872-4e03" value="1.0">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="151b-0067-9b80-7e9c" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd1f-23dc-7872-4e03" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="151b-0067-9b80-7e9c" type="max" />
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd1f-23dc-7872-4e03" type="min" />
       </constraints>
       <selectionEntryGroups>
         <selectionEntryGroup id="f787-2176-c2c2-fd23" name=" X: Iron Hands" publicationId="817a-6288-e016-7469" page="276" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="823d-dd6e-8769-250e" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a9c1-6795-5583-8743" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="823d-dd6e-8769-250e" type="max" />
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a9c1-6795-5583-8743" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="8848-6fa6-d46b-5e5c" name="The Eye of Vigilance (Traitor only)" publicationId="817a-6288-e016-7469" page="276" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8b6a-3304-ea3d-e16d" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="327c-1588-9c20-64a9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8b6a-3304-ea3d-e16d" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="327c-1588-9c20-64a9" type="max" />
               </constraints>
               <profiles>
                 <profile id="54a7-1bf9-2236-b2ae" name="The Eye of Vigilance" publicationId="817a-6288-e016-7469" page="276" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Traitor Allegiance.
-A Warlord with this Trait, and all models in any friendly unit that Warlord joins, gains the Preferred Enemy (Loyalist) special rule. In addition, once per battle, while the controlling player is the Reactive Player, the Warlord and any unit the Warlord has joined may make a single Reaction without expending a point from the army’s Reaction Allotment – this can allow the Warlord and his unit to make more than one Reaction in the same Phase, but that unit may not make the same Reaction twice.</characteristic>
+A Warlord with this Trait, and all models in any friendly unit that Warlord joins, gains the Preferred Enemy (Loyalist) special rule. In addition, once per battle, while the controlling player is the Reactive Player, the Warlord and any unit the Warlord has joined may make a single Reaction without expending a point from the army&#8217;s Reaction Allotment &#8211; this can allow the Warlord and his unit to make more than one Reaction in the same Phase, but that unit may not make the same Reaction twice.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="faa2-7825-f4a9-f003" name="Silver-iron Will" publicationId="817a-6288-e016-7469" page="276" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9f3d-fe61-27d3-aff9" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ef50-7e8b-8ce4-e3c9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9f3d-fe61-27d3-aff9" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ef50-7e8b-8ce4-e3c9" type="max" />
               </constraints>
               <profiles>
                 <profile id="3f91-3b60-998f-e5dd" name="Silver-iron Will" publicationId="817a-6288-e016-7469" page="276" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait and all models in any unit he has joined are never affected by any special rule or effect that lowers a Characteristic – including the Fear (X) and Rad-phage special rules and due to losing an assault where the enemy has inflicted more Wounds. In addition, an army whose Warlord has this Trait may not make Reactions during the Movement phase, but may make an additional Reaction in either one of the opposing player’s Shooting or Assault phases (but not both). If the Warlord is removed as a casualty then this additional Reaction is lost, but the army may make Reactions in the Movement phase as normal in any appropriate Phases after the Warlord has been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait and all models in any unit he has joined are never affected by any special rule or effect that lowers a Characteristic &#8211; including the Fear (X) and Rad-phage special rules and due to losing an assault where the enemy has inflicted more Wounds. In addition, an army whose Warlord has this Trait may not make Reactions during the Movement phase, but may make an additional Reaction in either one of the opposing player&#8217;s Shooting or Assault phases (but not both). If the Warlord is removed as a casualty then this additional Reaction is lost, but the army may make Reactions in the Movement phase as normal in any appropriate Phases after the Warlord has been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
-            <selectionEntry id="d39b-0ea5-6284-3211" name="From Hel’s Heart (Loyalist only)" publicationId="817a-6288-e016-7469" page="276" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="d39b-0ea5-6284-3211" name="From Hel&#8217;s Heart (Loyalist only)" publicationId="817a-6288-e016-7469" page="276" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6d3d-c5fe-9bce-b305" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="95da-8e31-9a49-6225" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6d3d-c5fe-9bce-b305" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="95da-8e31-9a49-6225" type="max" />
               </constraints>
               <profiles>
-                <profile id="199b-707a-a056-d412" name="From Hel’s Heart" publicationId="817a-6288-e016-7469" page="276" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="199b-707a-a056-d412" name="From Hel&#8217;s Heart" publicationId="817a-6288-e016-7469" page="276" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Loyalist Allegiance.
-A Warlord with this Trait, and all models in any unit he joins, gain the Fear (1) special rule and should the Warlord be reduced to 0 Wounds, the controlling player may choose to inflict D6 automatic Hits upon the unit whose attacks caused the final Wound, with these Hits allocated as per the standard rules. Each Hit is resolved using the profile of either any one of the Warlord’s ranged weapons if he lost his last Wound to a Shooting Attack, or using the profile of any one of the Warlord’s melee weapons if he lost his last Wound as part of an Assault, with all Hits resolved using the same profile (if the Wound is lost to neither a Shooting Attack nor a Melee Attack then this rule has no effect and no Hits are inflicted). In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+A Warlord with this Trait, and all models in any unit he joins, gain the Fear (1) special rule and should the Warlord be reduced to 0 Wounds, the controlling player may choose to inflict D6 automatic Hits upon the unit whose attacks caused the final Wound, with these Hits allocated as per the standard rules. Each Hit is resolved using the profile of either any one of the Warlord&#8217;s ranged weapons if he lost his last Wound to a Shooting Attack, or using the profile of any one of the Warlord&#8217;s melee weapons if he lost his last Wound as part of an Assault, with all Hits resolved using the same profile (if the Wound is lost to neither a Shooting Attack nor a Melee Attack then this rule has no effect and no Hits are inflicted). In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="05d9-9067-a598-766b" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+        <entryLink id="05d9-9067-a598-766b" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="8a62-e4e2-d57f-5c33" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="8047-f642-a311-b9b4" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="8047-f642-a311-b9b4" type="max" />
       </constraints>
       <entryLinks>
         <entryLink id="6e43-86d1-126f-4268" name="Command Squad, Cataphractii" hidden="false" collective="false" import="true" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="9f8a-3c65-6a66-e294" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
-        <entryLink id="92a3-5f51-0863-b6f8" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="9f8a-3c65-6a66-e294" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
+        <entryLink id="92a3-5f51-0863-b6f8" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Iron Warriors.cat
+++ b/2022 - LA - Iron Warriors.cat
@@ -1,6 +1,5 @@
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="2ee4-57ed-db44-8a63" name="LA -   IV: Iron Warriors" revision="17" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="29">
-  <entryLinks>
-    <entryLink id="fe10-3104-0252-96de" name="N&#226;rik Dreygur" hidden="true" collective="false" import="false" targetId="ac97-c8ce-16ba-9c49" type="selectionEntry">
+  <entryLinks><entryLink id="fe10-3104-0252-96de" name="N&#226;rik Dreygur" hidden="true" collective="false" import="false" targetId="ac97-c8ce-16ba-9c49" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -144,970 +143,1955 @@
         <categoryLink id="4a17-436d-d77f-9962" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="66d0-dab6-1aa9-95e1" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2339-93ae-9a31-3713" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c08a-3cde-7675-39eb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <entryLink id="66d0-dab6-1aa9-95e1" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="3480-0120-402f-9064" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6d4-581f-4746-bec3</comment></categoryLink>
+        <categoryLink id="f044-1ca9-4bac-955d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_2489-ee2a-45dd-b384</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
-    <entryLink id="910e-db57-8bf7-37b3" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9a27-96b5-d38d-eb8d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="824b-1bbe-552c-38d5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
-    <entryLink id="19a9-0c79-2acf-5beb" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink><entryLink id="910e-db57-8bf7-37b3" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b02f-e65f-4a88-a175</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_b87b-bf35-4238-b7c6</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1aff-27af-435e-8102</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_fdf9-4906-4180-a39d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2ca9-a2a3-04f2-9611" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="b70b-5b20-bed2-cf21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f6cd-9e7d-a5a3-6c59" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="e27d-220f-4a03-b6c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8378-ede4-476d-b657</comment></categoryLink>
+        <categoryLink id="1d60-3fa4-4195-ab02" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_d64f-ad19-426c-adf7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
-    <entryLink id="0f30-a6a9-c5b0-8ff0" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="f304-140b-60e4-c295" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="b95b-a766-4df8-abce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
-    <entryLink id="a5ba-c991-749b-898c" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e472-3b9d-e1bc-74e5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="ed2f-76c6-c5a0-105d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
-    <entryLink id="be21-9e50-1c3c-5076" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink><entryLink id="19a9-0c79-2acf-5beb" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_7fd1-8ce8-4d10-82e7</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_eaae-8c43-4d30-898c</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_f67d-8cf3-424f-b491</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_b949-6414-4f3d-b268</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f471-f8fd-d5ec-2e28" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="ca2d-8576-e9a5-fe1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8037-fb5c-9320-f27c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="c590-d302-4ddc-a356" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_ac26-e639-4d53-9b8b</comment></categoryLink>
+        <categoryLink id="69bf-4ea2-40b0-96ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_49af-0d08-4c7e-8ce6</comment></categoryLink>
+        <categoryLink id="873b-3f72-47e6-b16e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_b606-de16-4659-95cd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
-    <entryLink id="ef72-0d05-0a10-b9c0" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink><entryLink id="0f30-a6a9-c5b0-8ff0" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d086-3bb9-7bc2-5f75" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="b10d-42b8-3d7f-9a88" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
-    <entryLink id="a824-3610-2f85-23f4" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7583-6fa0-4089-a19e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_0e5c-99ab-41d3-a42e</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c296-e8e8-4a7a-989a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_8868-5bcb-4604-ba8e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="095a-8309-442d-8b8c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a009-a597-4b51-b228</comment></categoryLink>
+        <categoryLink id="926d-32ad-4163-9ea0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_24f4-9145-4016-80d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink><entryLink id="a5ba-c991-749b-898c" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_e732-7499-47bf-9748</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_81a5-a959-46b7-baa4</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7ec3-447a-4644-b012</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_71e2-c430-4c99-a559</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_df7b-3fb9-4f65-9165</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="60e0-2033-46ad-a797" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c165-3906-463a-9c73</comment></categoryLink>
+        <categoryLink id="4266-0626-4e8b-95ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6d1-d14c-473f-be09</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink><entryLink id="be21-9e50-1c3c-5076" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_27a3-1e4c-4b76-a594</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_d59a-dcd0-44fd-b866</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_0c8b-2b92-49ed-98c7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_bafe-f799-41d9-ac85</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_6369-288c-4fec-a640</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_fe53-8858-41dc-8ec4</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="52d4-20e2-b5ed-8900" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="846c-a018-f8a3-e78c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3e62-cb74-4bd2-8b75" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_3a22-caae-4eea-9bc5</comment></categoryLink>
+        <categoryLink id="cfc1-e3b1-4a06-80d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f759-f33e-4698-9f8a</comment></categoryLink>
+        <categoryLink id="1cbd-6dfa-412b-a0b9" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_c624-3ae0-46c0-9b06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
-    <entryLink id="b3b9-a1ba-0c76-0be1" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5479-41b7-273e-ba57" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="9079-51aa-5e7e-5de9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="cdf7-c602-9cdc-8429" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="02f3-3b9b-15e3-b1c9" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup" />
-        <entryLink id="28e3-321b-e149-3c0e" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink><entryLink id="ef72-0d05-0a10-b9c0" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_13b3-ce1e-4f9d-8319</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d681-9d81-4abd-b11b</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a57-e48b-4534-bca5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_1859-5641-4674-9097</comment>
+                </condition>
               </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
-    <entryLink id="fd61-4e6c-4dba-38a5" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
-      <modifiers>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9981-361e-47a2-bc0a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_251a-df5b-4bfd-ad63</comment></categoryLink>
+        <categoryLink id="90e4-0887-4f22-afe2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4644-98ab-4e3f-b1fd</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink><entryLink id="a824-3610-2f85-23f4" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_591d-d028-4663-918d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_0482-c5f9-4c95-9597</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_75a7-971d-4978-a83f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_a7d5-2bfe-4621-ac0c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9f13-b460-4f27-b0cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_31fc-e265-45a7-bb5b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2765-451e-b137-8298" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="49fe-d008-3c6f-a147" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="67ed-2abf-dbab-9a99" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="0ab3-6996-4738-8d35" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_67c2-df43-44fc-92d1</comment></categoryLink>
+        <categoryLink id="fc8b-e387-4c9a-8c08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4136-bb4e-4dd4-99f9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink><entryLink id="b3b9-a1ba-0c76-0be1" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry"><categoryLinks>
+        <categoryLink id="2cc2-0141-48aa-9425" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_2599-24e3-44e5-9568</comment></categoryLink>
+        <categoryLink id="145f-d5ef-45a4-bb63" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_285f-6e56-473b-b2fe</comment></categoryLink>
+        <categoryLink id="c71c-3b9e-4f6d-8f7c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_685e-022f-4e2f-a568</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="47e8-232a-f813-b1de" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup" />
-        <entryLink id="68ed-efab-d695-80a6" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup">
+        <entryLink id="6580-bafa-40eb-8d0d" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup"><comment>    template_id_2a38-6544-4267-b584    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="fda3-0662-4298-a9b4" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_8287-16ff-46ba-9838</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_81c1-fca9-44dc-ba4c</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_6e59-4592-47ef-b76d    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
-    <entryLink id="2e01-2fea-4564-cde8" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink><entryLink id="fd61-4e6c-4dba-38a5" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ad5d-3c79-4239-9116</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_60b1-049b-4a5f-85c2</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="ad10-2822-d6f3-5faa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="12c5-e1a9-1d43-eacb" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="bec7-13b6-471b-37c2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="eae0-c0a1-425f-9b02" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bd6a-0cda-4e0f-80ae</comment></categoryLink>
+        <categoryLink id="79c3-75c3-4738-8098" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_ae75-7cca-4701-9d56</comment></categoryLink>
+        <categoryLink id="7edf-55b9-42de-9706" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_e517-62d4-48f7-8174</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="05e4-26dc-4e5c-1b68" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup" />
-        <entryLink id="d826-77c9-5d8e-46f9" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup">
+        <entryLink id="8148-7730-48d4-8af3" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup"><comment>    template_id_fafb-6414-474a-8a09    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="3928-2a73-42a8-bb22" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_1e43-c980-4508-8ec2</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_4140-36a7-4203-b5e9</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_a6a6-9bc7-4d4e-86a7    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
-    <entryLink id="891b-f849-4179-2071" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0ae5-f3d2-43b8-f07c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="7f5f-a1f6-96c5-bcb5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink><entryLink id="2e01-2fea-4564-cde8" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry"><categoryLinks>
+        <categoryLink id="0795-8ad0-4168-8807" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fc9d-03d1-4bbd-a1c4</comment></categoryLink>
+        <categoryLink id="b5bb-04dd-4aec-be5c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_f51c-73d7-4f29-be1c</comment></categoryLink>
+        <categoryLink id="713b-44e8-4d73-90eb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_257d-78c0-4bab-ba65</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
-    <entryLink id="d1bf-1149-3a68-e317" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <entryLinks>
+        <entryLink id="3f44-1e71-4974-88b4" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup"><comment>    template_id_ac26-33db-40a7-bdba    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="51ba-965b-4e7f-879f" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_189b-db75-4db6-9fe9</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_cbdb-2500-4e13-876a</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_dc8e-2801-46d6-84f8    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink><entryLink id="891b-f849-4179-2071" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b43b-547f-472e-9076</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8ff9-0498-4540-8552</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fbfe-931a-489b-a589</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f4c3-5aa6-4caa-abf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_17f8-f055-4c9c-b757</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="6932-1690-b60d-53ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c6e2-9b2a-3c5f-5551" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="3467-53f0-4e43-9090" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f1c8-27fd-4f98-8527</comment></categoryLink>
+        <categoryLink id="7c50-c4ef-4e75-b303" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2b20-1a8b-4753-b657</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
-    <entryLink id="a2de-2601-7341-a58b" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink><entryLink id="d1bf-1149-3a68-e317" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_23fa-06dd-49f9-a7db</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5b26-059e-40b3-9d93</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f7bf-3a1c-4103-aed8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="65f2-4d62-ce1b-3938" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="bf48-2199-1971-a440" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e2be-bc6c-444c-bf15" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dd44-e0a8-42a8-bdcc</comment></categoryLink>
+        <categoryLink id="a0f8-b3c6-4e4d-935a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_c5b0-f9ae-468d-924a</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
-    <entryLink id="8fa9-6a06-2b7c-23c1" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink><entryLink id="a2de-2601-7341-a58b" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8396-e51c-4e2b-bada</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_13bb-9fb5-4580-92cf</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_bfb8-8125-4548-92f5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25e3-b8f5-4448-a7c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9e4f-5266-41cf-895a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_f926-27fd-4a92-97a1</comment></categoryLink>
+        <categoryLink id="572f-2424-4ccf-9aa7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_82e3-36e1-4e85-8fcb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink><entryLink id="8fa9-6a06-2b7c-23c1" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="fdca-882c-907a-656f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
         <categoryLink id="6e97-1320-d8bc-d928" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="a794-a023-9c8c-2a99" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
-      <modifiers>
+    <entryLink id="a794-a023-9c8c-2a99" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_658f-b1ad-4347-a998</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_12bc-3db2-4d28-abce</comment>
+            </condition>
           </conditions>
         </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="4d8c-50d0-0fad-aabc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="82c4-1284-3241-0234" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
-    <entryLink id="23f0-1740-f4e4-005f" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_9d83-7691-41d6-8dad</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_add7-ba48-46d4-8a02</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_1fb0-2421-40a4-9e49</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d565-e231-c7cc-dad0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="4b41-2860-b73b-36b7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e3a1-d878-d124-ea9d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="f2da-37d4-424c-92d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7004-b00d-481f-b740</comment></categoryLink>
+        <categoryLink id="6ab7-83f9-4fd1-80d3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4f88-2fc3-491c-bfb7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
-    <entryLink id="3a26-2631-a259-e7eb" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="03b2-35fc-13c1-1a95" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="790c-6f52-6389-0ec8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
-    <entryLink id="5b47-f6af-d9f3-aa17" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2d28-f74d-c6f9-6cc4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="f8a4-8649-246a-d43b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
-    <entryLink id="9eea-4f38-15d8-709e" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="732a-bf0a-fbe1-9072" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="83bb-470a-9752-3909" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
-    <entryLink id="f138-3e9f-27d9-1894" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b553-99bf-fd84-7042" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="33bd-daa1-1ac6-4a9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
-    <entryLink id="d6fe-9fe8-2d16-f05f" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="aa30-6175-bdf1-274a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e1ee-7f3d-2738-2557" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
-    <entryLink id="c54a-98be-4c8c-b986" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e923-aded-8787-05b6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="fec6-e8c2-5fb3-8a6c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
-    <entryLink id="c4be-f1d2-b4e4-2368" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="a4ad-92ce-1ecf-1f04" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="65a5-94cf-8c6e-1dee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
-    <entryLink id="2da2-a4bb-2d19-3f5a" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="c9cc-a355-e654-1ceb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8730-19a5-d9be-74ce" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
-    <entryLink id="88f8-8f15-3557-1fd7" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1496-c9e2-520b-ebc1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="dbd3-87e3-b5bc-81ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
-    <entryLink id="89c1-d7ab-0c11-fd80" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5abd-3b8a-87a0-e417" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2d29-70c1-30a7-8314" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
-    <entryLink id="a054-8fcc-6ad5-6b04" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="a5e9-2f17-cdd7-616b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="87c8-e23a-4fa3-394c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
-    <entryLink id="3d47-74eb-9941-0d1b" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="ef51-64c7-3a1c-3477" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="6f14-9fc4-b834-7574" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
-    <entryLink id="df4b-6149-47d9-a12e" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e0a0-152f-3978-5f9e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="b6db-894f-0246-1418" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
-    <entryLink id="5a31-fb32-ab18-bbfb" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8723-faec-89e5-88ee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2b2b-e5d6-7c9f-e90f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
-    <entryLink id="165e-4e79-911c-2ec0" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="755d-e23e-ac99-2894" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1c6c-d456-8f7f-9dae" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
-    <entryLink id="4401-1024-7e12-e6c2" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="5837-c1ba-6a20-0a63" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="0622-1da0-fee5-a3fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
-    <entryLink id="8532-6414-3304-df12" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7e41-3a91-4a34-d57e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="566e-f42e-68ed-faac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
-    <entryLink id="d3dc-d845-cc2a-0034" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0ae8-04bc-c760-ee71" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="f5b5-fa4e-8674-8aa3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
-    <entryLink id="33d5-a527-7327-6f0b" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e95f-1475-10b3-ff8a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="8434-4a31-20f1-69f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
-    <entryLink id="0ffa-c0a8-3d55-c6a7" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="bfc7-6e1e-3386-0c68" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="56c6-8a78-9103-ac32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
-    <entryLink id="1e92-5221-e3ab-2cc0" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="92f7-c001-d8b9-5ac9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="0bb1-7d83-7e8c-8f39" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
-    <entryLink id="ad57-864f-1271-eaf9" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="47dc-9d14-6804-12b7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="588d-1e81-0f6c-e8e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
-    <entryLink id="8f8b-c900-6eff-a33c" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="64f5-ae24-51c5-8606" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="7162-1b0c-26c3-9628" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
-    <entryLink id="fdde-30f4-4c3f-a916" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9242-b8ad-53af-00f8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="03ec-a16f-0545-cc14" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
-    <entryLink id="84e0-9ff7-a11d-73d1" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="95cc-a0e3-7c22-d141" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="668a-ad20-928e-e3eb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
-    <entryLink id="cd78-3a92-039d-5bdd" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7d91-a02d-52b1-693b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="8c3a-2ab9-03ec-2a68" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
-    <entryLink id="d4a6-50b9-fa28-fd20" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="86d4-1814-46c0-59da" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="7fe2-380b-8be3-1174" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
-    <entryLink id="f106-f532-e48b-122e" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4550-7c50-878a-5a12" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e5de-5249-3191-b610" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
-    <entryLink id="a1d1-2190-8894-032b" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e448-4ae2-ef3e-dd6e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="5569-eaef-9249-8c3b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
-    <entryLink id="8849-028a-7385-7638" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d6cf-6fda-3e03-5886" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="5dce-36eb-c3d3-a7bc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
-    <entryLink id="12ff-d11c-3933-74ab" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5584-80fa-9520-6016" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8b63-91ed-da36-20fc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
-    <entryLink id="4c07-c42c-76d5-bdb0" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f514-2d2f-d71f-4a4c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="0c0a-7dca-c05a-0c02" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="78f5-d1a1-1277-a225" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="53d7-8fc9-5fe7-6c3f" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup" />
-        <entryLink id="1e65-b6ca-42ec-7c77" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
-    <entryLink id="f437-01e0-3377-f816" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3887-7f0e-3031-886b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="f1ea-366d-a7e5-f689" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="87b2-35d1-eb65-61d2" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="9554-c773-913a-a4e7" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup" />
-        <entryLink id="0bb6-cf5b-3d95-5a2f" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
-    <entryLink id="d208-08ae-7eb0-91f9" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5ffd-0921-f375-47ba" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="0198-abcb-0e55-7e29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="edd1-ac09-6dc2-3752" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="be8d-2bb1-0779-ec6f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup" />
-        <entryLink id="976d-454f-82d3-9761" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
-    <entryLink id="b7da-ab33-b2b4-d945" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="bcce-7ffe-1719-0715" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2c03-fe62-ae37-fa14" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
-    <entryLink id="f45e-436f-6662-7304" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e8dd-96fc-93dc-86f9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="49f0-3dcc-0055-8126" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
-    <entryLink id="88ee-5558-83fa-5714" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ca93-2ddb-423b-5945" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="25e9-eaf7-1fe4-cbef" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
-    <entryLink id="61ed-4e55-a7ec-6bda" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8e89-f586-bace-e777" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="10a7-7c27-57a3-6dae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
-    <entryLink id="e61d-8855-f898-5f38" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="18dc-e8d0-2c58-3ea7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="a958-6d76-bd5c-5319" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
-    <entryLink id="0329-cab2-2daa-4baa" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3442-a2e2-0ae2-1b0d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="4359-2c5c-8299-5cae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
-    <entryLink id="cd4f-fb54-2b64-d47b" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6fdf-5314-9298-0955" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e9f2-55cd-5337-f54f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
-    <entryLink id="738a-3431-36a7-3fa6" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d942-91d3-b543-2ff3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="dd2a-180a-9293-61c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
-    <entryLink id="4181-41ef-e06f-60a5" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="751b-d884-6c84-80a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e58f-2106-1e57-11ee" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
-    <entryLink id="8ce3-2092-9f69-2379" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f7ad-7a76-75fd-6323" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="114e-b120-92fd-dbbb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
-    <entryLink id="d70d-082d-e74b-c141" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="43cf-f743-7a76-a072" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2400-2eb1-7903-8b52" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
-    <entryLink id="cf42-d578-6149-529c" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="fe85-e2cb-b1bb-1c34" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="bf58-7289-c006-4e1c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
-    <entryLink id="4aba-dfc5-b6ac-9881" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="52dc-b8bb-2b06-c9fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="163e-54d4-41ea-a209" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
-    <entryLink id="b6c8-3682-9ade-fd14" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3f6d-4e18-58c3-d74c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="cd01-0b40-2870-87d0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
-    <entryLink id="9847-9792-9726-d864" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="eb4c-640b-0e98-b478" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e96b-a59b-c820-1af7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
-    <entryLink id="3eb0-83a7-0893-0342" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4548-800d-5c39-8db5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="cc52-554c-d8c4-e9b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
-    <entryLink id="705d-1e9f-1eda-187b" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="fb76-acce-60dc-1fb6" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="6872-d952-166c-b566" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
-    <entryLink id="2cab-599b-7aca-b71e" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c425-6767-1e40-26d8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="4b2f-8cc0-d11a-7882" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
-    <entryLink id="26fc-1f77-f702-8275" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink><entryLink id="23f0-1740-f4e4-005f" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_8ed4-376d-4030-9439</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_8a11-c2a0-4335-99ef</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_fa8e-1af7-4d41-ac8c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_94bd-c771-4a85-8581</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b977-1383-c399-1c11" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1304-a4fe-8f32-8c9f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="3d76-62e4-26d2-a07f" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="db93-1605-4605-94c3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_361e-fb90-4b0e-ac3d</comment></categoryLink>
+        <categoryLink id="a077-017c-4442-bb3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d4ef-1074-45a9-959e</comment></categoryLink>
+        <categoryLink id="8489-fcd0-4f90-a2ab" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_febb-f536-4d25-a8ab</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
-    <entryLink id="c03f-c1cf-5451-8a71" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5623-5550-2fdc-ed9e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7fb8-a7a4-47bf-946d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink><entryLink id="3a26-2631-a259-e7eb" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="cda1-d0d1-482b-b163" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_473b-e812-4158-9416</comment></categoryLink>
+        <categoryLink id="07c1-4272-4338-ab97" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_00a2-63ff-4698-a35b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
-    <entryLink id="9098-f5bb-6560-b7ed" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink><entryLink id="5b47-f6af-d9f3-aa17" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7cf3-8a72-4f82-8cdc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_228c-5681-4ce8-b726</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_01bb-8abd-4253-9a4d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e126-8e97-6af8-0852" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="048a-6c30-801d-5478" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="fa03-9332-441f-9e4a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2a08-4432-42ad-bfdb</comment></categoryLink>
+        <categoryLink id="b1a7-093e-402b-9275" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_422e-0808-4897-8630</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
-    <entryLink id="a988-50f4-7bb2-fe34" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink><entryLink id="9eea-4f38-15d8-709e" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1af8-4459-4717-8e3b</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_06b4-92b9-438c-b1a5</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6c8d-8b28-417b-9a7c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_715d-8186-4aa6-b40c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_390e-358c-4f8e-ade8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="fb8f-6377-9b49-3370" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ab4e-c731-85a5-ada9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="0571-ed70-4eb3-aaf3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f4c0-4396-4f39-a34f</comment></categoryLink>
+        <categoryLink id="b42b-3442-4b95-9349" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1301-8415-490e-8f06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
-    <entryLink id="367c-b2ad-bcc9-b972" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink><entryLink id="f138-3e9f-27d9-1894" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d0c9-9a26-4324-b030</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4e9e-a61d-42f2-bacb</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ed9e-b634-4bec-9eb0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4614-ad0f-4fba-adaf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_8d08-24f6-41be-8931</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4604-bd74-40fe-8fc4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_caf6-5548-4b89-8102</comment></categoryLink>
+        <categoryLink id="ea56-d83a-4964-9e2b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_63a3-be61-428d-ab29</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink><entryLink id="d6fe-9fe8-2d16-f05f" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f318-4b03-4767-8c7f</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b8ef-7245-4df8-a8c4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_6bce-ec44-48cb-873a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="bab3-7f95-4133-9417" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0678-4fdd-48e6-8f61</comment></categoryLink>
+        <categoryLink id="018c-f3d6-4ab1-96b2" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0d82-10a9-4de2-8ad7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink><entryLink id="c54a-98be-4c8c-b986" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ada1-1e18-4cbc-9598</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b1d1-ac44-47dd-9159</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5d64-f00c-4464-891b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25f0-f825-4a83-8f0d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_64b1-9e36-44da-b36a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3df7-f550-4eb3-800b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_d53e-113f-4a40-a3d5</comment></categoryLink>
+        <categoryLink id="b4d4-0a58-4785-806d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1939-76b5-4279-9f8c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink><entryLink id="c4be-f1d2-b4e4-2368" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d765-3bb2-4b48-bd12</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_0ca1-cfb4-4a56-ab3b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b902-e766-f88a-c300" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="d80a-4c5d-e1db-7e8e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4ac2-2897-4488-9042" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e6f7-a6ca-4825-bfc5</comment></categoryLink>
+        <categoryLink id="de7a-dc1e-4bfc-9baf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dbec-e027-4ec1-8514</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
-    <entryLink id="f8dc-34ef-f371-c218" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink><entryLink id="2da2-a4bb-2d19-3f5a" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d8ee-81ed-45f9-8b79</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_8f4e-e8cb-4ac9-a415</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6062-9708-4eec-8d5f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_cefb-cfd7-4dc8-99c4</comment></categoryLink>
+        <categoryLink id="7bee-6aaf-45fc-b477" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a9fd-9d16-4a5e-855c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink><entryLink id="88f8-8f15-3557-1fd7" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e76b-46ca-4ab8-a93d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8035-75b8-43bb-97c9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_71a4-31e7-4927-a0ab</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b830-00ab-4d14-8e44" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_a56d-347b-4b09-a918</comment></categoryLink>
+        <categoryLink id="9e07-0767-407b-ae7d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_96e5-4531-4213-903e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink><entryLink id="89c1-d7ab-0c11-fd80" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1fb5-2375-4c22-b41e</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7d7c-255d-49b6-96b9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5321-254b-4890-9bf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ddf8-b8b7-4afb-b6dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="15fb-12b2-492f-bd8f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9441-d79b-4720-9667</comment></categoryLink>
+        <categoryLink id="9a61-6617-42a1-88b8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7d7e-32d3-4692-b401</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink><entryLink id="a054-8fcc-6ad5-6b04" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_99fc-5fe7-4b37-a62f</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_25f4-f6b8-4b44-8350</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_81f7-2311-4cce-95bc</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_09aa-af2a-4012-91d1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_00ae-fad3-4df6-9cb9</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="737d-bdad-c54e-4b3c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="541d-23ce-1ffa-4d42" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5014-85c3-4fa7-916b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f65b-8958-49b3-92a5</comment></categoryLink>
+        <categoryLink id="c486-7244-4be5-9aa2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0451-1929-4942-8c3f</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
-    <entryLink id="3e5f-dbb7-33ac-dca8" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="44a0-cf54-18b1-c86d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="5868-8c0f-c25d-b473" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
-    <entryLink id="925b-bd22-c6b2-b526" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink><entryLink id="3d47-74eb-9941-0d1b" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="fd59-3917-907b-f5b3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="5950-6e63-0838-d6f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
-    <entryLink id="89c8-b555-6b31-0cda" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0cac-5c7f-509d-bde7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="1278-e1b3-11cd-65aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
-    <entryLink id="e0bc-1323-236d-3e03" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_edc4-4915-40ba-bbf0</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_105f-ba26-4146-bc54</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7a2c-a76c-421c-a8a2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_05c9-0543-47ee-ba81</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e6ad-f0d7-4627-921b</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6fc8-7d80-33fc-da68" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="1a32-0907-0b4e-7a43" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="10b1-0b6d-4941-bbca" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c6a8-22a8-4d41-b969</comment></categoryLink>
+        <categoryLink id="3bb1-ddca-4b32-8f85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03ca-12cc-4e0a-b628</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
-    <entryLink id="0cb4-9c5d-0a5a-f61f" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="55be-f08b-f8d8-0099" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="b874-ec9d-0628-2d42" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
-    <entryLink id="8535-00b2-9aaf-e35c" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8bc4-c3b2-37d7-d4ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9f44-3a74-e225-41cd" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
-        <categoryLink id="f381-251d-3d94-a9d8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
-    <entryLink id="72a0-7ce5-5472-f0b5" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ea85-26b8-2770-e466" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7d54-6f14-ec60-d43c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
-    <entryLink id="6e9c-71ea-6b9e-f3f0" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink><entryLink id="df4b-6149-47d9-a12e" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ae67-ef52-4cac-958c</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fc61-7306-4d99-acde</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1be0-67e7-45a1-bdbb</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_42a8-7fda-4e05-af0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8d2b-fbad-65f6-0871" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="2c17-401e-40e4-7ec9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6543-5e6e-46bd-9c4b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_565a-1592-491f-8b9b</comment></categoryLink>
+        <categoryLink id="767f-1562-4412-9344" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_81d5-c14a-42ab-bdde</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
-    <entryLink id="b06e-2d8e-f55f-ec65" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="78c7-5535-63cc-225b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d372-95f5-71a1-f430" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
-    <entryLink id="8a1e-fea5-c86e-d00b" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a16d-3d1e-858b-9b5f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5a31-222a-d09d-7de2" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
-    <entryLink id="ebfc-98ae-c842-10a6" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink><entryLink id="5a31-fb32-ab18-bbfb" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1ae7-c41b-4818-be71</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_08a5-b1bb-4ba1-ba42</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d677-b5ad-4838-8746</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_537f-bc1f-4aaa-b0dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0a80-de16-3316-b30e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6f81-72d5-44b1-69d6" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="f770-c09a-405e-b5dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bc67-ce1f-4004-aeb7</comment></categoryLink>
+        <categoryLink id="4961-05b3-48f1-bc97" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_9a45-9699-4475-aeef</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
-    <entryLink id="c136-3a99-b744-4fff" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1d66-e356-515a-fed0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b476-6408-a64c-7724" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
-    <entryLink id="6be4-dbc0-31f4-7957" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink><entryLink id="165e-4e79-911c-2ec0" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_c28f-4109-44c4-ab64</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fdc1-a894-48bc-9e7c</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_4936-a68c-4524-9088</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb37-ac0c-49ae-9d6f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
-      <infoLinks>
-        <infoLink id="563e-680c-2c8f-b79c" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule" />
-      </infoLinks>
       <categoryLinks>
-        <categoryLink id="83b5-f52e-402a-7d7e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b016-648a-9bf1-8e03" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="c4c8-dec1-451b-8f98" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3afe-cfc0-4da6-a985</comment></categoryLink>
+        <categoryLink id="4e8d-b319-4c80-9c64" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_04a8-6aae-45ae-bd4c</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
-    <entryLink id="e43d-0457-b985-09e2" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink><entryLink id="4401-1024-7e12-e6c2" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ae19-30c0-43c5-920e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_6ebe-1bf3-4d78-9dd0</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1887-152d-48b7-b13f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_a7c4-ee6a-4f0b-8ab0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bd85-fa90-47ff-9f84</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_7bd6-9043-4d7e-ba37</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="93c1-d700-4d63-87cb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3610-c975-4d55-bdfe</comment></categoryLink>
+        <categoryLink id="cd76-3b14-4d48-8ffd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2fc2-f636-4c80-9608</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink><entryLink id="8532-6414-3304-df12" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_85c5-d4d9-4b23-9e4d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_80e8-d50b-4906-8153</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_b93b-d4f1-45eb-8a69</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e183-f183-4db7-83b5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0f39-204a-4217-b896</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_eee9-7bfd-4fea-a1bd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5efa-76e0-4d3c-aa3a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f81d-9435-4f11-99c1</comment></categoryLink>
+        <categoryLink id="aaf7-f995-4dc5-a20e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9568-6142-4fdd-be3a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink><entryLink id="d3dc-d845-cc2a-0034" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_005e-6607-4e2c-8dd2</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_7745-260c-4c36-b719</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_ba25-a4b2-4ba9-b023</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ddeb-f4c8-4091-9153</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4904-fd2f-429f-9cf7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_faea-b21b-43c5-b918</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e02c-2902-46ba-9918" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_b24f-3ae0-4cbb-b016</comment></categoryLink>
+        <categoryLink id="fb4d-63b5-4869-977c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fd26-8e6b-4521-92b9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink><entryLink id="33d5-a527-7327-6f0b" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6ecb-28e2-43ed-a6a0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_c067-1118-4d96-b28b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_250e-23c0-4e43-bf74</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1553-a6e6-4291-853f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_aab6-797b-427a-9fd8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="44c7-94e9-40ff-bad6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c77f-0819-473b-a8a2</comment></categoryLink>
+        <categoryLink id="501d-ed09-4cca-b4dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_89fb-c924-4daf-923d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink><entryLink id="0ffa-c0a8-3d55-c6a7" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d72c-519a-451f-81b6</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_3d16-444c-42c9-aad1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_f4b2-6371-494b-863a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_797f-a84b-42f6-8e66</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0d78-fe38-4829-9b12</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e778-1bd4-4ddf-ac4f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0397-c837-4fea-a527</comment></categoryLink>
+        <categoryLink id="b5a9-305e-4af8-baa1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_060b-bccb-4776-bd83</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink><entryLink id="1e92-5221-e3ab-2cc0" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3c84-6d74-4c42-b38d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_5b15-7aa4-4897-aaf1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_3326-31ed-4151-9b37</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6a0e-1b65-4057-ba5d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f8c7-abc9-45ec-955f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_2538-8dc5-446c-8344</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="84ef-e73b-4cf3-9fc2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_c1cf-cea4-4278-8f27</comment></categoryLink>
+        <categoryLink id="b553-6ad0-4f54-bb30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5f51-2734-4a46-9f72</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink><entryLink id="ad57-864f-1271-eaf9" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af71-f3ff-49b1-83e9</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_1c9e-b3bf-4e88-a43f</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_6d0d-1b1d-4065-89cf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d0b7-8686-491e-9d33</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_7db8-0874-487a-be6f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1034-29a0-44b1-a85f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5921-a8a9-4cdd-ac5f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_0c16-6841-42b2-b02d</comment></categoryLink>
+        <categoryLink id="99d0-fc77-464c-9b2e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_602d-2d2d-4ff4-a82a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink><entryLink id="8f8b-c900-6eff-a33c" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_22bd-baae-45f9-b366</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_52bd-55de-4d53-ba55</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_df1b-7476-4ab8-8d2f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_49fa-0dcf-4a61-a5b1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0ea-1443-4993-86e7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2a8-3fbe-448c-9902</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a709-44cd-4e7e-b92a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3632-0b5d-4622-ae33</comment></categoryLink>
+        <categoryLink id="4ffc-9835-4f7e-9298" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_da44-7815-4fdd-981c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink><entryLink id="fdde-30f4-4c3f-a916" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2bfa-b203-47e2-a828</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a39b-8a3c-49cf-bf62</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2a05-07b3-49c5-8145</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f730-87fb-44bd-b68e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_2d0e-6c49-4493-a022</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2e2-50c1-40c3-b4dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e1b8-dcaf-425c-8ca6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_5ad5-8701-42cd-b2b6</comment></categoryLink>
+        <categoryLink id="51cc-c71a-4db5-8db5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_20a4-4346-4a3b-a7d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink><entryLink id="84e0-9ff7-a11d-73d1" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_773a-1ea4-41a0-b766</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_9d4d-6fb8-4131-a5a3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e3bc-02f8-4ece-a5ea</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c371-76d9-4a4d-bc00</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b4c6-d4ba-4b2e-9b99</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="035e-3ba1-4860-97ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6ea9-a7e5-437d-9e35</comment></categoryLink>
+        <categoryLink id="7c94-1380-4864-a54e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_3cec-f053-42ab-a6eb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink><entryLink id="cd78-3a92-039d-5bdd" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1e60-42ba-4c8b-9077</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9860-f593-425e-b89b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_c842-10e8-4509-8eda</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ea52-ff41-40f6-8cf3</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_51e6-c5e1-4003-96bc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2dcd-ad62-4b7f-93e4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4d7c-201f-4c99-b89a</comment></categoryLink>
+        <categoryLink id="8ad9-deca-4ef2-9e81" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_10f9-4718-4e07-bb32</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink><entryLink id="d4a6-50b9-fa28-fd20" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="002d-47e7-49c0-b051" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4e52-ad1b-48d4-8eed</comment></categoryLink>
+        <categoryLink id="5011-e3b9-42ee-a1a7" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_6979-1ed3-4f1f-a025</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink><entryLink id="f106-f532-e48b-122e" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry"><categoryLinks>
+        <categoryLink id="e4c6-90d6-4495-ae83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6140-2404-46f9-bd42</comment></categoryLink>
+        <categoryLink id="b949-5c73-48c2-bb96" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_1c86-fad8-46ec-a0b0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink><entryLink id="a1d1-2190-8894-032b" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4729-bc86-456b-b73d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_cf0f-e3f4-4fb4-989d</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1cc8-5611-4d9a-9218</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_2e32-ca02-48f0-a8dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="eb43-c6b7-4479-9fc3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_0af1-d052-4bd7-aab6</comment></categoryLink>
+        <categoryLink id="ee23-807c-494d-9cff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_45ce-e338-43c9-b63e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink><entryLink id="8849-028a-7385-7638" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ad9a-89f0-970e-2d52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="44db-a8b6-0c8f-8e34" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="efd8-6a9a-4f0c-936a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_dc16-16d0-4890-a8e8</comment></categoryLink>
+        <categoryLink id="789d-debc-4333-bd74" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4b1e-3f1f-49cb-8343</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
-  </entryLinks>
-  <sharedSelectionEntries>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink><entryLink id="12ff-d11c-3933-74ab" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry"><categoryLinks>
+        <categoryLink id="2d71-dc2a-458f-a666" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ff9f-01cb-41b9-800e</comment></categoryLink>
+        <categoryLink id="3a0e-18e0-4bec-b172" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_1315-6051-4a46-b070</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink><entryLink id="4c07-c42c-76d5-bdb0" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry"><categoryLinks>
+        <categoryLink id="e4f1-f59e-4617-9c5e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_b084-df23-4f99-812f</comment></categoryLink>
+        <categoryLink id="c650-574f-4363-8723" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_84fc-9304-4e9e-ab78</comment></categoryLink>
+        <categoryLink id="7cd6-9ba5-4d53-a8c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d06a-7939-4691-9aed</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="603a-4eb5-4882-abf0" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup"><comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+        <entryLink id="c301-c3cd-4a76-a925" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup"><comment>    template_id_741d-8c09-4211-ada6    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink><entryLink id="f437-01e0-3377-f816" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_54a4-6ec8-4c61-9c3e</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_f7fd-2d16-4603-a065</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9326-922c-4f4d-80d3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_c0ac-4b8c-421c-a21b</comment></categoryLink>
+        <categoryLink id="c658-6fe2-4636-957a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8db9-079e-4482-b200</comment></categoryLink>
+        <categoryLink id="9f19-b281-4733-af84" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_413c-9273-4308-b546</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="6ca1-8166-4022-af95" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup"><comment>    template_id_bbc4-33fc-4664-a18e    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="a44a-2169-4900-b79c" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup"><comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink><entryLink id="d208-08ae-7eb0-91f9" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry"><categoryLinks>
+        <categoryLink id="e93d-8440-4fe3-9864" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_4c8d-96f6-48f9-9590</comment></categoryLink>
+        <categoryLink id="6b9a-1198-4ca0-83f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_049c-0fa5-4575-8fa8</comment></categoryLink>
+        <categoryLink id="a2c3-a253-466d-b2db" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_7358-52d7-4aae-8e07</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="1f4b-3f34-4a3d-9899" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup"><comment>    template_id_4784-b370-444b-93ae    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="3689-303c-4baa-b961" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup"><comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink><entryLink id="b7da-ab33-b2b4-d945" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_3c03-a823-4466-9bd6</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8bbb-f95b-413f-b6f4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_41b0-6b0a-482a-919e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e1f7-3cc6-4794-8b6d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2501-6406-4c26-8fd1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_05ce-cc31-40ad-9320</comment></categoryLink>
+        <categoryLink id="93ee-8601-4dc2-88c1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f13c-f8e1-4a50-bfe3</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink><entryLink id="f45e-436f-6662-7304" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_db78-4d49-42ab-954a</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_f14d-9943-47b6-866c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a95-938f-4a07-9727</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_7775-78e1-44cc-87c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a115-098d-48d0-9547" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_b822-3417-4613-be37</comment></categoryLink>
+        <categoryLink id="65f7-fece-4a9e-8f2b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_25db-b03f-4881-b310</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink><entryLink id="88ee-5558-83fa-5714" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry"><categoryLinks>
+        <categoryLink id="67c0-4a2a-4ae7-b919" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_75a7-dc06-445b-b2dc</comment></categoryLink>
+        <categoryLink id="9fb8-7ee6-4fe7-b8bc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_e21a-c03b-4885-ac46</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink><entryLink id="61ed-4e55-a7ec-6bda" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9a08-5fe6-4010-bbc3</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_72cf-cfce-4e02-b379</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6052-2220-443e-b908" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_f55b-7555-444b-beee</comment></categoryLink>
+        <categoryLink id="fc43-ee5f-47c5-8171" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3386-c9ad-4d74-9474</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink><entryLink id="e61d-8855-f898-5f38" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_a0f6-9606-4b75-a2f8</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_94b3-1331-474b-885b</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="deee-9b5c-48e8-b35a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_79fa-3370-4ae0-9e12</comment></categoryLink>
+        <categoryLink id="a39c-61e6-4112-85b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bb53-4e65-4fb6-9dd7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink><entryLink id="0329-cab2-2daa-4baa" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f8cc-833a-4ac1-bf89</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+              <comment>    node_id_5988-c012-4dad-9a66</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7ab4-4796-41a0-afa6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_8d82-3279-4481-84bb</comment></categoryLink>
+        <categoryLink id="ab27-f555-4e2e-af2b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e25c-925e-4b96-8bb3</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink><entryLink id="cd4f-fb54-2b64-d47b" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6b73-b21c-4e2b-9d14</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_a7fe-cc62-4a6f-a781</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5be1-1937-4964-a455</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_da1d-b2bc-4117-82a4</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0509-9c44-4352-867e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7010-be56-4709-b058</comment></categoryLink>
+        <categoryLink id="0c08-cb52-48d6-927a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7379-a740-47ba-a054</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink><entryLink id="738a-3431-36a7-3fa6" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_dd34-83cf-47d7-b557</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_be88-afef-49b3-bd1e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d4aa-4d4e-45d4-a6ad" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_944f-7420-4982-8ea9</comment></categoryLink>
+        <categoryLink id="12dc-27ef-472b-a6b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ea80-0efe-457d-a450</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink><entryLink id="4181-41ef-e06f-60a5" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><categoryLinks>
+        <categoryLink id="02e1-a201-4e89-add0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9a36-f261-43cc-9bd1</comment></categoryLink>
+        <categoryLink id="9b21-7ad6-49e8-9456" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a648-8396-442a-af59</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink><entryLink id="8ce3-2092-9f69-2379" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_cb81-0303-4b88-ae53</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9648-31e3-43aa-8cf3</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_0507-da81-4023-bfcf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0e84-54ff-488d-b066</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8ec4-6f33-4e7b-bafe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6ff-0977-4c92-bb28</comment></categoryLink>
+        <categoryLink id="a059-b004-45a1-b9b6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f555-7d39-458f-84c9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink><entryLink id="d70d-082d-e74b-c141" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8203-5b00-497b-b939</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_40ee-3e71-4978-b1e4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f6a8-f660-46dc-b3c5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_d988-3af6-48bf-b0a8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5a20-79d9-45ac-b724" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_39e5-eda5-45d1-a643</comment></categoryLink>
+        <categoryLink id="7051-3fbf-4dae-ab11" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_6416-21bb-4df4-9de8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink><entryLink id="cf42-d578-6149-529c" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b03e-5d91-4be3-8adc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_0443-29c0-46e9-ad1d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f2c9-7356-4c27-a22f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0e9-4a9e-4b2b-a9d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1465-07c9-4bb3-a0dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5528-2dac-4be5-900c</comment></categoryLink>
+        <categoryLink id="8567-bb82-4ce5-af08" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_dc8f-d888-4585-991d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink><entryLink id="4aba-dfc5-b6ac-9881" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1d3c-8e17-489f-9002</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5725-8bee-4bcc-878d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_be47-0d6f-49f2-9f4b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_863c-f3a4-4802-b80c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8278-2b32-4cd3-b76d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_899e-b052-4d5b-8c18</comment></categoryLink>
+        <categoryLink id="3c6c-f53a-4b59-b030" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f5e9-cff6-41d2-a016</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink><entryLink id="b6c8-3682-9ade-fd14" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_72da-1513-4e02-b595</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7a48-a3b0-4a26-849b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e232-25f3-4cb7-8ab2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_9aa4-5660-4697-8ab2</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2fbf-e65a-4230-b5b0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_09cd-2176-40af-bba6</comment></categoryLink>
+        <categoryLink id="c9ab-452c-4793-a7c6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_05e6-7c63-4a35-9ba0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink><entryLink id="9847-9792-9726-d864" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry"><categoryLinks>
+        <categoryLink id="cb99-5a42-4ec5-bdec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0dfa-4004-4751-8022</comment></categoryLink>
+        <categoryLink id="247b-436e-4331-a7e1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a669-0f5d-4fd3-811b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink><entryLink id="3eb0-83a7-0893-0342" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_09b5-4e3b-4c84-a574</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_32e5-ebba-41fb-9ff2</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_838e-0ccf-4d3a-aabd</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_dfef-0ec2-49fb-a534</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ac57-cabc-4112-bc71" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4f60-472b-45a9-ab9e</comment></categoryLink>
+        <categoryLink id="22e4-b1ad-46bd-a271" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e2e3-af36-45a6-a955</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink><entryLink id="705d-1e9f-1eda-187b" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_936f-1ef7-472e-840e</comment>
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+              <comment>    node_id_d73d-d52e-4c75-8ac0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="49b8-592e-459c-b0a8" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_7a55-ecb4-4e5d-b955</comment></categoryLink>
+        <categoryLink id="53bc-0879-4772-908e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f28c-710e-4ff8-9810</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink><entryLink id="2cab-599b-7aca-b71e" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_a743-0cc2-45ae-a7eb</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2721-e88d-41f7-bedc</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_e10f-1390-4b33-8fcc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9116-ad5f-42b5-8124" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2008-f1c4-4285-a14f</comment></categoryLink>
+        <categoryLink id="ccb8-0fa6-4dab-b5d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e88b-a95a-4647-af3b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink><entryLink id="26fc-1f77-f702-8275" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_25d8-330b-4574-b515</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7836-6878-47a8-8827</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_5ea9-46dd-4a11-9410</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_ab5d-961b-4924-a705</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e3a9-9416-46e1-8cee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9189-836c-475d-a52e</comment></categoryLink>
+        <categoryLink id="7174-7327-41b8-97bd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_e1fa-b7d8-47b0-a88a</comment></categoryLink>
+        <categoryLink id="9903-bddc-4348-8073" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_a137-e3c0-4d63-a48c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink><entryLink id="c03f-c1cf-5451-8a71" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry"><categoryLinks>
+        <categoryLink id="2506-cdf8-4b49-9f51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b1d5-fd75-4f17-bbf4</comment></categoryLink>
+        <categoryLink id="780d-be84-4521-b066" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_f221-bf81-4045-849b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink><entryLink id="9098-f5bb-6560-b7ed" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_b743-7a00-43e4-beb8</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d12f-2c98-4e62-a716</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d4d7-ba67-47aa-962f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+                  <comment>    node_id_1637-edee-457a-bb0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2b3e-1f42-44f3-94ef" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_f203-bc26-421f-b79e</comment></categoryLink>
+        <categoryLink id="6531-5f68-44fa-ad7d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_a53e-59d9-4ac2-a21f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink><entryLink id="a988-50f4-7bb2-fe34" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry"><categoryLinks>
+        <categoryLink id="cedb-bfd6-4c53-a3af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_51af-a137-4a1c-97a4</comment></categoryLink>
+        <categoryLink id="4373-3192-4a77-b7a1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ec1f-c326-40a8-9d1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink><entryLink id="367c-b2ad-bcc9-b972" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_c111-feb0-4012-98cd</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_63d7-8427-431d-9ae6</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="57ea-7ec4-4b74-bb61" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_e707-fde1-457f-91c4</comment></categoryLink>
+        <categoryLink id="c762-72df-44a2-84ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ec67-8573-4460-89db</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink><entryLink id="f8dc-34ef-f371-c218" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3348-16e4-4a9a-a549</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_bea4-c4a8-4843-b9fe</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2970-17ff-4be1-91e5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_503a-46e7-40e7-bd07</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_4555-15e1-43ff-80a0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3d93-e293-4654-9baa" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_fce3-801c-49c8-85d4</comment></categoryLink>
+        <categoryLink id="73cd-eb56-45bc-ac55" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0c2d-2349-44b6-9831</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink><entryLink id="3e5f-dbb7-33ac-dca8" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry"><categoryLinks>
+        <categoryLink id="4620-23a4-48a7-9966" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ac1c-b3bf-4011-918a</comment></categoryLink>
+        <categoryLink id="9c6e-80a7-4997-b0ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_589c-1d0e-4b7d-be6b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink><entryLink id="925b-bd22-c6b2-b526" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2f46-a0b6-48a5-a0ee</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_636f-0f8a-43f1-910b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c883-39c8-4a74-aeaa</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_0796-e467-4438-89b3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dacd-5aab-4251-8b95" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_5a04-9847-4c91-a49a</comment></categoryLink>
+        <categoryLink id="278b-c775-4921-aa54" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b4b4-daeb-483c-a306</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink><entryLink id="89c8-b555-6b31-0cda" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6087-a5e5-4d3c-9ebd</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c7e1-5f42-4528-bf07</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1950-08dc-4544-ab01</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_daf3-31ed-42c0-85dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0eb5-e3fe-4a63-9131" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_7d4f-547c-43ed-a520</comment></categoryLink>
+        <categoryLink id="69dd-d097-4bf2-a77d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f04e-04e8-4891-9b1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink><entryLink id="e0bc-1323-236d-3e03" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_dfdc-f6f6-49d2-a7b3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_354c-c71f-472f-b268</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1127-c974-4663-874d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_0843-bef2-4767-8307</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f3a6-be2c-4df2-b32b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_28e0-91e7-4ada-9fac</comment></categoryLink>
+        <categoryLink id="6d69-67b3-4cb0-9074" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4448-a712-4dd7-bf6d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink><entryLink id="0cb4-9c5d-0a5a-f61f" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d512-fd07-4a29-863a</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_55c6-a35f-485a-9f0d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d89e-cf1f-4ceb-b3de</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e2c9-0d01-403c-900e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_a7b8-c835-4cb2-b3d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="118b-3199-492f-9fe8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_e22a-c5f8-4825-a45f</comment></categoryLink>
+        <categoryLink id="5a6f-0328-4253-aee4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03fc-6a7f-45a5-bcb8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink><entryLink id="8535-00b2-9aaf-e35c" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry"><categoryLinks>
+        <categoryLink id="c474-4653-4f38-8770" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0aff-4f6e-4b03-a23c</comment></categoryLink>
+        <categoryLink id="08bf-7ff5-4aa9-b1c0" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"><comment>    template_id_7d5a-62e7-43ee-b79b</comment></categoryLink>
+        <categoryLink id="589b-0222-4b85-9039" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_4986-9157-49f2-b670</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink><entryLink id="72a0-7ce5-5472-f0b5" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_319e-90d4-44a3-8e83</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_28db-d943-4099-9abd</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1a45-a592-49df-9465</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb31-d0b2-4677-928e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d54a-47f1-4dd2-917e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1b86-0977-4a8b-adac</comment></categoryLink>
+        <categoryLink id="5a91-7e82-4a50-95ce" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_b449-403a-4e42-9239</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink><entryLink id="6e9c-71ea-6b9e-f3f0" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafa-470f-4c2c-8be3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_e2ba-a855-4de2-9f46</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_0171-b30d-44ee-9389</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fdfb-119b-4774-934a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_3891-9a00-4f8f-b95f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8bd7-c9e7-4ebe-b24f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e5df-17d4-4521-9d5b</comment></categoryLink>
+        <categoryLink id="a589-1bb3-4f05-9dbc" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"><comment>    template_id_0ecd-4873-4d3a-b28b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink><entryLink id="b06e-2d8e-f55f-ec65" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_fbfa-8d78-4d6d-8a05</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_21f2-0916-46bf-b75a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_4fbd-633b-4dd6-9fdd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="680a-b41e-448e-b91d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4f71-446f-4cff-afda</comment></categoryLink>
+        <categoryLink id="abca-f93d-4d99-8376" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_3f44-8647-43a4-ac22</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink><entryLink id="8a1e-fea5-c86e-d00b" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry"><categoryLinks>
+        <categoryLink id="f2b2-4cfb-4fb8-9f31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4207-8d8f-4b1a-836b</comment></categoryLink>
+        <categoryLink id="94f5-6e09-4b09-9b4f" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_2b34-077f-4279-86fb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink><entryLink id="ebfc-98ae-c842-10a6" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="87e4-4720-4830-b87d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6577-e0fb-4fda-834e</comment></categoryLink>
+        <categoryLink id="ff8c-ece8-4dff-b44a" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_5d59-09bf-4566-b7e1</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink><entryLink id="c136-3a99-b744-4fff" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"><categoryLinks>
+        <categoryLink id="4641-6be8-42e3-a291" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_aa93-057d-42f6-82d7</comment></categoryLink>
+        <categoryLink id="3f38-6c2f-4b2d-badc" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_403c-4e9c-4af5-84ec</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink><entryLink id="6be4-dbc0-31f4-7957" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af15-2c71-4f8b-833e</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_d95a-80b9-4463-af55</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4f29-096b-4233-bf17" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6b1-886e-4194-8bcd</comment></categoryLink>
+        <categoryLink id="21a8-298c-40fa-ab30" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_51b5-f9c1-4587-8fc7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink><entryLink id="e43d-0457-b985-09e2" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4dce-8632-4f7c-813e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_8a71-3995-4155-ac33</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d206-f2ce-41b8-945a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan">
+                  <comment>    node_id_2e02-cf1c-4a71-861c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ec81-bd33-45a8-8550</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_3344-743c-45d3-b930</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2cd2-b1d1-4b79-9868" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4272-9b9d-4c59-95f0</comment></categoryLink>
+        <categoryLink id="248a-a756-409e-b072" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_d85b-1ae7-40d5-9341</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink><entryLink id="1c84-01d7-40bf-a109" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
+    <entryLink id="3acc-b209-44f0-bb6e" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
+    <entryLink id="82fb-6fe3-4601-9f2b" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <entryLink id="ec30-7009-4a87-85fe" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3531-57d1-4081-882d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_f233-2361-4177-8ba7</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b932-667a-4b43-8331</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <entryLink id="3018-5fcc-48f0-af5b" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <entryLink id="3865-38e2-4e9f-b2ce" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3129-6f59-4365-906b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2bcb-0af1-4aea-9191" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <entryLink id="bf03-106a-49a3-b8e6" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ede2-d453-4e34-8cda</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2907-3215-4b01-96ff</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_c90c-959f-40fb-a4cb</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ba2d-50ad-45f1-91c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0e88-485e-43c2-8bef" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <entryLink id="b79c-ef83-4e1f-a2ff" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_409c-0a5d-4ef8-a871</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7078-c1c7-4af2-b43d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_9a69-0fdc-4957-8982</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1a4c-69b5-4219-8502" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fba0-3ea7-4eaf-b33a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <entryLink id="2b6c-e7d5-4b8c-9ab5" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
+    <entryLink id="e283-89de-4e42-9c85" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
+    <entryLink id="4b38-23fb-45b2-aaf8" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
+    <entryLink id="7443-223e-4949-934b" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+  </entryLinks><sharedSelectionEntries>
     <selectionEntry id="ac97-c8ce-16ba-9c49" name="N&#226;rik Dreygur" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0913-39cc-5597-5069" type="max" />

--- a/2022 - LA - Iron Warriors.cat
+++ b/2022 - LA - Iron Warriors.cat
@@ -692,7 +692,7 @@
         <categoryLink id="d6cf-6fda-3e03-5886" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="5dce-36eb-c3d3-a7bc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
     <entryLink id="12ff-d11c-3933-74ab" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5584-80fa-9520-6016" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />

--- a/2022 - LA - Iron Warriors.cat
+++ b/2022 - LA - Iron Warriors.cat
@@ -335,7 +335,7 @@
         <categoryLink id="6932-1690-b60d-53ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="c6e2-9b2a-3c5f-5551" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
     <entryLink id="a2de-2601-7341-a58b" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="65f2-4d62-ce1b-3938" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
@@ -763,7 +763,7 @@
         <categoryLink id="ca93-2ddb-423b-5945" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="25e9-eaf7-1fe4-cbef" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
     <entryLink id="61ed-4e55-a7ec-6bda" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
@@ -844,7 +844,7 @@
         <categoryLink id="52dc-b8bb-2b06-c9fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="163e-54d4-41ea-a209" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
     <entryLink id="b6c8-3682-9ade-fd14" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3f6d-4e18-58c3-d74c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -856,7 +856,7 @@
         <categoryLink id="eb4c-640b-0e98-b478" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="e96b-a59b-c820-1af7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
     <entryLink id="3eb0-83a7-0893-0342" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4548-800d-5c39-8db5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -938,7 +938,7 @@
         <categoryLink id="b902-e766-f88a-c300" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="d80a-4c5d-e1db-7e8e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
     <entryLink id="f8dc-34ef-f371-c218" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -966,7 +966,7 @@
         <categoryLink id="44a0-cf54-18b1-c86d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="5868-8c0f-c25d-b473" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
     <entryLink id="925b-bd22-c6b2-b526" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -1016,7 +1016,7 @@
         <categoryLink id="9f44-3a74-e225-41cd" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
         <categoryLink id="f381-251d-3d94-a9d8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
     <entryLink id="72a0-7ce5-5472-f0b5" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ea85-26b8-2770-e466" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />

--- a/2022 - LA - Iron Warriors.cat
+++ b/2022 - LA - Iron Warriors.cat
@@ -2844,7 +2844,7 @@
           </modifiers>
         </entryLink>
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_be38-a066-4f8e-ae54</comment></selectionEntryGroup>
     <selectionEntryGroup id="3447-379d-6e6b-6794" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -2933,7 +2933,7 @@
       <entryLinks>
         <entryLink id="1e29-d8a9-f323-a90f" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_7dee-602c-4b47-be09</comment></selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
     <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />

--- a/2022 - LA - Iron Warriors.cat
+++ b/2022 - LA - Iron Warriors.cat
@@ -1,31 +1,30 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2ee4-57ed-db44-8a63" name="LA -   IV: Iron Warriors" revision="17" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="29" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="2ee4-57ed-db44-8a63" name="LA -   IV: Iron Warriors" revision="17" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="29">
   <entryLinks>
-    <entryLink id="fe10-3104-0252-96de" name="Nârik Dreygur" hidden="true" collective="false" import="false" targetId="ac97-c8ce-16ba-9c49" type="selectionEntry">
+    <entryLink id="fe10-3104-0252-96de" name="N&#226;rik Dreygur" hidden="true" collective="false" import="false" targetId="ac97-c8ce-16ba-9c49" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="daf2-90f2-060e-054f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="a63e-60c5-2db0-676a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="684c-a721-6593-9e2a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="daf2-90f2-060e-054f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="a63e-60c5-2db0-676a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="684c-a721-6593-9e2a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="7fe3-8433-2dfa-2166" name="Perturabo" hidden="false" collective="false" import="false" targetId="f944-6641-a714-2fe8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4fe3-7aed-a86d-e3a9" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
-        <categoryLink id="23ea-8f2f-28bd-c663" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4fe3-7aed-a86d-e3a9" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true" />
+        <categoryLink id="23ea-8f2f-28bd-c663" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="ede1-9c07-8401-67f9" name="Iron Havocs" hidden="true" collective="false" import="false" targetId="d355-5488-1277-fabf" type="selectionEntry">
@@ -34,46 +33,46 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1e67-0fa0-e2ff-ea41" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="e64e-f755-b7d9-b016" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1e67-0fa0-e2ff-ea41" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="e64e-f755-b7d9-b016" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="9dc3-f518-9d31-3973" name="Iron Circle Maniple" hidden="false" collective="false" import="false" targetId="a6e3-baab-45b9-7fea" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9203-b759-34d2-9552" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="eb77-1b03-c09f-6681" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="9203-b759-34d2-9552" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="eb77-1b03-c09f-6681" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="6d85-0a41-fc02-2844" name="Tyrant Siege Terminator Squad" hidden="false" collective="false" import="false" targetId="795a-5698-a1bc-6ec6" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="002f-dc9a-b983-d44c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7da6-dade-1275-d75a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="002f-dc9a-b983-d44c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7da6-dade-1275-d75a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="ef25-725f-b90b-46fa" name="The Tormentor" hidden="true" collective="false" import="false" targetId="ec77-b9e7-904a-f49b" type="selectionEntry">
@@ -82,1052 +81,1052 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f944-6641-a714-2fe8" type="greaterThan"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f944-6641-a714-2fe8" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="23c5-64f4-07e9-0ac0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c205-4746-3526-3bb2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="23c5-64f4-07e9-0ac0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="c205-4746-3526-3bb2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="91c2-b28f-2fbe-4705" name="Kyr Vhalen" hidden="true" collective="false" import="false" targetId="35e0-3b3a-f569-3da8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3cb3-e3bb-c0cf-9678" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="df59-0d00-2be6-f275" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fbaf-2b4b-5a38-6925" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="3cb3-e3bb-c0cf-9678" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="df59-0d00-2be6-f275" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="fbaf-2b4b-5a38-6925" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="7471-1a1e-4285-65cb" name="Erasmus Golg" hidden="true" collective="false" import="false" targetId="3feb-3ea1-97c2-9861" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a813-57fa-9782-da6f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="621a-4766-c501-14df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f5c8-d1da-2871-3ba5" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="a813-57fa-9782-da6f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="621a-4766-c501-14df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f5c8-d1da-2871-3ba5" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="7cd1-2f14-2775-c1b2" name="Dominator Cohort" hidden="false" collective="false" import="false" targetId="1bfa-2413-beb9-5f32" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="019f-1e63-3d79-80c1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="9a0e-d1d8-e80c-7561" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="019f-1e63-3d79-80c1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="9a0e-d1d8-e80c-7561" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="9e4f-aa46-fb28-cbc6" name="   IV: Iron Warriors" hidden="false" collective="false" import="false" targetId="5f54-457a-fbb9-6730" type="selectionEntry">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0633-84dd-c5cb-8b68" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1a8-3243-43ed-49a9" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0633-84dd-c5cb-8b68" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1a8-3243-43ed-49a9" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="4a17-436d-d77f-9962" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="4a17-436d-d77f-9962" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="66d0-dab6-1aa9-95e1" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2339-93ae-9a31-3713" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c08a-3cde-7675-39eb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="2339-93ae-9a31-3713" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c08a-3cde-7675-39eb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
     <entryLink id="910e-db57-8bf7-37b3" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9a27-96b5-d38d-eb8d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="824b-1bbe-552c-38d5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="9a27-96b5-d38d-eb8d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="824b-1bbe-552c-38d5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
     <entryLink id="19a9-0c79-2acf-5beb" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2ca9-a2a3-04f2-9611" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="b70b-5b20-bed2-cf21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f6cd-9e7d-a5a3-6c59" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="2ca9-a2a3-04f2-9611" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="b70b-5b20-bed2-cf21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f6cd-9e7d-a5a3-6c59" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="0f30-a6a9-c5b0-8ff0" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f304-140b-60e4-c295" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="b95b-a766-4df8-abce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f304-140b-60e4-c295" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="b95b-a766-4df8-abce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
     <entryLink id="a5ba-c991-749b-898c" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e472-3b9d-e1bc-74e5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="ed2f-76c6-c5a0-105d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e472-3b9d-e1bc-74e5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="ed2f-76c6-c5a0-105d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
     <entryLink id="be21-9e50-1c3c-5076" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f471-f8fd-d5ec-2e28" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="ca2d-8576-e9a5-fe1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8037-fb5c-9320-f27c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="f471-f8fd-d5ec-2e28" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="ca2d-8576-e9a5-fe1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8037-fb5c-9320-f27c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
     <entryLink id="ef72-0d05-0a10-b9c0" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d086-3bb9-7bc2-5f75" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="b10d-42b8-3d7f-9a88" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d086-3bb9-7bc2-5f75" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="b10d-42b8-3d7f-9a88" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
     <entryLink id="a824-3610-2f85-23f4" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="52d4-20e2-b5ed-8900" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="846c-a018-f8a3-e78c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="52d4-20e2-b5ed-8900" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="846c-a018-f8a3-e78c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
     <entryLink id="b3b9-a1ba-0c76-0be1" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5479-41b7-273e-ba57" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="9079-51aa-5e7e-5de9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cdf7-c602-9cdc-8429" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="5479-41b7-273e-ba57" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="9079-51aa-5e7e-5de9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cdf7-c602-9cdc-8429" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="02f3-3b9b-15e3-b1c9" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup"/>
+        <entryLink id="02f3-3b9b-15e3-b1c9" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup" />
         <entryLink id="28e3-321b-e149-3c0e" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
     <entryLink id="fd61-4e6c-4dba-38a5" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2765-451e-b137-8298" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="49fe-d008-3c6f-a147" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="67ed-2abf-dbab-9a99" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="2765-451e-b137-8298" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="49fe-d008-3c6f-a147" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="67ed-2abf-dbab-9a99" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="47e8-232a-f813-b1de" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup"/>
+        <entryLink id="47e8-232a-f813-b1de" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup" />
         <entryLink id="68ed-efab-d695-80a6" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
     <entryLink id="2e01-2fea-4564-cde8" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ad10-2822-d6f3-5faa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="12c5-e1a9-1d43-eacb" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="bec7-13b6-471b-37c2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="ad10-2822-d6f3-5faa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="12c5-e1a9-1d43-eacb" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="bec7-13b6-471b-37c2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="05e4-26dc-4e5c-1b68" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup"/>
+        <entryLink id="05e4-26dc-4e5c-1b68" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup" />
         <entryLink id="d826-77c9-5d8e-46f9" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
     <entryLink id="891b-f849-4179-2071" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0ae5-f3d2-43b8-f07c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="7f5f-a1f6-96c5-bcb5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0ae5-f3d2-43b8-f07c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="7f5f-a1f6-96c5-bcb5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
     <entryLink id="d1bf-1149-3a68-e317" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6932-1690-b60d-53ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c6e2-9b2a-3c5f-5551" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6932-1690-b60d-53ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c6e2-9b2a-3c5f-5551" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
     <entryLink id="a2de-2601-7341-a58b" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="65f2-4d62-ce1b-3938" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="bf48-2199-1971-a440" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="65f2-4d62-ce1b-3938" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="bf48-2199-1971-a440" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
     <entryLink id="8fa9-6a06-2b7c-23c1" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fdca-882c-907a-656f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="6e97-1320-d8bc-d928" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fdca-882c-907a-656f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="6e97-1320-d8bc-d928" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="a794-a023-9c8c-2a99" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4d8c-50d0-0fad-aabc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="82c4-1284-3241-0234" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="4d8c-50d0-0fad-aabc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="82c4-1284-3241-0234" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
     <entryLink id="23f0-1740-f4e4-005f" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d565-e231-c7cc-dad0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="4b41-2860-b73b-36b7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e3a1-d878-d124-ea9d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="d565-e231-c7cc-dad0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="4b41-2860-b73b-36b7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e3a1-d878-d124-ea9d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="3a26-2631-a259-e7eb" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="03b2-35fc-13c1-1a95" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="790c-6f52-6389-0ec8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="03b2-35fc-13c1-1a95" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="790c-6f52-6389-0ec8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="5b47-f6af-d9f3-aa17" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2d28-f74d-c6f9-6cc4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="f8a4-8649-246a-d43b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2d28-f74d-c6f9-6cc4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="f8a4-8649-246a-d43b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
     <entryLink id="9eea-4f38-15d8-709e" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="732a-bf0a-fbe1-9072" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="83bb-470a-9752-3909" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="732a-bf0a-fbe1-9072" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="83bb-470a-9752-3909" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
     <entryLink id="f138-3e9f-27d9-1894" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b553-99bf-fd84-7042" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="33bd-daa1-1ac6-4a9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b553-99bf-fd84-7042" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="33bd-daa1-1ac6-4a9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
     <entryLink id="d6fe-9fe8-2d16-f05f" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="aa30-6175-bdf1-274a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e1ee-7f3d-2738-2557" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="aa30-6175-bdf1-274a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e1ee-7f3d-2738-2557" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
     <entryLink id="c54a-98be-4c8c-b986" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e923-aded-8787-05b6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="fec6-e8c2-5fb3-8a6c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e923-aded-8787-05b6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="fec6-e8c2-5fb3-8a6c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
     <entryLink id="c4be-f1d2-b4e4-2368" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a4ad-92ce-1ecf-1f04" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="65a5-94cf-8c6e-1dee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a4ad-92ce-1ecf-1f04" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="65a5-94cf-8c6e-1dee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
     <entryLink id="2da2-a4bb-2d19-3f5a" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c9cc-a355-e654-1ceb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8730-19a5-d9be-74ce" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="c9cc-a355-e654-1ceb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8730-19a5-d9be-74ce" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
     <entryLink id="88f8-8f15-3557-1fd7" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1496-c9e2-520b-ebc1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="dbd3-87e3-b5bc-81ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1496-c9e2-520b-ebc1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="dbd3-87e3-b5bc-81ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
     <entryLink id="89c1-d7ab-0c11-fd80" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5abd-3b8a-87a0-e417" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2d29-70c1-30a7-8314" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="5abd-3b8a-87a0-e417" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2d29-70c1-30a7-8314" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="a054-8fcc-6ad5-6b04" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a5e9-2f17-cdd7-616b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="87c8-e23a-4fa3-394c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a5e9-2f17-cdd7-616b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="87c8-e23a-4fa3-394c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
     <entryLink id="3d47-74eb-9941-0d1b" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ef51-64c7-3a1c-3477" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="6f14-9fc4-b834-7574" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ef51-64c7-3a1c-3477" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="6f14-9fc4-b834-7574" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
     <entryLink id="df4b-6149-47d9-a12e" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e0a0-152f-3978-5f9e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="b6db-894f-0246-1418" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e0a0-152f-3978-5f9e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="b6db-894f-0246-1418" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
     <entryLink id="5a31-fb32-ab18-bbfb" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8723-faec-89e5-88ee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2b2b-e5d6-7c9f-e90f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="8723-faec-89e5-88ee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2b2b-e5d6-7c9f-e90f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
     <entryLink id="165e-4e79-911c-2ec0" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="755d-e23e-ac99-2894" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1c6c-d456-8f7f-9dae" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="755d-e23e-ac99-2894" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1c6c-d456-8f7f-9dae" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
     <entryLink id="4401-1024-7e12-e6c2" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5837-c1ba-6a20-0a63" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="0622-1da0-fee5-a3fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5837-c1ba-6a20-0a63" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="0622-1da0-fee5-a3fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
     <entryLink id="8532-6414-3304-df12" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7e41-3a91-4a34-d57e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="566e-f42e-68ed-faac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7e41-3a91-4a34-d57e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="566e-f42e-68ed-faac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
     <entryLink id="d3dc-d845-cc2a-0034" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0ae8-04bc-c760-ee71" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="f5b5-fa4e-8674-8aa3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0ae8-04bc-c760-ee71" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="f5b5-fa4e-8674-8aa3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
     <entryLink id="33d5-a527-7327-6f0b" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e95f-1475-10b3-ff8a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="8434-4a31-20f1-69f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e95f-1475-10b3-ff8a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="8434-4a31-20f1-69f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
     <entryLink id="0ffa-c0a8-3d55-c6a7" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bfc7-6e1e-3386-0c68" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="56c6-8a78-9103-ac32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bfc7-6e1e-3386-0c68" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="56c6-8a78-9103-ac32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
     <entryLink id="1e92-5221-e3ab-2cc0" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="92f7-c001-d8b9-5ac9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="0bb1-7d83-7e8c-8f39" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="92f7-c001-d8b9-5ac9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="0bb1-7d83-7e8c-8f39" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
     <entryLink id="ad57-864f-1271-eaf9" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="47dc-9d14-6804-12b7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="588d-1e81-0f6c-e8e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="47dc-9d14-6804-12b7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="588d-1e81-0f6c-e8e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
     <entryLink id="8f8b-c900-6eff-a33c" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="64f5-ae24-51c5-8606" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="7162-1b0c-26c3-9628" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="64f5-ae24-51c5-8606" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="7162-1b0c-26c3-9628" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
     <entryLink id="fdde-30f4-4c3f-a916" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9242-b8ad-53af-00f8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="03ec-a16f-0545-cc14" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9242-b8ad-53af-00f8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="03ec-a16f-0545-cc14" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
     <entryLink id="84e0-9ff7-a11d-73d1" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="95cc-a0e3-7c22-d141" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="668a-ad20-928e-e3eb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="95cc-a0e3-7c22-d141" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="668a-ad20-928e-e3eb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
     <entryLink id="cd78-3a92-039d-5bdd" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7d91-a02d-52b1-693b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="8c3a-2ab9-03ec-2a68" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7d91-a02d-52b1-693b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="8c3a-2ab9-03ec-2a68" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
     <entryLink id="d4a6-50b9-fa28-fd20" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="86d4-1814-46c0-59da" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="7fe2-380b-8be3-1174" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="86d4-1814-46c0-59da" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="7fe2-380b-8be3-1174" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
     <entryLink id="f106-f532-e48b-122e" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4550-7c50-878a-5a12" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e5de-5249-3191-b610" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="4550-7c50-878a-5a12" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e5de-5249-3191-b610" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="a1d1-2190-8894-032b" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e448-4ae2-ef3e-dd6e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="5569-eaef-9249-8c3b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e448-4ae2-ef3e-dd6e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="5569-eaef-9249-8c3b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
     <entryLink id="8849-028a-7385-7638" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d6cf-6fda-3e03-5886" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="5dce-36eb-c3d3-a7bc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d6cf-6fda-3e03-5886" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="5dce-36eb-c3d3-a7bc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="12ff-d11c-3933-74ab" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5584-80fa-9520-6016" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8b63-91ed-da36-20fc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="5584-80fa-9520-6016" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8b63-91ed-da36-20fc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="4c07-c42c-76d5-bdb0" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f514-2d2f-d71f-4a4c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="0c0a-7dca-c05a-0c02" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="78f5-d1a1-1277-a225" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="f514-2d2f-d71f-4a4c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="0c0a-7dca-c05a-0c02" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="78f5-d1a1-1277-a225" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="53d7-8fc9-5fe7-6c3f" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup"/>
-        <entryLink id="1e65-b6ca-42ec-7c77" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup"/>
+        <entryLink id="53d7-8fc9-5fe7-6c3f" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup" />
+        <entryLink id="1e65-b6ca-42ec-7c77" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
     <entryLink id="f437-01e0-3377-f816" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3887-7f0e-3031-886b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="f1ea-366d-a7e5-f689" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="87b2-35d1-eb65-61d2" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="3887-7f0e-3031-886b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="f1ea-366d-a7e5-f689" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="87b2-35d1-eb65-61d2" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="9554-c773-913a-a4e7" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup"/>
-        <entryLink id="0bb6-cf5b-3d95-5a2f" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup"/>
+        <entryLink id="9554-c773-913a-a4e7" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup" />
+        <entryLink id="0bb6-cf5b-3d95-5a2f" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
     <entryLink id="d208-08ae-7eb0-91f9" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5ffd-0921-f375-47ba" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="0198-abcb-0e55-7e29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="edd1-ac09-6dc2-3752" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="5ffd-0921-f375-47ba" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="0198-abcb-0e55-7e29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="edd1-ac09-6dc2-3752" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="be8d-2bb1-0779-ec6f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup"/>
-        <entryLink id="976d-454f-82d3-9761" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup"/>
+        <entryLink id="be8d-2bb1-0779-ec6f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="3447-379d-6e6b-6794" type="selectionEntryGroup" />
+        <entryLink id="976d-454f-82d3-9761" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
     <entryLink id="b7da-ab33-b2b4-d945" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="bcce-7ffe-1719-0715" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2c03-fe62-ae37-fa14" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="bcce-7ffe-1719-0715" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2c03-fe62-ae37-fa14" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="f45e-436f-6662-7304" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e8dd-96fc-93dc-86f9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="49f0-3dcc-0055-8126" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e8dd-96fc-93dc-86f9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="49f0-3dcc-0055-8126" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
     <entryLink id="88ee-5558-83fa-5714" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ca93-2ddb-423b-5945" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="25e9-eaf7-1fe4-cbef" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="ca93-2ddb-423b-5945" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="25e9-eaf7-1fe4-cbef" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="61ed-4e55-a7ec-6bda" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8e89-f586-bace-e777" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="10a7-7c27-57a3-6dae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8e89-f586-bace-e777" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="10a7-7c27-57a3-6dae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
     <entryLink id="e61d-8855-f898-5f38" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="18dc-e8d0-2c58-3ea7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="a958-6d76-bd5c-5319" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="18dc-e8d0-2c58-3ea7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="a958-6d76-bd5c-5319" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
     <entryLink id="0329-cab2-2daa-4baa" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3442-a2e2-0ae2-1b0d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="4359-2c5c-8299-5cae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3442-a2e2-0ae2-1b0d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="4359-2c5c-8299-5cae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
     <entryLink id="cd4f-fb54-2b64-d47b" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6fdf-5314-9298-0955" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e9f2-55cd-5337-f54f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6fdf-5314-9298-0955" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e9f2-55cd-5337-f54f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
     <entryLink id="738a-3431-36a7-3fa6" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d942-91d3-b543-2ff3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="dd2a-180a-9293-61c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d942-91d3-b543-2ff3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="dd2a-180a-9293-61c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
     <entryLink id="4181-41ef-e06f-60a5" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="751b-d884-6c84-80a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e58f-2106-1e57-11ee" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="751b-d884-6c84-80a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e58f-2106-1e57-11ee" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
     <entryLink id="8ce3-2092-9f69-2379" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f7ad-7a76-75fd-6323" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="114e-b120-92fd-dbbb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="f7ad-7a76-75fd-6323" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="114e-b120-92fd-dbbb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
     <entryLink id="d70d-082d-e74b-c141" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="43cf-f743-7a76-a072" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2400-2eb1-7903-8b52" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="43cf-f743-7a76-a072" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2400-2eb1-7903-8b52" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
     <entryLink id="cf42-d578-6149-529c" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fe85-e2cb-b1bb-1c34" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bf58-7289-c006-4e1c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="fe85-e2cb-b1bb-1c34" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bf58-7289-c006-4e1c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
     <entryLink id="4aba-dfc5-b6ac-9881" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="52dc-b8bb-2b06-c9fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="163e-54d4-41ea-a209" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="52dc-b8bb-2b06-c9fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="163e-54d4-41ea-a209" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="b6c8-3682-9ade-fd14" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3f6d-4e18-58c3-d74c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cd01-0b40-2870-87d0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3f6d-4e18-58c3-d74c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cd01-0b40-2870-87d0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
     <entryLink id="9847-9792-9726-d864" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="eb4c-640b-0e98-b478" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e96b-a59b-c820-1af7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="eb4c-640b-0e98-b478" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e96b-a59b-c820-1af7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="3eb0-83a7-0893-0342" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4548-800d-5c39-8db5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="cc52-554c-d8c4-e9b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4548-800d-5c39-8db5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="cc52-554c-d8c4-e9b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
     <entryLink id="705d-1e9f-1eda-187b" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fb76-acce-60dc-1fb6" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="6872-d952-166c-b566" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fb76-acce-60dc-1fb6" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="6872-d952-166c-b566" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
     <entryLink id="2cab-599b-7aca-b71e" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c425-6767-1e40-26d8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="4b2f-8cc0-d11a-7882" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c425-6767-1e40-26d8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="4b2f-8cc0-d11a-7882" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
     <entryLink id="26fc-1f77-f702-8275" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b977-1383-c399-1c11" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1304-a4fe-8f32-8c9f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="3d76-62e4-26d2-a07f" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="b977-1383-c399-1c11" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1304-a4fe-8f32-8c9f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="3d76-62e4-26d2-a07f" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="c03f-c1cf-5451-8a71" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5623-5550-2fdc-ed9e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7fb8-a7a4-47bf-946d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="5623-5550-2fdc-ed9e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7fb8-a7a4-47bf-946d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
     <entryLink id="9098-f5bb-6560-b7ed" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e126-8e97-6af8-0852" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="048a-6c30-801d-5478" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e126-8e97-6af8-0852" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="048a-6c30-801d-5478" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
     <entryLink id="a988-50f4-7bb2-fe34" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fb8f-6377-9b49-3370" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ab4e-c731-85a5-ada9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="fb8f-6377-9b49-3370" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ab4e-c731-85a5-ada9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
     <entryLink id="367c-b2ad-bcc9-b972" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b902-e766-f88a-c300" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="d80a-4c5d-e1db-7e8e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b902-e766-f88a-c300" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="d80a-4c5d-e1db-7e8e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="f8dc-34ef-f371-c218" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="737d-bdad-c54e-4b3c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="541d-23ce-1ffa-4d42" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="737d-bdad-c54e-4b3c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="541d-23ce-1ffa-4d42" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
     <entryLink id="3e5f-dbb7-33ac-dca8" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="44a0-cf54-18b1-c86d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="5868-8c0f-c25d-b473" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="44a0-cf54-18b1-c86d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="5868-8c0f-c25d-b473" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="925b-bd22-c6b2-b526" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fd59-3917-907b-f5b3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="5950-6e63-0838-d6f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fd59-3917-907b-f5b3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="5950-6e63-0838-d6f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
     <entryLink id="89c8-b555-6b31-0cda" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0cac-5c7f-509d-bde7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="1278-e1b3-11cd-65aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0cac-5c7f-509d-bde7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="1278-e1b3-11cd-65aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
     <entryLink id="e0bc-1323-236d-3e03" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6fc8-7d80-33fc-da68" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="1a32-0907-0b4e-7a43" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6fc8-7d80-33fc-da68" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="1a32-0907-0b4e-7a43" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
     <entryLink id="0cb4-9c5d-0a5a-f61f" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="55be-f08b-f8d8-0099" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="b874-ec9d-0628-2d42" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="55be-f08b-f8d8-0099" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="b874-ec9d-0628-2d42" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
     <entryLink id="8535-00b2-9aaf-e35c" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8bc4-c3b2-37d7-d4ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9f44-3a74-e225-41cd" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="f381-251d-3d94-a9d8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="8bc4-c3b2-37d7-d4ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9f44-3a74-e225-41cd" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
+        <categoryLink id="f381-251d-3d94-a9d8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="72a0-7ce5-5472-f0b5" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ea85-26b8-2770-e466" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7d54-6f14-ec60-d43c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="ea85-26b8-2770-e466" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7d54-6f14-ec60-d43c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
     <entryLink id="6e9c-71ea-6b9e-f3f0" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8d2b-fbad-65f6-0871" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="2c17-401e-40e4-7ec9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8d2b-fbad-65f6-0871" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="2c17-401e-40e4-7ec9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
     <entryLink id="b06e-2d8e-f55f-ec65" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="78c7-5535-63cc-225b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d372-95f5-71a1-f430" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="78c7-5535-63cc-225b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d372-95f5-71a1-f430" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
     <entryLink id="8a1e-fea5-c86e-d00b" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a16d-3d1e-858b-9b5f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5a31-222a-d09d-7de2" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="a16d-3d1e-858b-9b5f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5a31-222a-d09d-7de2" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
     <entryLink id="ebfc-98ae-c842-10a6" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0a80-de16-3316-b30e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6f81-72d5-44b1-69d6" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="0a80-de16-3316-b30e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6f81-72d5-44b1-69d6" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
     <entryLink id="c136-3a99-b744-4fff" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1d66-e356-515a-fed0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b476-6408-a64c-7724" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="1d66-e356-515a-fed0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b476-6408-a64c-7724" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
     <entryLink id="6be4-dbc0-31f4-7957" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <infoLinks>
-        <infoLink id="563e-680c-2c8f-b79c" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
+        <infoLink id="563e-680c-2c8f-b79c" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="83b5-f52e-402a-7d7e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b016-648a-9bf1-8e03" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="83b5-f52e-402a-7d7e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b016-648a-9bf1-8e03" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
     <entryLink id="e43d-0457-b985-09e2" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ad9a-89f0-970e-2d52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="44db-a8b6-0c8f-8e34" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="ad9a-89f0-970e-2d52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="44db-a8b6-0c8f-8e34" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
   </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="ac97-c8ce-16ba-9c49" name="Nârik Dreygur" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="ac97-c8ce-16ba-9c49" name="N&#226;rik Dreygur" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0913-39cc-5597-5069" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0913-39cc-5597-5069" type="max" />
       </constraints>
       <profiles>
-        <profile id="1653-9be8-e7bc-0335" name="The Revenant&apos;s Pawn" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+        <profile id="1653-9be8-e7bc-0335" name="The Revenant's Pawn" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
           <characteristics>
-            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">When included in an Allied Detachment that is part of an army with a Primary Detachment whose Warlord is either Cassian Dracos Reborn or Xiaphas Jurr, the Allied Detachment that Nârik Dreygur is part of may include a unit of Legion Veterans with the Legiones Astartes (Iron Warriors) special rule that does not use up a Force Organisation choice and does not count for any minimum required units the army must select. In addition, Nârik Dreygur gains +1 Attack and the Stubborn special rule when within 12&quot; of Cassian Dracos Reborn.</characteristic>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">When included in an Allied Detachment that is part of an army with a Primary Detachment whose Warlord is either Cassian Dracos Reborn or Xiaphas Jurr, the Allied Detachment that N&#226;rik Dreygur is part of may include a unit of Legion Veterans with the Legiones Astartes (Iron Warriors) special rule that does not use up a Force Organisation choice and does not count for any minimum required units the army must select. In addition, N&#226;rik Dreygur gains +1 Attack and the Stubborn special rule when within 12" of Cassian Dracos Reborn.</characteristic>
           </characteristics>
         </profile>
         <profile id="6f1f-aa38-af41-b5b4" name="Cortex Designator" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
           <characteristics>
-            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">When rolling To Hit for a model with the Automata Unit Type, as part of a Shooting Attack, add +1 to the result of the roll if the enemy unit targeted by the attack has already been the target of another friendly model with this special rule in the same Shooting phase, and if the attacking model is within 6&quot; of that friendly model. This does not affect attacks made with the Blast or Barrage special rules.</characteristic>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">When rolling To Hit for a model with the Automata Unit Type, as part of a Shooting Attack, add +1 to the result of the roll if the enemy unit targeted by the attack has already been the target of another friendly model with this special rule in the same Shooting phase, and if the attacking model is within 6" of that friendly model. This does not affect attacks made with the Blast or Barrage special rules.</characteristic>
           </characteristics>
         </profile>
-        <profile id="631e-18d9-0539-c34f" name="Nârik Dreygur" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+        <profile id="631e-18d9-0539-c34f" name="N&#226;rik Dreygur" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1141,22 +1140,22 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="743f-7948-e22e-8414" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
-        <infoLink id="dbb6-09c4-549e-007c" name="Master of Automata" hidden="false" targetId="8eef-f84b-37cb-554b" type="rule"/>
-        <infoLink id="1684-2944-0cdd-be4f" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
-        <infoLink id="939a-42cc-bf7d-57e6" name="Legiones Cybernetica" hidden="false" targetId="a2ef-63a4-3531-db91" type="rule"/>
+        <infoLink id="743f-7948-e22e-8414" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule" />
+        <infoLink id="dbb6-09c4-549e-007c" name="Master of Automata" hidden="false" targetId="8eef-f84b-37cb-554b" type="rule" />
+        <infoLink id="1684-2944-0cdd-be4f" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule" />
+        <infoLink id="939a-42cc-bf7d-57e6" name="Legiones Cybernetica" hidden="false" targetId="a2ef-63a4-3531-db91" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="7837-eff0-6d84-4615" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="ee56-4096-c582-710a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="99a3-f200-6427-bcfb" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="3f0c-0709-e9a4-dafd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="7837-eff0-6d84-4615" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="ee56-4096-c582-710a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="99a3-f200-6427-bcfb" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="3f0c-0709-e9a4-dafd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e8e7-72f1-d3e3-e43a" name="Graviton Gauntlet" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d26d-3780-ea1d-a329" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28b3-c363-f673-0a4e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d26d-3780-ea1d-a329" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28b3-c363-f673-0a4e" type="max" />
           </constraints>
           <profiles>
             <profile id="325a-50fa-8194-fe08" name="Graviton Gauntlet" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1169,88 +1168,88 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="60e0-a4ca-cd89-e158" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
-            <infoLink id="9199-4eac-1938-c5ce" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
-            <infoLink id="291e-e28a-85a2-969c" name="Haywire" hidden="false" targetId="1dd4-7a75-5c59-8425" type="rule"/>
+            <infoLink id="60e0-a4ca-cd89-e158" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
+            <infoLink id="9199-4eac-1938-c5ce" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule" />
+            <infoLink id="291e-e28a-85a2-969c" name="Haywire" hidden="false" targetId="1dd4-7a75-5c59-8425" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="fe28-809b-6f2e-9131" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3de8-fe68-2f0d-5f40" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a17-a4ab-29da-e897" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3de8-fe68-2f0d-5f40" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a17-a4ab-29da-e897" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="1096-c0d6-7f8b-fd32" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2cb-9e26-848a-0da3" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e47-6d7e-5eeb-392f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2cb-9e26-848a-0da3" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e47-6d7e-5eeb-392f" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="e361-74ef-815b-3e39" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6856-c144-16e6-281f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6856-c144-16e6-281f" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="c04f-9c0f-ef67-124b" name="Stoic Defender" hidden="false" collective="false" import="true" targetId="dcbb-3e5a-e54e-239c" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a84-3a99-a693-777d" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b61a-d759-9fae-9f36" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a84-3a99-a693-777d" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b61a-d759-9fae-9f36" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
         </entryLink>
         <entryLink id="5e35-951b-c941-08ce" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cf7-af87-41ce-cdfa" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43e2-6986-eb77-03bc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cf7-af87-41ce-cdfa" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43e2-6986-eb77-03bc" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="631f-8cad-09bc-5bcf" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <modifiers>
-            <modifier type="append" field="name" value="(master-crafted)"/>
+            <modifier type="append" field="name" value="(master-crafted)" />
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6877-31ad-1080-9c09" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c128-591f-7f36-1e0e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6877-31ad-1080-9c09" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c128-591f-7f36-1e0e" type="max" />
           </constraints>
           <infoLinks>
-            <infoLink id="6b44-c1d1-bb1c-0988" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="6b44-c1d1-bb1c-0988" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
           </infoLinks>
         </entryLink>
         <entryLink id="1be1-5e41-93e2-6c3d" name="Cortex Controller" hidden="false" collective="false" import="true" targetId="2fda-455f-d34d-97e0" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a350-1e5c-7ee0-bf0d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9615-6254-eb87-2823" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a350-1e5c-7ee0-bf0d" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9615-6254-eb87-2823" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="dda4-92f5-8735-1822" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d866-cc59-322d-135d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a27-c4dc-9aac-4ff4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d866-cc59-322d-135d" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a27-c4dc-9aac-4ff4" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="f944-6641-a714-2fe8" name="Perturabo" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="448d-767c-67a2-aae4" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="448d-767c-67a2-aae4" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="652f-8767-983f-8259" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="2cb8-f4af-7359-ee4e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="652f-8767-983f-8259" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="2cb8-f4af-7359-ee4e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="877c-1463-cab0-6661" name="Forgebreaker Desecrated" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1381-8635-afe3-00d1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1381-8635-afe3-00d1" type="max" />
           </constraints>
           <profiles>
             <profile id="cd0f-de75-b671-240f" name="Forgebreaker Desecrated" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1265,31 +1264,31 @@
           <infoLinks>
             <infoLink id="8229-43c9-5dcd-8d84" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Brutal (2)"/>
+                <modifier type="set" field="name" value="Brutal (2)" />
               </modifiers>
             </infoLink>
-            <infoLink id="1c7b-e847-f2e8-b36c" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
-            <infoLink id="f36f-7e6b-8339-28b9" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+            <infoLink id="1c7b-e847-f2e8-b36c" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
+            <infoLink id="f36f-7e6b-8339-28b9" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
             <infoLink id="97a8-9945-463b-0157" name="Exoshock (X)" hidden="false" targetId="69ca-318a-b47a-7a3c" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Exoshock (3+)"/>
+                <modifier type="set" field="name" value="Exoshock (3+)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="8e7b-ac53-70d2-b03a" name="Perturabo" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e118-6e7c-ddf2-336c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9937-6602-2013-e72f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e118-6e7c-ddf2-336c" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9937-6602-2013-e72f" type="min" />
           </constraints>
           <profiles>
             <profile id="24a7-00e6-ae71-528f" name="Perturabo" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Primarch (Unique)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">7</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">7</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
@@ -1310,27 +1309,27 @@
           <infoLinks>
             <infoLink id="0e43-c630-942c-3062" name="Battlesmith (X)" hidden="false" targetId="5d57-4d02-1e36-4a82" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Battlesmith (2+)"/>
+                <modifier type="set" field="name" value="Battlesmith (2+)" />
               </modifiers>
             </infoLink>
             <infoLink id="56b1-985a-1362-c17d" name="Firing Protocols (X)" hidden="false" targetId="32a3-f599-5c92-2945" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Firing Protocols (2)"/>
+                <modifier type="set" field="name" value="Firing Protocols (2)" />
               </modifiers>
             </infoLink>
-            <infoLink id="abe7-e8a3-554b-475b" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
-            <infoLink id="6faf-27cb-0543-72fe" name="Master of Automata" hidden="false" targetId="8eef-f84b-37cb-554b" type="rule"/>
+            <infoLink id="abe7-e8a3-554b-475b" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule" />
+            <infoLink id="6faf-27cb-0543-72fe" name="Master of Automata" hidden="false" targetId="8eef-f84b-37cb-554b" type="rule" />
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="dac8-72d0-65ea-cc13" name="The Logos Array" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ec4-0b4a-5692-9e6a" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55ed-e8e7-38b6-d3c5" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ec4-0b4a-5692-9e6a" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55ed-e8e7-38b6-d3c5" type="min" />
               </constraints>
               <profiles>
                 <profile id="c37b-3e8c-7f71-1688" name="The Logos Array (Ranged)" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">30&quot;</characteristic>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">30"</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
                     <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 6, Twin-linked, Shred, Pinning, Shell Shock (1)</characteristic>
@@ -1346,55 +1345,55 @@
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="64b9-1a0a-fd36-e175" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
-                <infoLink id="2016-bd35-2ecd-e546" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
-                <infoLink id="74b4-c5e0-c9f6-eb11" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+                <infoLink id="64b9-1a0a-fd36-e175" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule" />
+                <infoLink id="2016-bd35-2ecd-e546" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
+                <infoLink id="74b4-c5e0-c9f6-eb11" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
                 <infoLink id="9702-9c16-5b87-4f4f" name="Shell Shock (X)" hidden="false" targetId="46b7-63a1-941c-96a5" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Shell Shock (1)"/>
+                    <modifier type="set" field="name" value="Shell Shock (1)" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="388e-ab58-573f-59d3" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+                <infoLink id="388e-ab58-573f-59d3" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="bb94-f24b-37d6-2e85" name="Cortex Controller" hidden="false" collective="false" import="true" targetId="2fda-455f-d34d-97e0" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7158-e5a5-ff0e-0ef4" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d780-ad76-e93d-4072" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7158-e5a5-ff0e-0ef4" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d780-ad76-e93d-4072" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="ce4a-f628-0d73-8df2" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9752-b713-049a-6d54" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5382-32c3-faf7-929b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9752-b713-049a-6d54" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5382-32c3-faf7-929b" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="20f3-1644-0c85-f596" name="Dedicated Transport" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cf20-a2b8-1407-7bb1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cf20-a2b8-1407-7bb1" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="a3fd-6aad-90ad-7f3b" name="The Tormentor" hidden="false" collective="false" import="true" targetId="ec77-b9e7-904a-f49b" type="selectionEntry"/>
+            <entryLink id="a3fd-6aad-90ad-7f3b" name="The Tormentor" hidden="false" collective="false" import="true" targetId="ec77-b9e7-904a-f49b" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="7bce-b7e8-15a4-476c" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4430-fbbd-1e44-59e7" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2726-1eed-1599-faae" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4430-fbbd-1e44-59e7" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2726-1eed-1599-faae" type="min" />
           </constraints>
           <profiles>
             <profile id="98ee-3a55-d4f4-b036" name="Sire of the Iron Warriors" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
@@ -1406,13 +1405,13 @@
         </entryLink>
         <entryLink id="8552-e6ba-d1da-8691" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8305-3311-a876-07ea" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="511e-c925-74a2-30f9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8305-3311-a876-07ea" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="511e-c925-74a2-30f9" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="425.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="425.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="d355-5488-1277-fabf" name="Iron Havocs" hidden="false" collective="false" import="true" type="unit">
@@ -1424,29 +1423,29 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="cfae-5bdb-6de8-a59f" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
+        <infoLink id="cfae-5bdb-6de8-a59f" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule" />
         <infoLink id="2e35-8fe3-0dd1-2da0" name="Precision Shots (X)" hidden="false" targetId="4b71-81ee-31f4-fa09" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Precision Shots (6+)"/>
+            <modifier type="set" field="name" value="Precision Shots (6+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ee64-c915-d9f8-3b09" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="57e9-d1c5-973b-1aca" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="32ae-ac04-cb33-39c9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="ee64-c915-d9f8-3b09" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="57e9-d1c5-973b-1aca" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="32ae-ac04-cb33-39c9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4cb3-bda9-065c-eed4" name="Iron Havoc" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c66b-747c-c4fa-c052" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c53b-6fa9-3522-1a9e" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c66b-747c-c4fa-c052" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c53b-6fa9-3522-1a9e" type="min" />
           </constraints>
           <profiles>
             <profile id="f793-f5e4-84dd-4e43" name="Iron Havoc" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1460,26 +1459,26 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="f48a-d158-ea79-0043" name="Iron Havoc Sgt" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8969-e951-2281-314b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b377-796b-0e10-c631" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8969-e951-2281-314b" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b377-796b-0e10-c631" type="max" />
           </constraints>
           <profiles>
             <profile id="a4d7-b1ae-6868-a655" name="Iron Havoc Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="f48a-d158-ea79-0043" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cd75-0296-9866-a8bd" type="equalTo"/>
+                    <condition field="selections" scope="f48a-d158-ea79-0043" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cd75-0296-9866-a8bd" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1493,22 +1492,22 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="5a36-b0f6-649f-c4f5" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="5a36-b0f6-649f-c4f5" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3455-cfff-8f3f-2765" name="May exchange main weapon for:" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cd9-9a2a-bb29-6a28" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cd9-9a2a-bb29-6a28" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="ca86-9249-87cb-2428" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="ac6b-3818-ee23-ad58" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1517,33 +1516,33 @@
               <entryLinks>
                 <entryLink id="cd75-0296-9866-a8bd" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7323-1e95-b8f7-ac69" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7323-1e95-b8f7-ac69" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="1acd-09ac-3d09-5ce3" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5fa-fb3d-6006-a735" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5fa-fb3d-6006-a735" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="95cd-cbd1-9135-7bd0" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3fc-f444-adfc-79ee" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3fc-f444-adfc-79ee" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1552,39 +1551,39 @@
           <entryLinks>
             <entryLink id="46de-773a-c5dd-7310" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3e0-0c84-984e-5668" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3e0-0c84-984e-5668" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="7cf2-d582-de09-3d39" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62d5-0908-2e9e-6167" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62d5-0908-2e9e-6167" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="9f73-aa52-71fe-aa95" name="1) Unit Weapon Option:" hidden="false" collective="false" import="true" defaultSelectionEntryId="3c0e-7bf0-7749-20b7">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8a6-1ce6-161a-09cb" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc68-11ac-fd1e-183d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8a6-1ce6-161a-09cb" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc68-11ac-fd1e-183d" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="3c0e-7bf0-7749-20b7" name="Shrapnel Cannon" hidden="false" collective="false" import="true" targetId="975e-14eb-caed-4b5b" type="selectionEntry"/>
+            <entryLink id="3c0e-7bf0-7749-20b7" name="Shrapnel Cannon" hidden="false" collective="false" import="true" targetId="975e-14eb-caed-4b5b" type="selectionEntry" />
             <entryLink id="2706-9874-e424-3adf" name="Lascannon" hidden="false" collective="false" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="15.0">
                   <repeats>
-                    <repeat field="selections" scope="d355-5488-1277-fabf" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="d355-5488-1277-fabf" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
                 <modifier type="decrement" field="d2ee-04cb-5f8a-2642" value="15.0">
                   <conditions>
-                    <condition field="selections" scope="d355-5488-1277-fabf" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3455-cfff-8f3f-2765" type="equalTo"/>
+                    <condition field="selections" scope="d355-5488-1277-fabf" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3455-cfff-8f3f-2765" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1593,29 +1592,29 @@
               <modifiers>
                 <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="d355-5488-1277-fabf" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="d355-5488-1277-fabf" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
                 <modifier type="decrement" field="d2ee-04cb-5f8a-2642" value="5.0">
                   <conditions>
-                    <condition field="selections" scope="d355-5488-1277-fabf" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3455-cfff-8f3f-2765" type="equalTo"/>
+                    <condition field="selections" scope="d355-5488-1277-fabf" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3455-cfff-8f3f-2765" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="e156-bb14-5b7c-3654" name="Autocannon" hidden="false" collective="false" import="true" targetId="56b3-de09-9fea-deb6" type="selectionEntry"/>
+            <entryLink id="e156-bb14-5b7c-3654" name="Autocannon" hidden="false" collective="false" import="true" targetId="56b3-de09-9fea-deb6" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="ade8-0750-c61c-a626" name="Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04ce-11d5-a9e4-57cc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04ce-11d5-a9e4-57cc" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="0fff-3a53-4f09-9a53" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1624,7 +1623,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1633,16 +1632,16 @@
         </selectionEntryGroup>
         <selectionEntryGroup id="ea47-6430-f4f4-c9f7" name="2) Bolt Pistol Option:" hidden="false" collective="false" import="true" defaultSelectionEntryId="33c7-3205-dfbf-5e36">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d43d-1e08-d362-476f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a5d-4100-987f-2310" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d43d-1e08-d362-476f" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a5d-4100-987f-2310" type="min" />
           </constraints>
           <entryLinks>
-            <entryLink id="33c7-3205-dfbf-5e36" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+            <entryLink id="33c7-3205-dfbf-5e36" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry" />
             <entryLink id="be3a-a2c7-23c0-cec7" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="d355-5488-1277-fabf" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="d355-5488-1277-fabf" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
@@ -1653,25 +1652,25 @@
       <entryLinks>
         <entryLink id="3a6a-bbd9-9755-f253" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45da-85ae-f4be-b766" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65b0-3443-9b21-2fd2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45da-85ae-f4be-b766" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65b0-3443-9b21-2fd2" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="413a-1e74-bd9a-777e" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73b1-686e-aed9-7902" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0db-0589-da85-6343" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73b1-686e-aed9-7902" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0db-0589-da85-6343" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="6909-be00-35c9-2286" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f05c-0c3a-8eb7-f9e1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d69-76ed-dbdb-c2b9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f05c-0c3a-8eb7-f9e1" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d69-76ed-dbdb-c2b9" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="a6e3-baab-45b9-7fea" name="Iron Circle Maniple" hidden="false" collective="false" import="true" type="unit">
@@ -1683,7 +1682,7 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f944-6641-a714-2fe8" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f944-6641-a714-2fe8" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
@@ -1691,47 +1690,47 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="b889-ad5a-31ca-e3b1" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
-        <infoLink id="cab7-b545-2ba6-46da" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="b889-ad5a-31ca-e3b1" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule" />
+        <infoLink id="cab7-b545-2ba6-46da" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="212e-f90d-ac7a-7f16" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (3)"/>
+            <modifier type="set" field="name" value="Hammer of Wrath (3)" />
           </modifiers>
         </infoLink>
         <infoLink id="3e54-ac0a-4cb2-0953" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+            <modifier type="set" field="name" value="Feel No Pain (5+)" />
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f944-6641-a714-2fe8" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f944-6641-a714-2fe8" type="notInstanceOf" />
               </conditions>
             </modifier>
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="5f56-93f9-d0e5-627d" name="Automata:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
-        <categoryLink id="f1af-9bb8-90df-4ae6" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="dfac-bd55-47dd-cf0f" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="5f56-93f9-d0e5-627d" name="Automata:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false" />
+        <categoryLink id="f1af-9bb8-90df-4ae6" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="dfac-bd55-47dd-cf0f" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="44e0-946b-0a3a-ae22" name="Domitar-ferrum" hidden="false" collective="false" import="true" type="model">
           <modifiers>
             <modifier type="set" field="9a5e-8830-1463-1060" value="3.0">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f944-6641-a714-2fe8" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f944-6641-a714-2fe8" type="instanceOf" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d395-e15d-9dc2-0ea9" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a5e-8830-1463-1060" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d395-e15d-9dc2-0ea9" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a5e-8830-1463-1060" type="min" />
           </constraints>
           <profiles>
             <profile id="0da0-5e6c-07c5-7b79" name="Domitar-ferrum" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica, Heavy)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
@@ -1745,13 +1744,13 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="205c-194e-4d88-f40f" name="Karceri Battle Shield" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9ff-4469-31c5-e85f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20c2-af62-ddf1-338a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9ff-4469-31c5-e85f" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20c2-af62-ddf1-338a" type="max" />
           </constraints>
           <profiles>
             <profile id="b143-c357-586e-c20f" name="Karceri Battle Shield" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
@@ -1761,62 +1760,62 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="e939-acd7-a9fc-9a2b" name="Shrapnel Cannon" hidden="false" collective="false" import="true" targetId="975e-14eb-caed-4b5b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbfa-f146-056b-8623" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58f2-8589-007a-5a63" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbfa-f146-056b-8623" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58f2-8589-007a-5a63" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="9e00-ab06-dde1-daa0" name="Graviton Maul" hidden="false" collective="false" import="true" targetId="b254-abfc-a57f-ab28" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6621-0692-d5bb-98f8" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8893-964a-1587-a5a8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6621-0692-d5bb-98f8" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8893-964a-1587-a5a8" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="795a-5698-a1bc-6ec6" name="Tyrant Siege Terminator Squad" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="a275-b71b-42fe-024b" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="5148-151c-8644-d393" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule"/>
+        <infoLink id="5148-151c-8644-d393" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule" />
         <infoLink id="6dc2-9dd9-8459-d4b8" name="Firing Protocols (X)" hidden="false" targetId="32a3-f599-5c92-2945" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Firing Protocols (2)"/>
+            <modifier type="set" field="name" value="Firing Protocols (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="3d6b-8698-77f8-dddd" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="7332-ee1c-1ce2-0d4b" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
+        <infoLink id="3d6b-8698-77f8-dddd" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="7332-ee1c-1ce2-0d4b" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="7a42-24a0-f251-742d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="d025-1500-764b-7cb1" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="1084-a64f-bae5-5999" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="029a-d8b2-d712-01df" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="7a42-24a0-f251-742d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="d025-1500-764b-7cb1" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
+        <categoryLink id="1084-a64f-bae5-5999" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="029a-d8b2-d712-01df" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="b977-01e2-61ff-64bf" name="Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d9bf-7d17-26d3-c9bf" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d9bf-7d17-26d3-c9bf" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="471f-46a0-6c9e-e19f" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"/>
+            <entryLink id="471f-46a0-6c9e-e19f" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry" />
             <entryLink id="1597-3aa1-eb8b-0585" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="795a-5698-a1bc-6ec6" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="selections" scope="795a-5698-a1bc-6ec6" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1825,19 +1824,19 @@
         </selectionEntryGroup>
         <selectionEntryGroup id="b357-3448-db76-7052" name=" Tyrants" hidden="false" collective="false" import="true" defaultSelectionEntryId="eff3-5da7-2f41-d2c2">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28ca-b42f-6e95-7059" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c59-60db-776c-0641" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28ca-b42f-6e95-7059" type="min" />
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c59-60db-776c-0641" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="eff3-5da7-2f41-d2c2" name=" Tyrant w/Power Fist" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c97-f74c-66d3-3f10" type="max"/>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c97-f74c-66d3-3f10" type="max" />
               </constraints>
               <profiles>
                 <profile id="a7d7-45bf-be8d-e27c" name="Tyrant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1853,30 +1852,30 @@
               <entryLinks>
                 <entryLink id="f666-c897-425e-90a6" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="0f3d-c07c-7a7e-d534" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40b5-28f3-b89b-a874" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="188f-ad4c-f92a-5e52" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40b5-28f3-b89b-a874" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="188f-ad4c-f92a-5e52" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="ea4c-841f-f5e8-1382" name="Power Fist" hidden="false" collective="false" import="true" targetId="2e14-2521-f3ea-e301" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2206-fe33-c770-9f42" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5d2-8d09-b670-c9c4" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2206-fe33-c770-9f42" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5d2-8d09-b670-c9c4" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="e3ec-cb69-e087-e5f4" name="Tyrant w/Chainfist" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ce8-22d6-d945-cc7b" type="max"/>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ce8-22d6-d945-cc7b" type="max" />
               </constraints>
               <profiles>
                 <profile id="cd1f-f069-1204-9011" name="Tyrant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1892,30 +1891,30 @@
               <entryLinks>
                 <entryLink id="5f12-0901-dc6e-42f5" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="0f3d-c07c-7a7e-d534" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6a0-45ed-5b44-7755" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09dd-f57d-c7dc-896d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6a0-45ed-5b44-7755" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09dd-f57d-c7dc-896d" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="6df7-26fc-6ae3-5b5f" name="Chainfist" hidden="false" collective="false" import="true" targetId="1b03-1224-cd1a-6d3e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d1d-6e66-0be5-d1cb" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7670-99ab-fdb6-5b75" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d1d-6e66-0be5-d1cb" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7670-99ab-fdb6-5b75" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="0e0b-e394-c43e-6704" name="Tyrant w/Pair of Lightning Claws" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28a4-f1a1-6e1b-f53e" type="max"/>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28a4-f1a1-6e1b-f53e" type="max" />
               </constraints>
               <profiles>
                 <profile id="283d-6722-2f46-e92d" name="Tyrant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1931,24 +1930,24 @@
               <entryLinks>
                 <entryLink id="35de-bcaa-0529-f610" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d8a-7e5e-c2d5-4561" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee0f-b0cc-98a4-b600" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d8a-7e5e-c2d5-4561" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee0f-b0cc-98a4-b600" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="0ed4-b94a-3fa5-e652" name=" Siege Master" hidden="false" collective="false" import="true" defaultSelectionEntryId="941a-cb5c-f6ca-c2f4">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e06a-40d1-285b-91fd" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c57-6f02-5361-ed59" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e06a-40d1-285b-91fd" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c57-6f02-5361-ed59" type="max" />
           </constraints>
           <categoryLinks>
-            <categoryLink id="1207-e255-854f-7988" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="1207-e255-854f-7988" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="941a-cb5c-f6ca-c2f4" name="Siege Master" hidden="false" collective="false" import="true" type="model">
@@ -1961,7 +1960,7 @@
                 <profile id="ad40-f3a3-dfb2-f9c1" name="Siege Master" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1975,19 +1974,19 @@
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="d563-34bc-8151-dc0c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink id="d563-34bc-8151-dc0c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="0e33-b309-d3c6-530e" name="Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0951-ae6b-e9e2-c773">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9f4-6035-aaf3-c367" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5bb-0479-abbb-acff" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9f4-6035-aaf3-c367" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5bb-0479-abbb-acff" type="max" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="0951-ae6b-e9e2-c773" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry"/>
+                    <entryLink id="0951-ae6b-e9e2-c773" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry" />
                     <entryLink id="220e-ca97-efdc-5384" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -1996,21 +1995,21 @@
               <entryLinks>
                 <entryLink id="51bd-666e-d8bf-ab44" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f99-e7ca-0a4a-48c6" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f99-e7ca-0a4a-48c6" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="a083-ebf2-9016-1f0d" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb52-feda-74e0-1168" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1635-489a-bfae-46fd" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb52-feda-74e0-1168" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1635-489a-bfae-46fd" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="7b8b-6634-c202-fb31" name="Siege Master w/Pair of Lightning Claws" hidden="false" collective="false" import="true" type="model">
@@ -2023,7 +2022,7 @@
                 <profile id="2f6c-d12b-6af7-0604" name="Siege Master" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2037,26 +2036,26 @@
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="e244-e220-41e3-2b9b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink id="e244-e220-41e3-2b9b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
               </categoryLinks>
               <entryLinks>
                 <entryLink id="e0f3-34cb-4b06-ec04" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ad3-b4ca-b4a8-b541" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ad3-b4ca-b4a8-b541" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="caa8-5210-84d8-2864" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de1a-ec3d-76ad-0ab3" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0630-1adb-9211-51da" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de1a-ec3d-76ad-0ab3" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0630-1adb-9211-51da" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2065,42 +2064,42 @@
       <entryLinks>
         <entryLink id="01ed-6200-8527-9ecc" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="314f-3096-ebfa-edba" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9730-a590-18db-6882" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="314f-3096-ebfa-edba" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9730-a590-18db-6882" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="83dc-3057-e0f5-c119" name="Tyrant Rocket Launcher" hidden="false" collective="false" import="true" targetId="d8da-1d85-da96-96a9" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44a7-a40a-11dc-8af7" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52c1-f5a4-01c1-926f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44a7-a40a-11dc-8af7" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52c1-f5a4-01c1-926f" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="80.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="80.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="ec77-b9e7-904a-f49b" name="The Tormentor" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="add" field="category" value="a335-d5b0-79b6-8117">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="add" field="category" value="6d0b-fe0e-911e-486f">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="56b0-a8c0-499d-7197" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="56b0-a8c0-499d-7197" type="max" />
       </constraints>
       <profiles>
         <profile id="2846-c447-3065-548f" name="The Tormentor" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName=" Vehicle">
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy, Transport, Unique)</characteristic>
-            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10"</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">5</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
@@ -2119,162 +2118,162 @@
       <infoLinks>
         <infoLink id="301b-949a-f4f7-cb02" name="Void Shields" hidden="false" targetId="c503-f5b8-3da0-16e6" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Void Shields (1)"/>
+            <modifier type="set" field="name" value="Void Shields (1)" />
           </modifiers>
         </infoLink>
-        <infoLink id="dc59-8af8-089f-dc6b" name="Transport Bay" hidden="false" targetId="0662-8b8d-38e8-60f8" type="rule"/>
-        <infoLink id="0c62-e71b-7348-6b5d" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
+        <infoLink id="dc59-8af8-089f-dc6b" name="Transport Bay" hidden="false" targetId="0662-8b8d-38e8-60f8" type="rule" />
+        <infoLink id="0c62-e71b-7348-6b5d" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="139a-249d-4c38-650d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="cf0b-835c-75dd-6527" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-        <categoryLink id="733c-2fe4-e40d-c3e4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="139a-249d-4c38-650d" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="cf0b-835c-75dd-6527" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false" />
+        <categoryLink id="733c-2fe4-e40d-c3e4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e241-8547-5f25-6bb1" name="Turret Mounted volcano cannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7533-cf6d-fd42-566a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2459-53b3-ee22-d1fa" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7533-cf6d-fd42-566a" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2459-53b3-ee22-d1fa" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="4f39-5e52-b81f-9f33" name="Volcano Cannon" hidden="false" collective="false" import="true" targetId="c65f-0423-6564-a622" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d56-34f4-24ff-28cd" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8a0-35c3-53b4-fc20" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d56-34f4-24ff-28cd" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8a0-35c3-53b4-fc20" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="991c-c07c-0d59-7825" name="Hull (Right) Mounted twin-linked heavy bolter" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fef-c37a-bab1-2480" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec51-0cfa-146b-3b05" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fef-c37a-bab1-2480" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec51-0cfa-146b-3b05" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="2b0b-1139-1a41-e3d8" name="Twin-linked Heavy Bolter" hidden="false" collective="false" import="true" targetId="d03c-9f7e-84fa-d6e8" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3048-db63-edfd-b47a" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8ce-f954-2ddc-fd7a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3048-db63-edfd-b47a" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8ce-f954-2ddc-fd7a" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="72cf-b3cd-47b6-ff35" name="Hull (Front) Mounted twin-linked heavy bolter" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03e3-1549-d246-f464" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69be-9c70-3df9-0f42" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03e3-1549-d246-f464" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69be-9c70-3df9-0f42" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="31e2-eb73-8101-ac5c" name="Twin-linked Heavy Bolter" hidden="false" collective="false" import="true" targetId="d03c-9f7e-84fa-d6e8" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a245-f675-c5a9-9288" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85d5-b81e-7baa-a2b9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a245-f675-c5a9-9288" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85d5-b81e-7baa-a2b9" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="5463-1794-887b-ba25" name="Hull (Right) Mounted lascannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c199-ad8b-1d15-2e74" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb06-6a8e-03b1-7bbe" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c199-ad8b-1d15-2e74" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb06-6a8e-03b1-7bbe" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="6dd3-ada3-fc1c-d047" name="Lascannon" hidden="false" collective="false" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91ab-3c04-136b-c762" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3464-4f76-4a5c-1d0d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91ab-3c04-136b-c762" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3464-4f76-4a5c-1d0d" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="e094-dc48-76e3-8394" name="Hull (Left) Mounted lascannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c594-79bb-1f82-35aa" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90e3-6a11-4443-de9b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c594-79bb-1f82-35aa" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90e3-6a11-4443-de9b" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="c461-faeb-2fbe-1123" name="Lascannon" hidden="false" collective="false" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a2b-6d4f-b4e9-a935" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92a4-4eb7-c283-16af" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a2b-6d4f-b4e9-a935" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92a4-4eb7-c283-16af" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="7b49-6469-2d4b-fc35" name="Hull (Left) Mounted twin-linked heavy bolter" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a06-2fec-9cc5-a6f3" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="589b-89b0-e5cd-5fc7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a06-2fec-9cc5-a6f3" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="589b-89b0-e5cd-5fc7" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="9aec-ad00-f835-3ca8" name="Twin-linked Heavy Bolter" hidden="false" collective="false" import="true" targetId="d03c-9f7e-84fa-d6e8" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89df-61d7-243b-084a" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ed1-34e6-8f44-be5a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89df-61d7-243b-084a" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ed1-34e6-8f44-be5a" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="1a5b-17ac-87b3-8208" name="Smoke Launchers" hidden="false" collective="false" import="true" targetId="0873-34dd-e52d-d33c" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7c6-78e7-3bf2-7415" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be07-4470-8341-5235" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7c6-78e7-3bf2-7415" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be07-4470-8341-5235" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="3afa-0f85-a599-d50a" name="Searchlights" hidden="false" collective="false" import="true" targetId="4ae3-79b4-6051-505e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86ea-8782-c56a-a900" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f092-7bbf-0051-0aa7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86ea-8782-c56a-a900" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f092-7bbf-0051-0aa7" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="900.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="900.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="35e0-3b3a-f569-3da8" name="Kyr Vhalen" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="472c-9b3a-ee97-9794" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="472c-9b3a-ee97-9794" type="max" />
       </constraints>
       <infoLinks>
-        <infoLink id="a301-b079-3cd3-9d37" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
+        <infoLink id="a301-b079-3cd3-9d37" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8279-3044-a1e7-7a13" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="5215-204f-c641-45e8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="aadf-fc65-d13f-de42" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="8279-3044-a1e7-7a13" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="5215-204f-c641-45e8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="aadf-fc65-d13f-de42" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="046a-5e7e-7b20-3043" name="Kyr Vhalen" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="80d5-ecef-1f33-9343" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9d8d-93aa-bd2c-67cd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="80d5-ecef-1f33-9343" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9d8d-93aa-bd2c-67cd" type="max" />
           </constraints>
           <profiles>
             <profile id="87f5-6460-89a2-32df" name="Kyr Vhalen" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2290,26 +2289,26 @@
           <infoLinks>
             <infoLink id="2824-afb5-7296-ee84" name="Battle-Hardened (X)" hidden="false" targetId="5c3b-ed0b-4ad0-d547" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Battle-Hardened (1)"/>
+                <modifier type="set" field="name" value="Battle-Hardened (1)" />
               </modifiers>
             </infoLink>
             <infoLink id="8ad5-363c-3a45-970a" name="Battlesmith (X)" hidden="false" targetId="5d57-4d02-1e36-4a82" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Battlesmith (3+)"/>
+                <modifier type="set" field="name" value="Battlesmith (3+)" />
               </modifiers>
             </infoLink>
             <infoLink id="b46e-a7e3-4eec-a732" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Feel No Pain (6+)"/>
+                <modifier type="set" field="name" value="Feel No Pain (6+)" />
               </modifiers>
             </infoLink>
-            <infoLink id="4537-50b8-11c3-8b5a" name="Master of Automata" hidden="false" targetId="8eef-f84b-37cb-554b" type="rule"/>
+            <infoLink id="4537-50b8-11c3-8b5a" name="Master of Automata" hidden="false" targetId="8eef-f84b-37cb-554b" type="rule" />
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="11a8-c231-b509-1e3f" name="Aegeas" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77bc-64e6-48cf-d649" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e583-4091-3332-cae9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77bc-64e6-48cf-d649" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e583-4091-3332-cae9" type="max" />
               </constraints>
               <profiles>
                 <profile id="0f64-cd97-bc88-0b5c" name="Aegeas" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2324,106 +2323,106 @@
               <infoLinks>
                 <infoLink id="e2fe-bcf3-4a31-7bad" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Breaching (4+)"/>
+                    <modifier type="set" field="name" value="Breaching (4+)" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="7d78-54d6-5054-0e0c" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule"/>
-                <infoLink id="abac-552e-3765-4f44" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="7d78-54d6-5054-0e0c" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule" />
+                <infoLink id="abac-552e-3765-4f44" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="6633-f4ff-51d4-323e" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3956-3761-d81c-c405" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2e7-4c3a-e345-ef0f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3956-3761-d81c-c405" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2e7-4c3a-e345-ef0f" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="2c92-f282-30e0-c4f6" name="Cortex Controller" hidden="false" collective="false" import="true" targetId="2fda-455f-d34d-97e0" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3223-3d72-c3a0-4a3c" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43a3-6b5b-69b9-c1c8" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3223-3d72-c3a0-4a3c" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43a3-6b5b-69b9-c1c8" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="38c6-02c6-e1ac-e577" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de4f-e106-4dcb-22ed" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7be-8d52-34fa-8b65" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de4f-e106-4dcb-22ed" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7be-8d52-34fa-8b65" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="2331-6aca-c560-b751" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9be6-7a78-770d-b602" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ec8-38e5-0869-ec4d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9be6-7a78-770d-b602" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ec8-38e5-0869-ec4d" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="34f1-b977-4fc8-d585" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6755-b077-ac02-2662" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3643-640c-5470-33e3" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6755-b077-ac02-2662" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3643-640c-5470-33e3" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="0c17-0081-370d-76f9" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5d3-1538-fc08-f34e" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b82-da26-a122-71b3" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5d3-1538-fc08-f34e" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b82-da26-a122-71b3" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="b661-9977-96e1-5063" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8987-4aa4-7e68-f201" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bb4-2c08-6a8a-02d1" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8987-4aa4-7e68-f201" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bb4-2c08-6a8a-02d1" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="e412-51b4-a21b-380c" name="Servo-Arm" hidden="false" collective="false" import="true" targetId="4168-fc85-8912-7188" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e09d-9503-4e8d-51b0" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9146-b342-b0c9-e230" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e09d-9503-4e8d-51b0" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9146-b342-b0c9-e230" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="8bc4-f2ee-146b-47c2" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ec9-d90a-02da-cb63" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ec9-d90a-02da-cb63" type="max" />
           </constraints>
           <profiles>
             <profile id="cd5d-f3de-d43e-5aaf" name="Battle Logistician" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When this Warlord Trait is selected, before deployment and before any models are placed on the board, the Controlling player may select a single unit of any type that begins the game deployed on the table. Whilst all models that are part of the selected unit are within the Controlling player’s deployment zone, this unit gains the Relentless special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When this Warlord Trait is selected, before deployment and before any models are placed on the board, the Controlling player may select a single unit of any type that begins the game deployed on the table. Whilst all models that are part of the selected unit are within the Controlling player&#8217;s deployment zone, this unit gains the Relentless special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
-        <entryLink id="33b9-3a3e-f8c4-cffa" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup"/>
+        <entryLink id="33b9-3a3e-f8c4-cffa" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup" />
         <entryLink id="d096-cbd9-33ef-924f" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37e5-a5a9-87e4-4fb9" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbe7-1ecc-38fe-bae1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37e5-a5a9-87e4-4fb9" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbe7-1ecc-38fe-bae1" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="195.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="195.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="3feb-3ea1-97c2-9861" name="Erasmus Golg" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b5a0-59f4-c382-cb72" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b5a0-59f4-c382-cb72" type="max" />
       </constraints>
       <profiles>
         <profile id="df7a-7eb7-ce68-259c" name="Erasmus Golg" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character, Unique)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2437,31 +2436,31 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="1377-dd02-3cc2-2d60" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="de72-baf5-9e66-5eca" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="1377-dd02-3cc2-2d60" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="de72-baf5-9e66-5eca" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
         <infoLink id="c326-ae1a-4a70-52de" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
         <infoLink id="462f-ff76-b13c-a182" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (2)"/>
+            <modifier type="set" field="name" value="Hammer of Wrath (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="311f-2a92-88cf-ea1f" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
+        <infoLink id="311f-2a92-88cf-ea1f" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="1e3b-3776-e033-cd91" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="3cce-4df7-9ff9-c8eb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="b6c3-bd97-0c98-5440" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="c0cf-d856-baa2-b2d9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="1e3b-3776-e033-cd91" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
+        <categoryLink id="3cce-4df7-9ff9-c8eb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="b6c3-bd97-0c98-5440" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="c0cf-d856-baa2-b2d9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9f1e-2af9-7313-02c2" name="Extricator" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed37-d211-edc1-f95c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03fc-27e6-0f69-087e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed37-d211-edc1-f95c" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03fc-27e6-0f69-087e" type="max" />
           </constraints>
           <profiles>
             <profile id="97c2-181b-1e87-64f2" name="Extricator" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2474,67 +2473,67 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="2c6b-87a1-a4d4-764d" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+            <infoLink id="2c6b-87a1-a4d4-764d" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
             <infoLink id="a20e-c383-9c65-8e10" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Armourbane (Melee)"/>
+                <modifier type="set" field="name" value="Armourbane (Melee)" />
               </modifiers>
             </infoLink>
-            <infoLink id="54ee-d42b-7403-0966" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="54ee-d42b-7403-0966" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="f535-2671-4e8b-4db1" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="0d1c-227e-a3f8-cd63" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f652-a361-5490-a932" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22ad-64d9-99db-8cd5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f652-a361-5490-a932" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22ad-64d9-99db-8cd5" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="931e-d657-c858-231d" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a1b-1297-e977-2041" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7da3-76b0-9c69-0181" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a1b-1297-e977-2041" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7da3-76b0-9c69-0181" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="803e-ad99-453c-5b2d" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5daa-52e1-24b9-6eac" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab0b-dbb5-557d-01ae" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5daa-52e1-24b9-6eac" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab0b-dbb5-557d-01ae" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="68e8-d1c1-c639-5e83" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f73e-df2e-fdb1-e0c5" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5b9-74dd-b0f0-6a35" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f73e-df2e-fdb1-e0c5" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5b9-74dd-b0f0-6a35" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="a3fd-67f5-89eb-5759" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbc2-286b-6239-e2f3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbc2-286b-6239-e2f3" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="a161-c328-4543-888d" name="Bloody-handed" hidden="false" collective="false" import="true" targetId="2b87-826d-22a1-682c" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a7b-ced9-c551-a1b9" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6ed-6d66-3191-c536" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a7b-ced9-c551-a1b9" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6ed-6d66-3191-c536" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="49cd-6d47-8ec6-0388" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup"/>
+        <entryLink id="49cd-6d47-8ec6-0388" name="Retinue" hidden="false" collective="false" import="true" targetId="6590-c91a-fceb-8048" type="selectionEntryGroup" />
         <entryLink id="b749-37f2-8318-f761" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed32-fd79-bd7b-52ac" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ed8-83c2-750d-8028" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed32-fd79-bd7b-52ac" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ed8-83c2-750d-8028" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="1bfa-2413-beb9-5f32" name="Dominator Cohort" hidden="false" collective="false" import="true" type="unit">
@@ -2543,66 +2542,66 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f944-6641-a714-2fe8" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f944-6641-a714-2fe8" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
-          <description>An Iron Warriors Dominator Cohort may be selected as a Retinue Squad in a Detachment that includes Perturabo, instead of as an Elites choice. A unit selected as a ‘Retinue Squad’ must have Perturabo as the Iron Warriors Dominator Cohort’s Leader for the purposes of this special rule. An Iron Warriors Dominator Cohort selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as Perturabo. An Iron Warriors Dominator Cohort selected as a Retinue Squad must be deployed with Perturabo as part of the unit and Perturabo may not voluntarily leave the Retinue Squad during play. All models in an Iron Warriors Dominator Cohort selected in this manner lose the Hatred (Automata) and instead gain the Feel No Pain (6+) special rule. In addition, if an army includes an Iron Warriors Dominator Cohort selected as a Retinue Squad for Perturabo, then the army may not include any ‘Iron Circle’ Domitar-ferrum class Battle-automata Maniples.</description>
+          <description>An Iron Warriors Dominator Cohort may be selected as a Retinue Squad in a Detachment that includes Perturabo, instead of as an Elites choice. A unit selected as a &#8216;Retinue Squad&#8217; must have Perturabo as the Iron Warriors Dominator Cohort&#8217;s Leader for the purposes of this special rule. An Iron Warriors Dominator Cohort selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as Perturabo. An Iron Warriors Dominator Cohort selected as a Retinue Squad must be deployed with Perturabo as part of the unit and Perturabo may not voluntarily leave the Retinue Squad during play. All models in an Iron Warriors Dominator Cohort selected in this manner lose the Hatred (Automata) and instead gain the Feel No Pain (6+) special rule. In addition, if an army includes an Iron Warriors Dominator Cohort selected as a Retinue Squad for Perturabo, then the army may not include any &#8216;Iron Circle&#8217; Domitar-ferrum class Battle-automata Maniples.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="50e3-efe3-d94c-88d8" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="6a67-fd8d-030e-f371" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
-        <infoLink id="bd8a-5a73-62cd-9781" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
-        <infoLink id="36d3-c143-4f6a-96dd" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
+        <infoLink id="50e3-efe3-d94c-88d8" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="6a67-fd8d-030e-f371" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
+        <infoLink id="bd8a-5a73-62cd-9781" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
+        <infoLink id="36d3-c143-4f6a-96dd" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule" />
         <infoLink id="bc1a-7a7f-93b8-5a5d" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hatred (Automata)"/>
+            <modifier type="set" field="name" value="Hatred (Automata)" />
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f944-6641-a714-2fe8" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f944-6641-a714-2fe8" type="instanceOf" />
               </conditions>
             </modifier>
           </modifiers>
         </infoLink>
         <infoLink id="3c5a-cec8-0829-49d2" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
         <infoLink id="19c4-8394-3c95-f767" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Feel No Pain (6+)"/>
+            <modifier type="set" field="name" value="Feel No Pain (6+)" />
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f944-6641-a714-2fe8" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f944-6641-a714-2fe8" type="notInstanceOf" />
               </conditions>
             </modifier>
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0be3-3ef2-06d5-513f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="7d54-110a-f4d0-fbac" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="eb9f-a770-ac11-f3c5" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="2c06-dd4a-568c-f5f3" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="0be3-3ef2-06d5-513f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="7d54-110a-f4d0-fbac" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="eb9f-a770-ac11-f3c5" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="2c06-dd4a-568c-f5f3" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9d1e-8246-4cef-5387" name="1) Dominators" hidden="false" collective="false" import="true" defaultSelectionEntryId="3285-cc6e-1b0f-15a9">
           <constraints>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da1b-76a7-ebe9-d816" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e834-2b85-a95f-2244" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da1b-76a7-ebe9-d816" type="max" />
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e834-2b85-a95f-2244" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="3285-cc6e-1b0f-15a9" name="Dominator" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98ac-9d9f-5755-be90" type="max"/>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98ac-9d9f-5755-be90" type="max" />
               </constraints>
               <profiles>
                 <profile id="7afc-5b54-81b0-d809" name="Dominator" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2618,69 +2617,69 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="b60d-076d-dd70-81b7" name="Melee Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="0403-9d7e-a1de-0e56">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e828-efe8-5189-af59" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ae4a-74eb-62e4-08dc" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e828-efe8-5189-af59" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ae4a-74eb-62e4-08dc" type="max" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="e6f2-55de-62cd-7c69" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry"/>
-                    <entryLink id="0403-9d7e-a1de-0e56" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry"/>
+                    <entryLink id="e6f2-55de-62cd-7c69" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry" />
+                    <entryLink id="0403-9d7e-a1de-0e56" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry" />
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="7628-f0f4-3e01-e546" name="Ranged Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="2dec-3954-1435-6494">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9096-3fab-ba20-07d6" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6d1f-9a67-2782-8915" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9096-3fab-ba20-07d6" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6d1f-9a67-2782-8915" type="max" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="2dec-3954-1435-6494" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                    <entryLink id="2dec-3954-1435-6494" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry" />
                     <entryLink id="d221-f163-58f1-40cf" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="bc04-97a0-0712-936f" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="856b-81c7-1fe9-b09e" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="cf6a-2ea2-db3f-9246" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="bd2b-f23e-ba11-25c3" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="4794-a3ce-730c-4c66" name="Dominator w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="0a43-11d3-397c-b15a" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="1bfa-2413-beb9-5f32" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="1bfa-2413-beb9-5f32" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="1bfa-2413-beb9-5f32" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0a43-11d3-397c-b15a" type="max"/>
+                <constraint field="selections" scope="1bfa-2413-beb9-5f32" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0a43-11d3-397c-b15a" type="max" />
               </constraints>
               <profiles>
                 <profile id="6fe6-1bf4-2400-2fbe" name="Dominator" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2696,40 +2695,40 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="52d2-98f8-7db8-4441" name="Melee Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="e70c-45dd-f9cf-b122">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ca4-9f9d-2038-75b1" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ccf0-bf64-7c80-b2f1" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ca4-9f9d-2038-75b1" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ccf0-bf64-7c80-b2f1" type="max" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="cf42-06e2-c155-d217" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry"/>
-                    <entryLink id="e70c-45dd-f9cf-b122" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry"/>
+                    <entryLink id="cf42-06e2-c155-d217" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry" />
+                    <entryLink id="e70c-45dd-f9cf-b122" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry" />
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="1097-46b0-84a5-81c6" name="Heavy Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="19bb-5b5c-686d-58ae">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c90-69c1-068c-bde2" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d1aa-828d-c6fb-4f17" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c90-69c1-068c-bde2" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d1aa-828d-c6fb-4f17" type="min" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="19bb-5b5c-686d-58ae" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="bcbf-a417-1606-14f6" name="Reaper Autocannon" hidden="false" collective="false" import="true" targetId="b87f-48de-6ced-043b" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="c6b6-74bb-598e-5d0b" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2738,20 +2737,20 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="1bfa-2413-beb9-5f32" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                <condition field="selections" scope="1bfa-2413-beb9-5f32" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a876-9f23-c9c7-7d41" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a876-9f23-c9c7-7d41" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="0175-4999-cdb3-4218" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry"/>
+            <entryLink id="0175-4999-cdb3-4218" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="2e14-2521-f3ea-e301" name="Power Fist" hidden="false" collective="true" import="true" type="upgrade">
@@ -2766,18 +2765,18 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="6c9a-3e1c-2b99-c2e2" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
-        <infoLink id="f7c5-2109-5ca3-57eb" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
+        <infoLink id="6c9a-3e1c-2b99-c2e2" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
+        <infoLink id="f7c5-2109-5ca3-57eb" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule" />
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="d8da-1d85-da96-96a9" name="Tyrant Rocket Launcher" hidden="false" collective="true" import="true" type="upgrade">
       <profiles>
         <profile id="3fcc-251b-0184-e866" name="Tyrant Rocket Launcher (Frag) " hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
           <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48"</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
             <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 4, Pinning</characteristic>
@@ -2785,7 +2784,7 @@
         </profile>
         <profile id="1d75-8488-81dd-a5fb" name="Tyrant Rocket Launcher (Flak)" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
           <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48"</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
             <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 2, Skyfire</characteristic>
@@ -2793,7 +2792,7 @@
         </profile>
         <profile id="6748-2629-a341-bc30" name="Tyrant Rocket Launcher (Krak)" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
           <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48"</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
             <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 2</characteristic>
@@ -2801,36 +2800,36 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="a308-3974-da41-7e03" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
-        <infoLink id="5b57-1ad0-d6c1-c61d" name="Skyfire" hidden="false" targetId="f2bf-5daa-9f93-0b01" type="rule"/>
+        <infoLink id="a308-3974-da41-7e03" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule" />
+        <infoLink id="5b57-1ad0-d6c1-c61d" name="Skyfire" hidden="false" targetId="f2bf-5daa-9f93-0b01" type="rule" />
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="6590-c91a-fceb-8048" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a265-44f2-c1df-221d" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a265-44f2-c1df-221d" type="max" />
       </constraints>
       <entryLinks>
         <entryLink id="cac9-4e9f-c05a-2380" name="Dominator Cohort" hidden="true" collective="false" import="true" targetId="1bfa-2413-beb9-5f32" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f944-6641-a714-2fe8" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f944-6641-a714-2fe8" type="instanceOf" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="fc39-8924-a69f-10b5" name="Tartaros Command Squad" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
-        <entryLink id="cd97-51bf-2a68-1186" name="Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="fc39-8924-a69f-10b5" name="Tartaros Command Squad" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
+        <entryLink id="cd97-51bf-2a68-1186" name="Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
         <entryLink id="9b82-c43c-3987-cea4" name="Iron Circle Maniple" hidden="true" collective="false" import="true" targetId="a6e3-baab-45b9-7fea" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f944-6641-a714-2fe8" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f944-6641-a714-2fe8" type="instanceOf" />
               </conditions>
             </modifier>
           </modifiers>
@@ -2839,7 +2838,7 @@
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -2850,93 +2849,93 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="f6d5-234c-4237-efb4" value="1.0">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="65ce-ef0f-b616-fb56" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6d5-234c-4237-efb4" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="65ce-ef0f-b616-fb56" type="max" />
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6d5-234c-4237-efb4" type="min" />
       </constraints>
       <selectionEntryGroups>
         <selectionEntryGroup id="a031-a816-817c-c73b" name="  IV: Iron Warriors" publicationId="09c5-eeae-f398-b653" page="176" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="73e6-5358-f9ff-c611" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="baa1-4eb5-a1c1-76cc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="73e6-5358-f9ff-c611" type="max" />
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="baa1-4eb5-a1c1-76cc" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="bc35-9f7c-54ea-b140" name="Tyrant of the Dodekathon" publicationId="09c5-eeae-f398-b653" page="176" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="57ca-0aa7-1c52-43c8" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c124-46c0-2532-8324" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="57ca-0aa7-1c52-43c8" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c124-46c0-2532-8324" type="max" />
               </constraints>
               <profiles>
                 <profile id="7e37-1b0c-4b26-1a94" name="Tyrant of the Dodekathon" publicationId="09c5-eeae-f398-b653" page="176" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">After all armies have been deployed onto the battlefield but before Scout moves and Infiltrators are placed, the controlling player of a Warlord with this Trait may nominate one area of terrain, Building or Fortification on the battlefield. If the chosen item is an area of terrain that provides a Cover Save, then that Cover Save is removed and the area counts as both Difficult Terrain and Dangerous Terrain instead. If the item chosen is a Building or Fortification then all rolls on the Building Damage table made for that Building or Fortification gain a modifier of +1. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">After all armies have been deployed onto the battlefield but before Scout moves and Infiltrators are placed, the controlling player of a Warlord with this Trait may nominate one area of terrain, Building or Fortification on the battlefield. If the chosen item is an area of terrain that provides a Cover Save, then that Cover Save is removed and the area counts as both Difficult Terrain and Dangerous Terrain instead. If the item chosen is a Building or Fortification then all rolls on the Building Damage table made for that Building or Fortification gain a modifier of +1. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="69b4-f80e-296b-dd3e" name="Tyrant of the Lyssatra" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f5e2-ddcb-3f3c-4457" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ad4-1683-9f06-2d6a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f5e2-ddcb-3f3c-4457" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ad4-1683-9f06-2d6a" type="max" />
               </constraints>
               <profiles>
                 <profile id="f48c-9402-cb1b-8e01" name="Tyrant of the Lyssatra" publicationId="09c5-eeae-f398-b653" page="177" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and every model with the Infantry Unit Type in a unit it has joined with the Legiones Astartes (Iron Warriors) special rule may choose to roll an additional dice when making a Shooting Attack with any Rapid Fire, Assault or Heavy weapon that does not have the Blast or Template special rules, but these weapons gain the Gets Hot special rule for that Shooting Attack. If a Warlord and/or unit under the effect of this Trait makes the Bitter Fury Reaction, then a single additional dice is added to the number of attacks made by each model after the effects of Bitter Fury have been applied. In addition, whenever a Warlord with this Trait, and any unit it has joined, is the target of an enemy Shooting Attack it must make either the Return Fire or Bitter Fury Reactions if possible – this Reaction does not cost a point of the Reactive player’s Reaction Allotment, but does not allow that unit to make any further Reactions in that Phase and does not allow the Bitter Fury Reaction to be made more than once per battle. However, a Warlord with this Trait and any unit it has joined may make no other Reaction in any Phase, excepting only the Interceptor Advanced Reaction.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and every model with the Infantry Unit Type in a unit it has joined with the Legiones Astartes (Iron Warriors) special rule may choose to roll an additional dice when making a Shooting Attack with any Rapid Fire, Assault or Heavy weapon that does not have the Blast or Template special rules, but these weapons gain the Gets Hot special rule for that Shooting Attack. If a Warlord and/or unit under the effect of this Trait makes the Bitter Fury Reaction, then a single additional dice is added to the number of attacks made by each model after the effects of Bitter Fury have been applied. In addition, whenever a Warlord with this Trait, and any unit it has joined, is the target of an enemy Shooting Attack it must make either the Return Fire or Bitter Fury Reactions if possible &#8211; this Reaction does not cost a point of the Reactive player&#8217;s Reaction Allotment, but does not allow that unit to make any further Reactions in that Phase and does not allow the Bitter Fury Reaction to be made more than once per battle. However, a Warlord with this Trait and any unit it has joined may make no other Reaction in any Phase, excepting only the Interceptor Advanced Reaction.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="3cad-39a2-1afc-ffc6" name="Tyrant of the Apolokron" publicationId="09c5-eeae-f398-b653" page="176" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9884-60c4-3c40-e666" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3b6-b80d-f01c-394c" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9884-60c4-3c40-e666" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3b6-b80d-f01c-394c" type="max" />
               </constraints>
               <profiles>
                 <profile id="51a5-ba7e-0484-baf7" name="Tyrant of the Apolokron" publicationId="09c5-eeae-f398-b653" page="176" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait gains the Fearless special rule, but may not join any unit that is not entirely compsed of models with the Legiones Astartes (Iron Warriors) special rule. However, the Warlord and all models in any unit it joins must adhere to the following restrictions: during both the controlling player&apos;s Shooting phase and the Charge sub-phase, the unit must attempt a Shooting Attack and/or Charge if there is an enemy unit within range, and must target the closest enemy unit possible that is within its line of sight and is a valid target for a Shooting Attack or Charge. If two or more targets are equally close then the controlling player chooses which will be the target of a Shooting Attack or Charge. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&apos;s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait gains the Fearless special rule, but may not join any unit that is not entirely compsed of models with the Legiones Astartes (Iron Warriors) special rule. However, the Warlord and all models in any unit it joins must adhere to the following restrictions: during both the controlling player's Shooting phase and the Charge sub-phase, the unit must attempt a Shooting Attack and/or Charge if there is an enemy unit within range, and must target the closest enemy unit possible that is within its line of sight and is a valid target for a Shooting Attack or Charge. If two or more targets are equally close then the controlling player chooses which will be the target of a Shooting Attack or Charge. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player's Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="7882-51de-1452-4035" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
+                <infoLink id="7882-51de-1452-4035" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="1e29-d8a9-f323-a90f" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+        <entryLink id="1e29-d8a9-f323-a90f" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Night Lords.cat
+++ b/2022 - LA - Night Lords.cat
@@ -3421,7 +3421,7 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
         <entryLink id="be72-b7b1-3b03-d38b" name="Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
         <entryLink id="4c57-238e-e66f-d49a" name="Tartaros Command Squad" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_be38-a066-4f8e-ae54</comment></selectionEntryGroup>
     <selectionEntryGroup id="7923-f342-c07f-4967" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -3514,7 +3514,7 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
       <entryLinks>
         <entryLink id="3269-26df-fcc4-f3b7" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_7dee-602c-4b47-be09</comment></selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
     <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />

--- a/2022 - LA - Night Lords.cat
+++ b/2022 - LA - Night Lords.cat
@@ -1,6 +1,5 @@
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="36dc-14fc-8872-476b" name="LA -   VIII: Night Lords" revision="16" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26">
-  <entryLinks>
-    <entryLink id="f491-c7fa-f6d3-917d" name="Contekar Terminator Squad" hidden="false" collective="false" import="false" targetId="837e-c3ca-437e-dfbf" type="selectionEntry">
+  <entryLinks><entryLink id="f491-c7fa-f6d3-917d" name="Contekar Terminator Squad" hidden="false" collective="false" import="false" targetId="837e-c3ca-437e-dfbf" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -161,947 +160,1957 @@
         <categoryLink id="fc50-4558-2e33-bedb" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="6b63-7c17-9adf-4290" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4398-8672-f7a9-b094" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="99f4-ce28-af50-bc04" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <entryLink id="6b63-7c17-9adf-4290" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="7dcc-af84-42fb-bd0c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6d4-581f-4746-bec3</comment></categoryLink>
+        <categoryLink id="477d-5ef3-4ff0-a6f5" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_2489-ee2a-45dd-b384</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
-    <entryLink id="dd80-d9d4-ff80-44df" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="dc5b-0c2e-cc60-eebf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9d16-6b6c-ba36-33d1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
-    <entryLink id="43e2-b2fb-d9d3-4590" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink><entryLink id="dd80-d9d4-ff80-44df" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b02f-e65f-4a88-a175</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_b87b-bf35-4238-b7c6</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1aff-27af-435e-8102</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_fdf9-4906-4180-a39d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c2f8-252b-55a0-40af" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="7c51-0be9-3483-90a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2540-c34a-e28f-2fa4" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="e20f-d8a9-4bd6-9a40" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8378-ede4-476d-b657</comment></categoryLink>
+        <categoryLink id="353c-ef8d-419c-8c82" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_d64f-ad19-426c-adf7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
-    <entryLink id="2323-ba5c-0fde-3f7e" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7710-34ef-d225-deb1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="e5c5-1ff1-280f-0a60" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
-    <entryLink id="dd2f-c7e6-c43d-50b5" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="f9ec-02b2-e955-c7c1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="bd64-ec2f-bc32-1b6f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
-    <entryLink id="eeb6-6f88-48ca-9d74" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink><entryLink id="43e2-b2fb-d9d3-4590" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_7fd1-8ce8-4d10-82e7</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_eaae-8c43-4d30-898c</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_f67d-8cf3-424f-b491</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_b949-6414-4f3d-b268</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3417-8f49-7272-ce18" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="6e19-a1ee-d25b-0123" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0ce7-0019-34d6-c77f" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="1c3b-258e-4ff4-aadc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_ac26-e639-4d53-9b8b</comment></categoryLink>
+        <categoryLink id="0caf-d428-4c28-b427" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_49af-0d08-4c7e-8ce6</comment></categoryLink>
+        <categoryLink id="199d-8e74-48c2-88cb" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_b606-de16-4659-95cd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
-    <entryLink id="9be5-ca48-3191-5e96" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink><entryLink id="2323-ba5c-0fde-3f7e" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="5bae-3bea-40de-98dd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="0ad4-1131-aa92-3d48" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
-    <entryLink id="520c-c37e-701b-2ade" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7583-6fa0-4089-a19e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_0e5c-99ab-41d3-a42e</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c296-e8e8-4a7a-989a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_8868-5bcb-4604-ba8e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9538-010c-4b21-a6ce" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a009-a597-4b51-b228</comment></categoryLink>
+        <categoryLink id="42fe-df5e-4f16-acbe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_24f4-9145-4016-80d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink><entryLink id="dd2f-c7e6-c43d-50b5" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_e732-7499-47bf-9748</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_81a5-a959-46b7-baa4</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7ec3-447a-4644-b012</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_71e2-c430-4c99-a559</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_df7b-3fb9-4f65-9165</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="091a-a587-4f76-b255" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c165-3906-463a-9c73</comment></categoryLink>
+        <categoryLink id="1cad-d4a2-48d2-9cd3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6d1-d14c-473f-be09</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink><entryLink id="eeb6-6f88-48ca-9d74" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_27a3-1e4c-4b76-a594</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_d59a-dcd0-44fd-b866</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_0c8b-2b92-49ed-98c7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_bafe-f799-41d9-ac85</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_6369-288c-4fec-a640</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_fe53-8858-41dc-8ec4</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1484-30c5-db06-179e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="2a11-43bb-ea70-4f01" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="830e-7e63-46c6-8462" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_3a22-caae-4eea-9bc5</comment></categoryLink>
+        <categoryLink id="32fb-ed0a-4dba-830e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f759-f33e-4698-9f8a</comment></categoryLink>
+        <categoryLink id="0746-adb1-4f09-b98f" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_c624-3ae0-46c0-9b06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
-    <entryLink id="c59f-e5d9-186b-a729" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c0a0-a5ba-5530-1bd2" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="e434-e205-d51e-0b7a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="daa9-127e-393b-8d69" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="153c-2715-6d5e-b80b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup" />
-        <entryLink id="353f-d51d-9a7f-65e6" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink><entryLink id="9be5-ca48-3191-5e96" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_13b3-ce1e-4f9d-8319</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d681-9d81-4abd-b11b</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a57-e48b-4534-bca5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_1859-5641-4674-9097</comment>
+                </condition>
               </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
-    <entryLink id="5407-fd2e-46a0-378d" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
-      <modifiers>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9425-9857-4af3-b1e4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_251a-df5b-4bfd-ad63</comment></categoryLink>
+        <categoryLink id="909d-97bd-4d17-a167" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4644-98ab-4e3f-b1fd</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink><entryLink id="520c-c37e-701b-2ade" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_591d-d028-4663-918d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_0482-c5f9-4c95-9597</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_75a7-971d-4978-a83f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_a7d5-2bfe-4621-ac0c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9f13-b460-4f27-b0cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_31fc-e265-45a7-bb5b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="373b-801c-89fa-beb6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5abb-c812-077b-83f8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="1c05-b5a1-3770-93fe" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="abc0-af4b-4353-b0f5" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_67c2-df43-44fc-92d1</comment></categoryLink>
+        <categoryLink id="4861-217c-4f4f-bd62" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4136-bb4e-4dd4-99f9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink><entryLink id="c59f-e5d9-186b-a729" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry"><categoryLinks>
+        <categoryLink id="2cce-6eb7-473b-87a3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_2599-24e3-44e5-9568</comment></categoryLink>
+        <categoryLink id="1a1b-5f70-44df-8835" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_285f-6e56-473b-b2fe</comment></categoryLink>
+        <categoryLink id="ebf2-439f-4d85-87f9" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_685e-022f-4e2f-a568</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="849b-f7aa-ed61-86ce" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup" />
-        <entryLink id="6656-56b0-6738-0796" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup">
+        <entryLink id="eb05-5544-4265-8f8f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup"><comment>    template_id_2a38-6544-4267-b584    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="1e04-e8b8-43f5-828a" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_8287-16ff-46ba-9838</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_81c1-fca9-44dc-ba4c</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_6e59-4592-47ef-b76d    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
-    <entryLink id="7129-2a2a-b24d-2223" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6aac-8aaf-df09-bea6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0338-f461-e1ae-9e45" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="057c-1aec-c106-4766" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="1bf9-30e2-69cf-6d43" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup" />
-        <entryLink id="770b-4012-4b33-dc8c" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
-    <entryLink id="7bfb-397f-f70b-f6d7" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ca4d-c0bb-3aa6-7974" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="3ffd-cc3c-889b-11c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
-    <entryLink id="b2a8-ede4-2774-1e57" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c3fa-7a49-5d0a-8075" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b883-640b-b657-7761" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
-    <entryLink id="c262-7af0-6986-95ac" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink><entryLink id="5407-fd2e-46a0-378d" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ad5d-3c79-4239-9116</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_60b1-049b-4a5f-85c2</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f725-e230-7147-4700" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ae6c-0eeb-5d48-c898" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="4b5e-43ed-44bb-9c45" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bd6a-0cda-4e0f-80ae</comment></categoryLink>
+        <categoryLink id="1ffb-b70d-47f6-be5a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_ae75-7cca-4701-9d56</comment></categoryLink>
+        <categoryLink id="38c0-8a86-4776-ab51" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_e517-62d4-48f7-8174</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
-    <entryLink id="2000-179d-70cc-8970" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
+      <entryLinks>
+        <entryLink id="c59e-80e0-4ac3-ae1a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup"><comment>    template_id_fafb-6414-474a-8a09    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="f64b-de11-4c4f-ade0" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_1e43-c980-4508-8ec2</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_4140-36a7-4203-b5e9</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_a6a6-9bc7-4d4e-86a7    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink><entryLink id="7129-2a2a-b24d-2223" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry"><categoryLinks>
+        <categoryLink id="71d3-1c71-4d58-b4f9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fc9d-03d1-4bbd-a1c4</comment></categoryLink>
+        <categoryLink id="1ced-0fde-44b2-824a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_f51c-73d7-4f29-be1c</comment></categoryLink>
+        <categoryLink id="0c4a-6dc5-4748-beca" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_257d-78c0-4bab-ba65</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="3761-d784-451f-8911" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup"><comment>    template_id_ac26-33db-40a7-bdba    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="f484-78e1-4f11-b550" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_189b-db75-4db6-9fe9</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_cbdb-2500-4e13-876a</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_dc8e-2801-46d6-84f8    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink><entryLink id="7bfb-397f-f70b-f6d7" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b43b-547f-472e-9076</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8ff9-0498-4540-8552</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fbfe-931a-489b-a589</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f4c3-5aa6-4caa-abf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_17f8-f055-4c9c-b757</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="e7a1-7ea9-e3be-429c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c398-8fe3-f6a5-317c" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="bf0b-ebc8-48fc-a53a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f1c8-27fd-4f98-8527</comment></categoryLink>
+        <categoryLink id="2580-f2ab-4d8a-909e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2b20-1a8b-4753-b657</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
-    <entryLink id="dd14-7b27-ecf6-3df2" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink><entryLink id="b2a8-ede4-2774-1e57" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry"><categoryLinks>
+        <categoryLink id="20eb-6929-4b51-adad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4207-8d8f-4b1a-836b</comment></categoryLink>
+        <categoryLink id="835c-c0f7-423c-bb94" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_2b34-077f-4279-86fb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink><entryLink id="c262-7af0-6986-95ac" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="1eca-56d9-f536-5b48" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="43b6-6500-f9f2-8cd2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="08ec-97df-4e60-8628" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6577-e0fb-4fda-834e</comment></categoryLink>
+        <categoryLink id="c26d-3fa1-4501-bae6" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_5d59-09bf-4566-b7e1</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
-    <entryLink id="14f8-46c6-5baf-ec66" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink><entryLink id="2000-179d-70cc-8970" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"><categoryLinks>
+        <categoryLink id="efd9-3653-4499-9015" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_aa93-057d-42f6-82d7</comment></categoryLink>
+        <categoryLink id="3719-de4b-4e4a-b83b" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_403c-4e9c-4af5-84ec</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink><entryLink id="dd14-7b27-ecf6-3df2" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_23fa-06dd-49f9-a7db</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5b26-059e-40b3-9d93</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f7bf-3a1c-4103-aed8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="bf7b-246b-a0fa-39ea" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="e343-0c42-3c25-b45e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0ff5-1690-4a71-bc80" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dd44-e0a8-42a8-bdcc</comment></categoryLink>
+        <categoryLink id="4f0a-1682-44b4-88a0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_c5b0-f9ae-468d-924a</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
-    <entryLink id="8717-7d90-29c6-0078" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink><entryLink id="14f8-46c6-5baf-ec66" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8396-e51c-4e2b-bada</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_13bb-9fb5-4580-92cf</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_bfb8-8125-4548-92f5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25e3-b8f5-4448-a7c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1ef9-54e1-48a0-bf97" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_f926-27fd-4a92-97a1</comment></categoryLink>
+        <categoryLink id="9f5d-6f6b-416d-bb66" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_82e3-36e1-4e85-8fcb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink><entryLink id="8717-7d90-29c6-0078" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="37b3-b94d-fa98-6285" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
         <categoryLink id="fd84-59fb-70b2-6e83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="0d78-fe66-5b49-c81a" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
-      <modifiers>
+    <entryLink id="0d78-fe66-5b49-c81a" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_658f-b1ad-4347-a998</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_12bc-3db2-4d28-abce</comment>
+            </condition>
           </conditions>
         </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e377-c212-88bb-b841" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3ba1-b53c-6e3b-a5ad" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
-    <entryLink id="8218-b17a-bde2-8383" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_9d83-7691-41d6-8dad</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_add7-ba48-46d4-8a02</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_1fb0-2421-40a4-9e49</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8efe-baba-177d-9872" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="4559-4f5b-d8d9-00ee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9bc8-7569-f56a-cac7" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="5928-e1ac-40fb-ad64" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7004-b00d-481f-b740</comment></categoryLink>
+        <categoryLink id="214c-637a-41a0-9526" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4f88-2fc3-491c-bfb7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
-    <entryLink id="e5a8-0153-f5a1-9c57" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d6e5-0345-79ef-3709" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ac1e-aecb-2eda-512c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
-    <entryLink id="589e-93e1-3cd7-d79c" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5c0b-fc42-41fa-9172" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="a085-0029-7499-79a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
-    <entryLink id="14da-091d-f2bf-4312" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2f62-7ddb-bf9c-c59b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="663b-5ce0-a3ca-acf4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
-    <entryLink id="0faa-25ee-9e8d-5462" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="95dd-60db-f855-6b1c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="14c8-4ba7-e3c1-8eaf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
-    <entryLink id="743a-0c64-2289-ce30" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4771-7a36-6092-446a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0bbe-97c4-53da-9e28" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
-    <entryLink id="29aa-8bfd-f9d9-4ea1" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2928-9538-52d5-86ca" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="e969-493e-ce81-1c4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
-    <entryLink id="8318-eb2b-c28e-4cd0" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="4d9b-2349-e9fe-03a1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="c4b9-3f76-ff76-c63f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
-    <entryLink id="6743-2670-6268-56da" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="30cd-1af9-ae9d-985c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d524-5b49-52e3-1c9e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
-    <entryLink id="35c9-4563-b9af-04df" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a3c5-e5db-edf8-ee9b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="6f23-a0eb-fd35-e99c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
-    <entryLink id="1e63-105c-377d-0e94" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c2fc-4f2d-8aa8-a4ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d95e-c52f-22d0-51db" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
-    <entryLink id="1a65-546e-f47e-6258" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7ec8-3f28-f8eb-28c3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="5a6d-9ad8-758c-078d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
-    <entryLink id="125c-026a-4be2-266a" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3436-02b2-cf64-c8c4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="1637-6f5b-2b7d-de77" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
-    <entryLink id="1aa7-1faf-cd9a-c2a6" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f61b-2884-44ff-47a1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="2c92-5eb9-75f8-96e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
-    <entryLink id="631e-1360-1656-131d" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2a5f-92f6-1023-24e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d5fc-f363-632f-9248" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
-    <entryLink id="9e86-53db-593a-f386" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4288-7dcb-a8bc-d52d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3878-2985-6a5f-c5b3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
-    <entryLink id="d1a5-d8bb-acec-3499" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="82e7-1141-8911-a3d3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="22b9-19ed-8243-6c9f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
-    <entryLink id="88ee-a5a9-8bc1-d642" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="cbb9-c5cb-a995-11a3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="5758-42fa-6483-ad1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
-    <entryLink id="d3f7-4b68-4620-71c0" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="edce-6dfa-009f-b888" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="6513-2ccd-3aad-1369" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
-    <entryLink id="9cb7-e623-a570-7f9b" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d6db-68ca-bc7c-a89f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="2d91-c42f-87be-75c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
-    <entryLink id="0918-bc53-3b57-d4bd" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="cec4-2f96-a9d8-b1ff" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="0dd4-8477-c6a5-2dda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
-    <entryLink id="b8b1-85a0-da81-84ef" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="31d0-f5dd-d590-f44c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="0fe2-1b79-06e7-cba5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
-    <entryLink id="75bb-bdff-c428-6980" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="ead6-b9ca-69dc-9e9d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="f72f-283a-b30e-5717" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
-    <entryLink id="a964-cde7-e4a6-214f" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="2f0c-4e80-0e67-18cb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="b4b6-455d-7034-933f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
-    <entryLink id="50ef-7431-d164-ddc3" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="2c88-5bb4-c0a2-b7dc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="dc15-12fc-5e96-6572" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
-    <entryLink id="c99d-d45c-e6df-c8d5" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6443-210d-76dd-2567" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d3b1-742a-a2f1-3dab" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
-    <entryLink id="77fc-1222-7a9e-e1d0" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="96b7-d05f-8520-1933" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="ee6c-4065-b963-db7a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
-    <entryLink id="cb29-6fb3-b99d-62ae" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="792b-953e-cad5-dbb2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="aa0a-9234-c3d8-88d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
-    <entryLink id="99a3-879d-2980-2285" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="bffa-6bd9-1c88-0af5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0d79-cf87-62b4-557a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
-    <entryLink id="640e-ab18-7e85-5f80" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="796c-021b-2134-3189" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="fcfc-0f68-773c-9c77" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
-    <entryLink id="13ba-a297-b455-efe5" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="bbd1-4554-3f4a-2a39" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="4aab-83b8-a919-908c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
-    <entryLink id="4b61-6cb1-1fbb-ded2" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7223-7250-0eea-eca9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4ed8-9475-c5fa-024f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
-    <entryLink id="966e-be19-0b84-c8a6" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b35f-75ec-b520-f042" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="4b01-28d8-740e-6337" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4277-100b-c6ac-2d59" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="5b68-5130-cc21-a675" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup" />
-        <entryLink id="23bb-5a03-28bb-15e5" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
-    <entryLink id="cbdd-df4a-3b5f-abdd" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="270f-52f9-2ae1-0910" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="10b9-627d-a7f9-6088" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a37d-4315-5f51-0ce9" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="f509-8bfa-a4a8-8e51" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup" />
-        <entryLink id="3379-0fc6-1e2f-d046" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
-    <entryLink id="8141-b381-6e35-cf64" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0ac5-d9ff-2054-8bbb" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="d200-a698-fda1-df05" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2bf2-736a-706b-9cf8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="d0d2-63f3-5ea7-540f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup" />
-        <entryLink id="525d-eb85-aaab-927a" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
-    <entryLink id="31be-fe57-8aa0-4c66" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c266-c2d1-6eda-b0f8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="576a-d259-9fb4-c382" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
-    <entryLink id="2a51-2646-dcef-b4b3" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="30e2-d071-4c17-946e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="8cce-a9f7-dfba-6c7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
-    <entryLink id="eb2b-1a8e-577c-4c49" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f34a-371d-c249-4692" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="cce8-dea3-3d25-665c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
-    <entryLink id="3630-3878-3a8d-67aa" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e427-495f-12a8-9f40" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="8708-7591-f986-1cc8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
-    <entryLink id="d8cd-1f7f-e904-30f2" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6a7d-054f-1d60-2f03" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="4d42-1cf9-a8f5-6419" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
-    <entryLink id="52fb-ffad-729d-cf07" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="171e-345f-e596-6ff3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="b0d3-0599-4f6e-ef7a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
-    <entryLink id="41f5-ec2d-a2c0-97a2" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3924-cd45-3ae0-ee94" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3e90-62df-96c8-d0d9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
-    <entryLink id="58e8-a073-7f80-608e" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d925-f60a-0175-051e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="45e9-2190-3f91-a5b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
-    <entryLink id="915c-23cf-cc58-2c1b" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e383-bb92-9efb-b845" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b740-0164-4ae8-12b9" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
-    <entryLink id="bd6a-d7fd-1d9a-476b" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="405a-8c92-9afd-a007" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="aeed-5588-4a82-c5f1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
-    <entryLink id="a09f-3151-5892-ce0f" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6958-c12e-8f67-8c8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f073-82c1-f147-90cf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
-    <entryLink id="a529-339a-abad-65c1" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5054-8532-49eb-7b26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0c8f-938a-adef-dc8d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
-    <entryLink id="43e2-e234-abfe-1776" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="be3e-2e23-4737-7d29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="096a-3648-aa71-cad6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
-    <entryLink id="5a0b-deca-f472-0d1c" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f7df-1040-50de-0719" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d182-4cbb-5162-2bbd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
-    <entryLink id="8a59-25da-927f-8deb" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8f49-526e-aebf-b1b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7e23-2d05-f9c4-94af" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
-    <entryLink id="d52c-f63c-d9c3-731f" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="29f3-ef3e-b1c1-5976" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="06b1-248d-c5af-2f01" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
-    <entryLink id="7312-5fe5-3530-21c8" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="27ea-438a-7033-4541" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="482c-ff5f-75ac-35de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
-    <entryLink id="733a-b7dc-4703-6144" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="897f-9843-57c3-bb5d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="ed76-c116-9f18-4446" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
-    <entryLink id="435f-3a9a-898f-829f" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink><entryLink id="8218-b17a-bde2-8383" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_8ed4-376d-4030-9439</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_8a11-c2a0-4335-99ef</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_fa8e-1af7-4d41-ac8c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_94bd-c771-4a85-8581</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="131a-2c1a-991a-4b31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="cfe7-c127-804c-7464" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="4c82-1160-a0e8-02d1" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="40b0-b037-48d3-b655" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_361e-fb90-4b0e-ac3d</comment></categoryLink>
+        <categoryLink id="5db3-da36-441c-8a1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d4ef-1074-45a9-959e</comment></categoryLink>
+        <categoryLink id="2c6c-8913-467b-a7ad" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_febb-f536-4d25-a8ab</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
-    <entryLink id="8894-a45b-f853-f28d" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9da1-705d-4f2c-2a9d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="cd71-d0a0-6c41-4037" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink><entryLink id="e5a8-0153-f5a1-9c57" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="2521-19ad-47f0-88d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_473b-e812-4158-9416</comment></categoryLink>
+        <categoryLink id="50f8-5b2f-4fcb-8e60" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_00a2-63ff-4698-a35b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
-    <entryLink id="390f-5485-7922-97e1" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink><entryLink id="589e-93e1-3cd7-d79c" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7cf3-8a72-4f82-8cdc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_228c-5681-4ce8-b726</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_01bb-8abd-4253-9a4d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6008-9981-ad5d-9281" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="38b3-f3ca-2d28-e0ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5403-d3a1-408c-9a15" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2a08-4432-42ad-bfdb</comment></categoryLink>
+        <categoryLink id="c69e-6eb9-488e-9f53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_422e-0808-4897-8630</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
-    <entryLink id="bedc-8b40-0c65-f773" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink><entryLink id="14da-091d-f2bf-4312" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1af8-4459-4717-8e3b</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_06b4-92b9-438c-b1a5</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6c8d-8b28-417b-9a7c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_715d-8186-4aa6-b40c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_390e-358c-4f8e-ade8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="7a79-e3ec-7380-4db5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f877-71c4-96e1-8b11" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="8770-764d-4914-b36b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f4c0-4396-4f39-a34f</comment></categoryLink>
+        <categoryLink id="8734-d5eb-4373-9790" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1301-8415-490e-8f06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
-    <entryLink id="7b4d-b51f-60a7-c0d5" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink><entryLink id="0faa-25ee-9e8d-5462" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d0c9-9a26-4324-b030</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4e9e-a61d-42f2-bacb</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ed9e-b634-4bec-9eb0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4614-ad0f-4fba-adaf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_8d08-24f6-41be-8931</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3703-2c7a-4113-b1ce" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_caf6-5548-4b89-8102</comment></categoryLink>
+        <categoryLink id="5417-e72a-4bee-8af1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_63a3-be61-428d-ab29</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink><entryLink id="743a-0c64-2289-ce30" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f318-4b03-4767-8c7f</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b8ef-7245-4df8-a8c4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_6bce-ec44-48cb-873a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c88a-fe1c-464d-a917" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0678-4fdd-48e6-8f61</comment></categoryLink>
+        <categoryLink id="5fb3-f7c4-4818-a185" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0d82-10a9-4de2-8ad7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink><entryLink id="29aa-8bfd-f9d9-4ea1" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ada1-1e18-4cbc-9598</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b1d1-ac44-47dd-9159</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5d64-f00c-4464-891b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25f0-f825-4a83-8f0d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_64b1-9e36-44da-b36a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2c29-6bb8-4d9a-8e0e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_d53e-113f-4a40-a3d5</comment></categoryLink>
+        <categoryLink id="b78b-b915-4119-9242" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1939-76b5-4279-9f8c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink><entryLink id="8318-eb2b-c28e-4cd0" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d765-3bb2-4b48-bd12</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_0ca1-cfb4-4a56-ab3b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a197-b2db-212a-ea62" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="9df2-031d-7da0-51ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c47b-9f16-460f-bb8f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e6f7-a6ca-4825-bfc5</comment></categoryLink>
+        <categoryLink id="13e3-d28a-4b97-b563" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dbec-e027-4ec1-8514</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
-    <entryLink id="ac8d-8f28-7672-77f4" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink><entryLink id="6743-2670-6268-56da" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d8ee-81ed-45f9-8b79</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_8f4e-e8cb-4ac9-a415</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="34c3-9322-4a2d-b364" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_cefb-cfd7-4dc8-99c4</comment></categoryLink>
+        <categoryLink id="f2b8-f8c0-4984-8310" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a9fd-9d16-4a5e-855c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink><entryLink id="35c9-4563-b9af-04df" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e76b-46ca-4ab8-a93d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8035-75b8-43bb-97c9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_71a4-31e7-4927-a0ab</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8f23-4166-4639-b66a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_a56d-347b-4b09-a918</comment></categoryLink>
+        <categoryLink id="1c32-6fa0-41e3-bcb5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_96e5-4531-4213-903e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink><entryLink id="1e63-105c-377d-0e94" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1fb5-2375-4c22-b41e</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7d7c-255d-49b6-96b9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5321-254b-4890-9bf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ddf8-b8b7-4afb-b6dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="59cb-1ac0-4d47-bbd2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9441-d79b-4720-9667</comment></categoryLink>
+        <categoryLink id="9bea-0bdf-4cfe-a02d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7d7e-32d3-4692-b401</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink><entryLink id="1a65-546e-f47e-6258" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_99fc-5fe7-4b37-a62f</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_25f4-f6b8-4b44-8350</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_81f7-2311-4cce-95bc</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_09aa-af2a-4012-91d1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_00ae-fad3-4df6-9cb9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="54af-a36f-4998-9914" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f65b-8958-49b3-92a5</comment></categoryLink>
+        <categoryLink id="da9d-0523-4242-a44f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0451-1929-4942-8c3f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink><entryLink id="125c-026a-4be2-266a" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_edc4-4915-40ba-bbf0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_105f-ba26-4146-bc54</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7a2c-a76c-421c-a8a2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_05c9-0543-47ee-ba81</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e6ad-f0d7-4627-921b</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a52d-649a-49bd-8d54" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c6a8-22a8-4d41-b969</comment></categoryLink>
+        <categoryLink id="477f-7e31-47ce-9dad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03ca-12cc-4e0a-b628</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink><entryLink id="1aa7-1faf-cd9a-c2a6" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ae67-ef52-4cac-958c</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fc61-7306-4d99-acde</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1be0-67e7-45a1-bdbb</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_42a8-7fda-4e05-af0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="bb85-c143-40a1-8a2d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_565a-1592-491f-8b9b</comment></categoryLink>
+        <categoryLink id="3aba-575e-49ac-ab61" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_81d5-c14a-42ab-bdde</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink><entryLink id="631e-1360-1656-131d" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1ae7-c41b-4818-be71</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_08a5-b1bb-4ba1-ba42</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d677-b5ad-4838-8746</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_537f-bc1f-4aaa-b0dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c9aa-124d-4314-8cac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bc67-ce1f-4004-aeb7</comment></categoryLink>
+        <categoryLink id="5d2b-5b8d-4748-8cbb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_9a45-9699-4475-aeef</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink><entryLink id="9e86-53db-593a-f386" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_c28f-4109-44c4-ab64</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fdc1-a894-48bc-9e7c</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_4936-a68c-4524-9088</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb37-ac0c-49ae-9d6f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="362f-6b4c-4684-88b0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3afe-cfc0-4da6-a985</comment></categoryLink>
+        <categoryLink id="0cc6-4a7a-402c-88c2" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_04a8-6aae-45ae-bd4c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink><entryLink id="d1a5-d8bb-acec-3499" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ae19-30c0-43c5-920e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_6ebe-1bf3-4d78-9dd0</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1887-152d-48b7-b13f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_a7c4-ee6a-4f0b-8ab0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bd85-fa90-47ff-9f84</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_7bd6-9043-4d7e-ba37</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cd66-d7f8-4628-910d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3610-c975-4d55-bdfe</comment></categoryLink>
+        <categoryLink id="e3b9-1b4a-432e-ac21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2fc2-f636-4c80-9608</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink><entryLink id="88ee-a5a9-8bc1-d642" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_85c5-d4d9-4b23-9e4d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_80e8-d50b-4906-8153</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_b93b-d4f1-45eb-8a69</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e183-f183-4db7-83b5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0f39-204a-4217-b896</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_eee9-7bfd-4fea-a1bd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7191-94cf-45c4-b1dd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f81d-9435-4f11-99c1</comment></categoryLink>
+        <categoryLink id="9aaa-bb7c-4480-9542" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9568-6142-4fdd-be3a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink><entryLink id="d3f7-4b68-4620-71c0" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_005e-6607-4e2c-8dd2</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_7745-260c-4c36-b719</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_ba25-a4b2-4ba9-b023</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ddeb-f4c8-4091-9153</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4904-fd2f-429f-9cf7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_faea-b21b-43c5-b918</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7897-ea6c-4555-b94b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_b24f-3ae0-4cbb-b016</comment></categoryLink>
+        <categoryLink id="2e6d-a5bc-484e-b30a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fd26-8e6b-4521-92b9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink><entryLink id="9cb7-e623-a570-7f9b" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6ecb-28e2-43ed-a6a0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_c067-1118-4d96-b28b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_250e-23c0-4e43-bf74</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1553-a6e6-4291-853f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_aab6-797b-427a-9fd8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6803-c8b6-465b-b4df" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c77f-0819-473b-a8a2</comment></categoryLink>
+        <categoryLink id="e6c5-ead9-4d61-9482" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_89fb-c924-4daf-923d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink><entryLink id="0918-bc53-3b57-d4bd" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d72c-519a-451f-81b6</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_3d16-444c-42c9-aad1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_f4b2-6371-494b-863a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_797f-a84b-42f6-8e66</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0d78-fe38-4829-9b12</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="bb6d-4e56-45f6-b5c4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0397-c837-4fea-a527</comment></categoryLink>
+        <categoryLink id="04f4-4a49-4cd9-be5b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_060b-bccb-4776-bd83</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink><entryLink id="b8b1-85a0-da81-84ef" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3c84-6d74-4c42-b38d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_5b15-7aa4-4897-aaf1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_3326-31ed-4151-9b37</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6a0e-1b65-4057-ba5d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f8c7-abc9-45ec-955f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_2538-8dc5-446c-8344</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8410-7398-4d4e-b5ea" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_c1cf-cea4-4278-8f27</comment></categoryLink>
+        <categoryLink id="4794-085e-4397-97ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5f51-2734-4a46-9f72</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink><entryLink id="75bb-bdff-c428-6980" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af71-f3ff-49b1-83e9</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_1c9e-b3bf-4e88-a43f</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_6d0d-1b1d-4065-89cf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d0b7-8686-491e-9d33</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_7db8-0874-487a-be6f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1034-29a0-44b1-a85f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="768b-5fde-4dbc-9b68" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_0c16-6841-42b2-b02d</comment></categoryLink>
+        <categoryLink id="e66f-8d16-4aa7-ba91" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_602d-2d2d-4ff4-a82a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink><entryLink id="a964-cde7-e4a6-214f" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_22bd-baae-45f9-b366</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_52bd-55de-4d53-ba55</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_df1b-7476-4ab8-8d2f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_49fa-0dcf-4a61-a5b1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0ea-1443-4993-86e7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2a8-3fbe-448c-9902</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a4cd-ccb4-46e2-beab" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3632-0b5d-4622-ae33</comment></categoryLink>
+        <categoryLink id="c3a9-a6c6-4053-9ea7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_da44-7815-4fdd-981c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink><entryLink id="50ef-7431-d164-ddc3" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2bfa-b203-47e2-a828</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a39b-8a3c-49cf-bf62</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2a05-07b3-49c5-8145</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f730-87fb-44bd-b68e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_2d0e-6c49-4493-a022</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2e2-50c1-40c3-b4dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a4e7-d254-4b62-ad9c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_5ad5-8701-42cd-b2b6</comment></categoryLink>
+        <categoryLink id="3a01-c9c9-4eff-ba30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_20a4-4346-4a3b-a7d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink><entryLink id="c99d-d45c-e6df-c8d5" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_773a-1ea4-41a0-b766</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_9d4d-6fb8-4131-a5a3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e3bc-02f8-4ece-a5ea</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c371-76d9-4a4d-bc00</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b4c6-d4ba-4b2e-9b99</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3e6e-7231-4ece-b0d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6ea9-a7e5-437d-9e35</comment></categoryLink>
+        <categoryLink id="8bc7-09e0-441c-bf4d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_3cec-f053-42ab-a6eb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink><entryLink id="77fc-1222-7a9e-e1d0" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1e60-42ba-4c8b-9077</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9860-f593-425e-b89b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_c842-10e8-4509-8eda</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ea52-ff41-40f6-8cf3</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_51e6-c5e1-4003-96bc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="822a-508a-4eb6-b16b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4d7c-201f-4c99-b89a</comment></categoryLink>
+        <categoryLink id="1905-2aea-47ba-9b72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_10f9-4718-4e07-bb32</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink><entryLink id="cb29-6fb3-b99d-62ae" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e074-bf55-4a58-8723" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4e52-ad1b-48d4-8eed</comment></categoryLink>
+        <categoryLink id="9346-5dec-4537-b9ca" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_6979-1ed3-4f1f-a025</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink><entryLink id="99a3-879d-2980-2285" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry"><categoryLinks>
+        <categoryLink id="1652-a9e2-4016-99f9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6140-2404-46f9-bd42</comment></categoryLink>
+        <categoryLink id="7a25-0f2f-4f0e-93c6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_1c86-fad8-46ec-a0b0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink><entryLink id="640e-ab18-7e85-5f80" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4729-bc86-456b-b73d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_cf0f-e3f4-4fb4-989d</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1cc8-5611-4d9a-9218</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_2e32-ca02-48f0-a8dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7a38-01cf-4342-ba85" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_0af1-d052-4bd7-aab6</comment></categoryLink>
+        <categoryLink id="9d88-31e8-4eae-8aee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_45ce-e338-43c9-b63e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink><entryLink id="13ba-a297-b455-efe5" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4dce-8632-4f7c-813e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_8a71-3995-4155-ac33</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d206-f2ce-41b8-945a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan">
+                  <comment>    node_id_2e02-cf1c-4a71-861c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ec81-bd33-45a8-8550</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_3344-743c-45d3-b930</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9c94-977a-d13e-b38b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="ce84-032d-97dd-f5e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7732-7063-4457-83ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4272-9b9d-4c59-95f0</comment></categoryLink>
+        <categoryLink id="0aeb-bf60-4a84-9103" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_d85b-1ae7-40d5-9341</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
-    <entryLink id="b7b4-0041-6e28-3c10" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5c33-bad0-f09d-b782" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="100f-0489-b6cc-9eea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink><entryLink id="4b61-6cb1-1fbb-ded2" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry"><categoryLinks>
+        <categoryLink id="e031-c589-47f4-8bfd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ff9f-01cb-41b9-800e</comment></categoryLink>
+        <categoryLink id="f85a-85ff-48a2-954b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_1315-6051-4a46-b070</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
-    <entryLink id="0a2f-1481-6fb4-27e9" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink><entryLink id="966e-be19-0b84-c8a6" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry"><categoryLinks>
+        <categoryLink id="b6e2-a6f7-44a6-983c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_b084-df23-4f99-812f</comment></categoryLink>
+        <categoryLink id="8524-eab4-42bb-8423" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_84fc-9304-4e9e-ab78</comment></categoryLink>
+        <categoryLink id="732a-b2d8-450b-b538" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d06a-7939-4691-9aed</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="8e1f-edff-4d8e-b2d9" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup"><comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+        <entryLink id="d1a4-18a8-4687-a476" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup"><comment>    template_id_741d-8c09-4211-ada6    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink><entryLink id="cbdd-df4a-3b5f-abdd" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_54a4-6ec8-4c61-9c3e</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_f7fd-2d16-4603-a065</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="85d8-5f9d-dca5-1923" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="06a4-3b9a-86f1-b6d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5b27-620c-4510-90d7" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_c0ac-4b8c-421c-a21b</comment></categoryLink>
+        <categoryLink id="e98e-2fa6-4e8d-b4a5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8db9-079e-4482-b200</comment></categoryLink>
+        <categoryLink id="2d0f-f63f-483c-a0e8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_413c-9273-4308-b546</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
-    <entryLink id="80cd-5309-cabd-c861" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="31f2-04f2-1e04-7f98" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="ba7f-7dad-1594-68da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      <entryLinks>
+        <entryLink id="9dcf-295e-44b1-be4d" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup"><comment>    template_id_bbc4-33fc-4664-a18e    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="7a29-3641-4216-a3b7" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup"><comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink><entryLink id="8141-b381-6e35-cf64" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry"><categoryLinks>
+        <categoryLink id="c558-ec22-4fc9-8bfe" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_4c8d-96f6-48f9-9590</comment></categoryLink>
+        <categoryLink id="8398-c025-4ffc-b897" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_049c-0fa5-4575-8fa8</comment></categoryLink>
+        <categoryLink id="f363-a25d-45ff-93c0" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_7358-52d7-4aae-8e07</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
-    <entryLink id="c6e7-5e01-e008-9218" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+      <entryLinks>
+        <entryLink id="85a5-c9db-43b1-adcf" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup"><comment>    template_id_4784-b370-444b-93ae    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="ea1b-a84f-4370-a62c" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup"><comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink><entryLink id="31be-fe57-8aa0-4c66" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_3c03-a823-4466-9bd6</comment>
           <conditionGroups>
-            <conditionGroup type="and">
+            <conditionGroup type="or">
+              <comment>    node_id_8bbb-f95b-413f-b6f4</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_41b0-6b0a-482a-919e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e1f7-3cc6-4794-8b6d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3fc4-d03f-42ab-1de9" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="564b-255c-3292-7021" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="41fc-4620-4bb9-86ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_05ce-cc31-40ad-9320</comment></categoryLink>
+        <categoryLink id="666c-a166-4c6c-8c2e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f13c-f8e1-4a50-bfe3</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
-    <entryLink id="663d-8263-9948-a54c" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8f29-e59c-9f90-4279" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="366f-3c14-f5c3-6a69" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
-    <entryLink id="8462-d44e-1751-a913" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0e29-6cef-3313-0fc7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="eefc-6e10-9659-356d" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
-        <categoryLink id="c586-1b0b-650a-a0da" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
-    <entryLink id="b783-0f58-baad-17ac" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8f9b-d0bd-3291-3ef8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="60e4-41b5-6288-a148" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
-    <entryLink id="59c1-6830-38d2-be24" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink><entryLink id="2a51-2646-dcef-b4b3" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_db78-4d49-42ab-954a</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_f14d-9943-47b6-866c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a95-938f-4a07-9727</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_7775-78e1-44cc-87c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="abfa-fc3b-4c42-9d61" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_b822-3417-4613-be37</comment></categoryLink>
+        <categoryLink id="a53d-e0d7-4eb7-b415" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_25db-b03f-4881-b310</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink><entryLink id="eb2b-1a8e-577c-4c49" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry"><categoryLinks>
+        <categoryLink id="80c9-5218-4641-bae1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_75a7-dc06-445b-b2dc</comment></categoryLink>
+        <categoryLink id="2580-4207-489e-aa4d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_e21a-c03b-4885-ac46</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink><entryLink id="3630-3878-3a8d-67aa" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9a08-5fe6-4010-bbc3</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_72cf-cfce-4e02-b379</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="de27-7454-955e-4652" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="232f-d991-8115-2ac2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f82b-91ed-484c-9b9f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_f55b-7555-444b-beee</comment></categoryLink>
+        <categoryLink id="9cf3-d17d-48cd-8dcb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3386-c9ad-4d74-9474</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
-    <entryLink id="fc35-9419-bb08-7a4b" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="296b-a648-8319-0bd8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3abb-d8da-4b54-c7df" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
-    <entryLink id="50e8-9ffd-91ff-0c7b" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink><entryLink id="d8cd-1f7f-e904-30f2" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_a0f6-9606-4b75-a2f8</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_94b3-1331-474b-885b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
-      <infoLinks>
-        <infoLink id="0fff-a1d4-c68d-08ce" name="Legiones Astartes (Night Lords) " hidden="false" targetId="8280-d4ea-b131-4970" type="rule" />
-      </infoLinks>
       <categoryLinks>
-        <categoryLink id="7a39-bbf3-4390-4463" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="31ea-3c73-3aa9-6891" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="a745-eb7d-44f6-8bbc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_79fa-3370-4ae0-9e12</comment></categoryLink>
+        <categoryLink id="29a3-13c8-4e5f-91db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bb53-4e65-4fb6-9dd7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
-  </entryLinks>
-  <sharedSelectionEntries>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink><entryLink id="52fb-ffad-729d-cf07" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f8cc-833a-4ac1-bf89</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+              <comment>    node_id_5988-c012-4dad-9a66</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="649f-c4fa-4936-b7ab" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_8d82-3279-4481-84bb</comment></categoryLink>
+        <categoryLink id="da31-6be4-44ce-9e02" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e25c-925e-4b96-8bb3</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink><entryLink id="41f5-ec2d-a2c0-97a2" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6b73-b21c-4e2b-9d14</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_a7fe-cc62-4a6f-a781</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5be1-1937-4964-a455</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_da1d-b2bc-4117-82a4</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4ceb-e727-472e-ba8f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7010-be56-4709-b058</comment></categoryLink>
+        <categoryLink id="921f-ae19-4188-a45e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7379-a740-47ba-a054</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink><entryLink id="58e8-a073-7f80-608e" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_dd34-83cf-47d7-b557</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_be88-afef-49b3-bd1e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f50c-5d0b-4f94-a4b4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_944f-7420-4982-8ea9</comment></categoryLink>
+        <categoryLink id="65e9-ac49-4ae4-b9fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ea80-0efe-457d-a450</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink><entryLink id="915c-23cf-cc58-2c1b" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><categoryLinks>
+        <categoryLink id="dfef-dbbe-44d1-b5cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9a36-f261-43cc-9bd1</comment></categoryLink>
+        <categoryLink id="a0c6-3f97-405c-990a" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a648-8396-442a-af59</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink><entryLink id="bd6a-d7fd-1d9a-476b" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_cb81-0303-4b88-ae53</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9648-31e3-43aa-8cf3</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_0507-da81-4023-bfcf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0e84-54ff-488d-b066</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4098-ae63-4093-a4ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6ff-0977-4c92-bb28</comment></categoryLink>
+        <categoryLink id="cc26-2614-43ad-af91" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f555-7d39-458f-84c9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink><entryLink id="a09f-3151-5892-ce0f" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8203-5b00-497b-b939</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_40ee-3e71-4978-b1e4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f6a8-f660-46dc-b3c5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_d988-3af6-48bf-b0a8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="967d-ba66-44bf-bf8a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_39e5-eda5-45d1-a643</comment></categoryLink>
+        <categoryLink id="9575-3728-4c83-ad11" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_6416-21bb-4df4-9de8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink><entryLink id="a529-339a-abad-65c1" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b03e-5d91-4be3-8adc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_0443-29c0-46e9-ad1d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f2c9-7356-4c27-a22f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0e9-4a9e-4b2b-a9d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fd20-4928-46a6-8c86" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5528-2dac-4be5-900c</comment></categoryLink>
+        <categoryLink id="77a6-1638-4c62-88f7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_dc8f-d888-4585-991d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink><entryLink id="43e2-e234-abfe-1776" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1d3c-8e17-489f-9002</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5725-8bee-4bcc-878d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_be47-0d6f-49f2-9f4b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_863c-f3a4-4802-b80c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0e50-9150-4de2-87a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_899e-b052-4d5b-8c18</comment></categoryLink>
+        <categoryLink id="d59f-1b0a-4978-84f6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f5e9-cff6-41d2-a016</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink><entryLink id="5a0b-deca-f472-0d1c" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_72da-1513-4e02-b595</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7a48-a3b0-4a26-849b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e232-25f3-4cb7-8ab2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_9aa4-5660-4697-8ab2</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="71f5-1695-46f9-aa7a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_09cd-2176-40af-bba6</comment></categoryLink>
+        <categoryLink id="dda6-2363-43ce-b9c8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_05e6-7c63-4a35-9ba0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink><entryLink id="8a59-25da-927f-8deb" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry"><categoryLinks>
+        <categoryLink id="987e-af6c-4b9a-8849" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0dfa-4004-4751-8022</comment></categoryLink>
+        <categoryLink id="13f9-946d-4e08-8c64" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a669-0f5d-4fd3-811b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink><entryLink id="d52c-f63c-d9c3-731f" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_09b5-4e3b-4c84-a574</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_32e5-ebba-41fb-9ff2</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_838e-0ccf-4d3a-aabd</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_dfef-0ec2-49fb-a534</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f54d-5040-4c15-a26e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4f60-472b-45a9-ab9e</comment></categoryLink>
+        <categoryLink id="e580-53be-45e2-b406" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e2e3-af36-45a6-a955</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink><entryLink id="7312-5fe5-3530-21c8" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_936f-1ef7-472e-840e</comment>
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+              <comment>    node_id_d73d-d52e-4c75-8ac0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="898e-7dcf-49e8-950d" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_7a55-ecb4-4e5d-b955</comment></categoryLink>
+        <categoryLink id="e04f-689d-4bc1-ad4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f28c-710e-4ff8-9810</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink><entryLink id="733a-b7dc-4703-6144" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_a743-0cc2-45ae-a7eb</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2721-e88d-41f7-bedc</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_e10f-1390-4b33-8fcc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e4c4-baf0-45c9-8cec" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2008-f1c4-4285-a14f</comment></categoryLink>
+        <categoryLink id="d87f-5e2d-4855-947b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e88b-a95a-4647-af3b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink><entryLink id="435f-3a9a-898f-829f" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_25d8-330b-4574-b515</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7836-6878-47a8-8827</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_5ea9-46dd-4a11-9410</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_ab5d-961b-4924-a705</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="83ce-b9ce-4eeb-91a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9189-836c-475d-a52e</comment></categoryLink>
+        <categoryLink id="2004-7997-40ad-ab5f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_e1fa-b7d8-47b0-a88a</comment></categoryLink>
+        <categoryLink id="6419-803a-4026-9ad1" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_a137-e3c0-4d63-a48c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink><entryLink id="8894-a45b-f853-f28d" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry"><categoryLinks>
+        <categoryLink id="a753-5733-4c87-aec7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b1d5-fd75-4f17-bbf4</comment></categoryLink>
+        <categoryLink id="32cc-ba06-4450-8d43" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_f221-bf81-4045-849b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink><entryLink id="390f-5485-7922-97e1" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_b743-7a00-43e4-beb8</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d12f-2c98-4e62-a716</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d4d7-ba67-47aa-962f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+                  <comment>    node_id_1637-edee-457a-bb0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7251-f5a7-4564-aef0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_f203-bc26-421f-b79e</comment></categoryLink>
+        <categoryLink id="3c09-b651-4e83-8c21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_a53e-59d9-4ac2-a21f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink><entryLink id="bedc-8b40-0c65-f773" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry"><categoryLinks>
+        <categoryLink id="1021-bda8-4fd8-9dc9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_51af-a137-4a1c-97a4</comment></categoryLink>
+        <categoryLink id="5eb3-a972-482b-bd54" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ec1f-c326-40a8-9d1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink><entryLink id="7b4d-b51f-60a7-c0d5" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_c111-feb0-4012-98cd</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_63d7-8427-431d-9ae6</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3a6f-8b15-450f-94bf" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_e707-fde1-457f-91c4</comment></categoryLink>
+        <categoryLink id="d9ab-1798-4b69-acb9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ec67-8573-4460-89db</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink><entryLink id="ac8d-8f28-7672-77f4" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3348-16e4-4a9a-a549</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_bea4-c4a8-4843-b9fe</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2970-17ff-4be1-91e5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_503a-46e7-40e7-bd07</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_4555-15e1-43ff-80a0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f455-4b29-440e-b681" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_fce3-801c-49c8-85d4</comment></categoryLink>
+        <categoryLink id="3e1e-9cd9-4ea7-9c0d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0c2d-2349-44b6-9831</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink><entryLink id="b7b4-0041-6e28-3c10" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry"><categoryLinks>
+        <categoryLink id="9a72-2f92-48ba-816d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ac1c-b3bf-4011-918a</comment></categoryLink>
+        <categoryLink id="8dd3-6f4f-4a1c-a60c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_589c-1d0e-4b7d-be6b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink><entryLink id="0a2f-1481-6fb4-27e9" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2f46-a0b6-48a5-a0ee</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_636f-0f8a-43f1-910b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c883-39c8-4a74-aeaa</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_0796-e467-4438-89b3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6899-41fb-496b-a002" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_5a04-9847-4c91-a49a</comment></categoryLink>
+        <categoryLink id="08e6-e6db-4a84-9755" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b4b4-daeb-483c-a306</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink><entryLink id="80cd-5309-cabd-c861" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6087-a5e5-4d3c-9ebd</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c7e1-5f42-4528-bf07</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1950-08dc-4544-ab01</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_daf3-31ed-42c0-85dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ca2b-ef56-4fa4-a834" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_7d4f-547c-43ed-a520</comment></categoryLink>
+        <categoryLink id="2052-e30a-455c-945e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f04e-04e8-4891-9b1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink><entryLink id="c6e7-5e01-e008-9218" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_dfdc-f6f6-49d2-a7b3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_354c-c71f-472f-b268</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1127-c974-4663-874d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_0843-bef2-4767-8307</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2fbe-e6e7-4ce4-9cba" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_28e0-91e7-4ada-9fac</comment></categoryLink>
+        <categoryLink id="9d4f-b1f1-4efa-80e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4448-a712-4dd7-bf6d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink><entryLink id="663d-8263-9948-a54c" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d512-fd07-4a29-863a</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_55c6-a35f-485a-9f0d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d89e-cf1f-4ceb-b3de</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e2c9-0d01-403c-900e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_a7b8-c835-4cb2-b3d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="bd11-a3ea-44c8-8c33" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_e22a-c5f8-4825-a45f</comment></categoryLink>
+        <categoryLink id="7e44-ba6b-4c81-b786" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03fc-6a7f-45a5-bcb8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink><entryLink id="8462-d44e-1751-a913" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d596-33d3-4ee0-9c52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0aff-4f6e-4b03-a23c</comment></categoryLink>
+        <categoryLink id="72c5-25f7-447e-bbc1" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"><comment>    template_id_7d5a-62e7-43ee-b79b</comment></categoryLink>
+        <categoryLink id="47b4-6372-46af-9acc" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_4986-9157-49f2-b670</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink><entryLink id="b783-0f58-baad-17ac" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_319e-90d4-44a3-8e83</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_28db-d943-4099-9abd</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1a45-a592-49df-9465</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb31-d0b2-4677-928e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d66a-c62c-4fc3-a4e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1b86-0977-4a8b-adac</comment></categoryLink>
+        <categoryLink id="befd-1b8a-4761-b747" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_b449-403a-4e42-9239</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink><entryLink id="59c1-6830-38d2-be24" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafa-470f-4c2c-8be3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_e2ba-a855-4de2-9f46</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_0171-b30d-44ee-9389</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fdfb-119b-4774-934a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_3891-9a00-4f8f-b95f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a9a8-daeb-4d8a-a024" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e5df-17d4-4521-9d5b</comment></categoryLink>
+        <categoryLink id="c32c-46fa-4396-a83e" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"><comment>    template_id_0ecd-4873-4d3a-b28b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink><entryLink id="fc35-9419-bb08-7a4b" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_fbfa-8d78-4d6d-8a05</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_21f2-0916-46bf-b75a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_4fbd-633b-4dd6-9fdd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="486d-1d49-4ae5-9ffd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4f71-446f-4cff-afda</comment></categoryLink>
+        <categoryLink id="bef6-be75-43a9-861b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_3f44-8647-43a4-ac22</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink><entryLink id="50e8-9ffd-91ff-0c7b" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af15-2c71-4f8b-833e</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_d95a-80b9-4463-af55</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="555b-514f-4c5a-a739" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6b1-886e-4194-8bcd</comment></categoryLink>
+        <categoryLink id="c5cb-077d-4210-9c26" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_51b5-f9c1-4587-8fc7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink><entryLink id="57b0-e9d6-4341-997c" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
+    <entryLink id="29cb-f248-48ba-915e" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
+    <entryLink id="9a90-bf3f-47bd-a72b" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
+    <entryLink id="53df-1390-4f92-bd40" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <entryLink id="b8e7-c647-485d-a1b3" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3531-57d1-4081-882d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_f233-2361-4177-8ba7</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b932-667a-4b43-8331</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <entryLink id="d6f9-b278-4ae5-81e6" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <entryLink id="9cd1-4cae-4e9f-9636" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3129-6f59-4365-906b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2bcb-0af1-4aea-9191" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <entryLink id="77bf-5371-412f-b0fe" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ede2-d453-4e34-8cda</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2907-3215-4b01-96ff</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_c90c-959f-40fb-a4cb</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ba2d-50ad-45f1-91c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0e88-485e-43c2-8bef" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <entryLink id="de83-fe11-4593-8e2a" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_409c-0a5d-4ef8-a871</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7078-c1c7-4af2-b43d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_9a69-0fdc-4957-8982</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1a4c-69b5-4219-8502" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fba0-3ea7-4eaf-b33a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <entryLink id="2a77-fbfe-4d2f-bc78" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
+    <entryLink id="af62-8bb1-458a-aa80" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
+    <entryLink id="02ef-3013-4137-a973" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
+    <entryLink id="a579-d2c1-42ad-8ad1" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+  </entryLinks><sharedSelectionEntries>
     <selectionEntry id="d2ce-94c1-242d-2a7f" name="Sevatar" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="54e2-11e9-e908-4ed9" type="max" />

--- a/2022 - LA - Night Lords.cat
+++ b/2022 - LA - Night Lords.cat
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="36dc-14fc-8872-476b" name="LA -   VIII: Night Lords" revision="16" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="36dc-14fc-8872-476b" name="LA -   VIII: Night Lords" revision="16" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26">
   <entryLinks>
     <entryLink id="f491-c7fa-f6d3-917d" name="Contekar Terminator Squad" hidden="false" collective="false" import="false" targetId="837e-c3ca-437e-dfbf" type="selectionEntry">
       <modifiers>
@@ -7,84 +6,84 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1636-d8d9-2428-f166" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2ce-94c1-242d-2a7f" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1636-d8d9-2428-f166" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2ce-94c1-242d-2a7f" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="037c-77b8-6f60-cefc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9908-6951-cb40-369c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="1132-38e8-0e5f-6d62" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="037c-77b8-6f60-cefc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9908-6951-cb40-369c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="1132-38e8-0e5f-6d62" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="77a5-7cca-d050-de27" name="Konrad Curze" hidden="false" collective="false" import="false" targetId="1636-d8d9-2428-f166" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c700-6253-d5c4-b462" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dead-a3bc-6447-64ea" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="c700-6253-d5c4-b462" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="dead-a3bc-6447-64ea" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="44dc-815a-7895-cfa0" name="Night Raptor Squad" hidden="false" collective="false" import="false" targetId="9bb8-8fe4-11c1-9e50" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0de9-ad2e-c5af-664a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="cb4b-49f7-d796-a3b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0de9-ad2e-c5af-664a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="cb4b-49f7-d796-a3b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="fb5a-4a13-3b2d-aeda" name="Sevatar" hidden="false" collective="false" import="false" targetId="d2ce-94c1-242d-2a7f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="57a9-a024-e7a3-e8bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5356-33e7-612f-b258" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="2f21-d05c-f877-7bf7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="57a9-a024-e7a3-e8bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5356-33e7-612f-b258" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="2f21-d05c-f877-7bf7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="ecad-ff3f-4ef3-d8ae" name="Terror Squad" hidden="false" collective="false" import="false" targetId="53ce-6dc9-aa69-fbaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4edc-3e13-084e-ba81" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="8ce1-4ddc-5784-6fda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4edc-3e13-084e-ba81" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="8ce1-4ddc-5784-6fda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="6ee2-037b-e211-5d0c" name="Atramentar Squad" hidden="false" collective="false" import="false" targetId="12d3-9df0-4118-997f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7d2a-c0c6-7ad0-b12b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="fa99-f56b-04df-4b60" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7d2a-c0c6-7ad0-b12b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="fa99-f56b-04df-4b60" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="a836-6c63-1be4-a8a5" name="   VIII: Night Lords" hidden="false" collective="false" import="false" targetId="b28b-71f7-e4f4-8f9c" type="selectionEntry">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68b1-c90e-c74f-1dab" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e039-6a9a-888c-e4cb" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68b1-c90e-c74f-1dab" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e039-6a9a-888c-e4cb" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="f61c-859c-a747-e46c" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="f61c-859c-a747-e46c" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="32c0-440e-bcd3-31d0" name="Contekar Terminator Squad" hidden="false" collective="false" import="false" targetId="837e-c3ca-437e-dfbf" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="90fa-b324-1d69-b9f7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8a66-cd15-98b3-053b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="90fa-b324-1d69-b9f7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8a66-cd15-98b3-053b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="d441-3ddb-a503-2d25" name="Flaymaster Mawdrym Llansahai" hidden="true" collective="false" import="false" targetId="71e4-4f49-a389-b80d" type="selectionEntry">
@@ -93,17 +92,17 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3ff4-9877-8cff-4bc3" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="c809-7da7-7cef-0b91" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9495-3e27-bd74-804a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="3ff4-9877-8cff-4bc3" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="c809-7da7-7cef-0b91" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9495-3e27-bd74-804a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="693a-aaca-0c13-ab35" name="Kheron Ophion of the Kyroptera" hidden="true" collective="false" import="false" targetId="021c-6d75-36ca-fe7a" type="selectionEntry">
@@ -112,17 +111,17 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6383-da25-4d31-9d0f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="fd32-a0de-1d51-721e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="88e9-963c-1da4-2970" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="6383-da25-4d31-9d0f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="fd32-a0de-1d51-721e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="88e9-963c-1da4-2970" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="0102-9a6f-effb-52f3" name="Nakrid Thole" hidden="true" collective="false" import="false" targetId="4e5b-9710-67f5-478c" type="selectionEntry">
@@ -131,17 +130,17 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d220-725f-227a-8331" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="de2e-45e1-c96a-f8dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e1a5-7428-ea5b-f5c1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="d220-725f-227a-8331" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="de2e-45e1-c96a-f8dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e1a5-7428-ea5b-f5c1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="d717-e23d-e2a2-0349" name="Atramentar Squad" hidden="false" collective="false" import="false" targetId="12d3-9df0-4118-997f" type="selectionEntry">
@@ -150,980 +149,980 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2193-063a-03e7-6c04" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2193-063a-03e7-6c04" type="equalTo" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2e80-7dc9-ea08-c397" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fc50-4558-2e33-bedb" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2e80-7dc9-ea08-c397" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="fc50-4558-2e33-bedb" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="6b63-7c17-9adf-4290" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4398-8672-f7a9-b094" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="99f4-ce28-af50-bc04" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="4398-8672-f7a9-b094" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="99f4-ce28-af50-bc04" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
     <entryLink id="dd80-d9d4-ff80-44df" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="dc5b-0c2e-cc60-eebf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9d16-6b6c-ba36-33d1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="dc5b-0c2e-cc60-eebf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9d16-6b6c-ba36-33d1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
     <entryLink id="43e2-b2fb-d9d3-4590" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c2f8-252b-55a0-40af" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="7c51-0be9-3483-90a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2540-c34a-e28f-2fa4" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="c2f8-252b-55a0-40af" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="7c51-0be9-3483-90a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2540-c34a-e28f-2fa4" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="2323-ba5c-0fde-3f7e" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7710-34ef-d225-deb1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="e5c5-1ff1-280f-0a60" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7710-34ef-d225-deb1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="e5c5-1ff1-280f-0a60" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
     <entryLink id="dd2f-c7e6-c43d-50b5" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f9ec-02b2-e955-c7c1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="bd64-ec2f-bc32-1b6f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f9ec-02b2-e955-c7c1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="bd64-ec2f-bc32-1b6f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
     <entryLink id="eeb6-6f88-48ca-9d74" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3417-8f49-7272-ce18" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="6e19-a1ee-d25b-0123" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0ce7-0019-34d6-c77f" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="3417-8f49-7272-ce18" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="6e19-a1ee-d25b-0123" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0ce7-0019-34d6-c77f" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
     <entryLink id="9be5-ca48-3191-5e96" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5bae-3bea-40de-98dd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="0ad4-1131-aa92-3d48" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5bae-3bea-40de-98dd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="0ad4-1131-aa92-3d48" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
     <entryLink id="520c-c37e-701b-2ade" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1484-30c5-db06-179e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="2a11-43bb-ea70-4f01" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1484-30c5-db06-179e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="2a11-43bb-ea70-4f01" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
     <entryLink id="c59f-e5d9-186b-a729" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c0a0-a5ba-5530-1bd2" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="e434-e205-d51e-0b7a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="daa9-127e-393b-8d69" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="c0a0-a5ba-5530-1bd2" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="e434-e205-d51e-0b7a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="daa9-127e-393b-8d69" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="153c-2715-6d5e-b80b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup"/>
+        <entryLink id="153c-2715-6d5e-b80b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup" />
         <entryLink id="353f-d51d-9a7f-65e6" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
     <entryLink id="5407-fd2e-46a0-378d" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="373b-801c-89fa-beb6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5abb-c812-077b-83f8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="1c05-b5a1-3770-93fe" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="373b-801c-89fa-beb6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5abb-c812-077b-83f8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="1c05-b5a1-3770-93fe" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="849b-f7aa-ed61-86ce" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup"/>
+        <entryLink id="849b-f7aa-ed61-86ce" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup" />
         <entryLink id="6656-56b0-6738-0796" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
     <entryLink id="7129-2a2a-b24d-2223" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6aac-8aaf-df09-bea6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0338-f461-e1ae-9e45" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="057c-1aec-c106-4766" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="6aac-8aaf-df09-bea6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0338-f461-e1ae-9e45" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="057c-1aec-c106-4766" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="1bf9-30e2-69cf-6d43" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup"/>
+        <entryLink id="1bf9-30e2-69cf-6d43" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup" />
         <entryLink id="770b-4012-4b33-dc8c" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
     <entryLink id="7bfb-397f-f70b-f6d7" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ca4d-c0bb-3aa6-7974" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="3ffd-cc3c-889b-11c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ca4d-c0bb-3aa6-7974" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="3ffd-cc3c-889b-11c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
     <entryLink id="b2a8-ede4-2774-1e57" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c3fa-7a49-5d0a-8075" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b883-640b-b657-7761" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="c3fa-7a49-5d0a-8075" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b883-640b-b657-7761" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
     <entryLink id="c262-7af0-6986-95ac" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f725-e230-7147-4700" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ae6c-0eeb-5d48-c898" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="f725-e230-7147-4700" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ae6c-0eeb-5d48-c898" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
     <entryLink id="2000-179d-70cc-8970" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e7a1-7ea9-e3be-429c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c398-8fe3-f6a5-317c" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="e7a1-7ea9-e3be-429c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c398-8fe3-f6a5-317c" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
     <entryLink id="dd14-7b27-ecf6-3df2" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1eca-56d9-f536-5b48" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="43b6-6500-f9f2-8cd2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1eca-56d9-f536-5b48" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="43b6-6500-f9f2-8cd2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
     <entryLink id="14f8-46c6-5baf-ec66" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="bf7b-246b-a0fa-39ea" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="e343-0c42-3c25-b45e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bf7b-246b-a0fa-39ea" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="e343-0c42-3c25-b45e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
     <entryLink id="8717-7d90-29c6-0078" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="37b3-b94d-fa98-6285" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="fd84-59fb-70b2-6e83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="37b3-b94d-fa98-6285" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="fd84-59fb-70b2-6e83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="0d78-fe66-5b49-c81a" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e377-c212-88bb-b841" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3ba1-b53c-6e3b-a5ad" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="e377-c212-88bb-b841" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3ba1-b53c-6e3b-a5ad" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
     <entryLink id="8218-b17a-bde2-8383" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8efe-baba-177d-9872" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="4559-4f5b-d8d9-00ee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9bc8-7569-f56a-cac7" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="8efe-baba-177d-9872" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="4559-4f5b-d8d9-00ee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9bc8-7569-f56a-cac7" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="e5a8-0153-f5a1-9c57" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d6e5-0345-79ef-3709" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ac1e-aecb-2eda-512c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="d6e5-0345-79ef-3709" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ac1e-aecb-2eda-512c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="589e-93e1-3cd7-d79c" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5c0b-fc42-41fa-9172" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="a085-0029-7499-79a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5c0b-fc42-41fa-9172" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="a085-0029-7499-79a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
     <entryLink id="14da-091d-f2bf-4312" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2f62-7ddb-bf9c-c59b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="663b-5ce0-a3ca-acf4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2f62-7ddb-bf9c-c59b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="663b-5ce0-a3ca-acf4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
     <entryLink id="0faa-25ee-9e8d-5462" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="95dd-60db-f855-6b1c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="14c8-4ba7-e3c1-8eaf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="95dd-60db-f855-6b1c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="14c8-4ba7-e3c1-8eaf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
     <entryLink id="743a-0c64-2289-ce30" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4771-7a36-6092-446a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0bbe-97c4-53da-9e28" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="4771-7a36-6092-446a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0bbe-97c4-53da-9e28" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
     <entryLink id="29aa-8bfd-f9d9-4ea1" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2928-9538-52d5-86ca" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="e969-493e-ce81-1c4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2928-9538-52d5-86ca" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="e969-493e-ce81-1c4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
     <entryLink id="8318-eb2b-c28e-4cd0" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4d9b-2349-e9fe-03a1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="c4b9-3f76-ff76-c63f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4d9b-2349-e9fe-03a1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="c4b9-3f76-ff76-c63f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
     <entryLink id="6743-2670-6268-56da" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="30cd-1af9-ae9d-985c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d524-5b49-52e3-1c9e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="30cd-1af9-ae9d-985c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d524-5b49-52e3-1c9e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
     <entryLink id="35c9-4563-b9af-04df" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a3c5-e5db-edf8-ee9b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="6f23-a0eb-fd35-e99c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a3c5-e5db-edf8-ee9b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="6f23-a0eb-fd35-e99c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
     <entryLink id="1e63-105c-377d-0e94" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c2fc-4f2d-8aa8-a4ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d95e-c52f-22d0-51db" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="c2fc-4f2d-8aa8-a4ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d95e-c52f-22d0-51db" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="1a65-546e-f47e-6258" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7ec8-3f28-f8eb-28c3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="5a6d-9ad8-758c-078d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7ec8-3f28-f8eb-28c3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="5a6d-9ad8-758c-078d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
     <entryLink id="125c-026a-4be2-266a" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3436-02b2-cf64-c8c4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="1637-6f5b-2b7d-de77" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3436-02b2-cf64-c8c4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="1637-6f5b-2b7d-de77" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
     <entryLink id="1aa7-1faf-cd9a-c2a6" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f61b-2884-44ff-47a1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="2c92-5eb9-75f8-96e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f61b-2884-44ff-47a1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="2c92-5eb9-75f8-96e2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
     <entryLink id="631e-1360-1656-131d" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2a5f-92f6-1023-24e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d5fc-f363-632f-9248" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="2a5f-92f6-1023-24e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d5fc-f363-632f-9248" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
     <entryLink id="9e86-53db-593a-f386" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4288-7dcb-a8bc-d52d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3878-2985-6a5f-c5b3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="4288-7dcb-a8bc-d52d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3878-2985-6a5f-c5b3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
     <entryLink id="d1a5-d8bb-acec-3499" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="82e7-1141-8911-a3d3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="22b9-19ed-8243-6c9f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="82e7-1141-8911-a3d3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="22b9-19ed-8243-6c9f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
     <entryLink id="88ee-a5a9-8bc1-d642" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cbb9-c5cb-a995-11a3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="5758-42fa-6483-ad1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="cbb9-c5cb-a995-11a3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="5758-42fa-6483-ad1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
     <entryLink id="d3f7-4b68-4620-71c0" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="edce-6dfa-009f-b888" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="6513-2ccd-3aad-1369" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="edce-6dfa-009f-b888" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="6513-2ccd-3aad-1369" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
     <entryLink id="9cb7-e623-a570-7f9b" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d6db-68ca-bc7c-a89f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="2d91-c42f-87be-75c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d6db-68ca-bc7c-a89f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="2d91-c42f-87be-75c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
     <entryLink id="0918-bc53-3b57-d4bd" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cec4-2f96-a9d8-b1ff" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="0dd4-8477-c6a5-2dda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="cec4-2f96-a9d8-b1ff" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="0dd4-8477-c6a5-2dda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
     <entryLink id="b8b1-85a0-da81-84ef" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="31d0-f5dd-d590-f44c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="0fe2-1b79-06e7-cba5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="31d0-f5dd-d590-f44c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="0fe2-1b79-06e7-cba5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
     <entryLink id="75bb-bdff-c428-6980" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ead6-b9ca-69dc-9e9d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="f72f-283a-b30e-5717" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ead6-b9ca-69dc-9e9d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="f72f-283a-b30e-5717" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
     <entryLink id="a964-cde7-e4a6-214f" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2f0c-4e80-0e67-18cb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="b4b6-455d-7034-933f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2f0c-4e80-0e67-18cb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="b4b6-455d-7034-933f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
     <entryLink id="50ef-7431-d164-ddc3" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2c88-5bb4-c0a2-b7dc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="dc15-12fc-5e96-6572" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2c88-5bb4-c0a2-b7dc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="dc15-12fc-5e96-6572" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
     <entryLink id="c99d-d45c-e6df-c8d5" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6443-210d-76dd-2567" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d3b1-742a-a2f1-3dab" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6443-210d-76dd-2567" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d3b1-742a-a2f1-3dab" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
     <entryLink id="77fc-1222-7a9e-e1d0" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="96b7-d05f-8520-1933" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="ee6c-4065-b963-db7a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="96b7-d05f-8520-1933" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="ee6c-4065-b963-db7a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
     <entryLink id="cb29-6fb3-b99d-62ae" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="792b-953e-cad5-dbb2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="aa0a-9234-c3d8-88d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="792b-953e-cad5-dbb2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="aa0a-9234-c3d8-88d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
     <entryLink id="99a3-879d-2980-2285" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="bffa-6bd9-1c88-0af5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0d79-cf87-62b4-557a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="bffa-6bd9-1c88-0af5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0d79-cf87-62b4-557a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="640e-ab18-7e85-5f80" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="796c-021b-2134-3189" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="fcfc-0f68-773c-9c77" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="796c-021b-2134-3189" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="fcfc-0f68-773c-9c77" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
     <entryLink id="13ba-a297-b455-efe5" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bbd1-4554-3f4a-2a39" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="4aab-83b8-a919-908c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bbd1-4554-3f4a-2a39" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4aab-83b8-a919-908c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="4b61-6cb1-1fbb-ded2" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7223-7250-0eea-eca9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4ed8-9475-c5fa-024f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="7223-7250-0eea-eca9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4ed8-9475-c5fa-024f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="966e-be19-0b84-c8a6" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b35f-75ec-b520-f042" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="4b01-28d8-740e-6337" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4277-100b-c6ac-2d59" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="b35f-75ec-b520-f042" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="4b01-28d8-740e-6337" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4277-100b-c6ac-2d59" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="5b68-5130-cc21-a675" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup"/>
-        <entryLink id="23bb-5a03-28bb-15e5" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup"/>
+        <entryLink id="5b68-5130-cc21-a675" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup" />
+        <entryLink id="23bb-5a03-28bb-15e5" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
     <entryLink id="cbdd-df4a-3b5f-abdd" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="270f-52f9-2ae1-0910" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="10b9-627d-a7f9-6088" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a37d-4315-5f51-0ce9" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="270f-52f9-2ae1-0910" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="10b9-627d-a7f9-6088" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a37d-4315-5f51-0ce9" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="f509-8bfa-a4a8-8e51" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup"/>
-        <entryLink id="3379-0fc6-1e2f-d046" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup"/>
+        <entryLink id="f509-8bfa-a4a8-8e51" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup" />
+        <entryLink id="3379-0fc6-1e2f-d046" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
     <entryLink id="8141-b381-6e35-cf64" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0ac5-d9ff-2054-8bbb" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="d200-a698-fda1-df05" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2bf2-736a-706b-9cf8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="0ac5-d9ff-2054-8bbb" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d200-a698-fda1-df05" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2bf2-736a-706b-9cf8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="d0d2-63f3-5ea7-540f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup"/>
-        <entryLink id="525d-eb85-aaab-927a" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup"/>
+        <entryLink id="d0d2-63f3-5ea7-540f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7923-f342-c07f-4967" type="selectionEntryGroup" />
+        <entryLink id="525d-eb85-aaab-927a" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
     <entryLink id="31be-fe57-8aa0-4c66" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c266-c2d1-6eda-b0f8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="576a-d259-9fb4-c382" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="c266-c2d1-6eda-b0f8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="576a-d259-9fb4-c382" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="2a51-2646-dcef-b4b3" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="30e2-d071-4c17-946e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="8cce-a9f7-dfba-6c7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="30e2-d071-4c17-946e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="8cce-a9f7-dfba-6c7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
     <entryLink id="eb2b-1a8e-577c-4c49" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f34a-371d-c249-4692" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cce8-dea3-3d25-665c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="f34a-371d-c249-4692" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cce8-dea3-3d25-665c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="3630-3878-3a8d-67aa" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e427-495f-12a8-9f40" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="8708-7591-f986-1cc8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e427-495f-12a8-9f40" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="8708-7591-f986-1cc8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
     <entryLink id="d8cd-1f7f-e904-30f2" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6a7d-054f-1d60-2f03" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="4d42-1cf9-a8f5-6419" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6a7d-054f-1d60-2f03" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="4d42-1cf9-a8f5-6419" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
     <entryLink id="52fb-ffad-729d-cf07" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="171e-345f-e596-6ff3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="b0d3-0599-4f6e-ef7a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="171e-345f-e596-6ff3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="b0d3-0599-4f6e-ef7a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
     <entryLink id="41f5-ec2d-a2c0-97a2" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3924-cd45-3ae0-ee94" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3e90-62df-96c8-d0d9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3924-cd45-3ae0-ee94" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3e90-62df-96c8-d0d9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
     <entryLink id="58e8-a073-7f80-608e" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d925-f60a-0175-051e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="45e9-2190-3f91-a5b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d925-f60a-0175-051e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="45e9-2190-3f91-a5b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
     <entryLink id="915c-23cf-cc58-2c1b" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e383-bb92-9efb-b845" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b740-0164-4ae8-12b9" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="e383-bb92-9efb-b845" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b740-0164-4ae8-12b9" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
     <entryLink id="bd6a-d7fd-1d9a-476b" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="405a-8c92-9afd-a007" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="aeed-5588-4a82-c5f1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="405a-8c92-9afd-a007" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="aeed-5588-4a82-c5f1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
     <entryLink id="a09f-3151-5892-ce0f" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6958-c12e-8f67-8c8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f073-82c1-f147-90cf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6958-c12e-8f67-8c8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f073-82c1-f147-90cf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
     <entryLink id="a529-339a-abad-65c1" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5054-8532-49eb-7b26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0c8f-938a-adef-dc8d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="5054-8532-49eb-7b26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0c8f-938a-adef-dc8d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
     <entryLink id="43e2-e234-abfe-1776" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="be3e-2e23-4737-7d29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="096a-3648-aa71-cad6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="be3e-2e23-4737-7d29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="096a-3648-aa71-cad6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="5a0b-deca-f472-0d1c" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f7df-1040-50de-0719" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d182-4cbb-5162-2bbd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="f7df-1040-50de-0719" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d182-4cbb-5162-2bbd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
     <entryLink id="8a59-25da-927f-8deb" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8f49-526e-aebf-b1b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7e23-2d05-f9c4-94af" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="8f49-526e-aebf-b1b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7e23-2d05-f9c4-94af" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="d52c-f63c-d9c3-731f" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="29f3-ef3e-b1c1-5976" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="06b1-248d-c5af-2f01" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="29f3-ef3e-b1c1-5976" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="06b1-248d-c5af-2f01" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
     <entryLink id="7312-5fe5-3530-21c8" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="27ea-438a-7033-4541" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="482c-ff5f-75ac-35de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="27ea-438a-7033-4541" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="482c-ff5f-75ac-35de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
     <entryLink id="733a-b7dc-4703-6144" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="897f-9843-57c3-bb5d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="ed76-c116-9f18-4446" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="897f-9843-57c3-bb5d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="ed76-c116-9f18-4446" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
     <entryLink id="435f-3a9a-898f-829f" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="131a-2c1a-991a-4b31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cfe7-c127-804c-7464" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="4c82-1160-a0e8-02d1" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="131a-2c1a-991a-4b31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cfe7-c127-804c-7464" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="4c82-1160-a0e8-02d1" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="8894-a45b-f853-f28d" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9da1-705d-4f2c-2a9d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cd71-d0a0-6c41-4037" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9da1-705d-4f2c-2a9d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cd71-d0a0-6c41-4037" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
     <entryLink id="390f-5485-7922-97e1" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6008-9981-ad5d-9281" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="38b3-f3ca-2d28-e0ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6008-9981-ad5d-9281" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="38b3-f3ca-2d28-e0ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
     <entryLink id="bedc-8b40-0c65-f773" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7a79-e3ec-7380-4db5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f877-71c4-96e1-8b11" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="7a79-e3ec-7380-4db5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f877-71c4-96e1-8b11" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
     <entryLink id="7b4d-b51f-60a7-c0d5" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a197-b2db-212a-ea62" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="9df2-031d-7da0-51ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a197-b2db-212a-ea62" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="9df2-031d-7da0-51ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="ac8d-8f28-7672-77f4" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9c94-977a-d13e-b38b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="ce84-032d-97dd-f5e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9c94-977a-d13e-b38b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="ce84-032d-97dd-f5e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
     <entryLink id="b7b4-0041-6e28-3c10" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5c33-bad0-f09d-b782" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="100f-0489-b6cc-9eea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5c33-bad0-f09d-b782" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="100f-0489-b6cc-9eea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="0a2f-1481-6fb4-27e9" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="85d8-5f9d-dca5-1923" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="06a4-3b9a-86f1-b6d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="85d8-5f9d-dca5-1923" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="06a4-3b9a-86f1-b6d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
     <entryLink id="80cd-5309-cabd-c861" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="31f2-04f2-1e04-7f98" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="ba7f-7dad-1594-68da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="31f2-04f2-1e04-7f98" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="ba7f-7dad-1594-68da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
     <entryLink id="c6e7-5e01-e008-9218" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3fc4-d03f-42ab-1de9" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="564b-255c-3292-7021" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3fc4-d03f-42ab-1de9" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="564b-255c-3292-7021" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
     <entryLink id="663d-8263-9948-a54c" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8f29-e59c-9f90-4279" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="366f-3c14-f5c3-6a69" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8f29-e59c-9f90-4279" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="366f-3c14-f5c3-6a69" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
     <entryLink id="8462-d44e-1751-a913" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0e29-6cef-3313-0fc7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="eefc-6e10-9659-356d" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="c586-1b0b-650a-a0da" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="0e29-6cef-3313-0fc7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="eefc-6e10-9659-356d" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
+        <categoryLink id="c586-1b0b-650a-a0da" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="b783-0f58-baad-17ac" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8f9b-d0bd-3291-3ef8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="60e4-41b5-6288-a148" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="8f9b-d0bd-3291-3ef8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="60e4-41b5-6288-a148" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
     <entryLink id="59c1-6830-38d2-be24" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="de27-7454-955e-4652" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="232f-d991-8115-2ac2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="de27-7454-955e-4652" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="232f-d991-8115-2ac2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
     <entryLink id="fc35-9419-bb08-7a4b" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="296b-a648-8319-0bd8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3abb-d8da-4b54-c7df" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="296b-a648-8319-0bd8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3abb-d8da-4b54-c7df" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
     <entryLink id="50e8-9ffd-91ff-0c7b" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <infoLinks>
-        <infoLink id="0fff-a1d4-c68d-08ce" name="Legiones Astartes (Night Lords) " hidden="false" targetId="8280-d4ea-b131-4970" type="rule"/>
+        <infoLink id="0fff-a1d4-c68d-08ce" name="Legiones Astartes (Night Lords) " hidden="false" targetId="8280-d4ea-b131-4970" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="7a39-bbf3-4390-4463" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="31ea-3c73-3aa9-6891" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="7a39-bbf3-4390-4463" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="31ea-3c73-3aa9-6891" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="d2ce-94c1-242d-2a7f" name="Sevatar" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="54e2-11e9-e908-4ed9" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="54e2-11e9-e908-4ed9" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="1647-bbf1-c523-59a9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="cb8a-15df-ffe4-a464" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="9289-d8b0-389a-48bf" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="a2a9-2111-1212-f029" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
+        <categoryLink id="1647-bbf1-c523-59a9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="cb8a-15df-ffe4-a464" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="9289-d8b0-389a-48bf" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="a2a9-2111-1212-f029" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0f6a-a772-4664-ce14" name="Sevatar" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64cf-319e-336c-74a6" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39f0-08d7-c050-7f76" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64cf-319e-336c-74a6" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39f0-08d7-c050-7f76" type="max" />
           </constraints>
           <profiles>
             <profile id="fe51-16fe-fc3b-690b" name="Sevatar " hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character,Psyker, Unique)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">7</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1148,37 +1147,37 @@
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="2289-d77d-d3f2-d8b7" name="Legiones Astartes (Night Lords) " hidden="false" targetId="8280-d4ea-b131-4970" type="rule"/>
-            <infoLink id="9510-3be0-ad5f-9121" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
-            <infoLink id="b844-4b2f-f115-3b45" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+            <infoLink id="2289-d77d-d3f2-d8b7" name="Legiones Astartes (Night Lords) " hidden="false" targetId="8280-d4ea-b131-4970" type="rule" />
+            <infoLink id="9510-3be0-ad5f-9121" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule" />
+            <infoLink id="b844-4b2f-f115-3b45" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
             <infoLink id="bbed-d5f5-eab8-6a2d" name="Fear (X)" hidden="false" targetId="21f6-7842-df5c-d2e7" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Fear (2)"/>
+                <modifier type="set" field="name" value="Fear (2)" />
               </modifiers>
             </infoLink>
             <infoLink id="e2ca-273e-452d-07f1" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Precision Strikes (4+)"/>
+                <modifier type="set" field="name" value="Precision Strikes (4+)" />
               </modifiers>
             </infoLink>
-            <infoLink id="d12d-0cc4-72a9-58dd" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
+            <infoLink id="d12d-0cc4-72a9-58dd" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule" />
           </infoLinks>
           <entryLinks>
             <entryLink id="02f8-bf2a-4a11-770e" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a02c-69bf-6247-af21" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ea0-cc83-d9fe-f56f" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a02c-69bf-6247-af21" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ea0-cc83-d9fe-f56f" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="c6cd-fc91-802f-af6e" name="Psychic Powers" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20e7-9265-c87e-8be6" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82fa-89bb-95d5-77f3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20e7-9265-c87e-8be6" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82fa-89bb-95d5-77f3" type="max" />
           </constraints>
           <profiles>
             <profile id="30d7-cf0b-c69b-9311" name="Shadows of Past and Future" hidden="false" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power">
@@ -1188,93 +1187,93 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
-        <selectionEntry id="7f78-82aa-0f99-9bc4" name="Night&apos;s Whisper" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="7f78-82aa-0f99-9bc4" name="Night's Whisper" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf4f-9c1b-36bf-bd17" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e01f-0896-2c04-154f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf4f-9c1b-36bf-bd17" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e01f-0896-2c04-154f" type="max" />
           </constraints>
           <profiles>
-            <profile id="fd8c-09a2-fef6-3c64" name="Night&apos;s Whisper" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="fd8c-09a2-fef6-3c64" name="Night's Whisper" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+2</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Two-handed, Duellist&apos;s Edge (1), Murderous Strike (6+), Master-crafted</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Two-handed, Duellist's Edge (1), Murderous Strike (6+), Master-crafted</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="e204-5abb-d112-8ec3" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
-            <infoLink id="85fa-12da-da53-f389" name="Duellist’s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule"/>
-            <infoLink id="c036-d7ae-7471-3630" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule"/>
-            <infoLink id="60fc-872f-24bc-27ca" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="e204-5abb-d112-8ec3" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
+            <infoLink id="85fa-12da-da53-f389" name="Duellist&#8217;s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule" />
+            <infoLink id="c036-d7ae-7471-3630" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule" />
+            <infoLink id="60fc-872f-24bc-27ca" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="2193-063a-03e7-6c04" name="Sworn Loyalty" hidden="true" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="d2ce-94c1-242d-2a7f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+                <condition field="selections" scope="d2ce-94c1-242d-2a7f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
               </conditions>
             </modifier>
             <modifier type="set" field="8d4b-a3ad-f0ee-3804" value="1.0">
               <conditions>
-                <condition field="selections" scope="d2ce-94c1-242d-2a7f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+                <condition field="selections" scope="d2ce-94c1-242d-2a7f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d4b-a3ad-f0ee-3804" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a52-a69c-fea4-f4a4" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d4b-a3ad-f0ee-3804" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a52-a69c-fea4-f4a4" type="max" />
           </constraints>
           <infoLinks>
-            <infoLink id="6b86-7cc4-0d92-0221" name="Sworn Loyalty" hidden="false" targetId="3938-864e-6801-3410" type="rule"/>
+            <infoLink id="6b86-7cc4-0d92-0221" name="Sworn Loyalty" hidden="false" targetId="3938-864e-6801-3410" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="3202-28de-6203-748e" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37db-a529-9e67-250e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3fd-4681-1225-e7f5" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37db-a529-9e67-250e" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3fd-4681-1225-e7f5" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="981d-7029-2eb5-9f2a" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="812e-c182-2f75-f2a8" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61de-3d1a-404b-61c0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="812e-c182-2f75-f2a8" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61de-3d1a-404b-61c0" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="de27-283d-6227-09cc" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bf7-8d8a-ea89-0d36" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9be2-69fa-f519-afe6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bf7-8d8a-ea89-0d36" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9be2-69fa-f519-afe6" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="b10a-13d2-bec6-346f" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64ae-d497-ef39-b073" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28c3-a631-b9e9-2c4c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64ae-d497-ef39-b073" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28c3-a631-b9e9-2c4c" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="398c-a6c7-49f2-c33d" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48e0-fa0c-8d51-432c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62b1-38c9-83ac-3745" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48e0-fa0c-8d51-432c" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62b1-38c9-83ac-3745" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="e9d0-3bba-2c1c-e3e2" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a2d-6c95-eb9e-a659" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a2d-6c95-eb9e-a659" type="max" />
           </constraints>
           <rules>
             <rule id="b300-fa84-4c3a-5cdf" name="Warlord: Master of the Atramentar" hidden="false">
@@ -1282,55 +1281,55 @@
             </rule>
           </rules>
         </entryLink>
-        <entryLink id="a253-dd64-74d1-559d" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup"/>
+        <entryLink id="a253-dd64-74d1-559d" name="Retinue" hidden="false" collective="false" import="true" targetId="f728-26bf-3c99-1529" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="53ce-6dc9-aa69-fbaa" name="Terror Squad" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="2325-6bc8-54f0-a18a" name="Fear (X)" hidden="false" targetId="21f6-7842-df5c-d2e7" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Fear (1)"/>
+            <modifier type="set" field="name" value="Fear (1)" />
           </modifiers>
         </infoLink>
         <infoLink id="f9d5-c8ea-b952-4913" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Precision Strikes (6+)"/>
+            <modifier type="set" field="name" value="Precision Strikes (6+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="4111-bb61-06a2-60f7" name="Infiltrate" hidden="false" targetId="0e32-5b92-a95a-8464" type="rule"/>
-        <infoLink id="b206-88b3-b00d-ffca" name="Bloody Murder" hidden="false" targetId="5072-2b33-d062-210f" type="rule"/>
+        <infoLink id="4111-bb61-06a2-60f7" name="Infiltrate" hidden="false" targetId="0e32-5b92-a95a-8464" type="rule" />
+        <infoLink id="b206-88b3-b00d-ffca" name="Bloody Murder" hidden="false" targetId="5072-2b33-d062-210f" type="rule" />
         <infoLink id="31ef-fac6-0210-3a8a" name="Preferred Enemy (X)" hidden="false" targetId="37ab-d4db-891a-de8c" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Preferred Enemy (Infantry)"/>
+            <modifier type="set" field="name" value="Preferred Enemy (Infantry)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="45ec-b1d0-a2e1-74b5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="f894-26fc-995c-2221" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="6562-0870-bbf3-d113" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="45ec-b1d0-a2e1-74b5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="f894-26fc-995c-2221" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="6562-0870-bbf3-d113" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="032a-578d-8f65-22b3" name="Headsman" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9ed-438a-3766-ae29" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff1f-9a69-7537-f19e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9ed-438a-3766-ae29" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff1f-9a69-7537-f19e" type="min" />
           </constraints>
           <profiles>
             <profile id="7caf-cd1a-2fbc-a309" name="Headsman" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="53ce-6dc9-aa69-fbaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                    <condition field="selections" scope="53ce-6dc9-aa69-fbaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Skirmish)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1344,73 +1343,73 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="632b-c772-22db-d185" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="632b-c772-22db-d185" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="dc80-f2a1-a2c9-7b57" name="May exchange his bolt pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1c45-d2db-70ef-4bbd">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f163-da2d-8aca-6b32" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10a1-110a-b235-ad31" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f163-da2d-8aca-6b32" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10a1-110a-b235-ad31" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="26c1-18e0-0cba-8587" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="8f70-8467-c1b1-0114" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="7580-844e-e66a-634c" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="1c45-d2db-70ef-4bbd" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+                <entryLink id="1c45-d2db-70ef-4bbd" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="f043-7656-1fa2-7d1b" name="May exchange his chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a2b4-3aaa-cafa-d170">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b493-6c5c-439d-caac" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f393-6ef2-fab5-b551" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b493-6c5c-439d-caac" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f393-6ef2-fab5-b551" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="3007-9249-aec1-436c" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="cea0-c557-74a5-3738" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="a2b4-3aaa-cafa-d170" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+                <entryLink id="a2b4-3aaa-cafa-d170" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
                 <entryLink id="ba4b-3f78-f7b5-2b28" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="f1a6-0834-eb16-0565" name="Chainblade" hidden="false" collective="false" import="true" targetId="8391-79c8-31ff-3705" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="eb89-d943-bd93-dfba" name="Chainaxe" hidden="false" collective="false" import="true" targetId="85b9-4e50-af11-c295" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="ed85-b279-0bb9-a533" name="Chainglaive" hidden="false" collective="false" import="true" targetId="2f96-d817-5180-9453" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="656c-2b10-275d-3850" name="Headsman&apos;s Axe" hidden="false" collective="false" import="true" targetId="4178-09b6-7569-5ca3" type="selectionEntry">
+                <entryLink id="656c-2b10-275d-3850" name="Headsman's Axe" hidden="false" collective="false" import="true" targetId="4178-09b6-7569-5ca3" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1419,17 +1418,17 @@
               <entryLinks>
                 <entryLink id="ae53-8cfe-0336-2992" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ddb-e54e-34db-8692" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ddb-e54e-34db-8692" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1438,32 +1437,32 @@
           <modifiers>
             <modifier type="increment" field="f75c-6cf3-ebd3-0d35" value="1.0">
               <repeats>
-                <repeat field="selections" scope="53ce-6dc9-aa69-fbaa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="53ce-6dc9-aa69-fbaa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f75c-6cf3-ebd3-0d35" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f75c-6cf3-ebd3-0d35" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="b4fa-00b8-1241-c206" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0" />
               </costs>
             </entryLink>
             <entryLink id="4625-b19b-a6b7-179a" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
               </costs>
             </entryLink>
             <entryLink id="8b93-d5a0-6de5-1326" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
             <entryLink id="7bf0-0b4c-747c-e4cb" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -1472,10 +1471,10 @@
           <entryLinks>
             <entryLink id="b60e-5345-1821-e52b" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2156-1952-0c5a-8eb2" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2156-1952-0c5a-8eb2" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -1484,30 +1483,30 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="53ce-6dc9-aa69-fbaa" value="11.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
+                <condition field="selections" scope="53ce-6dc9-aa69-fbaa" value="11.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83aa-4896-ce36-dde6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83aa-4896-ce36-dde6" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="e8da-f2f2-d054-b378" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="6c37-8dee-85f2-1542" name="Drop Pod" hidden="false" collective="false" import="true" targetId="83ac-f9cf-cc29-00a3" type="selectionEntry"/>
-            <entryLink id="7960-3ed1-cbdb-97df" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="true" targetId="bbe8-818d-3068-d79c" type="selectionEntry"/>
+            <entryLink id="6c37-8dee-85f2-1542" name="Drop Pod" hidden="false" collective="false" import="true" targetId="83ac-f9cf-cc29-00a3" type="selectionEntry" />
+            <entryLink id="7960-3ed1-cbdb-97df" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="true" targetId="bbe8-818d-3068-d79c" type="selectionEntry" />
             <entryLink id="891f-288e-7fa4-c628" name="Storm Eagle Gunship" hidden="true" collective="false" import="true" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1518,18 +1517,18 @@
           <entryLinks>
             <entryLink id="031c-7c70-bf36-07a4" name="Preysight" hidden="false" collective="false" import="true" targetId="b905-4d78-c141-4e63" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51a6-8d4c-a0d1-7230" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51a6-8d4c-a0d1-7230" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="b317-4b49-5027-cca9" name=" Executioners" hidden="false" collective="false" import="true" defaultSelectionEntryId="0be0-49a1-c80c-1a19">
           <constraints>
-            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05a5-4900-1e92-3d14" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="964f-b05b-bc79-11fa" type="min"/>
+            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05a5-4900-1e92-3d14" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="964f-b05b-bc79-11fa" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="0be0-49a1-c80c-1a19" name="Executioner w/Chainsword" hidden="false" collective="false" import="true" type="model">
@@ -1537,7 +1536,7 @@
                 <profile id="804a-5bae-3402-af07" name="Executioner" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1553,19 +1552,19 @@
               <entryLinks>
                 <entryLink id="f693-878a-038b-b79f" name="Chainsword" hidden="false" collective="false" import="true" targetId="b5b7-b50a-ac86-9173" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c41-4f2c-c618-a818" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a37-0ec9-6589-2ff0" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c41-4f2c-c618-a818" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a37-0ec9-6589-2ff0" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="8cf0-7f26-05d3-897e" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44d7-faec-d701-2d7b" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a9c-f644-a4d9-3713" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44d7-faec-d701-2d7b" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a9c-f644-a4d9-3713" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="35b7-94ae-96ad-3bac" name="Executioner w/Chainglaive" hidden="false" collective="false" import="true" type="model">
@@ -1573,7 +1572,7 @@
                 <profile id="a308-732a-7b5f-ccac" name="Executioner" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1589,19 +1588,19 @@
               <entryLinks>
                 <entryLink id="909f-4e9e-9db3-76b2" name="Chainglaive" hidden="false" collective="false" import="true" targetId="f4b1-a1d5-4c65-12d3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4130-6524-6340-ee0d" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36df-8b22-42fa-ced6" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4130-6524-6340-ee0d" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36df-8b22-42fa-ced6" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="51cb-fd9d-9e0a-ec34" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c4b-74b8-98ef-1615" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bc9-f990-148c-81fa" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c4b-74b8-98ef-1615" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bc9-f990-148c-81fa" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="28.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="28.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="2d06-4475-9e77-456d" name="Executioner w/Chainblade" hidden="false" collective="false" import="true" type="model">
@@ -1609,7 +1608,7 @@
                 <profile id="1339-f9ea-c360-3f6b" name="Executioner" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1625,19 +1624,19 @@
               <entryLinks>
                 <entryLink id="4e6b-987e-cb7c-2d39" name="Chainblade" hidden="false" collective="false" import="true" targetId="a528-cdc6-2004-cced" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15ce-4db8-5071-3f93" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9e5-d6e0-e397-62ab" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15ce-4db8-5071-3f93" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9e5-d6e0-e397-62ab" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="6f56-9228-cbeb-1e98" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6182-9f53-b9d2-d2c1" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca9d-732b-bd36-6da0" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6182-9f53-b9d2-d2c1" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca9d-732b-bd36-6da0" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="28.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="28.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="617e-40d5-35b3-3f7c" name="Executioner w/Chainaxe" hidden="false" collective="false" import="true" type="model">
@@ -1645,7 +1644,7 @@
                 <profile id="7a97-adb0-55d6-426a" name="Executioner" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1661,19 +1660,19 @@
               <entryLinks>
                 <entryLink id="7d2c-223f-f714-103a" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76cf-d2c8-4544-a8a0" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8dd-0f2e-6b78-4a6f" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76cf-d2c8-4544-a8a0" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8dd-0f2e-6b78-4a6f" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="fd68-3126-3222-ab2f" name="Chainaxe" hidden="false" collective="false" import="true" targetId="3a0d-c3bb-dc59-a4c3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dbf-64ef-04e3-3c2b" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc3d-b8c4-4e61-6448" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dbf-64ef-04e3-3c2b" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc3d-b8c4-4e61-6448" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="23.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="23.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1682,67 +1681,67 @@
       <entryLinks>
         <entryLink id="426e-98f6-f3a9-7162" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="514f-332b-7c2f-a252" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5463-42b6-a597-0287" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="514f-332b-7c2f-a252" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5463-42b6-a597-0287" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="1202-cb47-06e5-0eb6" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3362-485f-64f3-6e46" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af5c-8fd1-c422-c3e3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3362-485f-64f3-6e46" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af5c-8fd1-c422-c3e3" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="f027-d4e3-3b40-747b" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f503-2cca-b0de-84b6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7256-f85f-e2a4-1acd" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f503-2cca-b0de-84b6" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7256-f85f-e2a4-1acd" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="9bb8-8fe4-11c1-9e50" name="Night Raptor Squad" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="deb7-a315-6298-63ab" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="deb7-a315-6298-63ab" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="dec4-fd49-9010-e6f3" name="Sudden Strike (X)" hidden="false" targetId="58b3-7d84-b92d-1363" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Sudden Strike (1)"/>
+            <modifier type="set" field="name" value="Sudden Strike (1)" />
           </modifiers>
         </infoLink>
-        <infoLink id="7783-03a9-94e1-473a" name="Bloody Murder" hidden="false" targetId="5072-2b33-d062-210f" type="rule"/>
+        <infoLink id="7783-03a9-94e1-473a" name="Bloody Murder" hidden="false" targetId="5072-2b33-d062-210f" type="rule" />
         <infoLink id="a76c-6ba5-84d3-bd62" name="Fear (X)" hidden="false" targetId="21f6-7842-df5c-d2e7" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Fear (1)"/>
+            <modifier type="set" field="name" value="Fear (1)" />
           </modifiers>
         </infoLink>
-        <infoLink id="5b1f-dbdd-e28e-d28f" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
+        <infoLink id="5b1f-dbdd-e28e-d28f" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b113-30d1-8842-415d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="9fbe-1dcd-30c4-c310" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
-        <categoryLink id="cfa2-614d-454f-36d8" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="fc54-bc93-8aec-8c8c" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="b113-30d1-8842-415d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="9fbe-1dcd-30c4-c310" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false" />
+        <categoryLink id="cfa2-614d-454f-36d8" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="fc54-bc93-8aec-8c8c" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8c9e-a718-9d07-2e08" name="Huntmaster" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6c7-d024-7e85-c5a9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01a8-0cf3-064a-17e0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6c7-d024-7e85-c5a9" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01a8-0cf3-064a-17e0" type="max" />
           </constraints>
           <profiles>
             <profile id="1cdd-4bcd-f167-5b25" name="Huntmaster" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Skirmish)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1756,17 +1755,17 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="3359-c174-6c53-9968" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="3359-c174-6c53-9968" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="8f69-1e1e-3fc9-fa4f" name="Wargear:" hidden="false" collective="false" import="true">
               <entryLinks>
                 <entryLink id="f4bb-a2ea-47f8-0e96" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33f1-2af3-6a5f-fecb" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33f1-2af3-6a5f-fecb" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1775,83 +1774,83 @@
               <modifiers>
                 <modifier type="set" field="a4db-409d-8837-39cb" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="8c9e-a718-9d07-2e08" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a6d2-b3a9-6d2c-1f6f" type="greaterThan"/>
+                    <condition field="selections" scope="8c9e-a718-9d07-2e08" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a6d2-b3a9-6d2c-1f6f" type="greaterThan" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="39d2-e30a-92d4-e84d" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="8c9e-a718-9d07-2e08" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a6d2-b3a9-6d2c-1f6f" type="greaterThan"/>
+                    <condition field="selections" scope="8c9e-a718-9d07-2e08" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a6d2-b3a9-6d2c-1f6f" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4db-409d-8837-39cb" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39d2-e30a-92d4-e84d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4db-409d-8837-39cb" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39d2-e30a-92d4-e84d" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="6b63-0b6d-f567-a38e" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="9c1c-44b8-805b-dad4" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="d95d-5e68-a58a-6489" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+                <entryLink id="d95d-5e68-a58a-6489" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="5652-9ede-6f30-8f75" name="Chainsword Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5f1a-0510-120a-32ea">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06fc-f3cf-ce09-f0b8" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6774-9b0f-5e37-99be" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06fc-f3cf-ce09-f0b8" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6774-9b0f-5e37-99be" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="d3df-c51c-1d3a-28d9" name="Chainblade" hidden="false" collective="false" import="true" targetId="8391-79c8-31ff-3705" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="d90a-4a71-e3dc-5714" name="Chainglaive" hidden="false" collective="false" import="true" targetId="2f96-d817-5180-9453" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="5f1a-0510-120a-32ea" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+                <entryLink id="5f1a-0510-120a-32ea" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
                 <entryLink id="2090-1ee8-11c1-c530" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="bc59-a831-6b7e-8adf" name="Power Weapon" hidden="false" collective="false" import="true" targetId="36a7-1c39-670c-5fec" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="9640-0107-a18b-7867" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="742f-0bb9-989a-82e2" name="Headsman&apos;s Axe" hidden="false" collective="false" import="true" targetId="4178-09b6-7569-5ca3" type="selectionEntry">
+                <entryLink id="742f-0bb9-989a-82e2" name="Headsman's Axe" hidden="false" collective="false" import="true" targetId="4178-09b6-7569-5ca3" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="86b1-254a-82c8-fc3d" name=" Night Raptors" hidden="false" collective="false" import="true" defaultSelectionEntryId="b7d5-489d-e8dc-70cc">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0050-2c07-9410-d2e8" type="min"/>
-            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6a6-ee63-1c6e-2567" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0050-2c07-9410-d2e8" type="min" />
+            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6a6-ee63-1c6e-2567" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="928c-1fd8-8b47-973c" name="Night Raptor w/Pair of Lightning Claws" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
@@ -1859,7 +1858,7 @@
                 <profile id="9652-52cc-4914-ad13" name="Night Raptor" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1875,13 +1874,13 @@
               <entryLinks>
                 <entryLink id="e5ea-b75e-71f7-479f" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3975-ffa3-a2a4-2337" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9e4-bb14-6cc0-8430" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3975-ffa3-a2a4-2337" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9e4-bb14-6cc0-8430" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="bc9e-194c-d712-2dd0" name="Night Raptor w/Power Weapon" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
@@ -1889,7 +1888,7 @@
                 <profile id="5655-838d-1de0-cc1b" name="Night Raptor" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1905,28 +1904,28 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="e6f1-f958-80b3-91fd" name="Power Weapons:" hidden="false" collective="false" import="true" defaultSelectionEntryId="aa78-0cae-cdfb-31be">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48bf-50f2-d18a-4167" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5b7-fead-07c0-4eeb" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48bf-50f2-d18a-4167" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5b7-fead-07c0-4eeb" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="6688-5c3c-00b3-3b98" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="aa78-0cae-cdfb-31be" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="445b-0c5a-0387-9b58" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="8932-a9b1-0349-b6f4" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -1935,13 +1934,13 @@
               <entryLinks>
                 <entryLink id="4c58-a1f0-46b0-0eb0" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c613-205a-ad92-88dd" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85f7-56bc-6be8-9a4a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c613-205a-ad92-88dd" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85f7-56bc-6be8-9a4a" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="bc1a-52f8-a729-938c" name="Night Raptor w/Lightning Claw" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
@@ -1949,7 +1948,7 @@
                 <profile id="c111-c4d0-7d8f-45d2" name="Night Raptor" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1965,19 +1964,19 @@
               <entryLinks>
                 <entryLink id="2eb1-2350-1a39-090d" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c25e-4fd7-e0b3-7799" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d09d-80f3-5541-dcd1" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c25e-4fd7-e0b3-7799" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d09d-80f3-5541-dcd1" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="94d7-ab90-330c-56d5" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="2603-c45c-25ee-2a86" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="441b-7f5b-aefc-fa87" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fd4-887c-130d-64ac" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="441b-7f5b-aefc-fa87" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fd4-887c-130d-64ac" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="821f-583b-f322-71c0" name="Night Raptor w/Chainblade" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
@@ -1985,7 +1984,7 @@
                 <profile id="ff19-c55e-12b5-6937" name="Night Raptor" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2001,19 +2000,19 @@
               <entryLinks>
                 <entryLink id="2e45-1614-a149-43a2" name="Chainblade" hidden="false" collective="false" import="true" targetId="a528-cdc6-2004-cced" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08a7-9cde-83e0-3472" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cb2-86de-ced7-f019" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08a7-9cde-83e0-3472" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cb2-86de-ced7-f019" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="fcce-f4ee-6827-86a9" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="306d-8d09-2281-c548" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f7a-68f0-22bf-8d0d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="306d-8d09-2281-c548" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f7a-68f0-22bf-8d0d" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="14cb-d481-3fb3-37cc" name="Night Raptor w/Chainglaive" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
@@ -2021,7 +2020,7 @@
                 <profile id="10ce-ab11-abbb-5ff5" name="Night Raptor" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2037,19 +2036,19 @@
               <entryLinks>
                 <entryLink id="6176-2615-5141-8f65" name="Chainglaive" hidden="false" collective="false" import="true" targetId="f4b1-a1d5-4c65-12d3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09f1-9270-ebf6-9ef6" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="543f-0319-b21e-1523" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09f1-9270-ebf6-9ef6" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="543f-0319-b21e-1523" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="7265-b9f5-c896-0226" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="251e-88b1-4a78-a37d" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dce7-e56b-400c-33fb" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="251e-88b1-4a78-a37d" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dce7-e56b-400c-33fb" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="b7d5-489d-e8dc-70cc" name=" Night Raptor w/Chainsword" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
@@ -2057,7 +2056,7 @@
                 <profile id="adf2-b4cc-7feb-837f" name="Night Raptor" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2073,37 +2072,37 @@
               <entryLinks>
                 <entryLink id="160e-fb6f-7831-ad0a" name="Chainsword" hidden="false" collective="false" import="true" targetId="b5b7-b50a-ac86-9173" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8958-87e1-c7f3-82c2" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bff-ae82-74ab-13ea" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8958-87e1-c7f3-82c2" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bff-ae82-74ab-13ea" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="279e-d68c-441b-71c3" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38d0-5626-6b09-e489" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ef4-ac68-c492-6a39" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38d0-5626-6b09-e489" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ef4-ac68-c492-6a39" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="435c-7ace-9ec2-c863" name="Night Raptor w/Options (1 in 5)" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="b9bb-a979-e548-349c" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="9bb8-8fe4-11c1-9e50" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="9bb8-8fe4-11c1-9e50" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9bb-a979-e548-349c" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9bb-a979-e548-349c" type="max" />
               </constraints>
               <profiles>
                 <profile id="ff0d-68a1-5fe9-9cfd" name="Night Raptor" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2119,89 +2118,89 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="d29a-5035-67f6-6673" name="Pistol Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="b295-8f9e-c7eb-4b2c">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0de-fe4b-5968-7571" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3080-9dcd-2aa0-28cc" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0de-fe4b-5968-7571" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3080-9dcd-2aa0-28cc" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="a7ff-6a11-44d9-1700" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="b295-8f9e-c7eb-4b2c" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="868e-01a6-e65d-648e" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="3d04-edc9-ef63-ef67" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="06f2-e1dc-7c07-c456" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="5d96-7170-6fb4-7839" name="Melee Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="0029-88d4-79f6-aa16">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1225-acf3-525c-b9ba" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68e1-9b5e-5d13-40b9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1225-acf3-525c-b9ba" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68e1-9b5e-5d13-40b9" type="min" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="4dfe-2489-5bf2-9da5" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="9d68-361f-5199-887d" name="Chainblade" hidden="false" collective="false" import="true" targetId="8391-79c8-31ff-3705" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="bd3f-8e8f-a8d5-ce07" name="Chainglaive" hidden="false" collective="false" import="true" targetId="2f96-d817-5180-9453" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="8664-33f3-12a6-9395" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="8acd-dc02-f44a-974e" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="9020-076a-ec5f-d5b4" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="2449-36db-f3e4-6072" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
-                    <entryLink id="0029-88d4-79f6-aa16" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+                    <entryLink id="0029-88d4-79f6-aa16" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
                     <entryLink id="9c54-8cb1-f611-65f6" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2210,22 +2209,22 @@
           <entryLinks>
             <entryLink id="bd89-9d86-8296-b77e" name="Preysight" hidden="false" collective="false" import="true" targetId="b905-4d78-c141-4e63" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="686f-1bf7-b7e6-5e4c" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="686f-1bf7-b7e6-5e4c" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="1636-d8d9-2428-f166" name="Konrad Curze" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e86b-5ed4-4507-bc40" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e86b-5ed4-4507-bc40" type="max" />
       </constraints>
       <rules>
         <rule id="bb3c-af82-a6a9-1de9" name="A Death Long Foreseen" hidden="false">
@@ -2236,33 +2235,33 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="772d-b6eb-6387-6b79" name="Legiones Astartes (Night Lords) " hidden="false" targetId="8280-d4ea-b131-4970" type="rule"/>
-        <infoLink id="f3ee-e4e1-03d1-5220" name="Hit &amp; Run" hidden="false" targetId="5986-e960-d432-affd" type="rule"/>
+        <infoLink id="772d-b6eb-6387-6b79" name="Legiones Astartes (Night Lords) " hidden="false" targetId="8280-d4ea-b131-4970" type="rule" />
+        <infoLink id="f3ee-e4e1-03d1-5220" name="Hit &amp; Run" hidden="false" targetId="5986-e960-d432-affd" type="rule" />
         <infoLink id="1b2f-3e92-e00f-43fc" name="Fear (X)" hidden="false" targetId="21f6-7842-df5c-d2e7" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Fear (3)"/>
+            <modifier type="set" field="name" value="Fear (3)" />
           </modifiers>
         </infoLink>
-        <infoLink id="eafb-2c40-c418-6b6d" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
-        <infoLink id="a6fd-f1ca-33f0-44dd" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
-        <infoLink id="ba03-3704-c210-25fb" name="Bloody Murder" hidden="false" targetId="5072-2b33-d062-210f" type="rule"/>
+        <infoLink id="eafb-2c40-c418-6b6d" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule" />
+        <infoLink id="a6fd-f1ca-33f0-44dd" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule" />
+        <infoLink id="ba03-3704-c210-25fb" name="Bloody Murder" hidden="false" targetId="5072-2b33-d062-210f" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="3ecd-9823-e8e4-14f8" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
-        <categoryLink id="9bd6-18bb-2ebc-e958" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="9920-bfc8-5c9b-5ffc" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="3ecd-9823-e8e4-14f8" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false" />
+        <categoryLink id="9bd6-18bb-2ebc-e958" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="9920-bfc8-5c9b-5ffc" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7cea-1a9a-cee1-7d17" name="Konrad Curze" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45ae-129d-32b6-2705" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a33-4b89-9d70-8bf0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45ae-129d-32b6-2705" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a33-4b89-9d70-8bf0" type="min" />
           </constraints>
           <profiles>
             <profile id="822a-b979-59b6-5c23" name="Konrad Curze" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Primarch (Psyker, Unique)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">8</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">7</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
@@ -2276,13 +2275,13 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="c12d-0270-ecfe-f3e2" name="Mercy &amp; Forgiveness" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e43-39de-a6e9-487b" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f6b-5813-cd65-9de9" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e43-39de-a6e9-487b" type="max" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f6b-5813-cd65-9de9" type="min" />
           </constraints>
           <profiles>
             <profile id="d70a-a36f-8753-53f4" name="Mercy" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2303,22 +2302,22 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="2381-7bc6-7dc8-64c9" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
-            <infoLink id="94d8-dc15-ad91-769b" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule"/>
+            <infoLink id="2381-7bc6-7dc8-64c9" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
+            <infoLink id="94d8-dc15-ad91-769b" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="29e5-d85b-9237-9a26" name="The Widowmakers" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a708-1353-2827-1f52" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec33-e648-444c-7802" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a708-1353-2827-1f52" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec33-e648-444c-7802" type="min" />
           </constraints>
           <profiles>
             <profile id="f25a-dd6d-57ee-adc9" name="Widowmaker Volley" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">12"</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 3, Rending (4+)</characteristic>
@@ -2326,16 +2325,16 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="bbc8-15ea-ffae-1249" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule"/>
+            <infoLink id="bbc8-15ea-ffae-1249" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="f9b9-67c1-1284-1804" name="Glimpse of Death" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5057-17ad-d650-aeb6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae41-706f-bb21-c22e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5057-17ad-d650-aeb6" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae41-706f-bb21-c22e" type="min" />
           </constraints>
           <profiles>
             <profile id="72a8-7690-93a9-25fc" name="Glimpse of Death" hidden="false" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power">
@@ -2345,18 +2344,18 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="7510-011c-61e3-b07a" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule"/>
+            <infoLink id="7510-011c-61e3-b07a" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="07c8-e423-11bf-060c" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2fd-c252-9a53-66fc" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e466-5a29-f758-fe04" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2fd-c252-9a53-66fc" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e466-5a29-f758-fe04" type="min" />
           </constraints>
           <profiles>
             <profile id="a29d-d13d-18b5-f994" name="Sire of the Night Lords" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
@@ -2368,13 +2367,13 @@
         </entryLink>
         <entryLink id="fc46-d124-4287-f24e" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="866a-c482-ece1-7a40" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b696-cc08-7e75-70ef" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="866a-c482-ece1-7a40" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b696-cc08-7e75-70ef" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="450.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="450.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="837e-c3ca-437e-dfbf" name="Contekar Terminator Squad" publicationId="09c5-eeae-f398-b653" hidden="false" collective="false" import="true" type="unit">
@@ -2382,42 +2381,42 @@
         <rule id="33de-beff-3d71-ba95" name="Lords of the Night" hidden="false">
           <description>A single Contekar Terminator Squad numbering no more than 10 models may be taken as a Compulsory HQ choice in an army in which neither Sevatar nor Konrad Curze are present
 
-In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a Detachment that includes Sevatar, instead of as an Elites choice,  A unit selected as a Retinue Squad counts Sevatar as the Contekar Terminator Squad&apos;s Leader for the purposes of this special rule. A Contekar Terminator Squad selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as Sevatar. A Contekar Terminator Squad selected as a Retinue Squad must be deployed with Sevatar as part of the unit and Sevatar may not voluntarily leave the Retinue Squad during play.</description>
+In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a Detachment that includes Sevatar, instead of as an Elites choice,  A unit selected as a Retinue Squad counts Sevatar as the Contekar Terminator Squad's Leader for the purposes of this special rule. A Contekar Terminator Squad selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as Sevatar. A Contekar Terminator Squad selected as a Retinue Squad must be deployed with Sevatar as part of the unit and Sevatar may not voluntarily leave the Retinue Squad during play.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="7eda-c34e-00d3-0069" name="Legiones Astartes (Night Lords) " hidden="false" targetId="8280-d4ea-b131-4970" type="rule"/>
-        <infoLink id="ace7-b28e-b9e1-6ff7" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="339b-3898-ff33-5d93" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
+        <infoLink id="7eda-c34e-00d3-0069" name="Legiones Astartes (Night Lords) " hidden="false" targetId="8280-d4ea-b131-4970" type="rule" />
+        <infoLink id="ace7-b28e-b9e1-6ff7" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="339b-3898-ff33-5d93" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
         <infoLink id="4aa4-e41e-8595-d2b5" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="b4aa-dcdb-d91b-c89b" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
-        <infoLink id="3d9a-19b2-df67-4272" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+        <infoLink id="b4aa-dcdb-d91b-c89b" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
+        <infoLink id="3d9a-19b2-df67-4272" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule" />
         <infoLink id="d3b0-2e8c-6490-19fc" name="Fear (X)" hidden="false" targetId="21f6-7842-df5c-d2e7" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Fear (1)"/>
+            <modifier type="set" field="name" value="Fear (1)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="3aef-1623-40f8-2144" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="0714-07b8-9969-8559" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="8aab-8508-d7d0-37b6" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="3aef-1623-40f8-2144" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="0714-07b8-9969-8559" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="8aab-8508-d7d0-37b6" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="26f0-ee46-4dbb-2efd" name="Dissident" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01f0-6642-3bd0-d797" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d24-e2a9-8eaa-2009" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01f0-6642-3bd0-d797" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d24-e2a9-8eaa-2009" type="max" />
           </constraints>
           <profiles>
             <profile id="dd39-5a3e-ca71-b55a" name="Dissident" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2431,29 +2430,29 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="bca6-cd04-8a1f-52fa" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="bca6-cd04-8a1f-52fa" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="3640-6cce-b040-51d7" name="Contekars" hidden="false" collective="false" import="true" type="model">
           <modifiers>
             <modifier type="set" field="a578-8df4-de20-a189" value="9.0">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4f85-eb33-30c9-8f51" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4f85-eb33-30c9-8f51" type="instanceOf" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a578-8df4-de20-a189" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="647e-6211-4aab-0406" type="min"/>
+            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a578-8df4-de20-a189" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="647e-6211-4aab-0406" type="min" />
           </constraints>
           <profiles>
             <profile id="5ce4-0263-5ef3-2ca6" name="Contekar" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2467,7 +2466,7 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2476,35 +2475,35 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
           <modifiers>
             <modifier type="increment" field="1f1b-8634-d0b7-4498" value="1.0">
               <repeats>
-                <repeat field="selections" scope="837e-c3ca-437e-dfbf" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="837e-c3ca-437e-dfbf" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
             <modifier type="increment" field="05b0-6a3b-b119-2f24" value="1.0">
               <repeats>
-                <repeat field="selections" scope="837e-c3ca-437e-dfbf" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="837e-c3ca-437e-dfbf" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05b0-6a3b-b119-2f24" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f1b-8634-d0b7-4498" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05b0-6a3b-b119-2f24" type="max" />
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f1b-8634-d0b7-4498" type="min" />
           </constraints>
           <entryLinks>
-            <entryLink id="14d2-04ae-41e4-5a04" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry"/>
-            <entryLink id="3b34-1f71-8191-58fe" name="Volkite Cavitor" hidden="false" collective="false" import="true" targetId="16b9-f253-209d-7fba" type="selectionEntry"/>
+            <entryLink id="14d2-04ae-41e4-5a04" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry" />
+            <entryLink id="3b34-1f71-8191-58fe" name="Volkite Cavitor" hidden="false" collective="false" import="true" targetId="16b9-f253-209d-7fba" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="c1b3-f888-abd9-ba61" name="The Dissident may replace their Chainblade with:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="924d-ca17-3ee9-6eb4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="924d-ca17-3ee9-6eb4" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="0373-f772-feb6-05bc" name="Escaton Power Claw" hidden="false" collective="false" import="true" targetId="3504-bed7-057b-603b" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c87e-0969-0d76-d08f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c87e-0969-0d76-d08f" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -2513,10 +2512,10 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
           <entryLinks>
             <entryLink id="34dd-57d2-517a-7088" name="Preysight" hidden="false" collective="false" import="true" targetId="b905-4d78-c141-4e63" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04ce-d67b-c930-ab1a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04ce-d67b-c930-ab1a" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -2525,61 +2524,61 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
       <entryLinks>
         <entryLink id="b0bb-6053-96c0-a62a" name="Chainblade" hidden="false" collective="false" import="true" targetId="8391-79c8-31ff-3705" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc2e-6788-f951-7127" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2343-2f30-54cc-86b0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc2e-6788-f951-7127" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2343-2f30-54cc-86b0" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="8476-8d91-0f1b-18c8" name="Tartaros Terminator Armour" hidden="false" collective="false" import="true" targetId="f850-d0af-8663-ccac" type="selectionEntry"/>
+        <entryLink id="8476-8d91-0f1b-18c8" name="Tartaros Terminator Armour" hidden="false" collective="false" import="true" targetId="f850-d0af-8663-ccac" type="selectionEntry" />
         <entryLink id="0e39-23fa-22d8-e527" name="Warlord" hidden="true" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4f85-eb33-30c9-8f51" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4f85-eb33-30c9-8f51" type="instanceOf" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09d7-8f18-1936-935a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09d7-8f18-1936-935a" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="12d3-9df0-4118-997f" name="Atramentar Squad" publicationId="09b3-d525-cdea-260c" page="3" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="3938-864e-6801-3410" name="Sworn Loyalty" hidden="false">
-          <description>If Sevatar is the army’s Warlord, Night Lords Atramentar Squads may be selected as non-Compulsory Troops choices and count as Legion Terminator Squads for the purposes of the Master of the Atramentar Warlord Trait.</description>
+          <description>If Sevatar is the army&#8217;s Warlord, Night Lords Atramentar Squads may be selected as non-Compulsory Troops choices and count as Legion Terminator Squads for the purposes of the Master of the Atramentar Warlord Trait.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="fab4-2808-fac6-7c9e" name="Cloaked in Murder" hidden="false" targetId="be8a-5395-7470-d45b" type="rule"/>
-        <infoLink id="53c8-f38d-4334-4148" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule"/>
-        <infoLink id="3563-1fa5-8a6d-1f6d" name="Legiones Astartes (Night Lords) " hidden="false" targetId="8280-d4ea-b131-4970" type="rule"/>
+        <infoLink id="fab4-2808-fac6-7c9e" name="Cloaked in Murder" hidden="false" targetId="be8a-5395-7470-d45b" type="rule" />
+        <infoLink id="53c8-f38d-4334-4148" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule" />
+        <infoLink id="3563-1fa5-8a6d-1f6d" name="Legiones Astartes (Night Lords) " hidden="false" targetId="8280-d4ea-b131-4970" type="rule" />
         <infoLink id="634b-beee-5c9d-39f2" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
         <infoLink id="68fd-f606-2e78-80c1" name="Fear (X)" hidden="false" targetId="21f6-7842-df5c-d2e7" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Fear (1)"/>
+            <modifier type="set" field="name" value="Fear (1)" />
           </modifiers>
         </infoLink>
-        <infoLink id="e2be-770c-a8d6-3642" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="9783-3fe3-94c2-17fb" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+        <infoLink id="e2be-770c-a8d6-3642" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="9783-3fe3-94c2-17fb" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="f392-634b-9bb0-06e9" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="68f4-cc55-b1b9-8c1c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="0368-244a-7061-6fb7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="f392-634b-9bb0-06e9" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
+        <categoryLink id="68f4-cc55-b1b9-8c1c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="0368-244a-7061-6fb7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="228c-e0f5-6a56-aa84" name="Atramentar Trucidor" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ccb-6516-625b-420b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2485-d01f-7d51-9b7a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ccb-6516-625b-420b" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2485-d01f-7d51-9b7a" type="min" />
           </constraints>
           <profiles>
             <profile id="7327-3a73-4713-32b6" name="Atramentar Trucidor" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2599,134 +2598,134 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="b6a9-d248-76ec-f59d" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="b6a9-d248-76ec-f59d" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="0428-9fc4-ab99-98b1" name="1) Ranged Weapon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="716d-10fc-0e92-6028">
               <modifiers>
                 <modifier type="set" field="f8d1-b7fc-0d9b-8815" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aa6d-ada2-d84d-3661" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aa6d-ada2-d84d-3661" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="3df4-008c-3efb-2611" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aa6d-ada2-d84d-3661" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aa6d-ada2-d84d-3661" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3df4-008c-3efb-2611" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8d1-b7fc-0d9b-8815" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3df4-008c-3efb-2611" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8d1-b7fc-0d9b-8815" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="2305-82f4-f6d3-822d" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="716d-10fc-0e92-6028" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                <entryLink id="716d-10fc-0e92-6028" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry" />
                 <entryLink id="dd32-1461-d97b-cd95" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="a2b5-5047-0e75-f074" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="dee0-c5c7-63f9-9ac4" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="7013-bb5d-8f48-3712" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="5e1c-d901-a27c-80d9" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="37ab-7711-ef1a-f7a4" name="2) Melee Weapon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="84de-6972-e2c9-ce13">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d30-34fd-c0eb-d4c0" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2921-9937-6558-78a0" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d30-34fd-c0eb-d4c0" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2921-9937-6558-78a0" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="91a4-8e74-d920-8e4e" name="Chainblade" hidden="false" collective="false" import="true" targetId="8391-79c8-31ff-3705" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="b18d-0a22-4278-dbae" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="0dae-8a22-8a96-7630" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="2547-dbc3-91f1-461c" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="bbcc-a6b6-479c-a196" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="aa6d-ada2-d84d-3661" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="eecc-11dc-023d-3606" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
-                <entryLink id="4d99-34a8-2437-3dd6" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry"/>
-                <entryLink id="84de-6972-e2c9-ce13" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
-                <entryLink id="24a4-4e31-a575-ecb3" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
-                <entryLink id="7d13-3285-7cd9-fa83" name="Chainglaive" hidden="false" collective="false" import="true" targetId="2f96-d817-5180-9453" type="selectionEntry"/>
+                <entryLink id="eecc-11dc-023d-3606" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
+                <entryLink id="4d99-34a8-2437-3dd6" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry" />
+                <entryLink id="84de-6972-e2c9-ce13" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry" />
+                <entryLink id="24a4-4e31-a575-ecb3" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry" />
+                <entryLink id="7d13-3285-7cd9-fa83" name="Chainglaive" hidden="false" collective="false" import="true" targetId="2f96-d817-5180-9453" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="14eb-d119-4aa2-d094" name="3) May take:" hidden="false" collective="false" import="true">
               <entryLinks>
-                <entryLink id="bdde-4f62-9f32-7b6b" name="Headsman&apos;s Axe" hidden="false" collective="false" import="true" targetId="4178-09b6-7569-5ca3" type="selectionEntry">
+                <entryLink id="bdde-4f62-9f32-7b6b" name="Headsman's Axe" hidden="false" collective="false" import="true" targetId="4178-09b6-7569-5ca3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb57-8de1-0ed5-b7be" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb57-8de1-0ed5-b7be" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="191d-6242-a2f0-2543" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17b2-1524-1afe-2bdc" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17b2-1524-1afe-2bdc" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="810b-4bc6-93fa-5ec8" name=" Atramentar" hidden="false" collective="false" import="true" defaultSelectionEntryId="7044-697c-2b98-5547">
           <constraints>
-            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95a3-bcaf-5ab2-c0e4" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfdc-a6b5-b9ec-58e0" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95a3-bcaf-5ab2-c0e4" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfdc-a6b5-b9ec-58e0" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="7044-697c-2b98-5547" name="Atramentar" hidden="false" collective="false" import="true" type="model">
@@ -2750,91 +2749,91 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
               <selectionEntryGroups>
                 <selectionEntryGroup id="c002-b327-4d3f-9be4" name="2) Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b250-abe3-3ec2-aa27">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c98d-3f72-aac5-fe74" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45ff-e00f-3b63-ffda" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c98d-3f72-aac5-fe74" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45ff-e00f-3b63-ffda" type="min" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="b1e5-0e9c-0f1c-fd8e" name="Chainglaive" hidden="false" collective="false" import="true" targetId="2f96-d817-5180-9453" type="selectionEntry"/>
+                    <entryLink id="b1e5-0e9c-0f1c-fd8e" name="Chainglaive" hidden="false" collective="false" import="true" targetId="2f96-d817-5180-9453" type="selectionEntry" />
                     <entryLink id="f669-5a5b-09ca-6575" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="3dcd-71be-c862-ddbf" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="3b6d-bf5f-1282-b211" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="6775-8dde-4319-3cec" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
-                    <entryLink id="b250-abe3-3ec2-aa27" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
-                    <entryLink id="e88c-1ede-d5f3-01f1" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry"/>
-                    <entryLink id="00c7-32f2-021b-af37" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
-                    <entryLink id="e9b1-1e6f-087e-7074" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
+                    <entryLink id="b250-abe3-3ec2-aa27" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry" />
+                    <entryLink id="e88c-1ede-d5f3-01f1" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry" />
+                    <entryLink id="00c7-32f2-021b-af37" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
+                    <entryLink id="e9b1-1e6f-087e-7074" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry" />
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="dbf2-ae78-206a-fdb3" name="1) Ranged Weapon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f2c2-c65a-5826-4e9c">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ba4-5eff-e27b-f434" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e36-9900-115f-6a96" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ba4-5eff-e27b-f434" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e36-9900-115f-6a96" type="min" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="8da4-ea7a-fb70-1517" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
-                    <entryLink id="f2c2-c65a-5826-4e9c" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                    <entryLink id="f2c2-c65a-5826-4e9c" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry" />
                     <entryLink id="3706-a2cf-782e-87c9" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="efb8-d927-909a-0754" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="9083-3e6e-9233-ae37" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="2d8f-902c-bdb4-83c1" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="84c7-b34d-9fd8-acaf" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="424f-d61d-71f8-85b6" name="Atramentar w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="34e6-06a6-69cf-7e2d" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="12d3-9df0-4118-997f" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="12d3-9df0-4118-997f" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="12d3-9df0-4118-997f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="34e6-06a6-69cf-7e2d" type="max"/>
+                <constraint field="selections" scope="12d3-9df0-4118-997f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="34e6-06a6-69cf-7e2d" type="max" />
               </constraints>
               <profiles>
                 <profile id="1643-ece6-5dd7-df4c" name="Atramentar" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2856,63 +2855,63 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
               <selectionEntryGroups>
                 <selectionEntryGroup id="039f-dc7b-8b30-052a" name="2) Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1b34-645d-d217-1577">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73f2-4331-d2ec-0353" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96b0-3b08-c8eb-a993" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73f2-4331-d2ec-0353" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96b0-3b08-c8eb-a993" type="min" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="2ab7-c601-0435-fea5" name="Chainglaive" hidden="false" collective="false" import="true" targetId="2f96-d817-5180-9453" type="selectionEntry"/>
+                    <entryLink id="2ab7-c601-0435-fea5" name="Chainglaive" hidden="false" collective="false" import="true" targetId="2f96-d817-5180-9453" type="selectionEntry" />
                     <entryLink id="2b0f-04ce-e20b-d23d" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="3871-cccf-589a-caff" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="444c-440b-8145-513f" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="4bf2-dc1a-9068-f54f" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
-                    <entryLink id="1b34-645d-d217-1577" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
-                    <entryLink id="12fd-43c4-a344-982f" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry"/>
-                    <entryLink id="1237-53f1-de96-e74d" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
-                    <entryLink id="f243-597f-0b74-ab98" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry"/>
+                    <entryLink id="1b34-645d-d217-1577" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry" />
+                    <entryLink id="12fd-43c4-a344-982f" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry" />
+                    <entryLink id="1237-53f1-de96-e74d" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
+                    <entryLink id="f243-597f-0b74-ab98" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry" />
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="85f0-3e34-e07b-ab98" name="1) Heavy Ranged Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a5a7-4ebb-2c37-355d">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdc3-68d9-3db6-944e" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3ae-1e1d-d32e-f18b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdc3-68d9-3db6-944e" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3ae-1e1d-d32e-f18b" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="a5a7-4ebb-2c37-355d" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="161a-18b9-ebb8-307a" name="Reaper Autocannon" hidden="false" collective="false" import="true" targetId="b87f-48de-6ced-043b" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="9770-e724-ab94-2eaf" name="Plasma Blaster" hidden="false" collective="false" import="true" targetId="cd52-e9e8-3ab1-995c" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="ae9d-1789-6d81-08bc" name="Atramentar w/Pair of Lightning Claws" hidden="false" collective="false" import="true" type="model">
@@ -2936,16 +2935,16 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
               <entryLinks>
                 <entryLink id="b268-8483-c724-3c5c" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68bd-aa99-39d7-d081" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ff5-bd49-1eff-a0d3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68bd-aa99-39d7-d081" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ff5-bd49-1eff-a0d3" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2954,10 +2953,10 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
           <entryLinks>
             <entryLink id="16e2-1de6-f000-3061" name="Preysight" hidden="false" collective="false" import="true" targetId="b905-4d78-c141-4e63" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78ac-2c48-c537-807d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78ac-2c48-c537-807d" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -2966,35 +2965,35 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
       <entryLinks>
         <entryLink id="79ef-4e80-bea6-fd57" name="Tartaros Terminator Armour" hidden="false" collective="false" import="true" targetId="f850-d0af-8663-ccac" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bac-b4b8-22d0-0ab6" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cc1-e5f8-2ccc-06be" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bac-b4b8-22d0-0ab6" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cc1-e5f8-2ccc-06be" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="71e4-4f49-a389-b80d" name="Flaymaster Mawdrym Llansahai" publicationId="d0df-7166-5cd3-89fd" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ad68-cdd4-e29a-31a7" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ad68-cdd4-e29a-31a7" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="cc1b-8703-8170-fb3d" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="529d-c6da-a22c-ddf2" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="6af9-fdc8-c956-125c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="cc1b-8703-8170-fb3d" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="529d-c6da-a22c-ddf2" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="6af9-fdc8-c956-125c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1225-6430-b0ca-bf2a" name="Flaymaster Mawdrym Llansahai" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86c5-571e-1636-1d09" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f17-1382-069c-85c1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86c5-571e-1636-1d09" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f17-1382-069c-85c1" type="max" />
           </constraints>
           <profiles>
             <profile id="39d6-c009-5fe7-05d0" name="Flaymaster Mawdrym Llansahai" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -3014,20 +3013,20 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
 Additionally, all models with the Infantry or Cavalry Unit Types in a unit that Mawdrym Llansahai has joined gain the Feel No Pain (5+) special rule. Models with the Artillery Sub-type are not affected by this special rule and do not gain the Feel No Pain (X) special rule.</description>
             </rule>
             <rule id="e802-88c0-416d-71de" name="Unfit for Command" hidden="false">
-              <description>Mawdrym Llansahai may never be selected as the army’s Warlord.</description>
+              <description>Mawdrym Llansahai may never be selected as the army&#8217;s Warlord.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="7fc8-738d-d495-14ed" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
+            <infoLink id="7fc8-738d-d495-14ed" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="8207-ff39-342f-7905" name="Red Jaqa" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93f5-3ff8-d200-d2b6" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3e4-e1b5-9444-e3a8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93f5-3ff8-d200-d2b6" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3e4-e1b5-9444-e3a8" type="max" />
           </constraints>
           <profiles>
             <profile id="c0ba-1d36-f664-1701" name="Red Jaqa" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -3040,60 +3039,60 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="d911-ecd0-3b34-10b4" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db87-c34c-a9e1-980a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28b6-6555-f532-ed18" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db87-c34c-a9e1-980a" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28b6-6555-f532-ed18" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="32ab-4147-2a75-1704" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cb1-7d1d-3bf6-7eea" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7f0-2f67-2702-c498" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cb1-7d1d-3bf6-7eea" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7f0-2f67-2702-c498" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="6fb9-8bf6-8f72-cfa5" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48c6-f19e-e159-deb9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6ec-436a-a4e7-8f47" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48c6-f19e-e159-deb9" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6ec-436a-a4e7-8f47" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="42ce-9db2-6d5a-fcdb" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdf2-939c-6241-8879" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29fd-704e-ee06-c08d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdf2-939c-6241-8879" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29fd-704e-ee06-c08d" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="65dd-34a5-6125-1387" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1c8-854c-4672-d5a2" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c027-3599-d591-3446" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1c8-854c-4672-d5a2" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c027-3599-d591-3446" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="021c-6d75-36ca-fe7a" name="Kheron Ophion of the Kyroptera" publicationId="d0df-7166-5cd3-89fd" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8690-29d3-a450-6900" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8690-29d3-a450-6900" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="6344-0186-583a-9fd6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="a5a8-c39c-e2e1-7e00" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="170a-9067-b138-78e6" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="6344-0186-583a-9fd6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="a5a8-c39c-e2e1-7e00" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="170a-9067-b138-78e6" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0747-85e7-fea1-4526" name="Kheron Ophion of the Kyroptera" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55d6-3ad3-c66b-20b1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f7d-2c5b-068b-2035" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55d6-3ad3-c66b-20b1" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f7d-2c5b-068b-2035" type="max" />
           </constraints>
           <profiles>
             <profile id="beba-b84a-b7f7-ae25" name="Kheron Ophion of the Kyroptera" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -3118,19 +3117,19 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="b761-38ef-aa0d-7aed" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
-            <infoLink id="90fd-1161-1dc8-6509" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-            <infoLink id="051f-1753-cbd5-845c" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
-            <infoLink id="ab4a-2c77-8c3a-8ea9" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
+            <infoLink id="b761-38ef-aa0d-7aed" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule" />
+            <infoLink id="90fd-1161-1dc8-6509" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+            <infoLink id="051f-1753-cbd5-845c" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
+            <infoLink id="ab4a-2c77-8c3a-8ea9" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="ab56-ada5-5957-f889" name="Revenant" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d7b-834a-5aa6-030f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6e8-d301-1a9b-392f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d7b-834a-5aa6-030f" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6e8-d301-1a9b-392f" type="max" />
           </constraints>
           <profiles>
             <profile id="eeca-6d85-3090-0ac4" name="Revenant" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -3143,13 +3142,13 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="7975-b476-7883-be31" name="The Bloody Aegis" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6bf-ef9d-d25f-fb1c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9761-1a81-9331-88ef" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6bf-ef9d-d25f-fb1c" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9761-1a81-9331-88ef" type="max" />
           </constraints>
           <rules>
             <rule id="c884-b7be-1496-edd6" name="The Bloody Aegis" hidden="false">
@@ -3157,70 +3156,70 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
             </rule>
           </rules>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="c687-4416-d9e3-2df3" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9653-305d-0b1e-2278" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b282-16c1-1e4d-85c1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9653-305d-0b1e-2278" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b282-16c1-1e4d-85c1" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="dc5e-b541-ddcf-80b8" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c76-4231-7ef8-0970" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c662-3534-c899-8898" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c76-4231-7ef8-0970" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c662-3534-c899-8898" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="a34c-c1e9-8ee7-9648" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31dd-5888-9618-8b10" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0049-038a-9f5b-d9c7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31dd-5888-9618-8b10" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0049-038a-9f5b-d9c7" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="9168-34a4-4219-2b8c" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f62a-210f-abe8-1b2a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa45-b63e-5c38-9ca1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f62a-210f-abe8-1b2a" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa45-b63e-5c38-9ca1" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="b4fe-c595-0093-e72a" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34a7-d68f-1bd6-5d2a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ebc-7a7b-0aa8-bac8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34a7-d68f-1bd6-5d2a" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ebc-7a7b-0aa8-bac8" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="4700-dc81-074b-cd49" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c635-a62f-8ea3-de0b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c635-a62f-8ea3-de0b" type="max" />
           </constraints>
           <rules>
             <rule id="7fd2-6903-17c3-7040" name="Warlord: Aberrant Bravery" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Kheron Ophion automatically has Aberrant Bravery as his Warlord Trait and may not select any other.</description>
+              <description>If chosen as the army's Warlord, Kheron Ophion automatically has Aberrant Bravery as his Warlord Trait and may not select any other.</description>
             </rule>
           </rules>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="150.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="150.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="4e5b-9710-67f5-478c" name="Nakrid Thole" publicationId="d0df-7166-5cd3-89fd" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9001-0d6b-08b5-4ae8" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9001-0d6b-08b5-4ae8" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="9c95-019a-6895-f7d2" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="a5cc-6775-35e2-167c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="5e08-d8ee-cf56-6118" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="9c95-019a-6895-f7d2" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="a5cc-6775-35e2-167c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="5e08-d8ee-cf56-6118" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8bdb-96b0-dcb0-9d91" name="Nakrid Thole" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="192d-73a8-5c2c-be27" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0ce-fadb-5955-c1c6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="192d-73a8-5c2c-be27" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0ce-fadb-5955-c1c6" type="min" />
           </constraints>
           <profiles>
             <profile id="6b70-096b-7cf0-947e" name="Nakrid Thole" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -3240,33 +3239,33 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
             </profile>
           </profiles>
           <rules>
-            <rule id="c349-44ac-cc2a-680b" name="Valour&apos;s Shadow" hidden="false">
+            <rule id="c349-44ac-cc2a-680b" name="Valour's Shadow" hidden="false">
               <description>Nakrid Thole may not be allocated wounds due to the Precision Strikes (X) or Precision Shots (X) special rules. In addition, when Nakrid Thole is reduced to 0 Wounds, the controlling player must roll a D6. If the result is a 5+, then Nakrid Thole is still removed as a casualty, but does not count as being destroyed for the purposes of scoring Victory points or achieving specific mission Objectives.</description>
             </rule>
           </rules>
           <infoLinks>
             <infoLink id="376f-7bd3-f74c-bf11" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Counter-Attack (1)"/>
+                <modifier type="set" field="name" value="Counter-Attack (1)" />
               </modifiers>
             </infoLink>
             <infoLink id="46a4-43ce-8f35-0eef" name="Fear (X)" hidden="false" targetId="21f6-7842-df5c-d2e7" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Fear (1)"/>
+                <modifier type="set" field="name" value="Fear (1)" />
               </modifiers>
             </infoLink>
-            <infoLink id="647d-55e2-1139-5292" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
-            <infoLink id="99a7-5702-9b63-3716" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-            <infoLink id="d67e-ebb6-ef10-bcbf" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
+            <infoLink id="647d-55e2-1139-5292" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule" />
+            <infoLink id="99a7-5702-9b63-3716" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+            <infoLink id="d67e-ebb6-ef10-bcbf" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="1e83-8aa1-7329-2846" name="Nostraman Flay-whip" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6273-6429-d49b-f87c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3782-0fae-3e3a-0369" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6273-6429-d49b-f87c" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3782-0fae-3e3a-0369" type="min" />
           </constraints>
           <profiles>
             <profile id="d524-20ea-cb93-3299" name="Nostraman Flay-whip" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -3280,70 +3279,70 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
           </profiles>
           <rules>
             <rule id="886d-44ad-5de4-05a8" name="Electro-charge" hidden="false">
-              <description>Any model that suffers an unsaved wound from this weapon reduces its Initiative Characteristic to 1 until the end of its controlling player’s next turn.</description>
+              <description>Any model that suffers an unsaved wound from this weapon reduces its Initiative Characteristic to 1 until the end of its controlling player&#8217;s next turn.</description>
             </rule>
             <rule id="f69b-1fc7-e877-31bd" name="Web of Steel" hidden="false">
-              <description>A model with a melee weapon with this special rule may choose to forfeit all of its normal attacks in order to make a single attack against each enemy model from a unit that it is locked in combat with and within 2&quot; of the wielder, using the Flay-whip’s profile. If this option is used then the Electro-charge special rule cannot trigger from unsaved wounds.</description>
+              <description>A model with a melee weapon with this special rule may choose to forfeit all of its normal attacks in order to make a single attack against each enemy model from a unit that it is locked in combat with and within 2" of the wielder, using the Flay-whip&#8217;s profile. If this option is used then the Electro-charge special rule cannot trigger from unsaved wounds.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
-        <selectionEntry id="1128-5ecf-11ae-e88c" name="The Devil&apos;s Due" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="1128-5ecf-11ae-e88c" name="The Devil's Due" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5da0-3a50-9147-0ecc" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d018-2d12-a7ef-e648" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5da0-3a50-9147-0ecc" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d018-2d12-a7ef-e648" type="min" />
           </constraints>
           <profiles>
-            <profile id="e4bb-3d6d-9c4b-306c" name="The Devil&apos;s Due" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="e4bb-3d6d-9c4b-306c" name="The Devil's Due" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+2</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Unwieldy, The Devil&apos;s Due, Murderous Strike (6+), Master-crafted</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Unwieldy, The Devil's Due, Murderous Strike (6+), Master-crafted</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <rules>
-            <rule id="28d4-cedf-2827-893e" name="The Devil&apos;s Due" hidden="false">
-              <description>If an enemy model in base contact with this model has its Initiative Characteristic reduced by the effects of any other weapon or special rule then this model may make a single additional attack against the enemy model. This additional attack is made immediately before the enemy model would attack and uses the profile for The Devil’s Due shown above.</description>
+            <rule id="28d4-cedf-2827-893e" name="The Devil's Due" hidden="false">
+              <description>If an enemy model in base contact with this model has its Initiative Characteristic reduced by the effects of any other weapon or special rule then this model may make a single additional attack against the enemy model. This additional attack is made immediately before the enemy model would attack and uses the profile for The Devil&#8217;s Due shown above.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="d5d3-265f-fe69-5f8f" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31da-fcd8-d818-6625" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5596-3dec-8acf-a196" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31da-fcd8-d818-6625" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5596-3dec-8acf-a196" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="6271-aa82-44d0-d94e" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36de-c8a2-9b9e-8642" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04af-4e1a-3873-7d81" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36de-c8a2-9b9e-8642" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04af-4e1a-3873-7d81" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="91d4-131c-8ad6-d33d" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d09d-9dfd-1e49-2bb8" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac99-34bf-c51e-5c25" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d09d-9dfd-1e49-2bb8" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac99-34bf-c51e-5c25" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="a528-cdc6-2004-cced" name="Chainblade" hidden="false" collective="true" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b28b-71f7-e4f4-8f9c" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b28b-71f7-e4f4-8f9c" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
@@ -3358,15 +3357,15 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="a54a-c08a-7f3b-6fb6" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+        <infoLink id="a54a-c08a-7f3b-6fb6" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
         <infoLink id="981f-ccc7-254c-0f5e" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Breaching (6+)"/>
+            <modifier type="set" field="name" value="Breaching (6+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="f4b1-a1d5-4c65-12d3" name="Chainglaive" hidden="false" collective="true" import="true" type="upgrade">
@@ -3384,28 +3383,28 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
       <infoLinks>
         <infoLink id="48ae-c3ce-1ee6-761b" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Breaching (6+)"/>
+            <modifier type="set" field="name" value="Breaching (6+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="8180-ba3e-ac80-bbb0" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
-        <infoLink id="eb02-ec6c-4eb2-028f" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+        <infoLink id="8180-ba3e-ac80-bbb0" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
+        <infoLink id="eb02-ec6c-4eb2-028f" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="f728-26bf-3c99-1529" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="521c-86e7-f274-0750" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="521c-86e7-f274-0750" type="max" />
       </constraints>
       <entryLinks>
         <entryLink id="4689-a8e6-1599-eba5" name="Contekar Terminator Squad" hidden="true" collective="false" import="true" targetId="837e-c3ca-437e-dfbf" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0f6a-a772-4664-ce14" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0f6a-a772-4664-ce14" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -3414,110 +3413,110 @@ Additionally, all models with the Infantry or Cavalry Unit Types in a unit that 
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="be72-b7b1-3b03-d38b" name="Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
-        <entryLink id="4c57-238e-e66f-d49a" name="Tartaros Command Squad" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
+        <entryLink id="be72-b7b1-3b03-d38b" name="Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
+        <entryLink id="4c57-238e-e66f-d49a" name="Tartaros Command Squad" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="7923-f342-c07f-4967" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="5388-67a6-5038-df3f" value="1.0">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="654b-f635-7e72-3df3" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5388-67a6-5038-df3f" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="654b-f635-7e72-3df3" type="max" />
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5388-67a6-5038-df3f" type="min" />
       </constraints>
       <selectionEntryGroups>
         <selectionEntryGroup id="e342-15ec-af4b-a00a" name="  VIII: Night Lords " publicationId="09c5-eeae-f398-b653" page="196" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b28b-71f7-e4f4-8f9c" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b28b-71f7-e4f4-8f9c" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="36dc-93ee-651e-1ec7" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3e6b-d354-f587-8b8a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="36dc-93ee-651e-1ec7" type="max" />
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3e6b-d354-f587-8b8a" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="84a2-6533-2d3b-5880" name="Warmonger (Traitor only) (PLACEHOLDER)" publicationId="09c5-eeae-f398-b653" page="196" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b52d-b30f-8552-0544" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4439-8951-b00d-e6d2" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b52d-b30f-8552-0544" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4439-8951-b00d-e6d2" type="max" />
               </constraints>
               <profiles>
                 <profile id="f27c-8e0a-dba7-ca64" name="Warmonger" publicationId="09c5-eeae-f398-b653" page="196" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca" />
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="bfaf-01c3-416b-afcc" name="Flaymaster (PLACEHOLDER)" publicationId="09c5-eeae-f398-b653" page="196" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8a64-3c90-7182-e55f" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e141-f63d-5c6f-c223" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8a64-3c90-7182-e55f" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e141-f63d-5c6f-c223" type="max" />
               </constraints>
               <profiles>
                 <profile id="ebe4-5c8d-1fdc-945d" name="Flaymaster" publicationId="09c5-eeae-f398-b653" page="196" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca" />
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="58bf-c972-77f3-6fbc" name="Jadhek Clanlord (PLACEHOLDER)" publicationId="09c5-eeae-f398-b653" page="196" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b58b-0bac-aeb4-c083" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d1e6-5292-623d-a5c1" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b58b-0bac-aeb4-c083" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d1e6-5292-623d-a5c1" type="max" />
               </constraints>
               <profiles>
                 <profile id="db4c-07da-4fea-64b3" name="Jadhek Clanlord" publicationId="09c5-eeae-f398-b653" page="196" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca" />
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="3269-26df-fcc4-f3b7" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+        <entryLink id="3269-26df-fcc4-f3b7" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Night Lords.cat
+++ b/2022 - LA - Night Lords.cat
@@ -377,7 +377,7 @@
         <categoryLink id="1eca-56d9-f536-5b48" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="43b6-6500-f9f2-8cd2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
     <entryLink id="14f8-46c6-5baf-ec66" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="bf7b-246b-a0fa-39ea" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
@@ -805,7 +805,7 @@
         <categoryLink id="f34a-371d-c249-4692" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="cce8-dea3-3d25-665c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
     <entryLink id="3630-3878-3a8d-67aa" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
@@ -886,7 +886,7 @@
         <categoryLink id="be3e-2e23-4737-7d29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="096a-3648-aa71-cad6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
     <entryLink id="5a0b-deca-f472-0d1c" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f7df-1040-50de-0719" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -898,7 +898,7 @@
         <categoryLink id="8f49-526e-aebf-b1b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="7e23-2d05-f9c4-94af" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
     <entryLink id="d52c-f63c-d9c3-731f" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="29f3-ef3e-b1c1-5976" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -980,7 +980,7 @@
         <categoryLink id="a197-b2db-212a-ea62" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="9df2-031d-7da0-51ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
     <entryLink id="ac8d-8f28-7672-77f4" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -1008,7 +1008,7 @@
         <categoryLink id="5c33-bad0-f09d-b782" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="100f-0489-b6cc-9eea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
     <entryLink id="0a2f-1481-6fb4-27e9" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -1058,7 +1058,7 @@
         <categoryLink id="eefc-6e10-9659-356d" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
         <categoryLink id="c586-1b0b-650a-a0da" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
     <entryLink id="b783-0f58-baad-17ac" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8f9b-d0bd-3291-3ef8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />

--- a/2022 - LA - Raven Guard.cat
+++ b/2022 - LA - Raven Guard.cat
@@ -1,6 +1,5 @@
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="d21e-9c80-a7f8-728c" name="LA - XIX: Raven Guard" revision="11" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="22">
-  <entryLinks>
-    <entryLink id="84cc-e59c-174e-fb25" name="Mor Deythan Squad" hidden="false" collective="false" import="false" targetId="c268-08ac-5b90-d034" type="selectionEntry">
+  <entryLinks><entryLink id="84cc-e59c-174e-fb25" name="Mor Deythan Squad" hidden="false" collective="false" import="false" targetId="c268-08ac-5b90-d034" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2e94-0345-48a1-212d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="b955-7a72-615e-214c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -74,944 +73,1957 @@
         <categoryLink id="b526-7584-0877-2f74" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="794f-827b-88d4-dec9" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d6c6-e581-def5-324b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d831-4d0c-3a7d-0b2a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <entryLink id="794f-827b-88d4-dec9" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="63e5-1c89-414e-8f83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6d4-581f-4746-bec3</comment></categoryLink>
+        <categoryLink id="9bbc-33f0-4bc2-a090" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_2489-ee2a-45dd-b384</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
-    <entryLink id="d7ab-fdf4-b06a-baaf" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="abc6-8b32-76f5-dce7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5a2b-20ba-67f4-17b2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
-    <entryLink id="1d98-08bc-b1c4-e9b3" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink><entryLink id="d7ab-fdf4-b06a-baaf" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b02f-e65f-4a88-a175</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_b87b-bf35-4238-b7c6</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1aff-27af-435e-8102</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_fdf9-4906-4180-a39d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4a13-a002-9199-2b6e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="d9eb-65c7-f407-5d65" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="106e-703f-049f-3b57" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="b72e-bcf2-49cc-8730" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8378-ede4-476d-b657</comment></categoryLink>
+        <categoryLink id="9cf6-1cc4-4058-93eb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_d64f-ad19-426c-adf7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
-    <entryLink id="8cd4-b4d6-ce65-83af" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8c8c-98d4-ba95-bc51" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="a85d-afd0-c3fb-9864" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
-    <entryLink id="7fcd-68dc-c97d-aebf" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="11f0-e8d7-6b29-f95d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="82a8-bf4f-4c1a-bbc2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
-    <entryLink id="57d6-9147-79f2-72f9" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink><entryLink id="1d98-08bc-b1c4-e9b3" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_7fd1-8ce8-4d10-82e7</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_eaae-8c43-4d30-898c</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_f67d-8cf3-424f-b491</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_b949-6414-4f3d-b268</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="11d9-3906-0579-1ac9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="52e4-858c-d161-746f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a66a-497c-9577-e106" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="b19c-4fe6-4139-b847" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_ac26-e639-4d53-9b8b</comment></categoryLink>
+        <categoryLink id="2f2d-e8c3-4165-8da2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_49af-0d08-4c7e-8ce6</comment></categoryLink>
+        <categoryLink id="15d0-5877-4c62-bdca" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_b606-de16-4659-95cd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
-    <entryLink id="b381-7182-8f87-dd83" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink><entryLink id="8cd4-b4d6-ce65-83af" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e8ca-e120-0b1e-7c39" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="c554-afac-49ff-7065" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
-    <entryLink id="1610-e22d-f5cf-210f" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7583-6fa0-4089-a19e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_0e5c-99ab-41d3-a42e</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c296-e8e8-4a7a-989a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_8868-5bcb-4604-ba8e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="316d-d9e7-405f-b651" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a009-a597-4b51-b228</comment></categoryLink>
+        <categoryLink id="af7f-1eff-41e7-9bad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_24f4-9145-4016-80d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink><entryLink id="7fcd-68dc-c97d-aebf" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_e732-7499-47bf-9748</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_81a5-a959-46b7-baa4</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7ec3-447a-4644-b012</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_71e2-c430-4c99-a559</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_df7b-3fb9-4f65-9165</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="79e6-cbc0-472e-ae1f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c165-3906-463a-9c73</comment></categoryLink>
+        <categoryLink id="1b0f-2255-4236-b27c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6d1-d14c-473f-be09</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink><entryLink id="57d6-9147-79f2-72f9" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_27a3-1e4c-4b76-a594</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_d59a-dcd0-44fd-b866</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_0c8b-2b92-49ed-98c7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_bafe-f799-41d9-ac85</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_6369-288c-4fec-a640</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_fe53-8858-41dc-8ec4</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5048-8cfb-e7e0-490a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="f127-72dd-e91e-c81b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bf1e-7bf4-4c1f-8e76" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_3a22-caae-4eea-9bc5</comment></categoryLink>
+        <categoryLink id="d271-a153-4c71-991c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f759-f33e-4698-9f8a</comment></categoryLink>
+        <categoryLink id="efa2-845e-440e-8862" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_c624-3ae0-46c0-9b06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
-    <entryLink id="e56e-5679-f823-feab" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="62e0-10d6-b068-3719" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="034a-5c5b-0a43-aefe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0f3a-11fb-e951-0cbf" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="876f-e920-6f2b-05ce" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup" />
-        <entryLink id="8fad-9df2-eda8-842b" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink><entryLink id="b381-7182-8f87-dd83" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_13b3-ce1e-4f9d-8319</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d681-9d81-4abd-b11b</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a57-e48b-4534-bca5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_1859-5641-4674-9097</comment>
+                </condition>
               </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
-    <entryLink id="b925-3d50-c508-cc15" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
-      <modifiers>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="bbf6-df65-41e7-ac21" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_251a-df5b-4bfd-ad63</comment></categoryLink>
+        <categoryLink id="e7b2-8f50-4d52-b751" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4644-98ab-4e3f-b1fd</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink><entryLink id="1610-e22d-f5cf-210f" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_591d-d028-4663-918d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_0482-c5f9-4c95-9597</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_75a7-971d-4978-a83f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_a7d5-2bfe-4621-ac0c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9f13-b460-4f27-b0cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_31fc-e265-45a7-bb5b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="10a3-0817-3f5b-1b85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f56a-9c0c-35d7-06ed" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="9259-0001-e4e7-b534" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="423b-93b9-4581-a30c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_67c2-df43-44fc-92d1</comment></categoryLink>
+        <categoryLink id="b560-4eb5-49af-b5c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4136-bb4e-4dd4-99f9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink><entryLink id="e56e-5679-f823-feab" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry"><categoryLinks>
+        <categoryLink id="78a9-e7aa-4c7b-af4d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_2599-24e3-44e5-9568</comment></categoryLink>
+        <categoryLink id="06ba-7338-4b05-b9dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_285f-6e56-473b-b2fe</comment></categoryLink>
+        <categoryLink id="4e70-3c60-4298-9e26" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_685e-022f-4e2f-a568</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="87f5-dbd5-ed40-7f29" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup" />
-        <entryLink id="f2a4-248d-2238-206c" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup">
+        <entryLink id="e180-a988-457a-9ce0" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup"><comment>    template_id_2a38-6544-4267-b584    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="e331-e40c-453e-9361" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_8287-16ff-46ba-9838</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_81c1-fca9-44dc-ba4c</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_6e59-4592-47ef-b76d    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
-    <entryLink id="7734-d861-18f2-1a0c" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5320-4027-5049-461e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6f7c-846d-a97a-88c8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="31fc-fdb0-b5d8-c448" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="5f5a-12f5-c938-2399" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup" />
-        <entryLink id="5584-0075-d0f8-4569" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
-    <entryLink id="3aac-15a4-de34-a113" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c6ae-7a95-3211-03ff" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="3f6d-c0c5-d641-2ee4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
-    <entryLink id="b00c-2263-1932-f88b" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ebff-86ff-9f67-599a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b28b-8688-6bf5-4501" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
-    <entryLink id="ff73-39dc-6d96-14e6" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink><entryLink id="b925-3d50-c508-cc15" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ad5d-3c79-4239-9116</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_60b1-049b-4a5f-85c2</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f980-8e62-0348-466e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c890-a2a1-d1b8-682f" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="7c4b-d40c-48e5-ae27" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bd6a-0cda-4e0f-80ae</comment></categoryLink>
+        <categoryLink id="9e30-2435-4f76-b990" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_ae75-7cca-4701-9d56</comment></categoryLink>
+        <categoryLink id="1e2d-0f46-4772-85bf" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_e517-62d4-48f7-8174</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
-    <entryLink id="cdf8-ca69-9f1f-edc7" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
+      <entryLinks>
+        <entryLink id="d42c-3f75-4854-b54b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup"><comment>    template_id_fafb-6414-474a-8a09    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="41ba-e34e-4807-9f3e" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_1e43-c980-4508-8ec2</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_4140-36a7-4203-b5e9</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_a6a6-9bc7-4d4e-86a7    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink><entryLink id="7734-d861-18f2-1a0c" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry"><categoryLinks>
+        <categoryLink id="c817-6749-40af-b768" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fc9d-03d1-4bbd-a1c4</comment></categoryLink>
+        <categoryLink id="cfe0-ee8b-4dc0-8ed7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_f51c-73d7-4f29-be1c</comment></categoryLink>
+        <categoryLink id="39c0-e6e9-42c9-9cfd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_257d-78c0-4bab-ba65</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="8b24-5393-42ae-a92b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup"><comment>    template_id_ac26-33db-40a7-bdba    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="6368-9672-49d6-ae96" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_189b-db75-4db6-9fe9</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_cbdb-2500-4e13-876a</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_dc8e-2801-46d6-84f8    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink><entryLink id="3aac-15a4-de34-a113" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b43b-547f-472e-9076</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8ff9-0498-4540-8552</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fbfe-931a-489b-a589</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f4c3-5aa6-4caa-abf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_17f8-f055-4c9c-b757</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="c840-0955-7c04-906e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="de35-9d2e-a6ce-5576" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="e652-6315-4694-87fb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f1c8-27fd-4f98-8527</comment></categoryLink>
+        <categoryLink id="8fed-b877-4cf0-9433" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2b20-1a8b-4753-b657</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
-    <entryLink id="31cb-0e8f-9c63-a9f6" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink><entryLink id="b00c-2263-1932-f88b" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry"><categoryLinks>
+        <categoryLink id="28cd-8de6-46fc-829a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4207-8d8f-4b1a-836b</comment></categoryLink>
+        <categoryLink id="13a7-2a4c-4080-90da" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_2b34-077f-4279-86fb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink><entryLink id="ff73-39dc-6d96-14e6" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="c116-d80c-1387-fb57" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="173e-2ab5-019c-20a7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="2516-ca21-44f8-bf47" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6577-e0fb-4fda-834e</comment></categoryLink>
+        <categoryLink id="d225-bd9e-4b85-bc36" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_5d59-09bf-4566-b7e1</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
-    <entryLink id="b913-7cbf-afd3-ed83" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink><entryLink id="cdf8-ca69-9f1f-edc7" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"><categoryLinks>
+        <categoryLink id="fc5a-eda0-4b4f-8052" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_aa93-057d-42f6-82d7</comment></categoryLink>
+        <categoryLink id="f587-6c66-4b64-a8dc" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_403c-4e9c-4af5-84ec</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink><entryLink id="31cb-0e8f-9c63-a9f6" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_23fa-06dd-49f9-a7db</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5b26-059e-40b3-9d93</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f7bf-3a1c-4103-aed8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="acbf-2c66-ae4f-9e81" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="f1c2-bf1c-b906-919f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="eb1e-d785-45c8-b12a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dd44-e0a8-42a8-bdcc</comment></categoryLink>
+        <categoryLink id="8eba-dd10-432d-9091" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_c5b0-f9ae-468d-924a</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
-    <entryLink id="a16f-4eaf-739d-8127" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink><entryLink id="b913-7cbf-afd3-ed83" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8396-e51c-4e2b-bada</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_13bb-9fb5-4580-92cf</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_bfb8-8125-4548-92f5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25e3-b8f5-4448-a7c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e7eb-6d34-41a3-8ccb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_f926-27fd-4a92-97a1</comment></categoryLink>
+        <categoryLink id="25b6-6e9d-426f-9ae4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_82e3-36e1-4e85-8fcb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink><entryLink id="a16f-4eaf-739d-8127" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3b3a-5a53-f2ce-abf5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
         <categoryLink id="b2d9-9aea-673a-eb95" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="8e56-f8ba-fe32-f07a" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
-      <modifiers>
+    <entryLink id="8e56-f8ba-fe32-f07a" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_658f-b1ad-4347-a998</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_12bc-3db2-4d28-abce</comment>
+            </condition>
           </conditions>
         </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="feb3-386a-1670-4216" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7769-9e3d-367f-fa84" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
-    <entryLink id="b6ac-386a-c032-bcd6" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_9d83-7691-41d6-8dad</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_add7-ba48-46d4-8a02</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_1fb0-2421-40a4-9e49</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0cf3-02f0-05ae-2d7a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="974f-073d-e833-6ca6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1b01-b022-0d5a-643c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="52a8-13f1-4668-b626" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7004-b00d-481f-b740</comment></categoryLink>
+        <categoryLink id="5f33-7041-4508-a5db" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4f88-2fc3-491c-bfb7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
-    <entryLink id="d0a4-b1a8-a74f-224c" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="074f-7c2a-d5a0-88ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="73e3-4d6a-78fa-b765" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
-    <entryLink id="dae8-98ab-8ad7-362b" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ac18-eb6c-5cf0-de4d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="7382-3d70-8267-36c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
-    <entryLink id="2fb9-1d26-2679-13c6" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c060-58f0-9d44-bfd5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="ea6e-e5b5-243f-ccbd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
-    <entryLink id="498e-e241-dced-2a62" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="088b-338a-e8d5-6be6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="4a23-7c32-f4a6-84da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
-    <entryLink id="8f79-c68f-2352-2cdb" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="68bb-5075-1d33-ee00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="fa38-9230-3c20-f307" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
-    <entryLink id="772b-3d96-3951-5128" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d48f-5656-e218-6dcf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="bfc8-83cc-d935-3f1d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
-    <entryLink id="88b8-c93e-98d1-d299" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7217-fa86-bd36-372c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="3935-a521-fa72-8dd4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
-    <entryLink id="48f5-1057-5e28-0e4d" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0b7a-5159-8c86-36bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="79c7-c3f9-92e0-1e9f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
-    <entryLink id="39a5-85ba-0c78-7edf" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7607-24eb-4c5f-4356" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="d723-9931-d8fb-a848" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
-    <entryLink id="892d-959e-81e0-6df0" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a7d5-8cd6-bdbf-b3c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b92f-c1a0-f683-13a2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
-    <entryLink id="f92f-5852-8324-aae1" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e738-238d-7c2c-c9e7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="ede1-5f64-6eeb-fbd0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
-    <entryLink id="ba69-754d-6eb5-4bbd" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="510f-6790-c12a-fe0c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="86b4-8829-a4e2-1649" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
-    <entryLink id="f243-7c42-9f01-c04e" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d224-4db5-9ea7-28ce" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="bf92-eee8-cad1-3141" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
-    <entryLink id="5323-4dba-4ab7-393f" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4f9d-07dc-fffe-8def" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4297-6075-5764-dbe2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
-    <entryLink id="5161-0c16-c678-c1e7" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a4d8-47f5-a550-b1bd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6415-f2fc-188e-0e8c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
-    <entryLink id="bce4-ae64-1c77-aec7" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="2d71-86dc-43cc-e019" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="e9c4-649c-6888-d69a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
-    <entryLink id="212b-b1c8-03ea-3036" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="aaf9-e673-4b7b-577c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="f550-3cdf-db0e-1280" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
-    <entryLink id="2cfd-c944-f062-8f7c" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="c516-f7fa-20d6-769e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="f736-cced-8109-4734" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
-    <entryLink id="5e93-87f2-9808-5795" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="22e3-1010-015d-07d6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="e6a9-2f4c-c0c5-b3cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
-    <entryLink id="4ad6-4c42-5c0e-01f1" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1380-6a48-3fa5-9d47" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="2810-3db5-670f-3e5c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
-    <entryLink id="7cb7-9d12-2822-a53f" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="fc23-742f-0086-cbab" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="1b6b-fabe-6f28-b2b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
-    <entryLink id="36e8-6070-e914-287f" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="c9f8-6c11-70bd-322e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="1942-1686-a17c-4137" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
-    <entryLink id="5c5c-010c-b80c-0a36" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9fdd-9029-5cb7-83d0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="d7a5-09db-56f9-eec4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
-    <entryLink id="9d90-9fd1-630e-69e3" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="f9c8-6068-cb85-ed0b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="90b7-82e2-8f27-ca4a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
-    <entryLink id="5fa7-b457-7d5c-942f" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="cbd5-a4c7-6650-0ecf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9b25-77b9-30a6-fbc5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
-    <entryLink id="f15a-1db4-8ec1-57e6" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6785-b58e-07b7-90d1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="cb15-183a-65ae-0c78" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
-    <entryLink id="8ecb-a86c-8e99-64f5" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="892f-d746-4dc6-d0ba" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="1c46-8077-364c-a610" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
-    <entryLink id="b079-60fa-72a8-d6f6" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2032-c268-c6ed-1c77" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b001-2b83-953d-663d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
-    <entryLink id="94d6-d8e9-8ba6-88bc" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="a01f-ccb6-a9d8-fb93" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="8045-adb3-2fe6-e75d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
-    <entryLink id="b977-6ad0-1349-f70c" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="ce87-c06b-a21f-710f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="6abe-424d-2690-05eb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
-    <entryLink id="4f55-3621-d6f5-bdf7" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9a1a-99c5-4c87-9402" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3af1-5e5b-2067-bf5b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
-    <entryLink id="2b66-97ab-581b-f341" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0b16-feb6-8533-fc80" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="fce5-411e-19fd-0db2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="20d0-b4e9-8d7c-b088" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="eb61-0fa5-4c9c-d174" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup" />
-        <entryLink id="06e2-7154-5958-6015" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
-    <entryLink id="6c4b-e43e-b4e9-0362" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="540b-2e26-d7ee-8871" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="1e15-5399-b7e9-0ae9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7633-0a3e-30e3-c988" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="c2d0-c373-def1-2bbe" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup" />
-        <entryLink id="2033-ba42-eb89-6da3" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
-    <entryLink id="3199-a3b6-8e2e-4892" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="052f-fff3-d351-99ed" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="4449-8ecd-6670-1553" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c88d-3f57-f179-fe04" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="1c71-70b3-0c2a-e187" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup" />
-        <entryLink id="a751-60f0-d0f4-0e16" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
-    <entryLink id="a711-3e30-4de4-5c1a" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d6af-1e3f-a1a4-deed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f0d6-fbf4-dd3b-4926" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
-    <entryLink id="8c4d-d20e-d169-1756" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="a965-3add-803c-845f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="549d-595d-f03c-154d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
-    <entryLink id="2070-75a6-12ee-94f0" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="bcf3-bf62-984f-18de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a45d-a217-4962-d996" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
-    <entryLink id="32ad-9202-9b03-78a7" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3508-578d-1989-b668" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="f6b3-baeb-7c6f-9eab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
-    <entryLink id="7ebb-53ec-28b5-3604" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="45f5-eb3e-97b1-a108" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="61f9-bd09-10a9-6164" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
-    <entryLink id="7293-7085-dc21-7370" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8ce8-581e-2a58-fed8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="adb1-991b-519a-af6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
-    <entryLink id="b371-f3c9-6eb2-3dd3" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8e12-c52d-5855-dadc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c362-6c9a-e82c-1296" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
-    <entryLink id="f408-e0fb-e72e-e526" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0a26-0757-21d6-a9db" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="c74f-4c14-e13e-4d31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
-    <entryLink id="a1ed-5756-fb2e-6a18" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2fdb-209d-fa17-02f7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a445-8a9e-4a09-6cfa" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
-    <entryLink id="56bb-64e6-8627-a145" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="908a-c0b8-be38-3920" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7092-f0e3-02f8-0d23" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
-    <entryLink id="0caf-045b-8cd0-c94c" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="cf47-b843-1960-e1ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="fcf1-b943-59d3-513d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
-    <entryLink id="8973-a386-43fa-97d8" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6e1c-076f-f95e-4ae7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="195f-5e59-9b5c-1bdf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
-    <entryLink id="2def-48f3-6417-cace" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6290-20b4-083b-5cf7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="be31-9700-d4b9-a0f1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
-    <entryLink id="ee92-4ac2-994a-43d7" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="99fb-f163-58ab-81cc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9930-25f4-58a6-b2fd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
-    <entryLink id="6e96-96fd-4be3-8e76" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="29cd-a8a7-4f5e-ce1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ede2-3243-6027-1fd7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
-    <entryLink id="4d6a-b0fb-7f4b-c4d6" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3203-43fb-b4fd-26a1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="e512-7ba4-7da2-1159" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
-    <entryLink id="af65-340c-7fa4-7254" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3e3f-ed6c-199d-0b91" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="f3ed-64f9-6799-8a96" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
-    <entryLink id="7305-4db8-7bc3-792c" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="58da-27bf-f569-3210" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="8bd7-6af2-4c71-c636" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
-    <entryLink id="7da1-87b2-aefc-4592" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink><entryLink id="b6ac-386a-c032-bcd6" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_8ed4-376d-4030-9439</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_8a11-c2a0-4335-99ef</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_fa8e-1af7-4d41-ac8c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_94bd-c771-4a85-8581</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b497-4f8c-5c04-6cf2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="774f-58a1-9733-b996" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="1d56-2f12-584e-663a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="7e4a-65e9-4a91-85bd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_361e-fb90-4b0e-ac3d</comment></categoryLink>
+        <categoryLink id="6392-815a-4d97-8cc3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d4ef-1074-45a9-959e</comment></categoryLink>
+        <categoryLink id="35f1-d2aa-4ccf-85bf" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_febb-f536-4d25-a8ab</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
-    <entryLink id="41bd-40e9-7987-8136" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8133-a261-5383-b127" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d37b-2a08-bba2-5e7f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink><entryLink id="d0a4-b1a8-a74f-224c" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="81f8-f777-461f-98c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_473b-e812-4158-9416</comment></categoryLink>
+        <categoryLink id="18a0-c4f3-4278-96a7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_00a2-63ff-4698-a35b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
-    <entryLink id="c89a-902f-2ea0-3bcd" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink><entryLink id="dae8-98ab-8ad7-362b" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7cf3-8a72-4f82-8cdc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_228c-5681-4ce8-b726</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_01bb-8abd-4253-9a4d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8cb2-e427-0e3e-a31d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="c89f-9ad3-baf7-4829" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f76a-b401-4bd1-8962" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2a08-4432-42ad-bfdb</comment></categoryLink>
+        <categoryLink id="668d-e81a-4bab-bcda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_422e-0808-4897-8630</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
-    <entryLink id="3b5c-00f2-c9de-4b28" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink><entryLink id="2fb9-1d26-2679-13c6" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1af8-4459-4717-8e3b</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_06b4-92b9-438c-b1a5</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6c8d-8b28-417b-9a7c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_715d-8186-4aa6-b40c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_390e-358c-4f8e-ade8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="5ee9-c79e-6d35-c266" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="41e8-79b6-2e17-75a2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="6cf5-e741-48ae-aa61" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f4c0-4396-4f39-a34f</comment></categoryLink>
+        <categoryLink id="cb3c-99ec-4c48-9433" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1301-8415-490e-8f06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
-    <entryLink id="437a-002e-2e3e-df00" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink><entryLink id="498e-e241-dced-2a62" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d0c9-9a26-4324-b030</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4e9e-a61d-42f2-bacb</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ed9e-b634-4bec-9eb0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4614-ad0f-4fba-adaf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_8d08-24f6-41be-8931</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4cc5-34c1-4d18-ad47" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_caf6-5548-4b89-8102</comment></categoryLink>
+        <categoryLink id="15a4-02cd-436a-9d31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_63a3-be61-428d-ab29</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink><entryLink id="8f79-c68f-2352-2cdb" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f318-4b03-4767-8c7f</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b8ef-7245-4df8-a8c4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_6bce-ec44-48cb-873a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a9b8-3928-43a6-9c4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0678-4fdd-48e6-8f61</comment></categoryLink>
+        <categoryLink id="cb93-e8a0-45c0-b8aa" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0d82-10a9-4de2-8ad7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink><entryLink id="772b-3d96-3951-5128" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ada1-1e18-4cbc-9598</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b1d1-ac44-47dd-9159</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5d64-f00c-4464-891b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25f0-f825-4a83-8f0d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_64b1-9e36-44da-b36a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2464-9ef2-4105-9a60" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_d53e-113f-4a40-a3d5</comment></categoryLink>
+        <categoryLink id="a692-5c4e-4af2-8cf0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1939-76b5-4279-9f8c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink><entryLink id="88b8-c93e-98d1-d299" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d765-3bb2-4b48-bd12</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_0ca1-cfb4-4a56-ab3b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="da0d-7c3e-9491-1ce6" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="7f54-5e82-6421-4321" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b216-ae17-4883-b58e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e6f7-a6ca-4825-bfc5</comment></categoryLink>
+        <categoryLink id="a43d-081d-49ea-af4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dbec-e027-4ec1-8514</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
-    <entryLink id="3505-9023-0edf-26f0" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink><entryLink id="48f5-1057-5e28-0e4d" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d8ee-81ed-45f9-8b79</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_8f4e-e8cb-4ac9-a415</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b09a-c42b-46b8-b638" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_cefb-cfd7-4dc8-99c4</comment></categoryLink>
+        <categoryLink id="7a13-d258-4b91-8987" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a9fd-9d16-4a5e-855c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink><entryLink id="39a5-85ba-0c78-7edf" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e76b-46ca-4ab8-a93d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8035-75b8-43bb-97c9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_71a4-31e7-4927-a0ab</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="209b-a083-4aba-9e32" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_a56d-347b-4b09-a918</comment></categoryLink>
+        <categoryLink id="5153-ebd6-4b95-bf5b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_96e5-4531-4213-903e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink><entryLink id="892d-959e-81e0-6df0" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1fb5-2375-4c22-b41e</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7d7c-255d-49b6-96b9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5321-254b-4890-9bf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ddf8-b8b7-4afb-b6dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="95d3-c386-4cfa-bbec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9441-d79b-4720-9667</comment></categoryLink>
+        <categoryLink id="bfd5-eb9b-4f75-9b7b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7d7e-32d3-4692-b401</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink><entryLink id="f92f-5852-8324-aae1" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_99fc-5fe7-4b37-a62f</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_25f4-f6b8-4b44-8350</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_81f7-2311-4cce-95bc</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_09aa-af2a-4012-91d1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_00ae-fad3-4df6-9cb9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4a16-fdc2-4789-904b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f65b-8958-49b3-92a5</comment></categoryLink>
+        <categoryLink id="d522-c21f-4759-837e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0451-1929-4942-8c3f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink><entryLink id="ba69-754d-6eb5-4bbd" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_edc4-4915-40ba-bbf0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_105f-ba26-4146-bc54</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7a2c-a76c-421c-a8a2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_05c9-0543-47ee-ba81</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e6ad-f0d7-4627-921b</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b1de-1c2d-4f09-a5bf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c6a8-22a8-4d41-b969</comment></categoryLink>
+        <categoryLink id="5711-8926-47ca-9779" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03ca-12cc-4e0a-b628</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink><entryLink id="f243-7c42-9f01-c04e" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ae67-ef52-4cac-958c</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fc61-7306-4d99-acde</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1be0-67e7-45a1-bdbb</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_42a8-7fda-4e05-af0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6822-9b00-4245-b124" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_565a-1592-491f-8b9b</comment></categoryLink>
+        <categoryLink id="57cf-678e-410c-a71a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_81d5-c14a-42ab-bdde</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink><entryLink id="5323-4dba-4ab7-393f" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1ae7-c41b-4818-be71</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_08a5-b1bb-4ba1-ba42</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d677-b5ad-4838-8746</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_537f-bc1f-4aaa-b0dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="784d-988c-43f2-89b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bc67-ce1f-4004-aeb7</comment></categoryLink>
+        <categoryLink id="5b22-8837-4f07-b17c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_9a45-9699-4475-aeef</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink><entryLink id="5161-0c16-c678-c1e7" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_c28f-4109-44c4-ab64</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fdc1-a894-48bc-9e7c</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_4936-a68c-4524-9088</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb37-ac0c-49ae-9d6f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d979-76ef-422c-aaae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3afe-cfc0-4da6-a985</comment></categoryLink>
+        <categoryLink id="bf06-a4a7-45c5-932e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_04a8-6aae-45ae-bd4c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink><entryLink id="bce4-ae64-1c77-aec7" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ae19-30c0-43c5-920e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_6ebe-1bf3-4d78-9dd0</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1887-152d-48b7-b13f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_a7c4-ee6a-4f0b-8ab0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bd85-fa90-47ff-9f84</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_7bd6-9043-4d7e-ba37</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0219-3d5a-44fd-b899" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3610-c975-4d55-bdfe</comment></categoryLink>
+        <categoryLink id="303a-a24a-4086-b1de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2fc2-f636-4c80-9608</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink><entryLink id="212b-b1c8-03ea-3036" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_85c5-d4d9-4b23-9e4d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_80e8-d50b-4906-8153</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_b93b-d4f1-45eb-8a69</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e183-f183-4db7-83b5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0f39-204a-4217-b896</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_eee9-7bfd-4fea-a1bd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="aa4b-ac62-4bd9-85ef" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f81d-9435-4f11-99c1</comment></categoryLink>
+        <categoryLink id="37c1-a2d9-4e2a-a999" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9568-6142-4fdd-be3a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink><entryLink id="2cfd-c944-f062-8f7c" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_005e-6607-4e2c-8dd2</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_7745-260c-4c36-b719</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_ba25-a4b2-4ba9-b023</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ddeb-f4c8-4091-9153</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4904-fd2f-429f-9cf7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_faea-b21b-43c5-b918</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3b6d-2bfd-4d68-8e07" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_b24f-3ae0-4cbb-b016</comment></categoryLink>
+        <categoryLink id="3e5e-e13f-4248-9b38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fd26-8e6b-4521-92b9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink><entryLink id="5e93-87f2-9808-5795" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6ecb-28e2-43ed-a6a0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_c067-1118-4d96-b28b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_250e-23c0-4e43-bf74</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1553-a6e6-4291-853f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_aab6-797b-427a-9fd8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="36e8-41a4-4b0d-8c63" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c77f-0819-473b-a8a2</comment></categoryLink>
+        <categoryLink id="f39b-e2b6-4428-b550" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_89fb-c924-4daf-923d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink><entryLink id="4ad6-4c42-5c0e-01f1" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d72c-519a-451f-81b6</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_3d16-444c-42c9-aad1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_f4b2-6371-494b-863a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_797f-a84b-42f6-8e66</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0d78-fe38-4829-9b12</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="45ed-a549-4858-beef" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0397-c837-4fea-a527</comment></categoryLink>
+        <categoryLink id="4353-c50b-4b70-8329" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_060b-bccb-4776-bd83</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink><entryLink id="7cb7-9d12-2822-a53f" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3c84-6d74-4c42-b38d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_5b15-7aa4-4897-aaf1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_3326-31ed-4151-9b37</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6a0e-1b65-4057-ba5d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f8c7-abc9-45ec-955f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_2538-8dc5-446c-8344</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3a8d-7f7b-40cd-84cb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_c1cf-cea4-4278-8f27</comment></categoryLink>
+        <categoryLink id="63b6-fb4c-47c3-a604" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5f51-2734-4a46-9f72</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink><entryLink id="36e8-6070-e914-287f" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af71-f3ff-49b1-83e9</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_1c9e-b3bf-4e88-a43f</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_6d0d-1b1d-4065-89cf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d0b7-8686-491e-9d33</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_7db8-0874-487a-be6f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1034-29a0-44b1-a85f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0598-4a1e-4b51-830b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_0c16-6841-42b2-b02d</comment></categoryLink>
+        <categoryLink id="44b9-6897-4af3-be85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_602d-2d2d-4ff4-a82a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink><entryLink id="5c5c-010c-b80c-0a36" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_22bd-baae-45f9-b366</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_52bd-55de-4d53-ba55</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_df1b-7476-4ab8-8d2f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_49fa-0dcf-4a61-a5b1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0ea-1443-4993-86e7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2a8-3fbe-448c-9902</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4c91-0fc3-41d7-8721" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3632-0b5d-4622-ae33</comment></categoryLink>
+        <categoryLink id="adf6-a145-463a-83c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_da44-7815-4fdd-981c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink><entryLink id="9d90-9fd1-630e-69e3" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2bfa-b203-47e2-a828</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a39b-8a3c-49cf-bf62</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2a05-07b3-49c5-8145</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f730-87fb-44bd-b68e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_2d0e-6c49-4493-a022</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2e2-50c1-40c3-b4dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="72e8-deea-4936-a964" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_5ad5-8701-42cd-b2b6</comment></categoryLink>
+        <categoryLink id="be43-3a01-4c3a-9cb6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_20a4-4346-4a3b-a7d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink><entryLink id="5fa7-b457-7d5c-942f" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_773a-1ea4-41a0-b766</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_9d4d-6fb8-4131-a5a3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e3bc-02f8-4ece-a5ea</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c371-76d9-4a4d-bc00</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b4c6-d4ba-4b2e-9b99</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="28a7-c777-4419-959e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6ea9-a7e5-437d-9e35</comment></categoryLink>
+        <categoryLink id="7a9e-87b9-4234-a080" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_3cec-f053-42ab-a6eb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink><entryLink id="f15a-1db4-8ec1-57e6" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1e60-42ba-4c8b-9077</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9860-f593-425e-b89b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_c842-10e8-4509-8eda</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ea52-ff41-40f6-8cf3</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_51e6-c5e1-4003-96bc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5e79-4b95-4fe1-8e66" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4d7c-201f-4c99-b89a</comment></categoryLink>
+        <categoryLink id="eeb6-c8e0-4959-a9b3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_10f9-4718-4e07-bb32</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink><entryLink id="8ecb-a86c-8e99-64f5" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5ac9-82bf-494c-9124" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4e52-ad1b-48d4-8eed</comment></categoryLink>
+        <categoryLink id="3546-a4a8-4ee4-af96" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_6979-1ed3-4f1f-a025</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink><entryLink id="b079-60fa-72a8-d6f6" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry"><categoryLinks>
+        <categoryLink id="818e-9544-4faa-b645" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6140-2404-46f9-bd42</comment></categoryLink>
+        <categoryLink id="4a6f-02a8-4ffd-a013" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_1c86-fad8-46ec-a0b0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink><entryLink id="94d6-d8e9-8ba6-88bc" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4729-bc86-456b-b73d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_cf0f-e3f4-4fb4-989d</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1cc8-5611-4d9a-9218</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_2e32-ca02-48f0-a8dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f81b-595b-4c8a-ab0f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_0af1-d052-4bd7-aab6</comment></categoryLink>
+        <categoryLink id="d112-6051-49aa-9cb6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_45ce-e338-43c9-b63e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink><entryLink id="b977-6ad0-1349-f70c" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4dce-8632-4f7c-813e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_8a71-3995-4155-ac33</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d206-f2ce-41b8-945a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan">
+                  <comment>    node_id_2e02-cf1c-4a71-861c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ec81-bd33-45a8-8550</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_3344-743c-45d3-b930</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ae47-4313-8d1e-df9e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="a8c6-b2b9-23ac-b90b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d680-2aa4-445e-8a47" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4272-9b9d-4c59-95f0</comment></categoryLink>
+        <categoryLink id="4411-a034-461d-a1f9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_d85b-1ae7-40d5-9341</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
-    <entryLink id="33c1-628d-e7c8-122c" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="12bb-b57a-1b47-aeb9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="23af-e0b7-0f11-5732" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink><entryLink id="4f55-3621-d6f5-bdf7" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry"><categoryLinks>
+        <categoryLink id="117d-e805-49c4-b960" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ff9f-01cb-41b9-800e</comment></categoryLink>
+        <categoryLink id="1313-b6de-48ca-a5a9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_1315-6051-4a46-b070</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
-    <entryLink id="ec3e-c95c-6b3c-2986" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink><entryLink id="2b66-97ab-581b-f341" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d615-0120-420c-8c9d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_b084-df23-4f99-812f</comment></categoryLink>
+        <categoryLink id="0fe6-a94d-4a98-add3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_84fc-9304-4e9e-ab78</comment></categoryLink>
+        <categoryLink id="cdb9-066f-4620-b704" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d06a-7939-4691-9aed</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="283a-2cb7-41db-bc85" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup"><comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+        <entryLink id="9d5e-ce3b-44c2-ada3" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup"><comment>    template_id_741d-8c09-4211-ada6    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink><entryLink id="6c4b-e43e-b4e9-0362" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_54a4-6ec8-4c61-9c3e</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_f7fd-2d16-4603-a065</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fb0a-d43b-568b-cae7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="42b1-280f-30fb-b5d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b1e8-4ff6-4f7d-ab8a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_c0ac-4b8c-421c-a21b</comment></categoryLink>
+        <categoryLink id="221f-9ad3-4ab0-af9e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8db9-079e-4482-b200</comment></categoryLink>
+        <categoryLink id="7bbc-3f73-495f-b3d7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_413c-9273-4308-b546</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
-    <entryLink id="8499-9821-d3c3-8376" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="63c1-57f6-4612-25dd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="8f5a-adda-a50e-46b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      <entryLinks>
+        <entryLink id="cf04-0b5a-470f-972b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup"><comment>    template_id_bbc4-33fc-4664-a18e    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="da21-9501-4217-b7bf" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup"><comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink><entryLink id="3199-a3b6-8e2e-4892" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry"><categoryLinks>
+        <categoryLink id="91dd-d073-4c02-8578" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_4c8d-96f6-48f9-9590</comment></categoryLink>
+        <categoryLink id="c098-d02c-4451-a51d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_049c-0fa5-4575-8fa8</comment></categoryLink>
+        <categoryLink id="2679-a8c3-4327-b818" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_7358-52d7-4aae-8e07</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
-    <entryLink id="daed-8aa8-5696-793c" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+      <entryLinks>
+        <entryLink id="a5d3-96c9-440c-9ebc" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup"><comment>    template_id_4784-b370-444b-93ae    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="6e31-80e5-4df4-8f08" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup"><comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink><entryLink id="a711-3e30-4de4-5c1a" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_3c03-a823-4466-9bd6</comment>
           <conditionGroups>
-            <conditionGroup type="and">
+            <conditionGroup type="or">
+              <comment>    node_id_8bbb-f95b-413f-b6f4</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_41b0-6b0a-482a-919e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e1f7-3cc6-4794-8b6d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0161-52ea-cd43-0594" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="b736-29d3-6891-a62a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cb54-c32a-48b0-a7ef" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_05ce-cc31-40ad-9320</comment></categoryLink>
+        <categoryLink id="9fe3-6318-47d7-9901" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f13c-f8e1-4a50-bfe3</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
-    <entryLink id="b61b-8de4-1f2f-3904" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="09af-ccd7-cf50-09b0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="9bcb-3b7a-7d70-4bd3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
-    <entryLink id="0437-2483-6195-95b4" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8d20-10a7-154c-d709" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d6e5-e06e-f886-0f93" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
-        <categoryLink id="963a-9da7-a6d9-5065" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
-    <entryLink id="3409-9cde-1f7f-ae8a" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e46e-5f43-8d3d-5df1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4d7a-a1a9-127b-2f50" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
-    <entryLink id="7e31-d570-5037-30b8" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink><entryLink id="8c4d-d20e-d169-1756" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_db78-4d49-42ab-954a</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_f14d-9943-47b6-866c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a95-938f-4a07-9727</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_7775-78e1-44cc-87c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b69b-8ff5-4ea2-af1b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_b822-3417-4613-be37</comment></categoryLink>
+        <categoryLink id="b9ac-bba8-43d4-a25f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_25db-b03f-4881-b310</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink><entryLink id="2070-75a6-12ee-94f0" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry"><categoryLinks>
+        <categoryLink id="e97c-1261-431e-b132" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_75a7-dc06-445b-b2dc</comment></categoryLink>
+        <categoryLink id="6473-65c5-4214-a6a8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_e21a-c03b-4885-ac46</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink><entryLink id="32ad-9202-9b03-78a7" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9a08-5fe6-4010-bbc3</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_72cf-cfce-4e02-b379</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="68c2-d472-516b-4717" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="bce7-c5b0-6408-5f19" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2eb6-9bbd-4b22-b1ed" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_f55b-7555-444b-beee</comment></categoryLink>
+        <categoryLink id="10fd-6aa1-4f5b-93f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3386-c9ad-4d74-9474</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
-    <entryLink id="10fe-3e6c-5b96-572c" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7c67-54c3-2b77-82a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="aa89-9558-c12c-b5a8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
-    <entryLink id="ccb6-6158-d584-caa2" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink><entryLink id="7ebb-53ec-28b5-3604" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_a0f6-9606-4b75-a2f8</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_94b3-1331-474b-885b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5e69-9953-b8f4-f238" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9191-0da6-7ced-eb9b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="bd1c-6d99-4f1e-b99d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_79fa-3370-4ae0-9e12</comment></categoryLink>
+        <categoryLink id="f1fe-703f-45e9-b198" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bb53-4e65-4fb6-9dd7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
-  </entryLinks>
-  <sharedSelectionEntries>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink><entryLink id="7293-7085-dc21-7370" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f8cc-833a-4ac1-bf89</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+              <comment>    node_id_5988-c012-4dad-9a66</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3a59-42a9-4f4a-a4d4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_8d82-3279-4481-84bb</comment></categoryLink>
+        <categoryLink id="bfb1-2c19-46c5-897c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e25c-925e-4b96-8bb3</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink><entryLink id="b371-f3c9-6eb2-3dd3" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6b73-b21c-4e2b-9d14</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_a7fe-cc62-4a6f-a781</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5be1-1937-4964-a455</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_da1d-b2bc-4117-82a4</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="558a-bf56-43b2-9f45" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7010-be56-4709-b058</comment></categoryLink>
+        <categoryLink id="3840-4c77-4a41-b3d0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7379-a740-47ba-a054</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink><entryLink id="f408-e0fb-e72e-e526" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_dd34-83cf-47d7-b557</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_be88-afef-49b3-bd1e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5e26-1a5a-4eca-b8a5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_944f-7420-4982-8ea9</comment></categoryLink>
+        <categoryLink id="b56a-4992-4c56-b510" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ea80-0efe-457d-a450</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink><entryLink id="a1ed-5756-fb2e-6a18" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><categoryLinks>
+        <categoryLink id="bef6-7db0-40fa-9c01" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9a36-f261-43cc-9bd1</comment></categoryLink>
+        <categoryLink id="4085-1fb6-40a5-8a21" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a648-8396-442a-af59</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink><entryLink id="56bb-64e6-8627-a145" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_cb81-0303-4b88-ae53</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9648-31e3-43aa-8cf3</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_0507-da81-4023-bfcf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0e84-54ff-488d-b066</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="edb5-e16b-4f6e-8f58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6ff-0977-4c92-bb28</comment></categoryLink>
+        <categoryLink id="9315-ebd6-47a5-b414" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f555-7d39-458f-84c9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink><entryLink id="0caf-045b-8cd0-c94c" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8203-5b00-497b-b939</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_40ee-3e71-4978-b1e4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f6a8-f660-46dc-b3c5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_d988-3af6-48bf-b0a8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7173-2bd4-46b3-9fca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_39e5-eda5-45d1-a643</comment></categoryLink>
+        <categoryLink id="27ce-cfbd-465b-8c7f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_6416-21bb-4df4-9de8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink><entryLink id="8973-a386-43fa-97d8" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b03e-5d91-4be3-8adc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_0443-29c0-46e9-ad1d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f2c9-7356-4c27-a22f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0e9-4a9e-4b2b-a9d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2d99-4607-4d9d-94cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5528-2dac-4be5-900c</comment></categoryLink>
+        <categoryLink id="f587-fc12-4d71-98e6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_dc8f-d888-4585-991d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink><entryLink id="2def-48f3-6417-cace" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1d3c-8e17-489f-9002</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5725-8bee-4bcc-878d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_be47-0d6f-49f2-9f4b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_863c-f3a4-4802-b80c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="743c-0882-48ec-8d04" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_899e-b052-4d5b-8c18</comment></categoryLink>
+        <categoryLink id="1ee2-6adf-4a6a-b672" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f5e9-cff6-41d2-a016</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink><entryLink id="ee92-4ac2-994a-43d7" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_72da-1513-4e02-b595</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7a48-a3b0-4a26-849b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e232-25f3-4cb7-8ab2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_9aa4-5660-4697-8ab2</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7e50-ba01-4e46-ba63" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_09cd-2176-40af-bba6</comment></categoryLink>
+        <categoryLink id="cfde-ee52-4458-89c5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_05e6-7c63-4a35-9ba0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink><entryLink id="6e96-96fd-4be3-8e76" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d80f-e8f8-46c9-996f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0dfa-4004-4751-8022</comment></categoryLink>
+        <categoryLink id="0980-70d9-4334-812d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a669-0f5d-4fd3-811b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink><entryLink id="4d6a-b0fb-7f4b-c4d6" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_09b5-4e3b-4c84-a574</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_32e5-ebba-41fb-9ff2</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_838e-0ccf-4d3a-aabd</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_dfef-0ec2-49fb-a534</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6071-c953-4ab2-80f0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4f60-472b-45a9-ab9e</comment></categoryLink>
+        <categoryLink id="43c0-ab0a-4ea1-9d32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e2e3-af36-45a6-a955</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink><entryLink id="af65-340c-7fa4-7254" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_936f-1ef7-472e-840e</comment>
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+              <comment>    node_id_d73d-d52e-4c75-8ac0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a503-5766-4e75-b42d" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_7a55-ecb4-4e5d-b955</comment></categoryLink>
+        <categoryLink id="29bf-2c68-4848-b6fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f28c-710e-4ff8-9810</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink><entryLink id="7305-4db8-7bc3-792c" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_a743-0cc2-45ae-a7eb</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2721-e88d-41f7-bedc</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_e10f-1390-4b33-8fcc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="657a-ebf7-4c58-892e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2008-f1c4-4285-a14f</comment></categoryLink>
+        <categoryLink id="c983-6ea6-438c-bb93" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e88b-a95a-4647-af3b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink><entryLink id="7da1-87b2-aefc-4592" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_25d8-330b-4574-b515</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7836-6878-47a8-8827</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_5ea9-46dd-4a11-9410</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_ab5d-961b-4924-a705</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="487c-f6fb-453a-8cd0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9189-836c-475d-a52e</comment></categoryLink>
+        <categoryLink id="fd29-fedd-4934-ada9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_e1fa-b7d8-47b0-a88a</comment></categoryLink>
+        <categoryLink id="fac6-ec9d-482f-b18d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_a137-e3c0-4d63-a48c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink><entryLink id="41bd-40e9-7987-8136" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry"><categoryLinks>
+        <categoryLink id="a564-4822-444a-ac72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b1d5-fd75-4f17-bbf4</comment></categoryLink>
+        <categoryLink id="bfef-a58b-4804-9758" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_f221-bf81-4045-849b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink><entryLink id="c89a-902f-2ea0-3bcd" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_b743-7a00-43e4-beb8</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d12f-2c98-4e62-a716</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d4d7-ba67-47aa-962f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+                  <comment>    node_id_1637-edee-457a-bb0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="32a6-76d2-4a94-8416" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_f203-bc26-421f-b79e</comment></categoryLink>
+        <categoryLink id="8a8c-93d8-4c75-afc5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_a53e-59d9-4ac2-a21f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink><entryLink id="3b5c-00f2-c9de-4b28" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry"><categoryLinks>
+        <categoryLink id="c3e3-d8ba-41fb-8afa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_51af-a137-4a1c-97a4</comment></categoryLink>
+        <categoryLink id="dd72-9188-43cc-b502" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ec1f-c326-40a8-9d1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink><entryLink id="437a-002e-2e3e-df00" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_c111-feb0-4012-98cd</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_63d7-8427-431d-9ae6</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="179a-b4f4-4c8a-9efd" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_e707-fde1-457f-91c4</comment></categoryLink>
+        <categoryLink id="a0c4-af29-4c8d-9ba1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ec67-8573-4460-89db</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink><entryLink id="3505-9023-0edf-26f0" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3348-16e4-4a9a-a549</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_bea4-c4a8-4843-b9fe</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2970-17ff-4be1-91e5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_503a-46e7-40e7-bd07</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_4555-15e1-43ff-80a0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d056-e98f-4fe1-a660" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_fce3-801c-49c8-85d4</comment></categoryLink>
+        <categoryLink id="36cc-d983-4f05-9bab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0c2d-2349-44b6-9831</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink><entryLink id="33c1-628d-e7c8-122c" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry"><categoryLinks>
+        <categoryLink id="fc58-17bc-4622-8760" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ac1c-b3bf-4011-918a</comment></categoryLink>
+        <categoryLink id="00a7-4805-44f6-869f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_589c-1d0e-4b7d-be6b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink><entryLink id="ec3e-c95c-6b3c-2986" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2f46-a0b6-48a5-a0ee</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_636f-0f8a-43f1-910b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c883-39c8-4a74-aeaa</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_0796-e467-4438-89b3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3ae4-1d81-42fd-8801" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_5a04-9847-4c91-a49a</comment></categoryLink>
+        <categoryLink id="e79e-6e12-41cc-b516" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b4b4-daeb-483c-a306</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink><entryLink id="8499-9821-d3c3-8376" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6087-a5e5-4d3c-9ebd</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c7e1-5f42-4528-bf07</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1950-08dc-4544-ab01</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_daf3-31ed-42c0-85dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3970-9c1f-444d-a779" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_7d4f-547c-43ed-a520</comment></categoryLink>
+        <categoryLink id="a279-c317-4781-8829" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f04e-04e8-4891-9b1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink><entryLink id="daed-8aa8-5696-793c" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_dfdc-f6f6-49d2-a7b3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_354c-c71f-472f-b268</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1127-c974-4663-874d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_0843-bef2-4767-8307</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f047-bb66-44e6-bc5f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_28e0-91e7-4ada-9fac</comment></categoryLink>
+        <categoryLink id="0252-d8a2-403b-bcd7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4448-a712-4dd7-bf6d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink><entryLink id="b61b-8de4-1f2f-3904" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d512-fd07-4a29-863a</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_55c6-a35f-485a-9f0d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d89e-cf1f-4ceb-b3de</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e2c9-0d01-403c-900e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_a7b8-c835-4cb2-b3d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="23bb-d145-4e0c-9fbe" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_e22a-c5f8-4825-a45f</comment></categoryLink>
+        <categoryLink id="22ee-d30b-4180-94e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03fc-6a7f-45a5-bcb8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink><entryLink id="0437-2483-6195-95b4" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry"><categoryLinks>
+        <categoryLink id="a1b7-bf43-49fa-a355" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0aff-4f6e-4b03-a23c</comment></categoryLink>
+        <categoryLink id="dc90-bb8a-4c8d-854d" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"><comment>    template_id_7d5a-62e7-43ee-b79b</comment></categoryLink>
+        <categoryLink id="393c-263c-4b33-9f24" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_4986-9157-49f2-b670</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink><entryLink id="3409-9cde-1f7f-ae8a" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_319e-90d4-44a3-8e83</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_28db-d943-4099-9abd</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1a45-a592-49df-9465</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb31-d0b2-4677-928e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f196-06c7-426a-8386" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1b86-0977-4a8b-adac</comment></categoryLink>
+        <categoryLink id="0706-b651-4a0d-af76" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_b449-403a-4e42-9239</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink><entryLink id="7e31-d570-5037-30b8" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafa-470f-4c2c-8be3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_e2ba-a855-4de2-9f46</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_0171-b30d-44ee-9389</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fdfb-119b-4774-934a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_3891-9a00-4f8f-b95f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5719-c996-461a-9f61" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e5df-17d4-4521-9d5b</comment></categoryLink>
+        <categoryLink id="4183-9ce3-4e86-a556" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"><comment>    template_id_0ecd-4873-4d3a-b28b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink><entryLink id="10fe-3e6c-5b96-572c" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_fbfa-8d78-4d6d-8a05</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_21f2-0916-46bf-b75a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_4fbd-633b-4dd6-9fdd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="097b-11ff-4ff9-af73" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4f71-446f-4cff-afda</comment></categoryLink>
+        <categoryLink id="6d64-5f7b-448b-bdd8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_3f44-8647-43a4-ac22</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink><entryLink id="ccb6-6158-d584-caa2" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af15-2c71-4f8b-833e</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_d95a-80b9-4463-af55</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5172-d6d2-4505-a0b7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6b1-886e-4194-8bcd</comment></categoryLink>
+        <categoryLink id="1322-91e0-4cec-8bd1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_51b5-f9c1-4587-8fc7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink><entryLink id="e944-c6f3-4b9a-9aea" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
+    <entryLink id="7690-964e-4288-a5b1" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
+    <entryLink id="4380-9dc7-41b9-aa47" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
+    <entryLink id="7e4e-866f-44e9-a0b7" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <entryLink id="3979-6aab-4c82-a1ca" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3531-57d1-4081-882d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_f233-2361-4177-8ba7</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b932-667a-4b43-8331</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <entryLink id="fdef-c172-4dcd-a2e2" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <entryLink id="9d44-1996-4995-a126" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3129-6f59-4365-906b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2bcb-0af1-4aea-9191" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <entryLink id="68f4-b532-48e0-82e7" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ede2-d453-4e34-8cda</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2907-3215-4b01-96ff</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_c90c-959f-40fb-a4cb</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ba2d-50ad-45f1-91c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0e88-485e-43c2-8bef" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <entryLink id="8208-2883-4082-a0e4" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_409c-0a5d-4ef8-a871</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7078-c1c7-4af2-b43d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_9a69-0fdc-4957-8982</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1a4c-69b5-4219-8502" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fba0-3ea7-4eaf-b33a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <entryLink id="f15f-c9d5-4c8a-ba4d" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
+    <entryLink id="6a5d-bd56-4741-bf93" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
+    <entryLink id="1890-6fe1-4b79-94a4" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
+    <entryLink id="7155-81b1-4a9e-b97c" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+  </entryLinks><sharedSelectionEntries>
     <selectionEntry id="5be0-17a1-bb08-670f" name="Moritat-Prime Kaedes Nex" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="1bd3-f8f0-d234-1ecf" name="Ill-omened" hidden="false">

--- a/2022 - LA - Raven Guard.cat
+++ b/2022 - LA - Raven Guard.cat
@@ -290,7 +290,7 @@
         <categoryLink id="c116-d80c-1387-fb57" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="173e-2ab5-019c-20a7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
     <entryLink id="b913-7cbf-afd3-ed83" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="acbf-2c66-ae4f-9e81" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
@@ -718,7 +718,7 @@
         <categoryLink id="bcf3-bf62-984f-18de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="a45d-a217-4962-d996" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
     <entryLink id="32ad-9202-9b03-78a7" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
@@ -799,7 +799,7 @@
         <categoryLink id="6290-20b4-083b-5cf7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="be31-9700-d4b9-a0f1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
     <entryLink id="ee92-4ac2-994a-43d7" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="99fb-f163-58ab-81cc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -811,7 +811,7 @@
         <categoryLink id="29cd-a8a7-4f5e-ce1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="ede2-3243-6027-1fd7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
     <entryLink id="4d6a-b0fb-7f4b-c4d6" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3203-43fb-b4fd-26a1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -893,7 +893,7 @@
         <categoryLink id="da0d-7c3e-9491-1ce6" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="7f54-5e82-6421-4321" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
     <entryLink id="3505-9023-0edf-26f0" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -921,7 +921,7 @@
         <categoryLink id="12bb-b57a-1b47-aeb9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="23af-e0b7-0f11-5732" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
     <entryLink id="ec3e-c95c-6b3c-2986" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -971,7 +971,7 @@
         <categoryLink id="d6e5-e06e-f886-0f93" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
         <categoryLink id="963a-9da7-a6d9-5065" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
     <entryLink id="3409-9cde-1f7f-ae8a" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e46e-5f43-8d3d-5df1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />

--- a/2022 - LA - Raven Guard.cat
+++ b/2022 - LA - Raven Guard.cat
@@ -2688,7 +2688,7 @@ When in base to base contact with an enemy Infantry or Cavalry model whose Weapo
       <entryLinks>
         <entryLink id="2d0a-0666-fed5-39c4" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_7dee-602c-4b47-be09</comment></selectionEntryGroup>
     <selectionEntryGroup id="5a61-7572-048d-9bb4" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="4f8e-0e7a-b3fe-1e3c" type="max" />
@@ -2706,7 +2706,7 @@ When in base to base contact with an enemy Infantry or Cavalry model whose Weapo
         <entryLink id="ddf1-3ff4-ef67-c4f1" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
         <entryLink id="b94f-e962-0b23-adff" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_be38-a066-4f8e-ae54</comment></selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
     <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />

--- a/2022 - LA - Raven Guard.cat
+++ b/2022 - LA - Raven Guard.cat
@@ -1,1064 +1,1063 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d21e-9c80-a7f8-728c" name="LA - XIX: Raven Guard" revision="11" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="22" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="d21e-9c80-a7f8-728c" name="LA - XIX: Raven Guard" revision="11" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="22">
   <entryLinks>
     <entryLink id="84cc-e59c-174e-fb25" name="Mor Deythan Squad" hidden="false" collective="false" import="false" targetId="c268-08ac-5b90-d034" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2e94-0345-48a1-212d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="b955-7a72-615e-214c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2e94-0345-48a1-212d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="b955-7a72-615e-214c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="495b-4009-800a-2446" name="Moritat-Prime Kaedes Nex" hidden="true" collective="false" import="false" targetId="5be0-17a1-bb08-670f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="de3b-7a9e-8db8-3522" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="9642-f478-08f5-086c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="de3b-7a9e-8db8-3522" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="9642-f478-08f5-086c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="4d01-e777-0fc3-5af0" name="Dark Furies" hidden="false" collective="false" import="false" targetId="58f4-3d8d-f243-6e5d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b3bf-9ad9-9085-e594" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="c981-a1a9-1e0e-a0c6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b3bf-9ad9-9085-e594" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="c981-a1a9-1e0e-a0c6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="b259-41d9-dd0b-6e71" name="Strike Captain Alvarex Maun" hidden="true" collective="false" import="false" targetId="0e66-8311-405c-1e49" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="09fb-5221-1260-a028" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="35aa-395e-a852-77e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ca61-d4be-80ed-be27" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="09fb-5221-1260-a028" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="35aa-395e-a852-77e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ca61-d4be-80ed-be27" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="7e7b-c3d0-0f16-ffbf" name="Corvus Corax" hidden="false" collective="false" import="false" targetId="8ff5-cece-0fc2-100d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f2cb-5a4e-7c3e-733a" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
-        <categoryLink id="393b-c443-85dd-4f06" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f2cb-5a4e-7c3e-733a" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true" />
+        <categoryLink id="393b-c443-85dd-4f06" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="1efd-f4c5-634b-d9f2" name=" XIX: Raven Guard" hidden="false" collective="false" import="false" targetId="dc34-fe08-dd44-fb99" type="selectionEntry">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3a6-c535-9627-6541" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c91-701b-fcc4-bd97" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3a6-c535-9627-6541" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c91-701b-fcc4-bd97" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="12a0-1ec0-e39d-2b3f" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="12a0-1ec0-e39d-2b3f" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="eaff-3c75-ef08-341e" name="Deliverers Squad" hidden="false" collective="false" import="false" targetId="5d1d-8348-ed95-d366" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="493d-2397-2ace-e10d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="b526-7584-0877-2f74" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="493d-2397-2ace-e10d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="b526-7584-0877-2f74" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="794f-827b-88d4-dec9" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d6c6-e581-def5-324b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d831-4d0c-3a7d-0b2a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="d6c6-e581-def5-324b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d831-4d0c-3a7d-0b2a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
     <entryLink id="d7ab-fdf4-b06a-baaf" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="abc6-8b32-76f5-dce7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5a2b-20ba-67f4-17b2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="abc6-8b32-76f5-dce7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5a2b-20ba-67f4-17b2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
     <entryLink id="1d98-08bc-b1c4-e9b3" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4a13-a002-9199-2b6e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="d9eb-65c7-f407-5d65" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="106e-703f-049f-3b57" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="4a13-a002-9199-2b6e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="d9eb-65c7-f407-5d65" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="106e-703f-049f-3b57" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="8cd4-b4d6-ce65-83af" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8c8c-98d4-ba95-bc51" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="a85d-afd0-c3fb-9864" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8c8c-98d4-ba95-bc51" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="a85d-afd0-c3fb-9864" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
     <entryLink id="7fcd-68dc-c97d-aebf" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="11f0-e8d7-6b29-f95d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="82a8-bf4f-4c1a-bbc2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="11f0-e8d7-6b29-f95d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="82a8-bf4f-4c1a-bbc2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
     <entryLink id="57d6-9147-79f2-72f9" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="11d9-3906-0579-1ac9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="52e4-858c-d161-746f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a66a-497c-9577-e106" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="11d9-3906-0579-1ac9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="52e4-858c-d161-746f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a66a-497c-9577-e106" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
     <entryLink id="b381-7182-8f87-dd83" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e8ca-e120-0b1e-7c39" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="c554-afac-49ff-7065" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e8ca-e120-0b1e-7c39" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="c554-afac-49ff-7065" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
     <entryLink id="1610-e22d-f5cf-210f" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5048-8cfb-e7e0-490a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="f127-72dd-e91e-c81b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5048-8cfb-e7e0-490a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="f127-72dd-e91e-c81b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
     <entryLink id="e56e-5679-f823-feab" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="62e0-10d6-b068-3719" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="034a-5c5b-0a43-aefe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0f3a-11fb-e951-0cbf" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="62e0-10d6-b068-3719" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="034a-5c5b-0a43-aefe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0f3a-11fb-e951-0cbf" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="876f-e920-6f2b-05ce" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup"/>
+        <entryLink id="876f-e920-6f2b-05ce" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup" />
         <entryLink id="8fad-9df2-eda8-842b" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
     <entryLink id="b925-3d50-c508-cc15" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="10a3-0817-3f5b-1b85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f56a-9c0c-35d7-06ed" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="9259-0001-e4e7-b534" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="10a3-0817-3f5b-1b85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f56a-9c0c-35d7-06ed" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="9259-0001-e4e7-b534" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="87f5-dbd5-ed40-7f29" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup"/>
+        <entryLink id="87f5-dbd5-ed40-7f29" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup" />
         <entryLink id="f2a4-248d-2238-206c" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
     <entryLink id="7734-d861-18f2-1a0c" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5320-4027-5049-461e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6f7c-846d-a97a-88c8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="31fc-fdb0-b5d8-c448" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="5320-4027-5049-461e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6f7c-846d-a97a-88c8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="31fc-fdb0-b5d8-c448" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="5f5a-12f5-c938-2399" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup"/>
+        <entryLink id="5f5a-12f5-c938-2399" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup" />
         <entryLink id="5584-0075-d0f8-4569" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
     <entryLink id="3aac-15a4-de34-a113" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c6ae-7a95-3211-03ff" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="3f6d-c0c5-d641-2ee4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c6ae-7a95-3211-03ff" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="3f6d-c0c5-d641-2ee4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
     <entryLink id="b00c-2263-1932-f88b" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ebff-86ff-9f67-599a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b28b-8688-6bf5-4501" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="ebff-86ff-9f67-599a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b28b-8688-6bf5-4501" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
     <entryLink id="ff73-39dc-6d96-14e6" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f980-8e62-0348-466e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c890-a2a1-d1b8-682f" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="f980-8e62-0348-466e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c890-a2a1-d1b8-682f" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
     <entryLink id="cdf8-ca69-9f1f-edc7" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c840-0955-7c04-906e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="de35-9d2e-a6ce-5576" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="c840-0955-7c04-906e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="de35-9d2e-a6ce-5576" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
     <entryLink id="31cb-0e8f-9c63-a9f6" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c116-d80c-1387-fb57" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="173e-2ab5-019c-20a7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="c116-d80c-1387-fb57" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="173e-2ab5-019c-20a7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
     <entryLink id="b913-7cbf-afd3-ed83" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="acbf-2c66-ae4f-9e81" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="f1c2-bf1c-b906-919f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="acbf-2c66-ae4f-9e81" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="f1c2-bf1c-b906-919f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
     <entryLink id="a16f-4eaf-739d-8127" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3b3a-5a53-f2ce-abf5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="b2d9-9aea-673a-eb95" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3b3a-5a53-f2ce-abf5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="b2d9-9aea-673a-eb95" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="8e56-f8ba-fe32-f07a" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="feb3-386a-1670-4216" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7769-9e3d-367f-fa84" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="feb3-386a-1670-4216" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7769-9e3d-367f-fa84" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
     <entryLink id="b6ac-386a-c032-bcd6" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0cf3-02f0-05ae-2d7a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="974f-073d-e833-6ca6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1b01-b022-0d5a-643c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="0cf3-02f0-05ae-2d7a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="974f-073d-e833-6ca6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1b01-b022-0d5a-643c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="d0a4-b1a8-a74f-224c" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="074f-7c2a-d5a0-88ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="73e3-4d6a-78fa-b765" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="074f-7c2a-d5a0-88ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="73e3-4d6a-78fa-b765" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="dae8-98ab-8ad7-362b" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ac18-eb6c-5cf0-de4d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="7382-3d70-8267-36c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ac18-eb6c-5cf0-de4d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="7382-3d70-8267-36c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
     <entryLink id="2fb9-1d26-2679-13c6" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c060-58f0-9d44-bfd5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="ea6e-e5b5-243f-ccbd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c060-58f0-9d44-bfd5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="ea6e-e5b5-243f-ccbd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
     <entryLink id="498e-e241-dced-2a62" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="088b-338a-e8d5-6be6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="4a23-7c32-f4a6-84da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="088b-338a-e8d5-6be6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="4a23-7c32-f4a6-84da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
     <entryLink id="8f79-c68f-2352-2cdb" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="68bb-5075-1d33-ee00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fa38-9230-3c20-f307" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="68bb-5075-1d33-ee00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="fa38-9230-3c20-f307" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
     <entryLink id="772b-3d96-3951-5128" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d48f-5656-e218-6dcf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="bfc8-83cc-d935-3f1d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d48f-5656-e218-6dcf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="bfc8-83cc-d935-3f1d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
     <entryLink id="88b8-c93e-98d1-d299" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7217-fa86-bd36-372c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="3935-a521-fa72-8dd4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7217-fa86-bd36-372c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="3935-a521-fa72-8dd4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
     <entryLink id="48f5-1057-5e28-0e4d" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0b7a-5159-8c86-36bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="79c7-c3f9-92e0-1e9f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="0b7a-5159-8c86-36bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="79c7-c3f9-92e0-1e9f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
     <entryLink id="39a5-85ba-0c78-7edf" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7607-24eb-4c5f-4356" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="d723-9931-d8fb-a848" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7607-24eb-4c5f-4356" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="d723-9931-d8fb-a848" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
     <entryLink id="892d-959e-81e0-6df0" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a7d5-8cd6-bdbf-b3c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b92f-c1a0-f683-13a2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="a7d5-8cd6-bdbf-b3c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b92f-c1a0-f683-13a2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="f92f-5852-8324-aae1" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e738-238d-7c2c-c9e7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="ede1-5f64-6eeb-fbd0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e738-238d-7c2c-c9e7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="ede1-5f64-6eeb-fbd0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
     <entryLink id="ba69-754d-6eb5-4bbd" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="510f-6790-c12a-fe0c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="86b4-8829-a4e2-1649" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="510f-6790-c12a-fe0c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="86b4-8829-a4e2-1649" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
     <entryLink id="f243-7c42-9f01-c04e" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d224-4db5-9ea7-28ce" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="bf92-eee8-cad1-3141" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d224-4db5-9ea7-28ce" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="bf92-eee8-cad1-3141" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
     <entryLink id="5323-4dba-4ab7-393f" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4f9d-07dc-fffe-8def" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4297-6075-5764-dbe2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="4f9d-07dc-fffe-8def" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4297-6075-5764-dbe2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
     <entryLink id="5161-0c16-c678-c1e7" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a4d8-47f5-a550-b1bd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6415-f2fc-188e-0e8c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="a4d8-47f5-a550-b1bd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6415-f2fc-188e-0e8c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
     <entryLink id="bce4-ae64-1c77-aec7" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2d71-86dc-43cc-e019" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="e9c4-649c-6888-d69a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2d71-86dc-43cc-e019" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="e9c4-649c-6888-d69a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
     <entryLink id="212b-b1c8-03ea-3036" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="aaf9-e673-4b7b-577c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="f550-3cdf-db0e-1280" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="aaf9-e673-4b7b-577c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="f550-3cdf-db0e-1280" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
     <entryLink id="2cfd-c944-f062-8f7c" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c516-f7fa-20d6-769e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="f736-cced-8109-4734" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c516-f7fa-20d6-769e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="f736-cced-8109-4734" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
     <entryLink id="5e93-87f2-9808-5795" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="22e3-1010-015d-07d6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="e6a9-2f4c-c0c5-b3cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="22e3-1010-015d-07d6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="e6a9-2f4c-c0c5-b3cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
     <entryLink id="4ad6-4c42-5c0e-01f1" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1380-6a48-3fa5-9d47" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="2810-3db5-670f-3e5c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1380-6a48-3fa5-9d47" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="2810-3db5-670f-3e5c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
     <entryLink id="7cb7-9d12-2822-a53f" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fc23-742f-0086-cbab" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="1b6b-fabe-6f28-b2b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fc23-742f-0086-cbab" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="1b6b-fabe-6f28-b2b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
     <entryLink id="36e8-6070-e914-287f" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c9f8-6c11-70bd-322e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="1942-1686-a17c-4137" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c9f8-6c11-70bd-322e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="1942-1686-a17c-4137" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
     <entryLink id="5c5c-010c-b80c-0a36" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9fdd-9029-5cb7-83d0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="d7a5-09db-56f9-eec4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9fdd-9029-5cb7-83d0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="d7a5-09db-56f9-eec4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
     <entryLink id="9d90-9fd1-630e-69e3" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f9c8-6068-cb85-ed0b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="90b7-82e2-8f27-ca4a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f9c8-6068-cb85-ed0b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="90b7-82e2-8f27-ca4a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
     <entryLink id="5fa7-b457-7d5c-942f" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cbd5-a4c7-6650-0ecf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9b25-77b9-30a6-fbc5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="cbd5-a4c7-6650-0ecf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9b25-77b9-30a6-fbc5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
     <entryLink id="f15a-1db4-8ec1-57e6" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6785-b58e-07b7-90d1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="cb15-183a-65ae-0c78" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6785-b58e-07b7-90d1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="cb15-183a-65ae-0c78" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
     <entryLink id="8ecb-a86c-8e99-64f5" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="892f-d746-4dc6-d0ba" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="1c46-8077-364c-a610" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="892f-d746-4dc6-d0ba" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="1c46-8077-364c-a610" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
     <entryLink id="b079-60fa-72a8-d6f6" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2032-c268-c6ed-1c77" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b001-2b83-953d-663d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="2032-c268-c6ed-1c77" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b001-2b83-953d-663d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="94d6-d8e9-8ba6-88bc" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a01f-ccb6-a9d8-fb93" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="8045-adb3-2fe6-e75d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a01f-ccb6-a9d8-fb93" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="8045-adb3-2fe6-e75d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
     <entryLink id="b977-6ad0-1349-f70c" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ce87-c06b-a21f-710f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="6abe-424d-2690-05eb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ce87-c06b-a21f-710f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="6abe-424d-2690-05eb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="4f55-3621-d6f5-bdf7" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9a1a-99c5-4c87-9402" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3af1-5e5b-2067-bf5b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="9a1a-99c5-4c87-9402" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3af1-5e5b-2067-bf5b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="2b66-97ab-581b-f341" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0b16-feb6-8533-fc80" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="fce5-411e-19fd-0db2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="20d0-b4e9-8d7c-b088" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="0b16-feb6-8533-fc80" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="fce5-411e-19fd-0db2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="20d0-b4e9-8d7c-b088" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="eb61-0fa5-4c9c-d174" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup"/>
-        <entryLink id="06e2-7154-5958-6015" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup"/>
+        <entryLink id="eb61-0fa5-4c9c-d174" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup" />
+        <entryLink id="06e2-7154-5958-6015" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
     <entryLink id="6c4b-e43e-b4e9-0362" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="540b-2e26-d7ee-8871" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="1e15-5399-b7e9-0ae9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7633-0a3e-30e3-c988" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="540b-2e26-d7ee-8871" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="1e15-5399-b7e9-0ae9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7633-0a3e-30e3-c988" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="c2d0-c373-def1-2bbe" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup"/>
-        <entryLink id="2033-ba42-eb89-6da3" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup"/>
+        <entryLink id="c2d0-c373-def1-2bbe" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup" />
+        <entryLink id="2033-ba42-eb89-6da3" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
     <entryLink id="3199-a3b6-8e2e-4892" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="052f-fff3-d351-99ed" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="4449-8ecd-6670-1553" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c88d-3f57-f179-fe04" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="052f-fff3-d351-99ed" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="4449-8ecd-6670-1553" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c88d-3f57-f179-fe04" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="1c71-70b3-0c2a-e187" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup"/>
-        <entryLink id="a751-60f0-d0f4-0e16" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup"/>
+        <entryLink id="1c71-70b3-0c2a-e187" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="40ca-b143-a04e-4083" type="selectionEntryGroup" />
+        <entryLink id="a751-60f0-d0f4-0e16" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
     <entryLink id="a711-3e30-4de4-5c1a" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d6af-1e3f-a1a4-deed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f0d6-fbf4-dd3b-4926" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="d6af-1e3f-a1a4-deed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f0d6-fbf4-dd3b-4926" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="8c4d-d20e-d169-1756" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a965-3add-803c-845f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="549d-595d-f03c-154d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a965-3add-803c-845f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="549d-595d-f03c-154d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
     <entryLink id="2070-75a6-12ee-94f0" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="bcf3-bf62-984f-18de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a45d-a217-4962-d996" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="bcf3-bf62-984f-18de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a45d-a217-4962-d996" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="32ad-9202-9b03-78a7" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3508-578d-1989-b668" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="f6b3-baeb-7c6f-9eab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3508-578d-1989-b668" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="f6b3-baeb-7c6f-9eab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
     <entryLink id="7ebb-53ec-28b5-3604" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="45f5-eb3e-97b1-a108" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="61f9-bd09-10a9-6164" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="45f5-eb3e-97b1-a108" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="61f9-bd09-10a9-6164" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
     <entryLink id="7293-7085-dc21-7370" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8ce8-581e-2a58-fed8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="adb1-991b-519a-af6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8ce8-581e-2a58-fed8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="adb1-991b-519a-af6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
     <entryLink id="b371-f3c9-6eb2-3dd3" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8e12-c52d-5855-dadc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c362-6c9a-e82c-1296" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="8e12-c52d-5855-dadc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c362-6c9a-e82c-1296" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
     <entryLink id="f408-e0fb-e72e-e526" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0a26-0757-21d6-a9db" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="c74f-4c14-e13e-4d31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0a26-0757-21d6-a9db" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="c74f-4c14-e13e-4d31" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
     <entryLink id="a1ed-5756-fb2e-6a18" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2fdb-209d-fa17-02f7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a445-8a9e-4a09-6cfa" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="2fdb-209d-fa17-02f7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a445-8a9e-4a09-6cfa" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
     <entryLink id="56bb-64e6-8627-a145" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="908a-c0b8-be38-3920" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7092-f0e3-02f8-0d23" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="908a-c0b8-be38-3920" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7092-f0e3-02f8-0d23" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
     <entryLink id="0caf-045b-8cd0-c94c" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="cf47-b843-1960-e1ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fcf1-b943-59d3-513d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="cf47-b843-1960-e1ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="fcf1-b943-59d3-513d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
     <entryLink id="8973-a386-43fa-97d8" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6e1c-076f-f95e-4ae7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="195f-5e59-9b5c-1bdf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6e1c-076f-f95e-4ae7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="195f-5e59-9b5c-1bdf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
     <entryLink id="2def-48f3-6417-cace" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6290-20b4-083b-5cf7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="be31-9700-d4b9-a0f1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6290-20b4-083b-5cf7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="be31-9700-d4b9-a0f1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="ee92-4ac2-994a-43d7" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="99fb-f163-58ab-81cc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9930-25f4-58a6-b2fd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="99fb-f163-58ab-81cc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9930-25f4-58a6-b2fd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
     <entryLink id="6e96-96fd-4be3-8e76" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="29cd-a8a7-4f5e-ce1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ede2-3243-6027-1fd7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="29cd-a8a7-4f5e-ce1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ede2-3243-6027-1fd7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="4d6a-b0fb-7f4b-c4d6" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3203-43fb-b4fd-26a1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="e512-7ba4-7da2-1159" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3203-43fb-b4fd-26a1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="e512-7ba4-7da2-1159" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
     <entryLink id="af65-340c-7fa4-7254" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3e3f-ed6c-199d-0b91" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="f3ed-64f9-6799-8a96" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3e3f-ed6c-199d-0b91" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="f3ed-64f9-6799-8a96" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
     <entryLink id="7305-4db8-7bc3-792c" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="58da-27bf-f569-3210" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="8bd7-6af2-4c71-c636" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="58da-27bf-f569-3210" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="8bd7-6af2-4c71-c636" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
     <entryLink id="7da1-87b2-aefc-4592" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b497-4f8c-5c04-6cf2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="774f-58a1-9733-b996" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="1d56-2f12-584e-663a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="b497-4f8c-5c04-6cf2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="774f-58a1-9733-b996" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="1d56-2f12-584e-663a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="41bd-40e9-7987-8136" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8133-a261-5383-b127" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d37b-2a08-bba2-5e7f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="8133-a261-5383-b127" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d37b-2a08-bba2-5e7f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
     <entryLink id="c89a-902f-2ea0-3bcd" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8cb2-e427-0e3e-a31d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="c89f-9ad3-baf7-4829" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8cb2-e427-0e3e-a31d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="c89f-9ad3-baf7-4829" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
     <entryLink id="3b5c-00f2-c9de-4b28" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5ee9-c79e-6d35-c266" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="41e8-79b6-2e17-75a2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="5ee9-c79e-6d35-c266" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="41e8-79b6-2e17-75a2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
     <entryLink id="437a-002e-2e3e-df00" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="da0d-7c3e-9491-1ce6" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="7f54-5e82-6421-4321" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="da0d-7c3e-9491-1ce6" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="7f54-5e82-6421-4321" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="3505-9023-0edf-26f0" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ae47-4313-8d1e-df9e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="a8c6-b2b9-23ac-b90b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ae47-4313-8d1e-df9e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="a8c6-b2b9-23ac-b90b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
     <entryLink id="33c1-628d-e7c8-122c" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="12bb-b57a-1b47-aeb9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="23af-e0b7-0f11-5732" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="12bb-b57a-1b47-aeb9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="23af-e0b7-0f11-5732" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="ec3e-c95c-6b3c-2986" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fb0a-d43b-568b-cae7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="42b1-280f-30fb-b5d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fb0a-d43b-568b-cae7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="42b1-280f-30fb-b5d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
     <entryLink id="8499-9821-d3c3-8376" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="63c1-57f6-4612-25dd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="8f5a-adda-a50e-46b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="63c1-57f6-4612-25dd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="8f5a-adda-a50e-46b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
     <entryLink id="daed-8aa8-5696-793c" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0161-52ea-cd43-0594" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="b736-29d3-6891-a62a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0161-52ea-cd43-0594" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="b736-29d3-6891-a62a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
     <entryLink id="b61b-8de4-1f2f-3904" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="09af-ccd7-cf50-09b0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="9bcb-3b7a-7d70-4bd3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="09af-ccd7-cf50-09b0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="9bcb-3b7a-7d70-4bd3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
     <entryLink id="0437-2483-6195-95b4" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8d20-10a7-154c-d709" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d6e5-e06e-f886-0f93" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="963a-9da7-a6d9-5065" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="8d20-10a7-154c-d709" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d6e5-e06e-f886-0f93" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
+        <categoryLink id="963a-9da7-a6d9-5065" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="3409-9cde-1f7f-ae8a" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e46e-5f43-8d3d-5df1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4d7a-a1a9-127b-2f50" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="e46e-5f43-8d3d-5df1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4d7a-a1a9-127b-2f50" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
     <entryLink id="7e31-d570-5037-30b8" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="68c2-d472-516b-4717" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="bce7-c5b0-6408-5f19" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="68c2-d472-516b-4717" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="bce7-c5b0-6408-5f19" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
     <entryLink id="10fe-3e6c-5b96-572c" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7c67-54c3-2b77-82a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="aa89-9558-c12c-b5a8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="7c67-54c3-2b77-82a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="aa89-9558-c12c-b5a8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
     <entryLink id="ccb6-6158-d584-caa2" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5e69-9953-b8f4-f238" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9191-0da6-7ced-eb9b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="5e69-9953-b8f4-f238" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9191-0da6-7ced-eb9b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="5be0-17a1-bb08-670f" name="Moritat-Prime Kaedes Nex" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="1bd3-f8f0-d234-1ecf" name="Ill-omened" hidden="false">
-          <description>Moritat-Prime Kaedes Nex may not be taken as a Compulsory HQ choice, only as a non-Compulsory HQ choice. He may never be an army’s Warlord, and may not join other units except Legion Seeker Squads or Mor Deythan Squads.</description>
+          <description>Moritat-Prime Kaedes Nex may not be taken as a Compulsory HQ choice, only as a non-Compulsory HQ choice. He may never be an army&#8217;s Warlord, and may not join other units except Legion Seeker Squads or Mor Deythan Squads.</description>
         </rule>
         <rule id="1dae-23f1-96b3-6901" name="The Blood Crow" hidden="false">
           <description>When Moritat-Prime Kaedes Nex makes any attacks as part of a Shooting Attack, the range of any weapons is not restricted or affected by the Night Fighting rules, shroud bombs or any other special rule. In addition, Moritat-Prime Kaedes Nex never suffers any penalty to his Ballistic Skill from Night Fighting or any other special rules, always makes To Hit rolls using his full Ballistic Skill (including Snap Shots) and no model may make Shrouded rolls to negate Wounds inflicted by their  attacks.</description>
         </rule>
         <rule id="9bc5-768f-e23a-aa16" name="Relentless Stalker" hidden="false">
-          <description>When deploying Moritat-Prime Kaedes Nex onto the battlefield at the start of the battle, the controlling player may place him in any position on the battlefield, as long as Moritat-Prime Kaedes Nex is within Area Terrain, or at least 9&quot; from any enemy model if Moritat-Prime Kaedes Nex is not within Area Terrain, regardless of the line of sight of enemy models. If Moritat-Prime Kaedes Nex is deployed from Reserve after the start of the first turn, then he may enter play from any point on the battlefield’s edge, chosen by the controlling player. If Moritat-Prime Kaedes Nex joins a unit during deployment or whilst in Reserves and is deployed as part of that unit, he may not use any of the benefits of this special rule, but instead gains the Scout and Infiltrate special rules only if the unit he has joined also possesses those special rules.</description>
+          <description>When deploying Moritat-Prime Kaedes Nex onto the battlefield at the start of the battle, the controlling player may place him in any position on the battlefield, as long as Moritat-Prime Kaedes Nex is within Area Terrain, or at least 9" from any enemy model if Moritat-Prime Kaedes Nex is not within Area Terrain, regardless of the line of sight of enemy models. If Moritat-Prime Kaedes Nex is deployed from Reserve after the start of the first turn, then he may enter play from any point on the battlefield&#8217;s edge, chosen by the controlling player. If Moritat-Prime Kaedes Nex joins a unit during deployment or whilst in Reserves and is deployed as part of that unit, he may not use any of the benefits of this special rule, but instead gains the Scout and Infiltrate special rules only if the unit he has joined also possesses those special rules.</description>
         </rule>
         <rule id="71bb-eae6-a30b-f6e7" name="Moritat-Prime Kaedes Nex" hidden="false">
           <description>*Moritat-Prime Kaedes Nex gains the Falcons special rule and no other rules from the Shadow and Fury clause of the Legiones Astartes (Raven Guard) special rule, ignoring the usual requirements for gaining that rule.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="d3b0-bade-3cd1-8209" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="d3b0-bade-3cd1-8209" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
         <infoLink id="8126-35df-6e38-8928" name="Rampage (X)" hidden="false" targetId="3efb-2a2c-2d0b-92fc" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Rampage (3)"/>
+            <modifier type="set" field="name" value="Rampage (3)" />
           </modifiers>
         </infoLink>
         <infoLink id="f88b-223f-d2ee-2c83" name="Sudden Strike (X)" hidden="false" targetId="58b3-7d84-b92d-1363" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Sudden Strike (1)"/>
+            <modifier type="set" field="name" value="Sudden Strike (1)" />
           </modifiers>
         </infoLink>
         <infoLink id="7ce2-9d41-128b-ed58" name="Shrouded (X)" hidden="false" targetId="10c3-fdb0-089f-ca65" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Shrouded (5+)"/>
+            <modifier type="set" field="name" value="Shrouded (5+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="5f03-968d-7f7b-976c" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule"/>
-        <infoLink id="6d1d-134b-6029-5438" name="Pathfinder" hidden="false" targetId="ec97-7aa8-49f5-b298" type="rule"/>
+        <infoLink id="5f03-968d-7f7b-976c" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule" />
+        <infoLink id="6d1d-134b-6029-5438" name="Pathfinder" hidden="false" targetId="ec97-7aa8-49f5-b298" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="385b-e811-018a-cd64" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="d770-1c5b-320d-4c12" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="21b2-c021-325e-d0b3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="74fd-26f0-cda4-cd6b" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="385b-e811-018a-cd64" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="d770-1c5b-320d-4c12" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="21b2-c021-325e-d0b3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="74fd-26f0-cda4-cd6b" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6abf-622b-dee3-f98e" name="Moritat-Prime Kaedes Nex" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f85-5dc2-cefc-d51b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="836e-1630-be8c-7a4f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f85-5dc2-cefc-d51b" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="836e-1630-be8c-7a4f" type="min" />
           </constraints>
           <profiles>
             <profile id="f69d-3530-523e-8121" name="Moritat-Prime Kaedes Nex" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -1078,18 +1077,18 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="9054-a4c3-8387-4c76" name="Fulcrim Hand Cannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efcb-ced6-3587-451d" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6641-430b-86f4-ea84" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efcb-ced6-3587-451d" type="max" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6641-430b-86f4-ea84" type="min" />
           </constraints>
           <profiles>
             <profile id="b620-0e76-f6ab-4a7e" name="Pinpoint Strike" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">24"</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 1, Brutal (2), Concussive (1), Pinning, Sniper</characteristic>
@@ -1097,7 +1096,7 @@
             </profile>
             <profile id="66e9-5b6a-70a2-c7f9" name="Empty the Chambers" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">12"</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 6, Concussive (1), Pinning</characteristic>
@@ -1113,80 +1112,80 @@
             </profile>
             <profile id="e67f-453c-7cb4-82ad" name="Fulcrim Hand Cannon" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
               <characteristics>
-                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Fulcrum hand cannon are ‘Auto’ weapons for special rules that affect such weapons, and possess multiple profiles. When making a Shooting Attack the controlling player must select either Pinpoint Strike or Empty the Chambers and makes all attacks with both weapons using the same profile. In close assault the Point-blank profile must be used instead (note that in melee Moritat-Prime Kaedes Nex fighting with his Fulcrum hand cannon counts as having two weapons and gains the appropriate bonuses).</characteristic>
+                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Fulcrum hand cannon are &#8216;Auto&#8217; weapons for special rules that affect such weapons, and possess multiple profiles. When making a Shooting Attack the controlling player must select either Pinpoint Strike or Empty the Chambers and makes all attacks with both weapons using the same profile. In close assault the Point-blank profile must be used instead (note that in melee Moritat-Prime Kaedes Nex fighting with his Fulcrum hand cannon counts as having two weapons and gains the appropriate bonuses).</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <infoLinks>
             <infoLink id="b272-cecf-8df9-0d7e" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Brutal (2)"/>
+                <modifier type="set" field="name" value="Brutal (2)" />
               </modifiers>
             </infoLink>
             <infoLink id="8afe-33ac-067e-e297" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Concussive (1)"/>
+                <modifier type="set" field="name" value="Concussive (1)" />
               </modifiers>
             </infoLink>
-            <infoLink id="dde8-4dff-85b6-89ad" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
-            <infoLink id="c04f-f36f-b0c1-79c5" name="Sniper" hidden="false" targetId="9cd8-e726-5dbe-b106" type="rule"/>
+            <infoLink id="dde8-4dff-85b6-89ad" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule" />
+            <infoLink id="c04f-f36f-b0c1-79c5" name="Sniper" hidden="false" targetId="9cd8-e726-5dbe-b106" type="rule" />
             <infoLink id="bd1b-2c71-aeaf-1a32" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Precision Strikes (4+)"/>
+                <modifier type="set" field="name" value="Precision Strikes (4+)" />
               </modifiers>
             </infoLink>
-            <infoLink id="5302-e885-f90b-f64f" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
+            <infoLink id="5302-e885-f90b-f64f" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="969e-db81-f9a2-f3aa" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d75-aa12-4b59-981e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98c0-111c-1be9-f99a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d75-aa12-4b59-981e" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98c0-111c-1be9-f99a" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="cd07-b7ce-87fe-fee5" name="Shroud Bombs" hidden="false" collective="false" import="true" targetId="5d4d-36b7-6bf5-fc92" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da61-3c04-bc98-77e9" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b26b-7c40-6fd5-3cb6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da61-3c04-bc98-77e9" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b26b-7c40-6fd5-3cb6" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="3c7d-0bfb-4659-8923" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3501-201a-7425-4932" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39ec-7c1a-0b6b-7bfe" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3501-201a-7425-4932" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39ec-7c1a-0b6b-7bfe" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="ae64-aacb-dabe-01f5" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2816-8b64-7545-4531" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32b3-6dd2-b6b4-02d6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2816-8b64-7545-4531" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32b3-6dd2-b6b4-02d6" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="165.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="165.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="8ff5-cece-0fc2-100d" name="Corvus Corax" publicationId="817a-6288-e016-7469" page="333" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="856f-4cc1-a5a8-0459" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
+        <infoLink id="856f-4cc1-a5a8-0459" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="afca-b635-70d0-d41f" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="d718-986e-82a3-6418" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
-        <categoryLink id="077f-e8dd-5f24-86e9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="26ee-c51c-b946-63f4" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="afca-b635-70d0-d41f" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="d718-986e-82a3-6418" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false" />
+        <categoryLink id="077f-e8dd-5f24-86e9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="26ee-c51c-b946-63f4" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9115-3297-32da-6ac4" name="Corvus Corax" publicationId="817a-6288-e016-7469" page="333" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="878e-3ec0-da5b-5dc5" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38cd-ccde-cd3c-3d32" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="878e-3ec0-da5b-5dc5" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38cd-ccde-cd3c-3d32" type="max" />
           </constraints>
           <profiles>
             <profile id="7b16-c282-f509-3df6" name="Corvus Corax" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -1206,21 +1205,21 @@
             </profile>
           </profiles>
           <rules>
-            <rule id="1654-4021-8098-0327" name="The Shadowed Lord" hidden="false"/>
+            <rule id="1654-4021-8098-0327" name="The Shadowed Lord" hidden="false" />
           </rules>
           <infoLinks>
-            <infoLink id="da1b-f556-115f-cf7f" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
-            <infoLink id="b059-c4fd-b551-974c" name="Hit &amp; Run" hidden="false" targetId="5986-e960-d432-affd" type="rule"/>
+            <infoLink id="da1b-f556-115f-cf7f" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule" />
+            <infoLink id="b059-c4fd-b551-974c" name="Hit &amp; Run" hidden="false" targetId="5986-e960-d432-affd" type="rule" />
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="649c-ef41-8515-b223" name="Wrath &amp; Justice" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d154-5815-a414-caa0" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d154-5815-a414-caa0" type="min" />
               </constraints>
               <profiles>
                 <profile id="2dfd-0149-bd53-3475" name="Wrath &amp; Justice" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">12"</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
                     <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 1, Rending (3+), Deflagerate, Master-crafted</characteristic>
@@ -1230,36 +1229,36 @@
               <infoLinks>
                 <infoLink id="447d-19b6-6687-cce1" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Rending (3+)"/>
+                    <modifier type="set" field="name" value="Rending (3+)" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="b84f-2aee-0953-41f0" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
-                <infoLink id="6500-b042-c13e-55cb" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="b84f-2aee-0953-41f0" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule" />
+                <infoLink id="6500-b042-c13e-55cb" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="e894-54fb-38f5-69b0" name="The Korvidine Pinions" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1331-43e0-d6ef-9fb9" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1331-43e0-d6ef-9fb9" type="min" />
               </constraints>
               <profiles>
                 <profile id="0362-6ce2-ba25-111b" name="The Korvidine Pinions" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
                   <characteristics>
-                    <characteristic name="Description" typeId="347e-ee4a-764f-6be3">At the start of the controlling player&apos;s Movement phase, or when deployed as part of a Deep Strike Assault Corvus Corax’s Movement Characteristic may be set to a value of 14 for the duration of the controlling player’s turn (referred to as ‘activating’ this special rule). This allows Corvus Corax to move up to 14&quot;, regardless of the Movement Characteristic shown on his profile and gain any other benefits of a Movement Characteristic of 14 (including the bonus to Charge Distance). In addition, Corvus Corax may move over Impassable Terrain, vertical terrain or friendly and enemy models or units without penalty on any turn in which the Korvidine Pinions have been activated, but may not end his movement in Impassable Terrain or within 1&quot; of any model from a unit Corvus Corax is not part of. If Corvus Corax ends or begins his movement or a Charge in Dangerous Terrain during any turn in which the Korvidine Pinions have been activated, he automatically passes any Dangerous Terrain tests he is called upon to make.
+                    <characteristic name="Description" typeId="347e-ee4a-764f-6be3">At the start of the controlling player's Movement phase, or when deployed as part of a Deep Strike Assault Corvus Corax&#8217;s Movement Characteristic may be set to a value of 14 for the duration of the controlling player&#8217;s turn (referred to as &#8216;activating&#8217; this special rule). This allows Corvus Corax to move up to 14", regardless of the Movement Characteristic shown on his profile and gain any other benefits of a Movement Characteristic of 14 (including the bonus to Charge Distance). In addition, Corvus Corax may move over Impassable Terrain, vertical terrain or friendly and enemy models or units without penalty on any turn in which the Korvidine Pinions have been activated, but may not end his movement in Impassable Terrain or within 1" of any model from a unit Corvus Corax is not part of. If Corvus Corax ends or begins his movement or a Charge in Dangerous Terrain during any turn in which the Korvidine Pinions have been activated, he automatically passes any Dangerous Terrain tests he is called upon to make.
 				
-Corvus Corax may still Run on a turn when the Korvidine Pinions have been activated. When making a Run move after having activated the Korvidine Pinions, add Corvus Corax’s Initiative Characteristic to 14 to determine how far he may move – ignoring terrain and other models while making a Run move with the Korvidine Pinions activated as noted above, but may not make Shooting Attacks or declare a Charge in the same turn in which Corvus Corax has Run as per the normal rules for Running. The Korvidine Pinions may not be activated to gain any bonus to Corvus Corax&apos;s Movement Characteristic during a Reaction. </characteristic>
+Corvus Corax may still Run on a turn when the Korvidine Pinions have been activated. When making a Run move after having activated the Korvidine Pinions, add Corvus Corax&#8217;s Initiative Characteristic to 14 to determine how far he may move &#8211; ignoring terrain and other models while making a Run move with the Korvidine Pinions activated as noted above, but may not make Shooting Attacks or declare a Charge in the same turn in which Corvus Corax has Run as per the normal rules for Running. The Korvidine Pinions may not be activated to gain any bonus to Corvus Corax's Movement Characteristic during a Reaction. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="56b6-1d03-b986-e52f" name="The Panoply of the Raven Guard" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e332-b7d6-6683-1e27" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e332-b7d6-6683-1e27" type="min" />
               </constraints>
               <profiles>
                 <profile id="141a-969f-0c80-b168" name="The Panoply of the Raven Guard" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1272,20 +1271,20 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
                 </profile>
               </profiles>
               <rules>
-                <rule id="0504-ce14-8f28-9d3a" name="Fighting Style" hidden="false"/>
+                <rule id="0504-ce14-8f28-9d3a" name="Fighting Style" hidden="false" />
               </rules>
               <infoLinks>
-                <infoLink id="66b8-eebc-976b-aa09" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
-                <infoLink id="c2b1-4bb2-9e6d-0d39" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule"/>
-                <infoLink id="d1fd-45c5-7523-44a6" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+                <infoLink id="66b8-eebc-976b-aa09" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
+                <infoLink id="c2b1-4bb2-9e6d-0d39" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule" />
+                <infoLink id="d1fd-45c5-7523-44a6" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="e38c-dc86-fae8-eeaa" name="The Sable Armour" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2238-f958-d38b-b12f" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2238-f958-d38b-b12f" type="min" />
               </constraints>
               <profiles>
                 <profile id="651f-a8f4-5203-2d16" name="The Sable Armour" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
@@ -1295,78 +1294,78 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="9aca-25f9-591b-7fe1" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08a9-28c2-729e-930a" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b8e-9366-86e6-18d8" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08a9-28c2-729e-930a" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b8e-9366-86e6-18d8" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="3232-8111-0d3d-ed8b" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5be4-3528-736e-7a49" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43a2-231a-aeb5-b5d1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5be4-3528-736e-7a49" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43a2-231a-aeb5-b5d1" type="min" />
           </constraints>
           <profiles>
             <profile id="c1d1-51ed-2d12-3103" name="Sire of the Raven Guard" publicationId="817a-6288-e016-7469" page="332" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All models with the Legiones Astarts (Raven Guard) special rule and either the Infantry or Cavalry Unit Types in the same army as Corvus Corax gain the Scout and Crusader special rules. In addition, an army with Corvus Corax gains an additional Reaction in the opposing player&apos;s Movement phase as long as Corvus Corax has not been removed as a casualty. </characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All models with the Legiones Astarts (Raven Guard) special rule and either the Infantry or Cavalry Unit Types in the same army as Corvus Corax gain the Scout and Crusader special rules. In addition, an army with Corvus Corax gains an additional Reaction in the opposing player's Movement phase as long as Corvus Corax has not been removed as a casualty. </characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
         <entryLink id="e272-ab7e-26cd-a078" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff2b-51b9-13da-fbfd" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c205-b37a-4a6e-7463" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff2b-51b9-13da-fbfd" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c205-b37a-4a6e-7463" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="440.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="440.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="c268-08ac-5b90-d034" name="Mor Deythan Squad" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="8cb7-e948-d123-218e" name="Fatal Strike" hidden="false">
-          <description>Once per battle, a unit that includes any models with this special rule may declare a Fatal Strike at the start of any of the controlling player&apos;s Shooting Phases. For the duration of that Phase, the Shooting Attacks of all models in the unit with the Fatal Strike special rule gain the Rending (4+) special rule in addition to any other effct their weapons might have. This does not replace or improve any other versions of the Rending (X) special rule already possessed by the unit and ma not be used when attacking with weapons that have either the Template or the Blast (X) special rules.</description>
+          <description>Once per battle, a unit that includes any models with this special rule may declare a Fatal Strike at the start of any of the controlling player's Shooting Phases. For the duration of that Phase, the Shooting Attacks of all models in the unit with the Fatal Strike special rule gain the Rending (4+) special rule in addition to any other effct their weapons might have. This does not replace or improve any other versions of the Rending (X) special rule already possessed by the unit and ma not be used when attacking with weapons that have either the Template or the Blast (X) special rules.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="e4fd-5375-722c-1c23" name="Legiones Astartes (Raven Guard) " hidden="false" targetId="9924-9434-baa1-0894" type="rule"/>
-        <infoLink id="5ab3-8bc8-c517-74c8" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="c894-4d1b-4c4a-8201" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
+        <infoLink id="e4fd-5375-722c-1c23" name="Legiones Astartes (Raven Guard) " hidden="false" targetId="9924-9434-baa1-0894" type="rule" />
+        <infoLink id="5ab3-8bc8-c517-74c8" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="c894-4d1b-4c4a-8201" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9bde-6d45-2c6d-9437" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="9b5d-cc1c-07cf-48a2" name="Skirmish:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
-        <categoryLink id="af53-7c6c-7d0b-18f1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="9bde-6d45-2c6d-9437" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="9b5d-cc1c-07cf-48a2" name="Skirmish:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false" />
+        <categoryLink id="af53-7c6c-7d0b-18f1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="916e-4d5b-da33-1735" name="Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb69-1f8d-29e8-0d97" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb69-1f8d-29e8-0d97" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="acbb-746b-c25c-b7a0" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry"/>
-            <entryLink id="aae2-c86e-309f-8a14" name="Storm Eagle Gunship" hidden="false" collective="false" import="true" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"/>
+            <entryLink id="acbb-746b-c25c-b7a0" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry" />
+            <entryLink id="aae2-c86e-309f-8a14" name="Storm Eagle Gunship" hidden="false" collective="false" import="true" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="3042-c514-6b16-0c3c" name="1) Mor Deythan Shade" hidden="false" collective="false" import="true" defaultSelectionEntryId="0554-c445-7a20-b683">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ee2-b54b-90e4-7fdc" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88e8-53eb-be4d-0bb4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ee2-b54b-90e4-7fdc" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88e8-53eb-be4d-0bb4" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="0554-c445-7a20-b683" name=" Mor Deythan Shade" hidden="false" collective="false" import="true" type="model">
@@ -1374,7 +1373,7 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
                 <profile id="f720-cd2b-5c7f-2ad4" name="Mor Deythan Shade" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish, Character)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1392,122 +1391,122 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
                   <entryLinks>
                     <entryLink id="0e43-9317-adcb-f2ba" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97bc-09df-c163-5655" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97bc-09df-c163-5655" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="9d65-94ea-b062-9e1a" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c85-09e3-d3aa-5d15" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c85-09e3-d3aa-5d15" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="99ea-f5da-7c8b-6587" name="Infravisor" hidden="false" collective="false" import="true" targetId="bc5b-fcd7-aeed-e97c" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2900-8ebf-36b5-8ada" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2900-8ebf-36b5-8ada" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="72fd-05c0-1602-f825" name="1) Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="e526-830c-c7f3-c95d">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aa91-6a70-712f-3fae" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2900-d47d-ec12-92e5" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aa91-6a70-712f-3fae" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2900-d47d-ec12-92e5" type="min" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="e526-830c-c7f3-c95d" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+                    <entryLink id="e526-830c-c7f3-c95d" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
                     <entryLink id="7372-8588-266b-ae45" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="daa9-ecfa-a9a6-9607" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="faf2-9225-daf8-ab1f" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="9fbe-4ae9-974c-84a9" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="b083-e487-f39b-a068" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="5e50-ae0b-4dfb-96cd" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="d071-e1f8-8cdd-2611" name="2) Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="8815-a6e5-e85c-553d">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4eb1-3fe7-bd3e-7c6a" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f27d-ea96-7e89-5de8" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4eb1-3fe7-bd3e-7c6a" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f27d-ea96-7e89-5de8" type="min" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="8815-a6e5-e85c-553d" name="Astartes Shotgun" hidden="false" collective="false" import="true" targetId="6f79-5cf4-a689-7269" type="selectionEntry"/>
+                    <entryLink id="8815-a6e5-e85c-553d" name="Astartes Shotgun" hidden="false" collective="false" import="true" targetId="6f79-5cf4-a689-7269" type="selectionEntry" />
                     <entryLink id="d708-3720-0240-b7cb" name="Nemesis Bolter" hidden="false" collective="false" import="true" targetId="c10a-61f8-9c33-fe8a" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="d9c9-d33c-c942-ff68" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="fabe-b648-5f72-f897" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="c727-ff3f-d642-23a8" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="0774-57b1-3129-535e" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="a3ce-d1e5-a590-5f86" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="2851-3859-0740-a416" name=" Mor Deythan Shade w/Special Weapon" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8147-b0c0-e12f-3153" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8147-b0c0-e12f-3153" type="max" />
               </constraints>
               <profiles>
                 <profile id="0dde-2e01-49d4-75c8" name="Mor Deythan Shade" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish, Character)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1525,129 +1524,129 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
                   <entryLinks>
                     <entryLink id="deb2-9ee3-9670-7177" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6078-928b-d85f-a077" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6078-928b-d85f-a077" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="5b10-398e-0c42-ace5" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32d8-5d5d-3af3-7e4c" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32d8-5d5d-3af3-7e4c" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="be35-5599-11a4-3964" name="Infravisor" hidden="false" collective="false" import="true" targetId="bc5b-fcd7-aeed-e97c" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e659-1f0d-1bd6-7a2d" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e659-1f0d-1bd6-7a2d" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="5c31-54d4-3b42-e172" name="1) Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="ecdf-f696-4cd1-66aa">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="11c6-f6b4-b31f-2892" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a8ed-a885-d5cc-99c8" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="11c6-f6b4-b31f-2892" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a8ed-a885-d5cc-99c8" type="min" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="ecdf-f696-4cd1-66aa" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+                    <entryLink id="ecdf-f696-4cd1-66aa" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
                     <entryLink id="3171-ad20-1489-546f" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="1fb0-3bb0-3baf-2349" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="011c-6597-3a81-6ca6" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="5761-6d5b-20fb-9726" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="9331-27c6-4cc8-5672" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="1ca5-2f0e-38f8-5016" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="181c-65da-fdd8-3db0" name="2) Special Weapon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="54d4-565f-f961-c268">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2a7-187d-ef88-c962" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9770-7de1-1872-7536" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2a7-187d-ef88-c962" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9770-7de1-1872-7536" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="f888-caec-e923-00b5" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="54d4-565f-f961-c268" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="d0ab-604c-8d16-05cd" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="323f-76db-dbb6-fb86" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="8bbc-786b-c02d-3ad0" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="62cf-f7df-33d6-7412" name="Missile Launcher w/Frag &amp; Krak Missiles" hidden="false" collective="false" import="true" targetId="536a-06f1-e49b-8c6b" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="2c98-afb9-b091-cb16" name="2) Mor Deythan" hidden="false" collective="false" import="true" defaultSelectionEntryId="b06e-820e-501a-bd12">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35e1-8483-dd05-a171" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25d5-418a-c82e-dbc0" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35e1-8483-dd05-a171" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25d5-418a-c82e-dbc0" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="b06e-820e-501a-bd12" name="Mor Deythan" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ef6-e751-92ff-73d7" type="max"/>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ef6-e751-92ff-73d7" type="max" />
               </constraints>
               <profiles>
                 <profile id="9e9b-1562-811d-d0bf" name="Mor Deythan" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skrimish)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1663,108 +1662,108 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
               <selectionEntryGroups>
                 <selectionEntryGroup id="e66e-5b03-2677-0bbd" name="1) Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="637f-5541-fc5c-27c3">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="060a-e811-b637-f1df" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="979d-24d7-95cf-ab21" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="060a-e811-b637-f1df" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="979d-24d7-95cf-ab21" type="min" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="637f-5541-fc5c-27c3" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+                    <entryLink id="637f-5541-fc5c-27c3" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
                     <entryLink id="dbf3-4dfc-3c49-4d6c" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="fd5d-381a-186b-58e8" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="104b-567c-ee10-e1d3" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="1886-e2be-cd12-b49b" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="b1fe-594f-b783-e0b5" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="0119-c44c-ed0a-44ce" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="aa8b-bcc0-67d5-b57e" name="2) Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="abe4-fc80-0aa4-b098">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f4e-5059-2ba4-bcb1" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae17-c0b6-2f78-4cf4" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f4e-5059-2ba4-bcb1" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae17-c0b6-2f78-4cf4" type="min" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="abe4-fc80-0aa4-b098" name="Astartes Shotgun" hidden="false" collective="false" import="true" targetId="6f79-5cf4-a689-7269" type="selectionEntry"/>
+                    <entryLink id="abe4-fc80-0aa4-b098" name="Astartes Shotgun" hidden="false" collective="false" import="true" targetId="6f79-5cf4-a689-7269" type="selectionEntry" />
                     <entryLink id="4c6b-26ee-11a0-431e" name="Nemesis Bolter" hidden="false" collective="false" import="true" targetId="c10a-61f8-9c33-fe8a" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="78df-9a2a-3a1c-a3a8" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="c7d2-56b7-f033-486e" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="cb18-f7d4-489f-c440" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="508c-e3ac-fc41-dbcf" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="e147-e904-c5a0-eb05" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="e2db-b3b2-e938-62c5" name="Mor Deythan w/Special Weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="ddc9-1a20-756e-8230" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="c268-08ac-5b90-d034" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="c268-08ac-5b90-d034" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
                 <modifier type="decrement" field="ddc9-1a20-756e-8230" value="1.0">
                   <conditions>
-                    <condition field="selections" scope="c268-08ac-5b90-d034" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2851-3859-0740-a416" type="greaterThan"/>
+                    <condition field="selections" scope="c268-08ac-5b90-d034" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2851-3859-0740-a416" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddc9-1a20-756e-8230" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddc9-1a20-756e-8230" type="max" />
               </constraints>
               <profiles>
                 <profile id="573e-66b0-7d0a-970a" name="Mor Deythan" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skrimish)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1780,84 +1779,84 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
               <selectionEntryGroups>
                 <selectionEntryGroup id="7f6e-1e2c-8020-8ca8" name="1) Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="2f4b-076d-a4a2-cac3">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dac8-2310-b85b-9827" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c68a-394a-0527-3900" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dac8-2310-b85b-9827" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c68a-394a-0527-3900" type="min" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="2f4b-076d-a4a2-cac3" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+                    <entryLink id="2f4b-076d-a4a2-cac3" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
                     <entryLink id="0e22-481b-9be8-9c7a" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="fc48-f0f9-53e3-a28e" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="9cf2-067f-e7d2-4669" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="795f-6d48-d0ee-c06f" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="294b-2b26-17c1-9133" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="b1bd-1214-21dc-bde5" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="4bb1-a763-c1cc-b26c" name="2) Special Weapon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="fd1d-1afa-6c7a-72cf">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6353-116e-3ba3-4980" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e1a-4adf-c33b-05a4" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6353-116e-3ba3-4980" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e1a-4adf-c33b-05a4" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="dd7e-5530-cfcc-8bd5" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="fd1d-1afa-6c7a-72cf" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="8825-0bb1-d542-9c1c" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="6a19-e114-5249-337d" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="85d0-94fa-fb26-9b4e" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="327f-eb06-a9d7-28b2" name="Missile Launcher w/Frag &amp; Krak Missiles" hidden="false" collective="false" import="true" targetId="536a-06f1-e49b-8c6b" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1866,69 +1865,69 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
       <entryLinks>
         <entryLink id="df9c-c705-5389-db51" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d06c-91eb-05bc-071f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7d8-3e38-2864-fd94" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d06c-91eb-05bc-071f" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7d8-3e38-2864-fd94" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="7e57-7a64-514f-7047" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c95-1800-c4e6-0fcc" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e43-fdfa-1ae2-c588" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c95-1800-c4e6-0fcc" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e43-fdfa-1ae2-c588" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="f26d-ea3b-b507-7ac0" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c920-75c2-6037-582c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3921-1af2-450d-6cdf" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c920-75c2-6037-582c" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3921-1af2-450d-6cdf" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="2c74-84d8-018c-3ca9" name="Shroud Bombs" hidden="false" collective="false" import="true" targetId="5d4d-36b7-6bf5-fc92" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="589c-0f82-5b88-4faf" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ca3-c1c2-e33c-5cdf" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="589c-0f82-5b88-4faf" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ca3-c1c2-e33c-5cdf" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="a51b-cfeb-3a0b-9183" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41f2-d19e-99a1-2f92" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34da-b29e-f77e-cd1e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41f2-d19e-99a1-2f92" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34da-b29e-f77e-cd1e" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="58f4-3d8d-f243-6e5d" name="Dark Furies" publicationId="817a-6288-e016-7469" page="335" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="e4fb-b184-bf79-1e28" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Precision Strikes (6+)"/>
+            <modifier type="set" field="name" value="Precision Strikes (6+)" />
           </modifiers>
         </infoLink>
         <infoLink id="61d4-549c-05c6-b42d" name="Sudden Strike (X)" hidden="false" targetId="58b3-7d84-b92d-1363" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Sudden Strike (1)"/>
+            <modifier type="set" field="name" value="Sudden Strike (1)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="cf6d-8fba-9f4c-c28b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="ead3-4b26-1019-2b19" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
-        <categoryLink id="675d-d44e-ad5b-cebe" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="cf6d-8fba-9f4c-c28b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="ead3-4b26-1019-2b19" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false" />
+        <categoryLink id="675d-d44e-ad5b-cebe" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c1bd-12eb-7627-28f3" name="Dark Furies" hidden="false" collective="false" import="true" type="model">
           <modifiers>
             <modifier type="decrement" field="795b-3016-56c8-2406" value="1.0">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a454-113e-f900-cee3" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a454-113e-f900-cee3" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="795b-3016-56c8-2406" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0803-ddf2-6673-77d1" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="795b-3016-56c8-2406" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0803-ddf2-6673-77d1" type="min" />
           </constraints>
           <profiles>
             <profile id="b6c5-bafa-afe9-2006" name="Dark Fury" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -1948,23 +1947,23 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="e5b4-b19c-5d57-0059" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+            <infoLink id="e5b4-b19c-5d57-0059" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="a454-113e-f900-cee3" name="Chooser of the Slain" hidden="false" collective="false" import="true" type="model">
           <modifiers>
             <modifier type="set" field="d822-4b83-6c8c-1388" value="3.0">
               <conditions>
-                <condition field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast"/>
+                <condition field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d822-4b83-6c8c-1388" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b36b-c126-d273-7cdd" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d822-4b83-6c8c-1388" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b36b-c126-d273-7cdd" type="min" />
           </constraints>
           <profiles>
             <profile id="490b-0e0a-05c4-9ba2" name="Chooser of the Slain" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -1986,54 +1985,54 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
           <entryLinks>
             <entryLink id="db47-f468-7397-5ed1" name="Artificer Armour" hidden="false" collective="true" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec6f-62e6-8ad1-6fa9" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2023-7ff7-9144-b3ab" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec6f-62e6-8ad1-6fa9" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2023-7ff7-9144-b3ab" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="32c3-fe7c-a262-f756" name="Meltabombs" hidden="true" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="04fe-4d1a-c32c-f7dc" value="1.0">
                   <conditions>
-                    <condition field="selections" scope="58f4-3d8d-f243-6e5d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f1f5-16bd-ab2e-2e3a" type="equalTo"/>
+                    <condition field="selections" scope="58f4-3d8d-f243-6e5d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f1f5-16bd-ab2e-2e3a" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="58f4-3d8d-f243-6e5d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f1f5-16bd-ab2e-2e3a" type="equalTo"/>
+                    <condition field="selections" scope="58f4-3d8d-f243-6e5d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f1f5-16bd-ab2e-2e3a" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6649-f011-842d-491d" type="max"/>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04fe-4d1a-c32c-f7dc" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6649-f011-842d-491d" type="max" />
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04fe-4d1a-c32c-f7dc" type="min" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="8172-055e-a5cf-19c2" name="Infravisor" hidden="false" collective="false" import="true" targetId="bc5b-fcd7-aeed-e97c" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51b4-9fe4-4f55-68b7" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51b4-9fe4-4f55-68b7" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="751e-5ec3-c584-9dc0" name="All Choosers of the Slain may take melta bombs" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cee7-9962-1094-cf73" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cee7-9962-1094-cf73" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="f1f5-16bd-ab2e-2e3a" name="Meltabombs" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2042,50 +2041,50 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
       <entryLinks>
         <entryLink id="ea6a-4236-39e4-fba2" name="Corvid Pattern Jump Pack" hidden="false" collective="false" import="true" targetId="874d-6440-0698-f6e7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="041b-3116-114f-5b01" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fa6-b33c-64bf-7db0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="041b-3116-114f-5b01" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fa6-b33c-64bf-7db0" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="21c7-89ca-a057-2dd1" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44f3-e117-56c0-662b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b525-18c1-bfb2-3c46" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44f3-e117-56c0-662b" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b525-18c1-bfb2-3c46" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="f751-d234-1d76-a50b" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3245-2949-e291-8591" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e29-6f95-138f-3a74" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3245-2949-e291-8591" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e29-6f95-138f-3a74" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="c2a4-d3ff-a480-389b" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a40-0db8-11ca-3cf6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="599a-301c-3f40-abc8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a40-0db8-11ca-3cf6" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="599a-301c-3f40-abc8" type="min" />
           </constraints>
         </entryLink>
-        <entryLink id="bb84-043e-8273-e5d9" name="Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="08e4-5e02-da82-f296" type="selectionEntry">
+        <entryLink id="bb84-043e-8273-e5d9" name="Pair of Raven's Talons" hidden="false" collective="false" import="true" targetId="08e4-5e02-da82-f296" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="978c-dfe6-762b-f944" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e65-12c8-a4cc-3adb" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="978c-dfe6-762b-f944" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e65-12c8-a4cc-3adb" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="0e66-8311-405c-1e49" name="Strike Captain Alvarex Maun" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="7f6d-d71e-e019-98cc" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="734e-eb71-18b5-ff92" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="2fe0-6132-a9c3-7cc1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="7f6d-d71e-e019-98cc" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="734e-eb71-18b5-ff92" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="2fe0-6132-a9c3-7cc1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ee1f-8713-4ba0-2299" name="Strike Captain Alvarex Maun" publicationId="d0df-7166-5cd3-89fd" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4550-c9da-4c2a-c74f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="305e-a42c-bbb0-bd32" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4550-c9da-4c2a-c74f" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="305e-a42c-bbb0-bd32" type="min" />
           </constraints>
           <profiles>
             <profile id="2887-ea60-9714-ed6d" name="Strike Captain Alvarex Maun" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2107,24 +2106,24 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
           <selectionEntries>
             <selectionEntry id="6f3b-9903-b54b-cb04" name="Nightfall pattern strato-vox" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21f7-69a9-49c2-d575" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="096b-8f66-4057-074c" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21f7-69a9-49c2-d575" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="096b-8f66-4057-074c" type="max" />
               </constraints>
               <profiles>
                 <profile id="4744-bc28-707f-9fc7" name="Nightfall pattern strato-vox" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
                   <characteristics>
-                    <characteristic name="Description" typeId="347e-ee4a-764f-6be3">While Strike Captain Alvarex Maun is present on the battlefield and not Embarked in a Vehicle or Building, the controlling player may reduce the distance of any Scatter rolls made (whether as part of a weapon attack or the deployment of a model or unit) by 5, as long as Strike Captain Alvarex Maun is within 12&quot; of the unit targeted by the attack or the point chosen as the target of the deployment. In addition, Strike Captain Alvarex Maun and any unit that he has joined ignores the -1 penalty to Leadership imposed by the Night Fighting rules. </characteristic>
+                    <characteristic name="Description" typeId="347e-ee4a-764f-6be3">While Strike Captain Alvarex Maun is present on the battlefield and not Embarked in a Vehicle or Building, the controlling player may reduce the distance of any Scatter rolls made (whether as part of a weapon attack or the deployment of a model or unit) by 5, as long as Strike Captain Alvarex Maun is within 12" of the unit targeted by the attack or the point chosen as the target of the deployment. In addition, Strike Captain Alvarex Maun and any unit that he has joined ignores the -1 penalty to Leadership imposed by the Night Fighting rules. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="653b-9b86-d653-79fd" name="Tolaedus" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c9b-be21-d38a-97aa" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e84-fb7d-0a7f-3674" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c9b-be21-d38a-97aa" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e84-fb7d-0a7f-3674" type="min" />
               </constraints>
               <profiles>
                 <profile id="8346-7008-b938-5c71" name="Tolaedus" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2139,131 +2138,131 @@ Corvus Corax may still Run on a turn when the Korvidine Pinions have been activa
               <infoLinks>
                 <infoLink id="cbef-6f61-66f5-34bc" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Breaching (5+)"/>
+                    <modifier type="set" field="name" value="Breaching (5+)" />
                   </modifiers>
                 </infoLink>
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="b035-d31f-2799-9e25" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd84-9463-011c-e727" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f76a-7715-668a-b12d" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd84-9463-011c-e727" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f76a-7715-668a-b12d" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="0f2e-1876-be0b-542d" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3538-148d-72aa-3922" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c4c-5676-ca73-7ff6" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3538-148d-72aa-3922" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c4c-5676-ca73-7ff6" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="ba1a-73de-356c-ca59" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2aa5-1b2f-d51e-3b36" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb14-d36a-d5d2-0fde" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2aa5-1b2f-d51e-3b36" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb14-d36a-d5d2-0fde" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="9438-3f69-fc6d-e3cc" name="Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90f6-af0e-67dc-7f4b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90f6-af0e-67dc-7f4b" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="44cc-f5e3-68e1-266b" name="Drop Pod" hidden="false" collective="false" import="true" targetId="83ac-f9cf-cc29-00a3" type="selectionEntry"/>
-            <entryLink id="6a85-9732-cbf3-70c3" name="Storm Eagle Gunship" hidden="false" collective="false" import="true" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"/>
+            <entryLink id="44cc-f5e3-68e1-266b" name="Drop Pod" hidden="false" collective="false" import="true" targetId="83ac-f9cf-cc29-00a3" type="selectionEntry" />
+            <entryLink id="6a85-9732-cbf3-70c3" name="Storm Eagle Gunship" hidden="false" collective="false" import="true" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="7361-e0e6-ea49-f7df" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c6f-2832-8752-9068" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c6f-2832-8752-9068" type="max" />
           </constraints>
           <profiles>
             <profile id="6927-6279-7bbb-6e3f" name="Warlord Trait: Coordinated Planetstrike" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Coordinated Planetstrike: As long as Strike Captain Alvarex Maun has not been removed as a casualty, the controlling player may re-roll failed Reserve rolls for any Deep Strike Assault that Strike Captain Alvarex Maun is part of. In addition, an army with Strike Captain Alvarex Maun as its Warlord may make an additional Reaction during the opponent’s Movement phase as long as Strike Captain Alvarex Maun is deployed on the battlefield and has not been removed as a casualty. </characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Coordinated Planetstrike: As long as Strike Captain Alvarex Maun has not been removed as a casualty, the controlling player may re-roll failed Reserve rolls for any Deep Strike Assault that Strike Captain Alvarex Maun is part of. In addition, an army with Strike Captain Alvarex Maun as its Warlord may make an additional Reaction during the opponent&#8217;s Movement phase as long as Strike Captain Alvarex Maun is deployed on the battlefield and has not been removed as a casualty. </characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
         <entryLink id="1da6-2389-10d0-08e6" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1a7-f9d1-ad9f-a173" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ae2-f6f9-6b87-a36a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1a7-f9d1-ad9f-a173" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ae2-f6f9-6b87-a36a" type="min" />
           </constraints>
         </entryLink>
-        <entryLink id="9ae4-9d11-aa95-e24d" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup"/>
+        <entryLink id="9ae4-9d11-aa95-e24d" name="Retinue" hidden="false" collective="false" import="true" targetId="5a61-7572-048d-9bb4" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="140.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="140.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="5d1d-8348-ed95-d366" name="Deliverers Squad" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a825-305b-4c29-19a3" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a825-305b-4c29-19a3" type="max" />
       </constraints>
       <rules>
-        <rule id="e61b-37aa-0364-68da" name="Corax&apos;s Shame" publicationId="09b3-d525-cdea-260c" page="15" hidden="false">
+        <rule id="e61b-37aa-0364-68da" name="Corax's Shame" publicationId="09b3-d525-cdea-260c" page="15" hidden="false">
           <description>If selected as part of an army with the Loyalist Allegiance, models with this special rule gain the Battle-hardened (1) special rule. If selected as part of an army with the Traitor Allegiance, models with this special rule gain the Hatred (Corvus Corax) special rule. 
 
-Additionally, if selected as part of an army that includes Corvus Corax, no models with this special rule may be deployed within 18&quot; of Corvus Corax (including when models from this unit enter play from Reserves) and Corvus Corax may never join a unit that has any models with this special rule.</description>
+Additionally, if selected as part of an army that includes Corvus Corax, no models with this special rule may be deployed within 18" of Corvus Corax (including when models from this unit enter play from Reserves) and Corvus Corax may never join a unit that has any models with this special rule.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="033d-e381-5c7f-02f8" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
-        <infoLink id="20b5-4b86-f533-f797" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="033d-e381-5c7f-02f8" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
+        <infoLink id="20b5-4b86-f533-f797" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="9126-9bd1-72fc-7a5b" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="15c7-f900-d1ff-d769" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+        <infoLink id="15c7-f900-d1ff-d769" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule" />
         <infoLink id="8b0a-d314-b356-2768" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hatred (Corvus Corax)"/>
+            <modifier type="set" field="name" value="Hatred (Corvus Corax)" />
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
         </infoLink>
         <infoLink id="38e6-a330-126a-ca5f" name="Battle-Hardened (X)" hidden="false" targetId="5c3b-ed0b-4ad0-d547" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Battle-hardened (1)"/>
+            <modifier type="set" field="name" value="Battle-hardened (1)" />
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="188c-d76b-84a6-638f" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="9cc5-6040-2587-922f" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="c489-7c99-cc6f-01d0" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="5877-4eb0-e84d-2158" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="188c-d76b-84a6-638f" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="9cc5-6040-2587-922f" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="c489-7c99-cc6f-01d0" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="5877-4eb0-e84d-2158" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="3118-b41f-ad1e-c10d" name="1) Deliverer Chieftain" hidden="false" collective="false" import="true" defaultSelectionEntryId="2fd7-841f-206a-9f2b">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc56-2ce5-85f7-cb3f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70e0-13ee-adc8-f927" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc56-2ce5-85f7-cb3f" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70e0-13ee-adc8-f927" type="min" />
           </constraints>
           <selectionEntries>
-            <selectionEntry id="8618-1e90-c852-d60b" name=" Deliverer Chieftain w/Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" type="model">
+            <selectionEntry id="8618-1e90-c852-d60b" name=" Deliverer Chieftain w/Pair of Raven's Talons" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="c430-f24b-2a79-c1b7" name="Deliverer Chieftan" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
@@ -2282,29 +2281,29 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="6cf3-6064-94d9-766c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink id="6cf3-6064-94d9-766c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
               </categoryLinks>
               <entryLinks>
                 <entryLink id="7243-41b8-68b3-d513" name="Infravisor" hidden="false" collective="false" import="true" targetId="bc5b-fcd7-aeed-e97c" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7073-cb2d-0416-7f6a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7073-cb2d-0416-7f6a" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="e5a7-f250-f60b-d342" name="Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="08e4-5e02-da82-f296" type="selectionEntry">
+                <entryLink id="e5a7-f250-f60b-d342" name="Pair of Raven's Talons" hidden="false" collective="false" import="true" targetId="08e4-5e02-da82-f296" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddcc-6918-fe5c-fdce" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef8a-b1b6-5d38-eb51" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddcc-6918-fe5c-fdce" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef8a-b1b6-5d38-eb51" type="min" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="2fd7-841f-206a-9f2b" name=" Deliverer Chieftain" hidden="false" collective="false" import="true" type="model">
@@ -2326,22 +2325,22 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="0e24-4422-ed3e-dec5" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink id="0e24-4422-ed3e-dec5" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
               </categoryLinks>
               <entryLinks>
-                <entryLink id="000d-22ac-47f1-b8e0" name="Deliverer Melee Weapon" hidden="false" collective="false" import="true" targetId="d48a-b33b-002e-fc23" type="selectionEntryGroup"/>
-                <entryLink id="21b0-9662-c009-fbd7" name="Deliverer Ranged Weapon" hidden="false" collective="false" import="true" targetId="d1aa-12d3-aee7-e709" type="selectionEntryGroup"/>
+                <entryLink id="000d-22ac-47f1-b8e0" name="Deliverer Melee Weapon" hidden="false" collective="false" import="true" targetId="d48a-b33b-002e-fc23" type="selectionEntryGroup" />
+                <entryLink id="21b0-9662-c009-fbd7" name="Deliverer Ranged Weapon" hidden="false" collective="false" import="true" targetId="d1aa-12d3-aee7-e709" type="selectionEntryGroup" />
                 <entryLink id="8d7a-e3ca-e725-de31" name="Infravisor" hidden="false" collective="false" import="true" targetId="bc5b-fcd7-aeed-e97c" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20fe-776e-76a5-9b1e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20fe-776e-76a5-9b1e" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="1ca5-717a-5346-81c1" name=" Deliverer Chieftain w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
@@ -2363,30 +2362,30 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="58e3-212f-ea8d-ec37" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink id="58e3-212f-ea8d-ec37" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
               </categoryLinks>
               <entryLinks>
-                <entryLink id="3af5-0c60-c79f-75ae" name="Deliverer Heavy Weapons" hidden="false" collective="false" import="true" targetId="2c85-3ae3-fbdf-2e60" type="selectionEntryGroup"/>
-                <entryLink id="2ad8-f105-0281-cf53" name="Deliverer Melee Weapon" hidden="false" collective="false" import="true" targetId="d48a-b33b-002e-fc23" type="selectionEntryGroup"/>
+                <entryLink id="3af5-0c60-c79f-75ae" name="Deliverer Heavy Weapons" hidden="false" collective="false" import="true" targetId="2c85-3ae3-fbdf-2e60" type="selectionEntryGroup" />
+                <entryLink id="2ad8-f105-0281-cf53" name="Deliverer Melee Weapon" hidden="false" collective="false" import="true" targetId="d48a-b33b-002e-fc23" type="selectionEntryGroup" />
                 <entryLink id="8e28-f747-2ae3-7f51" name="Infravisor" hidden="false" collective="false" import="true" targetId="bc5b-fcd7-aeed-e97c" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1425-6a56-ec5d-ca42" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1425-6a56-ec5d-ca42" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="f846-2432-36ce-d996" name="2) Deliverers" hidden="false" collective="false" import="true" defaultSelectionEntryId="0916-503d-0637-3f8e">
           <constraints>
-            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6120-2a09-cefa-9793" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e50b-2087-e9a9-13ec" type="min"/>
+            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6120-2a09-cefa-9793" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e50b-2087-e9a9-13ec" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="0916-503d-0637-3f8e" name="Deliverer" hidden="false" collective="false" import="true" type="model">
@@ -2408,14 +2407,14 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="3e00-1e0c-63c5-6e5a" name="Deliverer Melee Weapon" hidden="false" collective="false" import="true" targetId="d48a-b33b-002e-fc23" type="selectionEntryGroup"/>
-                <entryLink id="cd1b-dc5f-d015-7354" name="Deliverer Ranged Weapon" hidden="false" collective="false" import="true" targetId="d1aa-12d3-aee7-e709" type="selectionEntryGroup"/>
+                <entryLink id="3e00-1e0c-63c5-6e5a" name="Deliverer Melee Weapon" hidden="false" collective="false" import="true" targetId="d48a-b33b-002e-fc23" type="selectionEntryGroup" />
+                <entryLink id="cd1b-dc5f-d015-7354" name="Deliverer Ranged Weapon" hidden="false" collective="false" import="true" targetId="d1aa-12d3-aee7-e709" type="selectionEntryGroup" />
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0" />
               </costs>
             </selectionEntry>
-            <selectionEntry id="acb7-6b25-f268-1e56" name="Deliverer w/Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" type="model">
+            <selectionEntry id="acb7-6b25-f268-1e56" name="Deliverer w/Pair of Raven's Talons" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="3677-f1a2-ccdf-4e11" name="Deliverer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
@@ -2434,32 +2433,32 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="73d6-ac8f-84e2-8fd8" name="Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="08e4-5e02-da82-f296" type="selectionEntry">
+                <entryLink id="73d6-ac8f-84e2-8fd8" name="Pair of Raven's Talons" hidden="false" collective="false" import="true" targetId="08e4-5e02-da82-f296" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af6b-f178-07e1-293c" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4917-c62e-383b-28b7" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af6b-f178-07e1-293c" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4917-c62e-383b-28b7" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="a74c-a81e-519d-6339" name="Deliverer w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="79eb-8173-4e4e-7bf0" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="5d1d-8348-ed95-d366" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="5d1d-8348-ed95-d366" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
                 <modifier type="decrement" field="79eb-8173-4e4e-7bf0" value="1.0">
                   <conditions>
-                    <condition field="selections" scope="5d1d-8348-ed95-d366" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1ca5-717a-5346-81c1" type="greaterThan"/>
+                    <condition field="selections" scope="5d1d-8348-ed95-d366" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1ca5-717a-5346-81c1" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="5d1d-8348-ed95-d366" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="79eb-8173-4e4e-7bf0" type="max"/>
+                <constraint field="selections" scope="5d1d-8348-ed95-d366" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="79eb-8173-4e4e-7bf0" type="max" />
               </constraints>
               <profiles>
                 <profile id="b553-b1cf-be43-12c1" name="Deliverer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2479,11 +2478,11 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="ce9c-c4f2-11a8-5ed6" name="Deliverer Heavy Weapons" hidden="false" collective="false" import="true" targetId="2c85-3ae3-fbdf-2e60" type="selectionEntryGroup"/>
-                <entryLink id="9054-f336-11e3-4a50" name="Deliverer Melee Weapon" hidden="false" collective="false" import="true" targetId="d48a-b33b-002e-fc23" type="selectionEntryGroup"/>
+                <entryLink id="ce9c-c4f2-11a8-5ed6" name="Deliverer Heavy Weapons" hidden="false" collective="false" import="true" targetId="2c85-3ae3-fbdf-2e60" type="selectionEntryGroup" />
+                <entryLink id="9054-f336-11e3-4a50" name="Deliverer Melee Weapon" hidden="false" collective="false" import="true" targetId="d48a-b33b-002e-fc23" type="selectionEntryGroup" />
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2492,224 +2491,224 @@ Additionally, if selected as part of an army that includes Corvus Corax, no mode
       <entryLinks>
         <entryLink id="6145-e9fa-7753-90e9" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1381-df00-9845-4ace" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8a6-8663-6825-7240" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1381-df00-9845-4ace" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8a6-8663-6825-7240" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="d1aa-12d3-aee7-e709" name="Deliverer Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="265b-6415-da86-a271">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="12dd-12f8-d879-814c" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7401-9c54-0faa-18f3" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="12dd-12f8-d879-814c" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7401-9c54-0faa-18f3" type="max" />
       </constraints>
       <entryLinks>
-        <entryLink id="265b-6415-da86-a271" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+        <entryLink id="265b-6415-da86-a271" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry" />
         <entryLink id="3f63-74c8-7927-7b5e" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
           </costs>
         </entryLink>
         <entryLink id="8e16-1824-b29a-436d" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry">
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
           </costs>
         </entryLink>
         <entryLink id="7341-9e34-07c1-78d9" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry">
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
           </costs>
         </entryLink>
         <entryLink id="fa0d-4ab9-4718-1d6e" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry">
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
           </costs>
         </entryLink>
         <entryLink id="8956-e397-4e7b-82fc" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
           </costs>
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="2c85-3ae3-fbdf-2e60" name="Deliverer Heavy Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="46e3-6301-b027-dc67">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8e5-11da-3f65-274a" type="max"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fe6-3a14-abe5-cbda" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8e5-11da-3f65-274a" type="max" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fe6-3a14-abe5-cbda" type="min" />
       </constraints>
       <entryLinks>
         <entryLink id="46e3-6301-b027-dc67" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eeaa-343c-4c47-64be" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eeaa-343c-4c47-64be" type="max" />
           </constraints>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
           </costs>
         </entryLink>
         <entryLink id="4c3e-a82c-09d6-fdd0" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebfc-6ca5-2b10-f4fd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebfc-6ca5-2b10-f4fd" type="max" />
           </constraints>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
           </costs>
         </entryLink>
         <entryLink id="4177-71e3-e19d-ab3f" name="Reaper Autocannon" hidden="false" collective="false" import="true" targetId="b87f-48de-6ced-043b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb9c-97ff-6dd8-50b8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb9c-97ff-6dd8-50b8" type="max" />
           </constraints>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
           </costs>
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="d48a-b33b-002e-fc23" name="Deliverer Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="4cc4-7efe-17a1-b281">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43a9-68b4-5152-312a" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c814-990b-53f2-3d64" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43a9-68b4-5152-312a" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c814-990b-53f2-3d64" type="max" />
       </constraints>
       <entryLinks>
         <entryLink id="a9e5-57ca-c540-d40c" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
           </costs>
         </entryLink>
         <entryLink id="32a8-b85a-fd8a-1ead" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
           </costs>
         </entryLink>
-        <entryLink id="4cc4-7efe-17a1-b281" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry"/>
+        <entryLink id="4cc4-7efe-17a1-b281" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry" />
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="40ca-b143-a04e-4083" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="4bb6-bc4f-1115-c5d7" value="1.0">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e427-717b-ae53-0264" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bb6-bc4f-1115-c5d7" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e427-717b-ae53-0264" type="max" />
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bb6-bc4f-1115-c5d7" type="min" />
       </constraints>
       <selectionEntryGroups>
         <selectionEntryGroup id="70c5-8899-2e6b-62d3" name="XIX: Raven Guard" publicationId="817a-6288-e016-7469" page="328" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fa5a-a3c1-4d16-8fa3" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="87b4-5b89-21bc-237f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fa5a-a3c1-4d16-8fa3" type="max" />
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="87b4-5b89-21bc-237f" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="2a9f-3d0a-7ee5-7fb8" name="The Bane of Tyrants (Loyalist only)" publicationId="817a-6288-e016-7469" page="328" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="129f-8410-72a2-5b03" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="02d2-c235-ad13-7e0b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="129f-8410-72a2-5b03" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="02d2-c235-ad13-7e0b" type="max" />
               </constraints>
               <profiles>
                 <profile id="6f54-6a95-a964-2f02" name="The Bane of Tyrants" publicationId="817a-6288-e016-7469" page="328" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Loyalist Allegiance.
-This Warlord increases his Attacks and Strength Characteristics by +1 when Engaged in a Challenge, and by +2 when Engaged in a Challenge with the enemy Warlord. In addition, an army whose Warlord has this Trait may make an additional Reaction during their opponent’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+This Warlord increases his Attacks and Strength Characteristics by +1 when Engaged in a Challenge, and by +2 when Engaged in a Challenge with the enemy Warlord. In addition, an army whose Warlord has this Trait may make an additional Reaction during their opponent&#8217;s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="d316-252b-5f3a-5156" name="No Gods or Masters (Traitor only)" publicationId="817a-6288-e016-7469" page="328" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9c29-b6d1-d10f-8a73" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1fab-9c80-39e1-98cd" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9c29-b6d1-d10f-8a73" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1fab-9c80-39e1-98cd" type="max" />
               </constraints>
               <profiles>
                 <profile id="3bf7-7902-c096-311d" name="No Gods or Masters" publicationId="817a-6288-e016-7469" page="328" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Traitor Allegiance.
-When in base to base contact with an enemy Infantry or Cavalry model whose Weapon Skill, Strength or Initiative is higher than this Warlord’s, a Warlord with this Trait increases their Weapon Skill, Strength and/or Initiative to match those of the enemy model with the highest value in that Characteristic that it is in base contact with. In addition, an army whose Warlord has this Trait may, once per battle, make a single Reaction without spending a point of the controlling player’s Reaction Allotment, as long as the Reaction is made by the Warlord or a unit the Warlord has joined.</characteristic>
+When in base to base contact with an enemy Infantry or Cavalry model whose Weapon Skill, Strength or Initiative is higher than this Warlord&#8217;s, a Warlord with this Trait increases their Weapon Skill, Strength and/or Initiative to match those of the enemy model with the highest value in that Characteristic that it is in base contact with. In addition, an army whose Warlord has this Trait may, once per battle, make a single Reaction without spending a point of the controlling player&#8217;s Reaction Allotment, as long as the Reaction is made by the Warlord or a unit the Warlord has joined.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="0798-9f16-6b70-3373" name="The Hidden Hand" publicationId="817a-6288-e016-7469" page="328" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a52-4644-f060-8054" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ab21-f992-f21b-9a3d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a52-4644-f060-8054" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ab21-f992-f21b-9a3d" type="max" />
               </constraints>
               <profiles>
                 <profile id="e734-243c-23cc-1b63" name="The Hidden Hand" publicationId="817a-6288-e016-7469" page="328" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">While a Warlord with this Trait is in Reserves, the controlling player may choose to re-roll all failed Reserves rolls and when deployed to the battlefield the Warlord and all models in any unit he has joined gain the Fleet (2) special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">While a Warlord with this Trait is in Reserves, the controlling player may choose to re-roll all failed Reserves rolls and when deployed to the battlefield the Warlord and all models in any unit he has joined gain the Fleet (2) special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="2d0a-0666-fed5-39c4" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+        <entryLink id="2d0a-0666-fed5-39c4" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="5a61-7572-048d-9bb4" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="4f8e-0e7a-b3fe-1e3c" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="4f8e-0e7a-b3fe-1e3c" type="max" />
       </constraints>
       <entryLinks>
         <entryLink id="d33b-21f8-f253-f312" name="Command Squad, Cataphractii" hidden="false" collective="false" import="true" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="ddf1-3ff4-ef67-c4f1" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
-        <entryLink id="b94f-e962-0b23-adff" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="ddf1-3ff4-ef67-c4f1" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
+        <entryLink id="b94f-e962-0b23-adff" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Salamanders.cat
+++ b/2022 - LA - Salamanders.cat
@@ -1,13 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3547-84d8-d789-bab7" name="LA -  XVIII: Salamanders" revision="12" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="3547-84d8-d789-bab7" name="LA -  XVIII: Salamanders" revision="12" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26">
   <entryLinks>
     <entryLink id="93d2-b1cb-b684-a9b3" name="  XVIII: Salamanders" hidden="false" collective="false" import="false" targetId="c805-ca3a-ff93-5e2f" type="selectionEntry">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8033-566b-1abe-f966" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57d2-e62d-e196-295b" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8033-566b-1abe-f966" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57d2-e62d-e196-295b" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="e7bb-068e-33b8-7e33" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="e7bb-068e-33b8-7e33" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="a4b6-92c9-7e8b-bfcd" name="Cassian Dracos Reborn" hidden="true" collective="false" import="false" targetId="fb8a-ab72-52ce-38f3" type="selectionEntry">
@@ -16,73 +15,73 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2de5-e3bc-f6bc-5558" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="b475-cb4a-5a9b-cf9b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="e43c-2895-7503-366a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2de5-e3bc-f6bc-5558" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="b475-cb4a-5a9b-cf9b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="e43c-2895-7503-366a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="34f6-2994-6de1-98cc" name="Firedrake Terminator Squad" hidden="false" collective="false" import="false" targetId="6775-8379-8d6b-9614" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="26b1-529c-841e-80c6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="1975-3b0c-9330-e098" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="26b1-529c-841e-80c6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="1975-3b0c-9330-e098" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="13d2-61df-c76d-7b32" name="Lord Chaplain Nomus Rhy&apos;Tan" hidden="true" collective="false" import="false" targetId="74f6-96f4-ee55-9c78" type="selectionEntry">
+    <entryLink id="13d2-61df-c76d-7b32" name="Lord Chaplain Nomus Rhy'Tan" hidden="true" collective="false" import="false" targetId="74f6-96f4-ee55-9c78" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ac1a-5683-b0a6-a1f5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="2ac4-69c5-3a1e-7314" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="1b50-8e8f-a15c-45d0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ac1a-5683-b0a6-a1f5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="2ac4-69c5-3a1e-7314" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="1b50-8e8f-a15c-45d0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="5e51-de9f-0a93-825b" name="Pyroclast Squad" hidden="false" collective="false" import="false" targetId="71fe-d3bc-b7f9-75ca" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="eaf6-1e7a-32ab-b017" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="00dc-c4a6-a6fe-adf5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="eaf6-1e7a-32ab-b017" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="00dc-c4a6-a6fe-adf5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="4c5f-15e0-0de3-af6a" name="Vulkan" hidden="true" collective="false" import="false" targetId="8c74-40b1-5019-f4d4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="64a8-ba7d-4c9b-3f3e" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
-        <categoryLink id="6d75-8f0a-3caa-689d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="64a8-ba7d-4c9b-3f3e" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true" />
+        <categoryLink id="6d75-8f0a-3caa-689d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="2607-05cd-6852-2f52" name="Xiaphas Jurr" hidden="true" collective="false" import="false" targetId="30b8-05a5-fef7-fe66" type="selectionEntry">
@@ -91,959 +90,959 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="61c9-1410-be7e-6c64" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="28d1-eb1c-4e2e-0ce6" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="61c9-1410-be7e-6c64" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="28d1-eb1c-4e2e-0ce6" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="81db-d314-0661-7945" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2575-8d54-4168-2c10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1f5c-3beb-4a74-0ec8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="2575-8d54-4168-2c10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1f5c-3beb-4a74-0ec8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
     <entryLink id="d29f-6ff1-84f6-fa78" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7a4e-cbea-e037-f104" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c50a-53f0-b496-5c46" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="7a4e-cbea-e037-f104" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c50a-53f0-b496-5c46" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
     <entryLink id="a4da-67bc-f8a8-f809" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2c09-6a41-9893-34c6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="c7d2-d2ea-9b06-b573" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2a85-707d-60e2-21ea" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="2c09-6a41-9893-34c6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="c7d2-d2ea-9b06-b573" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2a85-707d-60e2-21ea" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="0898-4828-d0b4-f629" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fb3c-ebcb-ac62-66c0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="77b2-cc51-cf71-6112" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fb3c-ebcb-ac62-66c0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="77b2-cc51-cf71-6112" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
     <entryLink id="a8eb-cf15-3625-2bd2" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0b05-b45f-95af-4b51" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="28fd-4f67-4e60-0344" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0b05-b45f-95af-4b51" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="28fd-4f67-4e60-0344" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
     <entryLink id="5bfe-4044-5d78-0010" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4de4-52c1-f0c0-b14f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="aa51-5de8-4934-d7c7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="30f5-313f-cfa5-62a9" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="4de4-52c1-f0c0-b14f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="aa51-5de8-4934-d7c7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="30f5-313f-cfa5-62a9" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
     <entryLink id="99aa-c0e7-1b96-3a16" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="01b1-d867-1a9e-2221" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="6602-8207-41a8-af41" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="01b1-d867-1a9e-2221" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="6602-8207-41a8-af41" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
     <entryLink id="beb6-cd17-653f-f71a" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="de79-bac1-4fdf-d2aa" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="3d2e-a0b5-cdd6-7d36" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="de79-bac1-4fdf-d2aa" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="3d2e-a0b5-cdd6-7d36" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
     <entryLink id="1a43-badf-f37d-866c" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3a09-9c4d-4701-2bd3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="fe08-d2c4-0104-8eb0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d30b-33d3-3895-058f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="3a09-9c4d-4701-2bd3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="fe08-d2c4-0104-8eb0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d30b-33d3-3895-058f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="bf0b-6dcd-883e-a50e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup"/>
+        <entryLink id="bf0b-6dcd-883e-a50e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup" />
         <entryLink id="8dc0-4f4c-fba6-ce03" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
     <entryLink id="4463-b41c-deb4-3495" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="536b-55ec-64e3-3339" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a089-1a0c-a856-f1c6" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="281a-0ff0-c1d5-4303" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="536b-55ec-64e3-3339" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a089-1a0c-a856-f1c6" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="281a-0ff0-c1d5-4303" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="7d4f-db79-17da-cfce" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup"/>
+        <entryLink id="7d4f-db79-17da-cfce" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup" />
         <entryLink id="f448-55cd-8812-d0fd" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
     <entryLink id="be2f-c121-0fe4-6f13" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8013-8909-bf63-61cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="563c-b68f-2cb8-51b3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="9530-0aa1-4769-e9f1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="8013-8909-bf63-61cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="563c-b68f-2cb8-51b3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="9530-0aa1-4769-e9f1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="b45a-f78c-80ef-652f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup"/>
+        <entryLink id="b45a-f78c-80ef-652f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup" />
         <entryLink id="04ca-1b50-068a-09ad" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
     <entryLink id="4bd9-ad7d-215d-6bfc" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="da60-a77d-9cdc-0fcb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c9f6-5883-be33-e7b0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="da60-a77d-9cdc-0fcb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="c9f6-5883-be33-e7b0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
     <entryLink id="5458-163e-22de-4a00" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a557-bc81-0d6d-e93c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3200-7f1f-fe3d-5045" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="a557-bc81-0d6d-e93c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3200-7f1f-fe3d-5045" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
     <entryLink id="dba9-1176-0331-fc7e" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5240-5030-764b-30f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e453-0d15-62ce-54f0" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="5240-5030-764b-30f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e453-0d15-62ce-54f0" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
     <entryLink id="c4ec-a665-f42a-0af3" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="abed-6219-485b-8c51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7cf2-7d2f-81fb-6e97" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="abed-6219-485b-8c51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7cf2-7d2f-81fb-6e97" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
     <entryLink id="7f94-d6be-ac35-1421" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5a15-a183-b579-4582" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e190-93c2-a41e-ff95" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="5a15-a183-b579-4582" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e190-93c2-a41e-ff95" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
     <entryLink id="68c6-587b-0403-66bc" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3cf3-34db-1c09-24cf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="b22d-b29d-3ecb-d581" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3cf3-34db-1c09-24cf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="b22d-b29d-3ecb-d581" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
     <entryLink id="64a2-5b02-e2ba-5e4a" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c2cb-7510-cd37-984e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="a882-1a9b-4d57-93b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c2cb-7510-cd37-984e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="a882-1a9b-4d57-93b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="76bf-bd99-3067-5d7f" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="567e-df81-a311-7066" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b1fb-1de8-2a32-a2f8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="567e-df81-a311-7066" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b1fb-1de8-2a32-a2f8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
     <entryLink id="19bd-cdfd-0295-3a7d" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d540-e102-a516-dc6a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="f921-c892-6bd5-58ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="715d-22ae-4b10-3e39" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="d540-e102-a516-dc6a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="f921-c892-6bd5-58ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="715d-22ae-4b10-3e39" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="eef1-e56b-4752-b723" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c847-d0d0-392d-ba9d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5431-0db2-96d0-7f7e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="c847-d0d0-392d-ba9d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5431-0db2-96d0-7f7e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="13c7-f976-5bce-99e3" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a07e-4c3e-d9a0-003a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="c7a5-1f0b-f52f-8e4c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a07e-4c3e-d9a0-003a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="c7a5-1f0b-f52f-8e4c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
     <entryLink id="877a-d43b-10d1-f561" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0197-885c-5bbc-d9e1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="6571-df3a-e918-f0c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0197-885c-5bbc-d9e1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="6571-df3a-e918-f0c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
     <entryLink id="cd1d-73b9-ba01-2166" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c528-6fb0-d7c9-6204" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="1952-c05e-5d56-5a6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c528-6fb0-d7c9-6204" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="1952-c05e-5d56-5a6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
     <entryLink id="4282-f953-0998-4a79" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4eb7-1ef3-c705-dd39" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4815-79c1-278c-cba5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="4eb7-1ef3-c705-dd39" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4815-79c1-278c-cba5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
     <entryLink id="815c-31c8-b4a1-6f10" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e62b-f0f1-fb5e-0b63" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="b602-a000-95a0-2ff4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e62b-f0f1-fb5e-0b63" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="b602-a000-95a0-2ff4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
     <entryLink id="0e62-b141-65fa-29a7" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="830a-68c2-eed3-bf57" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="67c0-24ee-1bde-0a32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="830a-68c2-eed3-bf57" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="67c0-24ee-1bde-0a32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
     <entryLink id="f424-c704-68e1-64f2" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="05ad-4d0d-6cd4-a98e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5a92-755e-6166-acf5" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="05ad-4d0d-6cd4-a98e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5a92-755e-6166-acf5" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
     <entryLink id="536b-275d-4547-f363" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3798-dae4-dffd-5497" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="384d-e3d3-e3b2-a1d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3798-dae4-dffd-5497" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="384d-e3d3-e3b2-a1d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
     <entryLink id="e3ea-2f97-1420-cda3" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7ebb-7ab9-2c59-bc60" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2455-1393-8d97-fd6d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="7ebb-7ab9-2c59-bc60" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2455-1393-8d97-fd6d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="8d1a-e08c-09a1-c590" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7aba-02fa-3a7b-bbad" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="cc96-375d-5076-77fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7aba-02fa-3a7b-bbad" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="cc96-375d-5076-77fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
     <entryLink id="fea4-16d5-7648-03a8" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ca30-e889-6a62-90da" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="fcd0-8295-a3c4-fb37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ca30-e889-6a62-90da" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="fcd0-8295-a3c4-fb37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
     <entryLink id="9693-4501-d924-2b12" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="596b-e4d9-81c2-0c8a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="2996-257d-8206-9b96" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="596b-e4d9-81c2-0c8a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="2996-257d-8206-9b96" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
     <entryLink id="b4ec-d19d-a8f1-50c0" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9664-0758-9137-9479" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9fcc-f317-6757-72b1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="9664-0758-9137-9479" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9fcc-f317-6757-72b1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
     <entryLink id="adb2-4de8-afe3-91e8" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="bd7d-bdc0-7c19-027e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="438a-a395-39dc-392a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="bd7d-bdc0-7c19-027e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="438a-a395-39dc-392a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
     <entryLink id="9358-fb65-0ca9-ebc2" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ae7a-f0ff-19f5-5f2f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="f364-032f-cfae-fc52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ae7a-f0ff-19f5-5f2f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="f364-032f-cfae-fc52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
     <entryLink id="3e47-03f4-f686-e15e" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e7b4-f439-2771-1c54" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="ad53-6061-7ea9-c8a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e7b4-f439-2771-1c54" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="ad53-6061-7ea9-c8a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
     <entryLink id="591f-5a82-e2ba-37da" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a0d8-fe2b-d2c5-f3d3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="64d0-e728-337f-5745" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a0d8-fe2b-d2c5-f3d3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="64d0-e728-337f-5745" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
     <entryLink id="1632-273a-4ab9-745b" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="acd7-03e0-ce50-f825" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="4ff1-41d7-a2f9-5c1b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="acd7-03e0-ce50-f825" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="4ff1-41d7-a2f9-5c1b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
     <entryLink id="3899-9a92-0dc8-0554" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1e57-93d7-b64f-da48" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="f002-1c76-128a-cc7e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1e57-93d7-b64f-da48" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="f002-1c76-128a-cc7e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
     <entryLink id="a37d-f3d2-c0ee-e902" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6138-4382-c5a8-7214" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="9d4f-6e0f-9155-5b48" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6138-4382-c5a8-7214" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="9d4f-6e0f-9155-5b48" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
     <entryLink id="f3d7-db2a-86be-e0d4" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="00a3-1b8f-655d-5005" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="604f-99c8-c7bc-2c3a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="00a3-1b8f-655d-5005" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="604f-99c8-c7bc-2c3a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
     <entryLink id="359d-0a15-9916-9c24" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fa44-6b35-f2b4-8647" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="2b63-8f80-0766-7c7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fa44-6b35-f2b4-8647" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="2b63-8f80-0766-7c7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
     <entryLink id="6b9d-c046-31f7-df14" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ce95-7cc1-15e5-0109" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="46c0-958c-3e3a-90f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ce95-7cc1-15e5-0109" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="46c0-958c-3e3a-90f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
     <entryLink id="eb80-0c80-2a5d-444d" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6208-bf62-662a-27c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="eaee-4ba7-ed31-a68d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6208-bf62-662a-27c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="eaee-4ba7-ed31-a68d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
     <entryLink id="f385-591a-76ae-6c96" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d593-48a9-a4ea-2872" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="0619-e8a6-a2e5-ce33" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d593-48a9-a4ea-2872" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="0619-e8a6-a2e5-ce33" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
     <entryLink id="66a1-77c7-24f2-6f33" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="44d8-bced-205a-2708" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="2657-51a4-cea5-be46" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="44d8-bced-205a-2708" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="2657-51a4-cea5-be46" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
     <entryLink id="5213-d143-4913-79d0" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8731-1db0-6aee-9d3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c79b-d713-273a-ea2d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="8731-1db0-6aee-9d3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c79b-d713-273a-ea2d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="8748-3b55-7bf5-e2c0" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c571-11e3-7014-e476" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="c127-4ea2-ac32-0533" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c571-11e3-7014-e476" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c127-4ea2-ac32-0533" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
     <entryLink id="bff1-7771-3d8d-e5c5" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ba9e-9237-7cf0-2cdf" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="bc05-9542-2277-62a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ba9e-9237-7cf0-2cdf" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="bc05-9542-2277-62a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="6610-b4bd-958a-7c83" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8042-9564-5467-e404" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bf7d-39dc-51f3-47a1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="8042-9564-5467-e404" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bf7d-39dc-51f3-47a1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="7db3-340c-ba11-4a1e" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b9ac-3a35-2624-bacc" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="173c-273f-cb7d-86b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5f72-ca1e-15d3-fea5" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="b9ac-3a35-2624-bacc" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="173c-273f-cb7d-86b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5f72-ca1e-15d3-fea5" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="3aa7-404f-d499-041c" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup"/>
-        <entryLink id="1d93-4a37-42b4-fbda" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup"/>
+        <entryLink id="3aa7-404f-d499-041c" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup" />
+        <entryLink id="1d93-4a37-42b4-fbda" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
     <entryLink id="1acd-d0b1-d78d-68bc" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bd89-d9ef-4a18-7b84" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="b3ce-1178-7096-4527" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a163-1629-a0db-e90a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="bd89-d9ef-4a18-7b84" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="b3ce-1178-7096-4527" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a163-1629-a0db-e90a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="6991-cb22-811f-3935" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup"/>
-        <entryLink id="89d9-43d8-856e-d1e0" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup"/>
+        <entryLink id="6991-cb22-811f-3935" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup" />
+        <entryLink id="89d9-43d8-856e-d1e0" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
     <entryLink id="da7d-be52-7812-61bb" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="79ec-28c1-ec3b-4210" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="482e-828e-7fa4-07f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="af3b-c056-7a37-8ab1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="79ec-28c1-ec3b-4210" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="482e-828e-7fa4-07f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="af3b-c056-7a37-8ab1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="1c15-2119-4405-ad03" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup"/>
-        <entryLink id="4946-1cb8-219b-c505" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup"/>
+        <entryLink id="1c15-2119-4405-ad03" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup" />
+        <entryLink id="4946-1cb8-219b-c505" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
     <entryLink id="44a2-f6df-fc05-0f43" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9681-ed26-675b-936e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="34df-50a4-147b-7f8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="9681-ed26-675b-936e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="34df-50a4-147b-7f8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="bfdc-b6f8-3138-8993" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b042-556b-affd-a549" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="bbc8-4a63-f7da-3277" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b042-556b-affd-a549" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="bbc8-4a63-f7da-3277" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
     <entryLink id="04be-2dc8-bf31-92c7" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9e53-bf1b-df8d-242b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7f71-49ae-a8cc-92c6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="9e53-bf1b-df8d-242b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7f71-49ae-a8cc-92c6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="7654-4428-0eaf-2bb3" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8310-c7f7-2c1d-81f6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="a750-723e-d54c-55f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8310-c7f7-2c1d-81f6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="a750-723e-d54c-55f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
     <entryLink id="71c8-b9c3-03b7-5e46" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="94bf-9f97-a6cc-bdbd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="b499-29d1-1084-9c1b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="94bf-9f97-a6cc-bdbd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="b499-29d1-1084-9c1b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
     <entryLink id="55e3-53f8-aff1-56f0" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b654-0713-dbcb-fac2" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="396b-66cf-fde7-6b45" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b654-0713-dbcb-fac2" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="396b-66cf-fde7-6b45" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
     <entryLink id="7cad-f100-ccda-a2c1" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b87e-e496-5d32-636a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a617-6b7d-855f-51d4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="b87e-e496-5d32-636a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a617-6b7d-855f-51d4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
     <entryLink id="1905-93de-51a5-c39a" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f754-2f56-75b8-39bf" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="6736-d5b0-cac5-f893" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f754-2f56-75b8-39bf" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="6736-d5b0-cac5-f893" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
     <entryLink id="4fff-23a6-e0ad-0040" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9ec9-a831-8230-aed1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d162-0b9b-3468-ffc7" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="9ec9-a831-8230-aed1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d162-0b9b-3468-ffc7" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
     <entryLink id="d44f-c5aa-43fe-f35a" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3f6c-1b86-d49a-81cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ef92-356d-bb25-4a7d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3f6c-1b86-d49a-81cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ef92-356d-bb25-4a7d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
     <entryLink id="279f-7714-301f-2ccb" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1007-272e-be59-3e53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="04a2-9cc9-83f4-a3f6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="1007-272e-be59-3e53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="04a2-9cc9-83f4-a3f6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
     <entryLink id="b5ed-8cb8-70d7-d337" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="58a6-399b-95e2-fba4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="532e-6998-04cb-82d5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="58a6-399b-95e2-fba4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="532e-6998-04cb-82d5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
     <entryLink id="5738-89d2-d898-dd43" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5f74-6f21-6cc9-20fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1e39-1810-c70a-7a3a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="5f74-6f21-6cc9-20fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1e39-1810-c70a-7a3a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="d5e8-eda5-2bba-8981" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="58d1-ba27-3195-3d6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ee32-1f6f-8f4f-742d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="58d1-ba27-3195-3d6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ee32-1f6f-8f4f-742d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
     <entryLink id="b2d9-6f4a-cc5f-e78c" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1cb1-7fa2-7338-4df6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7d4b-dd38-5a01-a103" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="1cb1-7fa2-7338-4df6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7d4b-dd38-5a01-a103" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="8e34-be48-fc63-1061" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e242-af15-f16b-99f0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="44c7-56d4-0c47-31af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e242-af15-f16b-99f0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="44c7-56d4-0c47-31af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
     <entryLink id="28e1-088a-a00b-14a5" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9808-f361-416c-03d1" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="a743-dc77-7516-e95c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9808-f361-416c-03d1" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="a743-dc77-7516-e95c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
     <entryLink id="e5f8-9815-7d06-4090" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="01b2-fd1e-2294-5d82" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="2f4e-1098-6b0e-b788" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="01b2-fd1e-2294-5d82" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="2f4e-1098-6b0e-b788" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
     <entryLink id="9223-b6a2-72c3-f158" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3bea-73b6-8ffe-4dca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0eb7-2d24-5c4f-7b36" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="77b5-2752-298a-c4a9" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="3bea-73b6-8ffe-4dca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0eb7-2d24-5c4f-7b36" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="77b5-2752-298a-c4a9" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="ef99-24bb-258b-d38c" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0512-465f-44fa-31a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="14ff-8be5-1fe9-c875" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="0512-465f-44fa-31a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="14ff-8be5-1fe9-c875" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
     <entryLink id="e182-b167-658c-777d" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8f9f-20c5-d188-6895" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="140b-5729-a0b5-22e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8f9f-20c5-d188-6895" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="140b-5729-a0b5-22e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
     <entryLink id="d9d6-f726-7d7b-1ffb" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="cd37-4063-e2a5-338c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f59c-c588-3941-1bbd" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="cd37-4063-e2a5-338c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f59c-c588-3941-1bbd" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
     <entryLink id="7b7b-2196-728e-38b0" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f80a-83c5-663b-bb6e" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="669a-3be3-1c78-94ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f80a-83c5-663b-bb6e" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="669a-3be3-1c78-94ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="f91b-17f1-641e-4f44" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7286-858d-7b12-757d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="f6f5-060e-5033-5561" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7286-858d-7b12-757d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="f6f5-060e-5033-5561" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
     <entryLink id="86ed-08f1-a8ec-dc32" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2a39-857d-f54d-9c2c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="a647-e450-e635-41ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2a39-857d-f54d-9c2c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="a647-e450-e635-41ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="88d1-f74f-1ce1-b28b" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="736d-dea2-e8c1-5a0c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="17db-f60d-520a-d6e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="736d-dea2-e8c1-5a0c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="17db-f60d-520a-d6e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
     <entryLink id="1f94-02a7-c8b1-904a" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f032-b807-395c-20c2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="6452-0568-f373-36ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f032-b807-395c-20c2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="6452-0568-f373-36ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
     <entryLink id="1191-d33e-b4cd-60a9" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1215-3850-b799-00dd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="9e71-7304-0a04-c353" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1215-3850-b799-00dd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="9e71-7304-0a04-c353" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
     <entryLink id="2260-bbe6-a8c2-1d7d" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="832e-3147-9188-d333" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="2205-836c-f187-f54e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="832e-3147-9188-d333" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="2205-836c-f187-f54e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
     <entryLink id="1042-91c1-17c2-50e5" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="590a-64f1-a0fc-7f28" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2f58-074e-4b84-d0b5" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="3931-9a80-26ee-1472" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="590a-64f1-a0fc-7f28" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2f58-074e-4b84-d0b5" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
+        <categoryLink id="3931-9a80-26ee-1472" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="59f9-fb6b-cbcc-603f" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="30ad-d5ba-6803-4c1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7c04-f138-c644-d921" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="30ad-d5ba-6803-4c1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7c04-f138-c644-d921" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
     <entryLink id="75fa-5312-9b7b-4254" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fa87-a330-0a86-a6d4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="be46-4a53-ce54-1b0a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fa87-a330-0a86-a6d4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="be46-4a53-ce54-1b0a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
     <entryLink id="4d2e-1b91-bb2c-ec0e" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a154-dcf6-2800-217f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3de0-b87a-7b60-7eb7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="a154-dcf6-2800-217f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3de0-b87a-7b60-7eb7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
     <entryLink id="46fb-2fd0-838e-7eea" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b46b-8f20-ae5f-adcf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dc72-17d7-73c1-6a95" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="b46b-8f20-ae5f-adcf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="dc72-17d7-73c1-6a95" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="8c74-40b1-5019-f4d4" name="Vulkan" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65d8-0392-0de1-6820" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65d8-0392-0de1-6820" type="max" />
       </constraints>
       <profiles>
         <profile id="e9c4-70b0-428e-2d3e" name="Vulkan" publicationId="817a-6288-e016-7469" page="314" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -1070,19 +1069,19 @@
       <infoLinks>
         <infoLink id="9855-2de1-1749-7fe0" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="It Will Not Die (4+)"/>
+            <modifier type="set" field="name" value="It Will Not Die (4+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="97f1-63ad-b403-6ae7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="ff2f-d33d-2e7c-9895" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="97f1-63ad-b403-6ae7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="ff2f-d33d-2e7c-9895" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b52a-be67-5e91-6268" name="Dawnbringer" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b20a-b402-3cca-0ee5" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d2b-61d9-db46-d465" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b20a-b402-3cca-0ee5" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d2b-61d9-db46-d465" type="max" />
           </constraints>
           <profiles>
             <profile id="2d09-73bf-786f-3016" name="Dawnbringer" publicationId="817a-6288-e016-7469" page="315" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1095,28 +1094,28 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="3838-94ec-e581-075c" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
-            <infoLink id="3096-ed64-c1de-5585" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+            <infoLink id="3838-94ec-e581-075c" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
+            <infoLink id="3096-ed64-c1de-5585" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
             <infoLink id="1721-bb9b-d3c2-a547" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Armourbane (Melee)"/>
+                <modifier type="set" field="name" value="Armourbane (Melee)" />
               </modifiers>
             </infoLink>
-            <infoLink id="5a92-5530-1be3-6d87" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
+            <infoLink id="5a92-5530-1be3-6d87" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
-        <selectionEntry id="0b0a-6d48-9513-fbbf" name="The Furnace&apos;s Heart" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="0b0a-6d48-9513-fbbf" name="The Furnace's Heart" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3dc0-9e4f-f81d-55ce" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c3f-97f7-be13-09de" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3dc0-9e4f-f81d-55ce" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c3f-97f7-be13-09de" type="max" />
           </constraints>
           <profiles>
-            <profile id="3a16-fd7b-1980-53c2" name="The Furnace&apos;s Heart" publicationId="817a-6288-e016-7469" page="315" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="3a16-fd7b-1980-53c2" name="The Furnace's Heart" publicationId="817a-6288-e016-7469" page="315" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">18"</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 1</characteristic>
@@ -1129,49 +1128,49 @@
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="8293-a025-d658-c377" name="Lance" hidden="false" targetId="3d6b-9e0b-56f0-8a1e" type="rule"/>
-            <infoLink id="eed9-317e-d1b9-e78d" name="Shock Pulse" hidden="false" targetId="9222-f6c5-dc19-905a" type="rule"/>
+            <infoLink id="8293-a025-d658-c377" name="Lance" hidden="false" targetId="3d6b-9e0b-56f0-8a1e" type="rule" />
+            <infoLink id="eed9-317e-d1b9-e78d" name="Shock Pulse" hidden="false" targetId="9222-f6c5-dc19-905a" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="636d-097e-8b4d-9603" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5c7-a5a0-07f4-4211" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5c7-adc1-478f-0948" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5c7-a5a0-07f4-4211" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5c7-adc1-478f-0948" type="min" />
           </constraints>
         </entryLink>
-        <entryLink id="8528-e282-de0a-8bb4" name="Dragon&apos;s Breath Heavy Flamer" hidden="false" collective="false" import="true" targetId="1a5c-0c5f-d798-a067" type="selectionEntry">
+        <entryLink id="8528-e282-de0a-8bb4" name="Dragon's Breath Heavy Flamer" hidden="false" collective="false" import="true" targetId="1a5c-0c5f-d798-a067" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d1a-1e53-d7d4-a5ac" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7630-9187-a9d0-5877" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d1a-1e53-d7d4-a5ac" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7630-9187-a9d0-5877" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="ee55-740f-5176-67e0" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c782-6733-4ebc-a5bb" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ace-2e5f-cd90-f745" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c782-6733-4ebc-a5bb" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ace-2e5f-cd90-f745" type="min" />
           </constraints>
           <profiles>
             <profile id="ae6c-bdeb-868e-698b" name="Sire of the Salamanders" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All models with both the Infantry Unit Type and the Legiones Astartes (Salamanders) special rule in the same army as Vulkan gain the Stubborn special rule. In addition, an army with Vulkan as its Warlord gains an additional Reaction in the opposing player&apos;s Shooting phase as long as Vulkan has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All models with both the Infantry Unit Type and the Legiones Astartes (Salamanders) special rule in the same army as Vulkan gain the Stubborn special rule. In addition, an army with Vulkan as its Warlord gains an additional Reaction in the opposing player's Shooting phase as long as Vulkan has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
         <entryLink id="9729-c225-9b38-e741" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ca3-c8b5-982e-c8ff" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22be-1ff5-91c7-8d7d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ca3-c8b5-982e-c8ff" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22be-1ff5-91c7-8d7d" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="465.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="465.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="71fe-d3bc-b7f9-75ca" name="Pyroclast Squad" hidden="false" collective="false" import="true" type="unit">
@@ -1181,28 +1180,28 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="78ac-0e70-651e-01fa" name="Legiones Astartes (Salamanders) " hidden="false" targetId="5b72-d9a6-92c3-4a1c" type="rule"/>
+        <infoLink id="78ac-0e70-651e-01fa" name="Legiones Astartes (Salamanders) " hidden="false" targetId="5b72-d9a6-92c3-4a1c" type="rule" />
         <infoLink id="614e-38bb-0602-4acd" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="It Will Not Die (5+)"/>
+            <modifier type="set" field="name" value="It Will Not Die (5+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="d837-e352-e6f6-6b63" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="0f09-6dcb-5b34-c507" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="d837-e352-e6f6-6b63" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="0f09-6dcb-5b34-c507" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c8d5-7b74-c1d6-2535" name="Pyroclasts" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e02-b478-e703-1dda" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb78-1203-8b64-cf3c" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e02-b478-e703-1dda" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb78-1203-8b64-cf3c" type="min" />
           </constraints>
           <profiles>
             <profile id="43f3-26bc-ec9d-40af" name="Pyroclasts" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1216,19 +1215,19 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="59b5-2903-41d4-da1c" name="Pyroclast Warden" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f260-6299-5f47-d4d7" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75c0-5a2c-caf0-1a48" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f260-6299-5f47-d4d7" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75c0-5a2c-caf0-1a48" type="min" />
           </constraints>
           <profiles>
             <profile id="73e1-2cf6-ef77-011d" name="Pyroclast Warden" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1242,55 +1241,55 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="ad9b-ee4b-9a7f-081f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="ad9b-ee4b-9a7f-081f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a058-7b3e-3f47-c9eb" name="Warden Melee:" hidden="false" collective="false" import="true" defaultSelectionEntryId="3028-3f3e-8046-4a4f">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="046e-2446-2513-3767" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1af-4894-82b7-7160" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="046e-2446-2513-3767" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1af-4894-82b7-7160" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="1ed1-0846-d846-45bc" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="4043-39ae-b665-0dd2" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="bb96-3744-6045-7822" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="b499-f866-9173-0a45" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="672d-cf3e-640b-2b20" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="3028-3f3e-8046-4a4f" name="Basic Close Combat Weapon" hidden="false" collective="false" import="true" targetId="7b0e-d0bf-8ed2-8f30" type="selectionEntry"/>
+                <entryLink id="3028-3f3e-8046-4a4f" name="Basic Close Combat Weapon" hidden="false" collective="false" import="true" targetId="7b0e-d0bf-8ed2-8f30" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="4348-0119-3bab-4d4c" name="Master-craft one weapon" hidden="false" collective="false" import="true" targetId="3d6e-5c80-d195-0f2e" type="selectionEntry"/>
+            <entryLink id="4348-0119-3bab-4d4c" name="Master-craft one weapon" hidden="false" collective="false" import="true" targetId="3d6e-5c80-d195-0f2e" type="selectionEntry" />
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="7411-dded-ec1f-bb6d" name="Pyroclast Flame Projector" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65e7-d03c-1583-3aa6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d90a-8acc-2324-9dd8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65e7-d03c-1583-3aa6" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d90a-8acc-2324-9dd8" type="min" />
           </constraints>
           <profiles>
             <profile id="79df-2877-93f2-bad3" name="Pyroclast Flame Projector - Dispersed" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1298,12 +1297,12 @@
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">Template</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Dragon&apos;s Breath</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Dragon's Breath</characteristic>
               </characteristics>
             </profile>
             <profile id="5734-2977-9bae-0276" name="Pyroclast Flame Projector - Focused" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">12"</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Armourbane (Melta)</characteristic>
@@ -1311,29 +1310,29 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="0ce0-4bed-203c-292c" name="Dragon&apos;s Breath" hidden="false" targetId="655c-988f-74b5-7e17" type="rule"/>
+            <infoLink id="0ce0-4bed-203c-292c" name="Dragon's Breath" hidden="false" targetId="655c-988f-74b5-7e17" type="rule" />
             <infoLink id="fd22-8d76-6794-92cf" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Armourbane (Melta)"/>
+                <modifier type="set" field="name" value="Armourbane (Melta)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="e42d-59a0-15a8-4958" name="Dedicated Transport" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dd0-1194-98b8-06e4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dd0-1194-98b8-06e4" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="58de-afbd-b0ab-1e6c" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1342,7 +1341,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1351,7 +1350,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1362,86 +1361,86 @@
       <entryLinks>
         <entryLink id="8e95-3747-be36-5b6e" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0625-805f-1fe2-aeef" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8039-2f69-8753-5b06" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0625-805f-1fe2-aeef" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8039-2f69-8753-5b06" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="6e5f-c295-2fe1-2389" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86de-244d-28bf-e1db" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="681f-6b92-0c46-8d59" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86de-244d-28bf-e1db" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="681f-6b92-0c46-8d59" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="7ab6-e184-e76b-fd79" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f877-4d63-eff3-d04e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e51-3023-b3e6-9a9a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f877-4d63-eff3-d04e" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e51-3023-b3e6-9a9a" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="e2ec-9889-8c19-c34c" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23d4-4235-474c-5ed3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="684a-4a80-7722-2e2e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23d4-4235-474c-5ed3" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="684a-4a80-7722-2e2e" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="1241-864f-447d-ed3b" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f546-59d2-b9e7-2b09" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f03-5f77-90c3-808b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f546-59d2-b9e7-2b09" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f03-5f77-90c3-808b" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="529b-cd98-3804-d24f" name="Basic Close Combat Weapon" hidden="false" collective="false" import="true" targetId="7b0e-d0bf-8ed2-8f30" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a2b8-8c53-ad03-2d72" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2048-702a-e772-53d7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a2b8-8c53-ad03-2d72" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2048-702a-e772-53d7" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="6775-8379-8d6b-9614" name="Firedrake Terminator Squad" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="5643-e6a1-a722-b0c6" name="Favoured of Vulkan " hidden="true">
-          <description>A Firedrake Squad may be selected as a Retinue Squad in a Detachment that includes at least one model with both the Master of the Legion and Legiones Astartes (Salamanders) special rules, instead of as an Elites choice. A unit selected as a ‘Retinue Squad’ must have one model with both the Master of the Legion and Legiones Astartes (Salamanders) special rules from the same Detachment selected by the controlling player as the Firedrake Squad’s Leader for the purposes of this special rule. A Firedrake Squad selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. A Firedrake Squad selected as a Retinue Squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Retinue Squad during play</description>
+          <description>A Firedrake Squad may be selected as a Retinue Squad in a Detachment that includes at least one model with both the Master of the Legion and Legiones Astartes (Salamanders) special rules, instead of as an Elites choice. A unit selected as a &#8216;Retinue Squad&#8217; must have one model with both the Master of the Legion and Legiones Astartes (Salamanders) special rules from the same Detachment selected by the controlling player as the Firedrake Squad&#8217;s Leader for the purposes of this special rule. A Firedrake Squad selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. A Firedrake Squad selected as a Retinue Squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Retinue Squad during play</description>
         </rule>
         <rule id="3918-9a84-af8e-96b2" name="Forge-craft of Nocturne" hidden="false">
           <description>The controlling player of a model with this special rule may re-roll all failed To Hit rolls of 1 for weapons of the Melee type.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="3ad0-6c67-01f3-4d7a" name="Legiones Astartes (Salamanders) " hidden="false" targetId="5b72-d9a6-92c3-4a1c" type="rule"/>
-        <infoLink id="96b4-a039-5166-5365" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="3ad0-6c67-01f3-4d7a" name="Legiones Astartes (Salamanders) " hidden="false" targetId="5b72-d9a6-92c3-4a1c" type="rule" />
+        <infoLink id="96b4-a039-5166-5365" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="9c8a-ead3-d69d-7110" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="1b90-b832-8635-91c5" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="1b90-b832-8635-91c5" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
         <infoLink id="62ae-f85b-4774-54d1" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="It Will Not Die (5+)"/>
+            <modifier type="set" field="name" value="It Will Not Die (5+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b47e-4128-4626-5ab1" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="0d65-1662-e010-f889" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="f28b-f86f-8c4f-ba4f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="a1cf-3d0c-18a6-773d" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="b47e-4128-4626-5ab1" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="0d65-1662-e010-f889" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="f28b-f86f-8c4f-ba4f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="a1cf-3d0c-18a6-773d" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a06f-66d8-a8c1-63fa" name="Firedrakes" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e987-1355-d39b-5aa3" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dee5-edd6-5dd8-237a" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e987-1355-d39b-5aa3" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dee5-edd6-5dd8-237a" type="min" />
           </constraints>
           <profiles>
             <profile id="906d-a6e2-3a9d-06cb" name="Firedrake" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1457,26 +1456,26 @@
           <selectionEntryGroups>
             <selectionEntryGroup id="ce52-8553-5fe4-a475" name="1) Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5ac5-5bcc-7563-22a4">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c2d-8bb7-e274-1c1c" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3da6-9245-c23f-41b8" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c2d-8bb7-e274-1c1c" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3da6-9245-c23f-41b8" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="b75b-28f6-b135-8dc0" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
-                <entryLink id="5ac5-5bcc-7563-22a4" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
-                <entryLink id="6bbe-3687-7c8d-6686" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
+                <entryLink id="b75b-28f6-b135-8dc0" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
+                <entryLink id="5ac5-5bcc-7563-22a4" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry" />
+                <entryLink id="6bbe-3687-7c8d-6686" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry" />
                 <entryLink id="37b9-9e40-eaf3-8bcb" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="0cd2-9418-c58f-a408" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="7ebe-953c-b979-e289" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1485,69 +1484,69 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="599c-723a-7917-cff8" type="equalTo"/>
+                    <condition field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="599c-723a-7917-cff8" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="6eb3-9389-ea95-66d7" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="599c-723a-7917-cff8" type="equalTo"/>
+                    <condition field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="599c-723a-7917-cff8" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="7ab5-4102-b635-708d" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="599c-723a-7917-cff8" type="equalTo"/>
+                    <condition field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="599c-723a-7917-cff8" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ab5-4102-b635-708d" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6eb3-9389-ea95-66d7" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ab5-4102-b635-708d" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6eb3-9389-ea95-66d7" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="07bc-1cd0-b38a-e782" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="3e8b-5920-89dc-8bdb" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="f5ea-d4ff-92d9-c034" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                <entryLink id="f5ea-d4ff-92d9-c034" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="ca9b-aacb-7bb3-0667" name="One model may exchange either their Combi-bolter or Dragonscale Shield with:" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b537-84b5-8d8e-1404" type="max"/>
-                <constraint field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5be1-a957-9af0-3bfb" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b537-84b5-8d8e-1404" type="max" />
+                <constraint field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5be1-a957-9af0-3bfb" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="b1bb-6ec3-4402-f9d9" name="Dragon&apos;s Breath Heavy Flamer" hidden="false" collective="false" import="true" targetId="1a5c-0c5f-d798-a067" type="selectionEntry">
+                <entryLink id="b1bb-6ec3-4402-f9d9" name="Dragon's Breath Heavy Flamer" hidden="false" collective="false" import="true" targetId="1a5c-0c5f-d798-a067" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a9e5-436d-136b-6ec4" type="max"/>
+                    <constraint field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a9e5-436d-136b-6ec4" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="d8b7-2197-33f3-6668" name="Firedrake Master" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f311-4d90-dbbd-05c4" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd7b-4588-ade8-b5ac" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f311-4d90-dbbd-05c4" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd7b-4588-ade8-b5ac" type="min" />
           </constraints>
           <profiles>
             <profile id="6d1a-2120-51a7-406c" name="Firedrake Master" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Heavy)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1561,47 +1560,47 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="7493-b565-8d7b-ebe9" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="7493-b565-8d7b-ebe9" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="5aec-2671-da16-e919" name="1) Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="c167-f4c9-6ab3-7a15">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="982e-7d12-4379-5538" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6f0-ced1-d4d9-a2d8" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="982e-7d12-4379-5538" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6f0-ced1-d4d9-a2d8" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="d225-f3bc-ded4-bc25" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
-                <entryLink id="c167-f4c9-6ab3-7a15" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
-                <entryLink id="555c-03b3-7f2e-da29" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
+                <entryLink id="d225-f3bc-ded4-bc25" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
+                <entryLink id="c167-f4c9-6ab3-7a15" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry" />
+                <entryLink id="555c-03b3-7f2e-da29" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry" />
                 <entryLink id="bb94-c4b3-a6c8-564b" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="52ed-c8e7-debd-6d5c" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="5596-0bb5-495f-2dde" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="4a62-eb83-337a-5daa" name="One model may exchange either their Combi-bolter or Dragonscale Shield with:" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff5e-afcb-e186-b5e3" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="382a-d2ad-f3e5-0998" type="max"/>
+                <constraint field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff5e-afcb-e186-b5e3" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="382a-d2ad-f3e5-0998" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="4c7d-c23c-41ce-0b12" name="Dragon&apos;s Breath Heavy Flamer" hidden="false" collective="false" import="true" targetId="1a5c-0c5f-d798-a067" type="selectionEntry">
+                <entryLink id="4c7d-c23c-41ce-0b12" name="Dragon's Breath Heavy Flamer" hidden="false" collective="false" import="true" targetId="1a5c-0c5f-d798-a067" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4826-a730-1b04-74dd" type="max"/>
+                    <constraint field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4826-a730-1b04-74dd" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1610,59 +1609,59 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="599c-723a-7917-cff8" type="equalTo"/>
+                    <condition field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="599c-723a-7917-cff8" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="0978-66a2-363a-6557" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="599c-723a-7917-cff8" type="equalTo"/>
+                    <condition field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="599c-723a-7917-cff8" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="e54a-5fee-f1d7-1dc8" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="599c-723a-7917-cff8" type="equalTo"/>
+                    <condition field="selections" scope="6775-8379-8d6b-9614" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="599c-723a-7917-cff8" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0978-66a2-363a-6557" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e54a-5fee-f1d7-1dc8" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0978-66a2-363a-6557" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e54a-5fee-f1d7-1dc8" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="6176-c633-6203-d255" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="c3be-d3a2-7d71-bf0e" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="5df0-2fc6-a4ac-2fcf" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                <entryLink id="5df0-2fc6-a4ac-2fcf" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="c12f-2514-969e-617d" name="Master-craft one weapon" hidden="false" collective="false" import="true" targetId="3d6e-5c80-d195-0f2e" type="selectionEntry"/>
+            <entryLink id="c12f-2514-969e-617d" name="Master-craft one weapon" hidden="false" collective="false" import="true" targetId="3d6e-5c80-d195-0f2e" type="selectionEntry" />
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="cb99-db0b-3c35-1894" name="Dedicated Transport" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da50-52b8-f67f-d9f4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da50-52b8-f67f-d9f4" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="9a77-82bb-35c7-ad9a" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"/>
+            <entryLink id="9a77-82bb-35c7-ad9a" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry" />
             <entryLink id="f489-0fd9-fa96-2acb" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="6775-8379-8d6b-9614" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="selections" scope="6775-8379-8d6b-9614" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1675,33 +1674,33 @@
               <modifiers>
                 <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30b1-9a31-ce7d-22a6" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30b1-9a31-ce7d-22a6" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="0202-ea46-e65e-99e9" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry"/>
+        <entryLink id="0202-ea46-e65e-99e9" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="fb8a-ab72-52ce-38f3" name="Cassian Dracos Reborn" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="05bb-a7ee-45fa-877a" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="05bb-a7ee-45fa-877a" type="max" />
       </constraints>
       <profiles>
         <profile id="03c1-b57e-9f00-23a6" name="Cassian Dracos Reborn" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Dreadnought (Heavy, Unique)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
@@ -1713,7 +1712,7 @@
             <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
           </characteristics>
         </profile>
-        <profile id="0f09-cbd9-a8be-5706" name="Two Gravis power fists with in-built Dragon’s breath heavy flamers.*" publicationId="d0df-7166-5cd3-89fd" page="69" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+        <profile id="0f09-cbd9-a8be-5706" name="Two Gravis power fists with in-built Dragon&#8217;s breath heavy flamers.*" publicationId="d0df-7166-5cd3-89fd" page="69" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
           <characteristics>
             <characteristic name="Description" typeId="347e-ee4a-764f-6be3">*The additional close combat attacks are already included in profile.</characteristic>
           </characteristics>
@@ -1724,36 +1723,36 @@
           <description>Cassian Dracos Reborn has the Cybertheurgic Arcana: Artificia Machina (see Liber Mechanicum).</description>
         </rule>
         <rule id="34da-6158-0050-f6c2" name="Avatar of the Sacred Flames" publicationId="d0df-7166-5cd3-89fd" page="69" hidden="false">
-          <description>As long as no HQ choices other than Xiaphas Jurr and Nârik Dreygur are included in the same Detachment, Cassian Dracos Reborn may be selected as the army’s Warlord. If selected as the army’s Warlord, Cassian Dracos must use the Bloody-handed Warlord Trait.</description>
+          <description>As long as no HQ choices other than Xiaphas Jurr and N&#226;rik Dreygur are included in the same Detachment, Cassian Dracos Reborn may be selected as the army&#8217;s Warlord. If selected as the army&#8217;s Warlord, Cassian Dracos must use the Bloody-handed Warlord Trait.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="61e5-b6c9-2ba2-c317" name="Ferromantic Deflector" hidden="false" targetId="7884-e18a-16ee-068c" type="profile"/>
+        <infoLink id="61e5-b6c9-2ba2-c317" name="Ferromantic Deflector" hidden="false" targetId="7884-e18a-16ee-068c" type="profile" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="3af7-46b2-2419-4a55" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="d849-8fbc-0faa-8dfb" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
-        <categoryLink id="2ff0-6e13-57f0-e139" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="3af7-46b2-2419-4a55" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="d849-8fbc-0faa-8dfb" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false" />
+        <categoryLink id="2ff0-6e13-57f0-e139" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <entryLinks>
         <entryLink id="8df9-b411-be3d-51a9" name="Dreadnought Drop Pod" hidden="false" collective="false" import="true" targetId="1ffe-82e4-12db-538d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="113d-649d-2712-e7d3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="113d-649d-2712-e7d3" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="2df1-a876-8813-ed61" name="Gravis Power Fist" hidden="false" collective="false" import="true" targetId="08be-6994-6a63-6279" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="becd-2d72-199e-92cf" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73ca-d233-ba23-6352" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="becd-2d72-199e-92cf" type="min" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73ca-d233-ba23-6352" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="edb7-11c3-d4c5-6818" name="Dragon&apos;s Breath Heavy Flamer" hidden="false" collective="false" import="true" targetId="1a5c-0c5f-d798-a067" type="selectionEntry">
+        <entryLink id="edb7-11c3-d4c5-6818" name="Dragon's Breath Heavy Flamer" hidden="false" collective="false" import="true" targetId="1a5c-0c5f-d798-a067" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="name" value="In-built Dragon&apos;s Breath Heavy Flamer"/>
+            <modifier type="set" field="name" value="In-built Dragon's Breath Heavy Flamer" />
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb96-3d6b-1505-61c9" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6784-262f-b315-51f5" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb96-3d6b-1505-61c9" type="max" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6784-262f-b315-51f5" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="5e10-2ac4-044b-8d62" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
@@ -1762,44 +1761,44 @@
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3766-ea98-0aa7-62d0" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1b79-1951-5a63-4b9e" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3760-204e-444c-1044" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="25a2-7a52-632a-6b2c" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f806-8a4e-d0d6-beaa" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="03be-5d55-d05a-771d" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e337-8239-5e92-7f5f" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3766-ea98-0aa7-62d0" type="greaterThan" />
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1b79-1951-5a63-4b9e" type="greaterThan" />
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3760-204e-444c-1044" type="greaterThan" />
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="25a2-7a52-632a-6b2c" type="greaterThan" />
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f806-8a4e-d0d6-beaa" type="greaterThan" />
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="03be-5d55-d05a-771d" type="greaterThan" />
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e337-8239-5e92-7f5f" type="greaterThan" />
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e38e-3f0f-0960-5a76" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e38e-3f0f-0960-5a76" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="b5b6-e87c-10c6-efbf" name="Bloody-handed" hidden="false" collective="false" import="true" targetId="2b87-826d-22a1-682c" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e96-241f-12f1-2c4c" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f0f-19bf-18cb-027d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e96-241f-12f1-2c4c" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f0f-19bf-18cb-027d" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="310.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="310.0" />
       </costs>
     </selectionEntry>
-    <selectionEntry id="74f6-96f4-ee55-9c78" name="Lord Chaplain Nomus Rhy&apos;Tan" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="74f6-96f4-ee55-9c78" name="Lord Chaplain Nomus Rhy'Tan" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="918e-d896-4cbf-4b53" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="918e-d896-4cbf-4b53" type="max" />
       </constraints>
       <profiles>
-        <profile id="4307-c42a-fc2f-5651" name="Lord Chaplain Nomus Rhy&apos;Tan" publicationId="d0df-7166-5cd3-89fd" page="70" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+        <profile id="4307-c42a-fc2f-5651" name="Lord Chaplain Nomus Rhy'Tan" publicationId="d0df-7166-5cd3-89fd" page="70" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1813,24 +1812,24 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="61ab-fc87-edda-aab7" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="4c76-c529-12b4-d083" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="61ab-fc87-edda-aab7" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="4c76-c529-12b4-d083" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
         <infoLink id="af12-4093-15a8-1270" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hatred (Everything)"/>
+            <modifier type="set" field="name" value="Hatred (Everything)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="f22c-47a5-ca44-ccdc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="b624-3e54-171d-2b09" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="a0e0-976d-1292-1fc3" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="f22c-47a5-ca44-ccdc" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="b624-3e54-171d-2b09" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="a0e0-976d-1292-1fc3" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ad7a-6a4c-6cc0-a007" name="Darkstar Falling" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b12d-de34-e96b-d4b0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="950b-f722-41c3-dd89" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b12d-de34-e96b-d4b0" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="950b-f722-41c3-dd89" type="max" />
           </constraints>
           <profiles>
             <profile id="56af-6142-3b02-9ee6" name="Darkstar Falling" publicationId="d0df-7166-5cd3-89fd" page="70" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1843,89 +1842,89 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="7d13-8a2a-aa1c-b384" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
-            <infoLink id="d978-604d-a917-e108" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+            <infoLink id="7d13-8a2a-aa1c-b384" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
+            <infoLink id="d978-604d-a917-e108" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="b3de-e055-306a-c9c0" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c76d-b08f-ea58-b2f8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c76d-b08f-ea58-b2f8" type="max" />
           </constraints>
           <profiles>
             <profile id="af9f-4a39-2626-23a4" name="Keeper of the Keys" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any model with the Dreadnought Unit Type and the Legiones Astartes (Salamanders) special rule within 6&quot; of a Warlord with this Trait may add +2&quot; to their Charge Distance. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any model with the Dreadnought Unit Type and the Legiones Astartes (Salamanders) special rule within 6" of a Warlord with this Trait may add +2" to their Charge Distance. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
         <entryLink id="bc8e-4fe8-003b-7976" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba4c-5848-4df8-f151" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="323b-ffdc-bea2-e0ec" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba4c-5848-4df8-f151" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="323b-ffdc-bea2-e0ec" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="6281-3735-3315-6f1d" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cb9-23d3-7dbb-f0c0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ead-24db-9898-c66c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cb9-23d3-7dbb-f0c0" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ead-24db-9898-c66c" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="eb74-cc50-9659-586b" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2009-42cc-a83a-a974" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa8d-9626-5d34-36ec" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2009-42cc-a83a-a974" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa8d-9626-5d34-36ec" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="5927-cd3c-e333-8755" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6a0-29cd-adb9-6451" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1605-be23-169e-08d4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6a0-29cd-adb9-6451" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1605-be23-169e-08d4" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="4de3-b46b-b96e-b470" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="256b-3a34-d900-fe00" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bfe-a939-bd09-c10f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="256b-3a34-d900-fe00" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bfe-a939-bd09-c10f" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="f509-080e-d334-a5a3" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a83c-7749-70c2-890c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3016-4345-4f5f-aaac" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a83c-7749-70c2-890c" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3016-4345-4f5f-aaac" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="dffd-a4de-8572-9947" name="Mantle of the Elder Drake" hidden="false" collective="false" import="true" targetId="bba6-42e4-5147-fe4f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6679-560b-88ad-cf03" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2184-eed5-4497-8364" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6679-560b-88ad-cf03" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2184-eed5-4497-8364" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="5bbc-3c8d-025b-4a37" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42a0-d2cd-f14e-78a3" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a013-8f9e-9e53-f47d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42a0-d2cd-f14e-78a3" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a013-8f9e-9e53-f47d" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="215.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="215.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="30b8-05a5-fef7-fe66" name="Xiaphas Jurr" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ad8d-9fdb-7550-1d9d" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ad8d-9fdb-7550-1d9d" type="max" />
       </constraints>
       <profiles>
         <profile id="cb39-0702-a198-6f3a" name="Xiaphas Jurr" publicationId="d0df-7166-5cd3-89fd" page="71" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1944,24 +1943,24 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="3180-2202-fd13-8a8a" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="4460-a5a9-4d10-ecb4" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="3180-2202-fd13-8a8a" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="4460-a5a9-4d10-ecb4" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
         <infoLink id="588e-6359-b745-8f85" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hatred (Everything)"/>
+            <modifier type="set" field="name" value="Hatred (Everything)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8e0a-7307-985f-50a6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="4585-3e1e-8e4c-4a36" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="0aae-444b-0567-6f6a" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="8e0a-7307-985f-50a6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="4585-3e1e-8e4c-4a36" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="0aae-444b-0567-6f6a" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9c05-d6b4-ed8b-c06a" name="Ignatus" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="641e-c75a-be68-c063" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49a3-8780-d396-5d50" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="641e-c75a-be68-c063" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49a3-8780-d396-5d50" type="min" />
           </constraints>
           <profiles>
             <profile id="aebd-6744-2b6a-6aab" name="Ignatus" publicationId="d0df-7166-5cd3-89fd" page="71" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1974,17 +1973,17 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="2cec-8f0d-b8e7-153c" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule"/>
-            <infoLink id="f010-74ed-ea87-6b5b" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="2cec-8f0d-b8e7-153c" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule" />
+            <infoLink id="f010-74ed-ea87-6b5b" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="f728-18e4-8ddd-cf4a" name="The Burning Halo" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a491-328a-d198-37a8" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="904d-d426-2efd-c0eb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a491-328a-d198-37a8" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="904d-d426-2efd-c0eb" type="min" />
           </constraints>
           <profiles>
             <profile id="c859-89a8-8127-5326" name="The Burning Halo" publicationId="d0df-7166-5cd3-89fd" page="71" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
@@ -1994,56 +1993,56 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="3fd8-a2c8-d71c-5fee" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c17-b7ea-f6cf-10b9" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27f6-f6ac-ae46-ad4a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c17-b7ea-f6cf-10b9" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27f6-f6ac-ae46-ad4a" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="c223-d630-15c1-c75d" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5233-49f8-ae4f-83b5" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2f1-c530-bb8f-8c76" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5233-49f8-ae4f-83b5" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2f1-c530-bb8f-8c76" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="8ef5-9570-8242-2c45" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee64-93f3-e775-5091" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7378-84d3-ba17-bab9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee64-93f3-e775-5091" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7378-84d3-ba17-bab9" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="5dcd-e5b9-32d3-2ebb" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d42d-6e64-a870-9a1d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d08a-3630-5987-d9dd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d42d-6e64-a870-9a1d" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d08a-3630-5987-d9dd" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="338b-c02f-8448-41e8" name="Dragonscale Shield" hidden="false" collective="false" import="true" targetId="489d-88d0-a0d8-b3e6" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b8e-1c0a-d954-56cd" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfd0-aaad-f4bf-42d2" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b8e-1c0a-d954-56cd" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfd0-aaad-f4bf-42d2" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="ea59-d357-bf9b-9ce7" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a43c-4dd6-0187-b9ed" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a43c-4dd6-0187-b9ed" type="max" />
           </constraints>
           <profiles>
             <profile id="9609-d25d-0456-a8cf" name="Beacon of Hope" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">As long as Xiaphas Jurr has not been removed from play, is in Reserve or Embarked upon a model with the Transport Sub-type, a single friendly unit comprised of models with the Legiones Astartes (Salamanders) special rules may choose to use Xiaphas Jurr’s unmodified Leadership value instead of their own, when making a Morale check or Pinning test in any turn.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">As long as Xiaphas Jurr has not been removed from play, is in Reserve or Embarked upon a model with the Transport Sub-type, a single friendly unit comprised of models with the Legiones Astartes (Salamanders) special rules may choose to use Xiaphas Jurr&#8217;s unmodified Leadership value instead of their own, when making a Morale check or Pinning test in any turn.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="145.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="145.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="7b0e-d0bf-8ed2-8f30" name="Basic Close Combat Weapon" hidden="false" collective="false" import="true" type="upgrade">
@@ -2058,7 +2057,7 @@
         </profile>
       </profiles>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -2067,105 +2066,105 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="eba1-f155-f6db-8d28" value="1.0">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ba71-a7fc-1847-0479" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eba1-f155-f6db-8d28" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ba71-a7fc-1847-0479" type="max" />
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eba1-f155-f6db-8d28" type="min" />
       </constraints>
       <selectionEntryGroups>
         <selectionEntryGroup id="3efd-33a8-8a4c-9522" name=" XVIII: Salamanders" publicationId="817a-6288-e016-7469" page="309" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9f01-ab77-2342-bd5d" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e45b-9a18-2afa-9f4e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9f01-ab77-2342-bd5d" type="max" />
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e45b-9a18-2afa-9f4e" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="601c-aa31-fd5d-0d12" name="The Weight of Duty (Loyalist only)" publicationId="817a-6288-e016-7469" page="309" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="efa1-453d-7d63-a728" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f67-21d0-660a-ab51" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="efa1-453d-7d63-a728" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f67-21d0-660a-ab51" type="max" />
               </constraints>
               <profiles>
                 <profile id="a5a8-119c-88a5-06d7" name="The Weight of Duty" publicationId="817a-6288-e016-7469" page="309" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and all models in any unit he has joined, gain a bonus of +1 to their Strength Characteristic when locked in combat with any enemy unit that includes one or more models with any variant of the Fear special rule. Furthermore, this Warlord and any models in a unit he has joined composed entirely of models with the Legiones Astartes (Salamanders) special rule gain the Hatred (Traitors) special rule while the Warlord is part of the unit. An army whose Warlord has this Warlord Trait may not include Legion Destroyer Assault Squads, Legion Mortalis Destroyer Squads or Legion Centurions with the Moritat Consul upgrade that also have the Legiones Astartes (Salamanders) special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&apos;s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and all models in any unit he has joined, gain a bonus of +1 to their Strength Characteristic when locked in combat with any enemy unit that includes one or more models with any variant of the Fear special rule. Furthermore, this Warlord and any models in a unit he has joined composed entirely of models with the Legiones Astartes (Salamanders) special rule gain the Hatred (Traitors) special rule while the Warlord is part of the unit. An army whose Warlord has this Warlord Trait may not include Legion Destroyer Assault Squads, Legion Mortalis Destroyer Squads or Legion Centurions with the Moritat Consul upgrade that also have the Legiones Astartes (Salamanders) special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player's Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="c0a9-3a62-79e0-7fb3" name="Redemption of Flames (Traitor only)" publicationId="817a-6288-e016-7469" page="309" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="be73-d058-fba5-7b33" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="458b-aade-45c7-9999" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="be73-d058-fba5-7b33" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="458b-aade-45c7-9999" type="max" />
               </constraints>
               <profiles>
                 <profile id="5809-17ed-bd36-d1a9" name="Redemption of Flames" publicationId="817a-6288-e016-7469" page="309" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and all models in a unit he has joined with the Legiones Astartes (Salamanders) special rule, gains a bonus of +1 for all To Wound rolls or Armour Penetration rolls made for Flame or Volkite weapons that are used by those units to make Shooting Attacks. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&apos;s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and all models in a unit he has joined with the Legiones Astartes (Salamanders) special rule, gains a bonus of +1 for all To Wound rolls or Armour Penetration rolls made for Flame or Volkite weapons that are used by those units to make Shooting Attacks. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player's Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="186d-8f80-26e4-c6d0" name="Promethean Will" publicationId="817a-6288-e016-7469" page="309" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9227-f118-8b32-ed8c" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4321-d9ce-ced9-754d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9227-f118-8b32-ed8c" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4321-d9ce-ced9-754d" type="max" />
               </constraints>
               <profiles>
                 <profile id="07e8-24a1-20e2-726f" name="Promethean Will" publicationId="817a-6288-e016-7469" page="309" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and all models in any friendly unit composed entirely of models with the Legiones Astartes (Salamanders) special rule that is part of the same Detachment, gains a bonus of +1 to their Leadership Characteristic when making Pinning Tests (to a maximum of 11) and reduce the effects of the Fear special rule by 1 (note that this means the Fear(1) special rule has no effect on models granted this benefit, and negative modifiers conferred by other variants of the Fear special rule are reduced in effect by 1). An army whose Warlord has this trait may not include Legion Destroyer Assault Squads, Legion Mortalis Destroyer Squads or Legion Centurions with the Moritat Consul upgrade that also have the Legiones Astartes (Salamanders) special rule. In addition, an army whose Warlord has this trait may make an additional Reaction during the opposing player&apos;s Shooting phase as long as the Warlord has not been removed as a causalty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and all models in any friendly unit composed entirely of models with the Legiones Astartes (Salamanders) special rule that is part of the same Detachment, gains a bonus of +1 to their Leadership Characteristic when making Pinning Tests (to a maximum of 11) and reduce the effects of the Fear special rule by 1 (note that this means the Fear(1) special rule has no effect on models granted this benefit, and negative modifiers conferred by other variants of the Fear special rule are reduced in effect by 1). An army whose Warlord has this trait may not include Legion Destroyer Assault Squads, Legion Mortalis Destroyer Squads or Legion Centurions with the Moritat Consul upgrade that also have the Legiones Astartes (Salamanders) special rule. In addition, an army whose Warlord has this trait may make an additional Reaction during the opposing player's Shooting phase as long as the Warlord has not been removed as a causalty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="a684-5ee4-dec2-31ba" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+        <entryLink id="a684-5ee4-dec2-31ba" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="ec53-0911-52b7-dafa" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="467b-133a-c09c-b969" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="467b-133a-c09c-b969" type="max" />
       </constraints>
       <entryLinks>
         <entryLink id="420e-70d3-d9fe-a868" name="Command Squad, Cataphractii" hidden="false" collective="false" import="true" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
@@ -2174,19 +2173,19 @@
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="f7b0-e209-7d07-e62c" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
-        <entryLink id="9d06-d7bf-1138-373a" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="f7b0-e209-7d07-e62c" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
+        <entryLink id="9d06-d7bf-1138-373a" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Salamanders.cat
+++ b/2022 - LA - Salamanders.cat
@@ -318,7 +318,7 @@
         <categoryLink id="5a15-a183-b579-4582" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="e190-93c2-a41e-ff95" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
     <entryLink id="68c6-587b-0403-66bc" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3cf3-34db-1c09-24cf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
@@ -746,7 +746,7 @@
         <categoryLink id="9e53-bf1b-df8d-242b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="7f71-49ae-a8cc-92c6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
     <entryLink id="7654-4428-0eaf-2bb3" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
@@ -827,7 +827,7 @@
         <categoryLink id="5f74-6f21-6cc9-20fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="1e39-1810-c70a-7a3a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
     <entryLink id="d5e8-eda5-2bba-8981" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="58d1-ba27-3195-3d6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -839,7 +839,7 @@
         <categoryLink id="1cb1-7fa2-7338-4df6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="7d4b-dd38-5a01-a103" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
     <entryLink id="8e34-be48-fc63-1061" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e242-af15-f16b-99f0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -921,7 +921,7 @@
         <categoryLink id="f80a-83c5-663b-bb6e" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="669a-3be3-1c78-94ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
     <entryLink id="f91b-17f1-641e-4f44" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -949,7 +949,7 @@
         <categoryLink id="2a39-857d-f54d-9c2c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="a647-e450-e635-41ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
     <entryLink id="88d1-f74f-1ce1-b28b" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -999,7 +999,7 @@
         <categoryLink id="2f58-074e-4b84-d0b5" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
         <categoryLink id="3931-9a80-26ee-1472" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
     <entryLink id="59f9-fb6b-cbcc-603f" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="30ad-d5ba-6803-4c1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />

--- a/2022 - LA - Salamanders.cat
+++ b/2022 - LA - Salamanders.cat
@@ -1,6 +1,5 @@
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="3547-84d8-d789-bab7" name="LA -  XVIII: Salamanders" revision="12" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26">
-  <entryLinks>
-    <entryLink id="93d2-b1cb-b684-a9b3" name="  XVIII: Salamanders" hidden="false" collective="false" import="false" targetId="c805-ca3a-ff93-5e2f" type="selectionEntry">
+  <entryLinks><entryLink id="93d2-b1cb-b684-a9b3" name="  XVIII: Salamanders" hidden="false" collective="false" import="false" targetId="c805-ca3a-ff93-5e2f" type="selectionEntry">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8033-566b-1abe-f966" type="min" />
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57d2-e62d-e196-295b" type="max" />
@@ -102,944 +101,1957 @@
         <categoryLink id="28d1-eb1c-4e2e-0ce6" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="81db-d314-0661-7945" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2575-8d54-4168-2c10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1f5c-3beb-4a74-0ec8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <entryLink id="81db-d314-0661-7945" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="1cae-4341-45fd-bcde" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6d4-581f-4746-bec3</comment></categoryLink>
+        <categoryLink id="c0d3-a31b-4300-aa17" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_2489-ee2a-45dd-b384</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
-    <entryLink id="d29f-6ff1-84f6-fa78" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7a4e-cbea-e037-f104" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c50a-53f0-b496-5c46" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
-    <entryLink id="a4da-67bc-f8a8-f809" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink><entryLink id="d29f-6ff1-84f6-fa78" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b02f-e65f-4a88-a175</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_b87b-bf35-4238-b7c6</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1aff-27af-435e-8102</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_fdf9-4906-4180-a39d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2c09-6a41-9893-34c6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="c7d2-d2ea-9b06-b573" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2a85-707d-60e2-21ea" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="0ccf-1f3f-481e-85c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8378-ede4-476d-b657</comment></categoryLink>
+        <categoryLink id="018d-836e-4382-afa8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_d64f-ad19-426c-adf7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
-    <entryLink id="0898-4828-d0b4-f629" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="fb3c-ebcb-ac62-66c0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="77b2-cc51-cf71-6112" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
-    <entryLink id="a8eb-cf15-3625-2bd2" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0b05-b45f-95af-4b51" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="28fd-4f67-4e60-0344" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
-    <entryLink id="5bfe-4044-5d78-0010" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink><entryLink id="a4da-67bc-f8a8-f809" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_7fd1-8ce8-4d10-82e7</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_eaae-8c43-4d30-898c</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_f67d-8cf3-424f-b491</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_b949-6414-4f3d-b268</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4de4-52c1-f0c0-b14f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="aa51-5de8-4934-d7c7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="30f5-313f-cfa5-62a9" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="5bf5-4ac8-43a4-a38e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_ac26-e639-4d53-9b8b</comment></categoryLink>
+        <categoryLink id="43b2-c165-47b1-8203" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_49af-0d08-4c7e-8ce6</comment></categoryLink>
+        <categoryLink id="0600-9f43-4ed8-8e9b" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_b606-de16-4659-95cd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
-    <entryLink id="99aa-c0e7-1b96-3a16" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink><entryLink id="0898-4828-d0b4-f629" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="01b1-d867-1a9e-2221" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="6602-8207-41a8-af41" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
-    <entryLink id="beb6-cd17-653f-f71a" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7583-6fa0-4089-a19e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_0e5c-99ab-41d3-a42e</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c296-e8e8-4a7a-989a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_8868-5bcb-4604-ba8e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7953-5224-4c78-b2a2" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a009-a597-4b51-b228</comment></categoryLink>
+        <categoryLink id="9286-37b6-4590-9652" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_24f4-9145-4016-80d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink><entryLink id="a8eb-cf15-3625-2bd2" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_e732-7499-47bf-9748</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_81a5-a959-46b7-baa4</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7ec3-447a-4644-b012</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_71e2-c430-4c99-a559</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_df7b-3fb9-4f65-9165</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dd14-1d3d-4948-9026" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c165-3906-463a-9c73</comment></categoryLink>
+        <categoryLink id="5570-22c6-4883-816d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6d1-d14c-473f-be09</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink><entryLink id="5bfe-4044-5d78-0010" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_27a3-1e4c-4b76-a594</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_d59a-dcd0-44fd-b866</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_0c8b-2b92-49ed-98c7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_bafe-f799-41d9-ac85</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_6369-288c-4fec-a640</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_fe53-8858-41dc-8ec4</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="de79-bac1-4fdf-d2aa" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="3d2e-a0b5-cdd6-7d36" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0ab7-cfe4-4181-b426" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_3a22-caae-4eea-9bc5</comment></categoryLink>
+        <categoryLink id="5417-f8d1-429a-be73" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f759-f33e-4698-9f8a</comment></categoryLink>
+        <categoryLink id="0725-3585-4873-9ff3" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_c624-3ae0-46c0-9b06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
-    <entryLink id="1a43-badf-f37d-866c" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3a09-9c4d-4701-2bd3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="fe08-d2c4-0104-8eb0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d30b-33d3-3895-058f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="bf0b-6dcd-883e-a50e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup" />
-        <entryLink id="8dc0-4f4c-fba6-ce03" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink><entryLink id="99aa-c0e7-1b96-3a16" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_13b3-ce1e-4f9d-8319</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d681-9d81-4abd-b11b</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a57-e48b-4534-bca5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_1859-5641-4674-9097</comment>
+                </condition>
               </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
-    <entryLink id="4463-b41c-deb4-3495" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
-      <modifiers>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a152-cf3a-4ae7-ae76" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_251a-df5b-4bfd-ad63</comment></categoryLink>
+        <categoryLink id="c335-7798-46bf-b262" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4644-98ab-4e3f-b1fd</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink><entryLink id="beb6-cd17-653f-f71a" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_591d-d028-4663-918d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_0482-c5f9-4c95-9597</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_75a7-971d-4978-a83f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_a7d5-2bfe-4621-ac0c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9f13-b460-4f27-b0cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_31fc-e265-45a7-bb5b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="536b-55ec-64e3-3339" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a089-1a0c-a856-f1c6" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="281a-0ff0-c1d5-4303" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="e71e-4bde-4fb5-a257" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_67c2-df43-44fc-92d1</comment></categoryLink>
+        <categoryLink id="77fa-b4f4-4489-8590" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4136-bb4e-4dd4-99f9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink><entryLink id="1a43-badf-f37d-866c" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry"><categoryLinks>
+        <categoryLink id="20f3-74e0-4adc-a20b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_2599-24e3-44e5-9568</comment></categoryLink>
+        <categoryLink id="b7bd-8720-4ed8-a1db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_285f-6e56-473b-b2fe</comment></categoryLink>
+        <categoryLink id="c018-0673-4071-86e4" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_685e-022f-4e2f-a568</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="7d4f-db79-17da-cfce" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup" />
-        <entryLink id="f448-55cd-8812-d0fd" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup">
+        <entryLink id="3b5b-5e94-4bae-922e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup"><comment>    template_id_2a38-6544-4267-b584    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="5ed3-9d8b-441b-9aff" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_8287-16ff-46ba-9838</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_81c1-fca9-44dc-ba4c</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_6e59-4592-47ef-b76d    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
-    <entryLink id="be2f-c121-0fe4-6f13" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8013-8909-bf63-61cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="563c-b68f-2cb8-51b3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="9530-0aa1-4769-e9f1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="b45a-f78c-80ef-652f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup" />
-        <entryLink id="04ca-1b50-068a-09ad" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
-    <entryLink id="4bd9-ad7d-215d-6bfc" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="da60-a77d-9cdc-0fcb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="c9f6-5883-be33-e7b0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
-    <entryLink id="5458-163e-22de-4a00" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a557-bc81-0d6d-e93c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3200-7f1f-fe3d-5045" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
-    <entryLink id="dba9-1176-0331-fc7e" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink><entryLink id="4463-b41c-deb4-3495" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ad5d-3c79-4239-9116</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_60b1-049b-4a5f-85c2</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5240-5030-764b-30f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e453-0d15-62ce-54f0" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="7c7f-7da2-4096-b255" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bd6a-0cda-4e0f-80ae</comment></categoryLink>
+        <categoryLink id="c7bf-deff-4f8a-a375" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_ae75-7cca-4701-9d56</comment></categoryLink>
+        <categoryLink id="bc9d-aa70-42f9-bb35" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_e517-62d4-48f7-8174</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
-    <entryLink id="c4ec-a665-f42a-0af3" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
+      <entryLinks>
+        <entryLink id="d810-1b3b-49ab-9e10" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup"><comment>    template_id_fafb-6414-474a-8a09    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="0db3-fde1-448e-9d6b" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_1e43-c980-4508-8ec2</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_4140-36a7-4203-b5e9</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_a6a6-9bc7-4d4e-86a7    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink><entryLink id="be2f-c121-0fe4-6f13" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry"><categoryLinks>
+        <categoryLink id="5afb-b9f0-4250-bc70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fc9d-03d1-4bbd-a1c4</comment></categoryLink>
+        <categoryLink id="a13d-b111-4497-a336" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_f51c-73d7-4f29-be1c</comment></categoryLink>
+        <categoryLink id="4e60-69e0-408a-ae50" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_257d-78c0-4bab-ba65</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="ae23-5af5-49ac-82df" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup"><comment>    template_id_ac26-33db-40a7-bdba    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="a017-aac8-452b-88a8" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_189b-db75-4db6-9fe9</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_cbdb-2500-4e13-876a</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_dc8e-2801-46d6-84f8    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink><entryLink id="4bd9-ad7d-215d-6bfc" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b43b-547f-472e-9076</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8ff9-0498-4540-8552</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fbfe-931a-489b-a589</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f4c3-5aa6-4caa-abf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_17f8-f055-4c9c-b757</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="abed-6219-485b-8c51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7cf2-7d2f-81fb-6e97" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="a4dd-958d-479a-af3b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f1c8-27fd-4f98-8527</comment></categoryLink>
+        <categoryLink id="cb13-6872-45b5-86e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2b20-1a8b-4753-b657</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
-    <entryLink id="7f94-d6be-ac35-1421" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink><entryLink id="5458-163e-22de-4a00" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry"><categoryLinks>
+        <categoryLink id="8a63-c4d9-4139-9cf4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4207-8d8f-4b1a-836b</comment></categoryLink>
+        <categoryLink id="793c-b0a0-4e5d-b164" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_2b34-077f-4279-86fb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink><entryLink id="dba9-1176-0331-fc7e" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="5a15-a183-b579-4582" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e190-93c2-a41e-ff95" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="a892-a7ba-4d11-9a36" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6577-e0fb-4fda-834e</comment></categoryLink>
+        <categoryLink id="b0d0-d3e5-4358-b231" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_5d59-09bf-4566-b7e1</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
-    <entryLink id="68c6-587b-0403-66bc" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink><entryLink id="c4ec-a665-f42a-0af3" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"><categoryLinks>
+        <categoryLink id="5ff9-d6a7-450a-af4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_aa93-057d-42f6-82d7</comment></categoryLink>
+        <categoryLink id="fbc0-c28c-4add-9ec4" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_403c-4e9c-4af5-84ec</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink><entryLink id="7f94-d6be-ac35-1421" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_23fa-06dd-49f9-a7db</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5b26-059e-40b3-9d93</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f7bf-3a1c-4103-aed8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="3cf3-34db-1c09-24cf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="b22d-b29d-3ecb-d581" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ea-64df-45e2-9fa5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dd44-e0a8-42a8-bdcc</comment></categoryLink>
+        <categoryLink id="0b27-e58e-41c7-b4a9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_c5b0-f9ae-468d-924a</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
-    <entryLink id="64a2-5b02-e2ba-5e4a" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink><entryLink id="68c6-587b-0403-66bc" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8396-e51c-4e2b-bada</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_13bb-9fb5-4580-92cf</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_bfb8-8125-4548-92f5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25e3-b8f5-4448-a7c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="981e-f795-4464-af3a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_f926-27fd-4a92-97a1</comment></categoryLink>
+        <categoryLink id="cd18-7307-4146-a32a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_82e3-36e1-4e85-8fcb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink><entryLink id="64a2-5b02-e2ba-5e4a" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c2cb-7510-cd37-984e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
         <categoryLink id="a882-1a9b-4d57-93b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="76bf-bd99-3067-5d7f" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
-      <modifiers>
+    <entryLink id="76bf-bd99-3067-5d7f" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_658f-b1ad-4347-a998</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_12bc-3db2-4d28-abce</comment>
+            </condition>
           </conditions>
         </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="567e-df81-a311-7066" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b1fb-1de8-2a32-a2f8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
-    <entryLink id="19bd-cdfd-0295-3a7d" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_9d83-7691-41d6-8dad</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_add7-ba48-46d4-8a02</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_1fb0-2421-40a4-9e49</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d540-e102-a516-dc6a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="f921-c892-6bd5-58ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="715d-22ae-4b10-3e39" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="94a8-c0ba-464d-9044" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7004-b00d-481f-b740</comment></categoryLink>
+        <categoryLink id="6fa0-f9a3-451f-a4a3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4f88-2fc3-491c-bfb7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
-    <entryLink id="eef1-e56b-4752-b723" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c847-d0d0-392d-ba9d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5431-0db2-96d0-7f7e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
-    <entryLink id="13c7-f976-5bce-99e3" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a07e-4c3e-d9a0-003a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="c7a5-1f0b-f52f-8e4c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
-    <entryLink id="877a-d43b-10d1-f561" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0197-885c-5bbc-d9e1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="6571-df3a-e918-f0c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
-    <entryLink id="cd1d-73b9-ba01-2166" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c528-6fb0-d7c9-6204" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="1952-c05e-5d56-5a6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
-    <entryLink id="4282-f953-0998-4a79" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4eb7-1ef3-c705-dd39" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4815-79c1-278c-cba5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
-    <entryLink id="815c-31c8-b4a1-6f10" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e62b-f0f1-fb5e-0b63" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="b602-a000-95a0-2ff4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
-    <entryLink id="0e62-b141-65fa-29a7" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="830a-68c2-eed3-bf57" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="67c0-24ee-1bde-0a32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
-    <entryLink id="f424-c704-68e1-64f2" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="05ad-4d0d-6cd4-a98e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5a92-755e-6166-acf5" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
-    <entryLink id="536b-275d-4547-f363" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3798-dae4-dffd-5497" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="384d-e3d3-e3b2-a1d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
-    <entryLink id="e3ea-2f97-1420-cda3" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7ebb-7ab9-2c59-bc60" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2455-1393-8d97-fd6d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
-    <entryLink id="8d1a-e08c-09a1-c590" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7aba-02fa-3a7b-bbad" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="cc96-375d-5076-77fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
-    <entryLink id="fea4-16d5-7648-03a8" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="ca30-e889-6a62-90da" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="fcd0-8295-a3c4-fb37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
-    <entryLink id="9693-4501-d924-2b12" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="596b-e4d9-81c2-0c8a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="2996-257d-8206-9b96" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
-    <entryLink id="b4ec-d19d-a8f1-50c0" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9664-0758-9137-9479" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9fcc-f317-6757-72b1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
-    <entryLink id="adb2-4de8-afe3-91e8" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="bd7d-bdc0-7c19-027e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="438a-a395-39dc-392a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
-    <entryLink id="9358-fb65-0ca9-ebc2" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="ae7a-f0ff-19f5-5f2f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="f364-032f-cfae-fc52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
-    <entryLink id="3e47-03f4-f686-e15e" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e7b4-f439-2771-1c54" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="ad53-6061-7ea9-c8a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
-    <entryLink id="591f-5a82-e2ba-37da" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="a0d8-fe2b-d2c5-f3d3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="64d0-e728-337f-5745" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
-    <entryLink id="1632-273a-4ab9-745b" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="acd7-03e0-ce50-f825" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="4ff1-41d7-a2f9-5c1b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
-    <entryLink id="3899-9a92-0dc8-0554" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1e57-93d7-b64f-da48" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="f002-1c76-128a-cc7e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
-    <entryLink id="a37d-f3d2-c0ee-e902" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6138-4382-c5a8-7214" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="9d4f-6e0f-9155-5b48" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
-    <entryLink id="f3d7-db2a-86be-e0d4" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="00a3-1b8f-655d-5005" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="604f-99c8-c7bc-2c3a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
-    <entryLink id="359d-0a15-9916-9c24" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="fa44-6b35-f2b4-8647" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="2b63-8f80-0766-7c7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
-    <entryLink id="6b9d-c046-31f7-df14" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="ce95-7cc1-15e5-0109" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="46c0-958c-3e3a-90f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
-    <entryLink id="eb80-0c80-2a5d-444d" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6208-bf62-662a-27c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="eaee-4ba7-ed31-a68d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
-    <entryLink id="f385-591a-76ae-6c96" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d593-48a9-a4ea-2872" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="0619-e8a6-a2e5-ce33" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
-    <entryLink id="66a1-77c7-24f2-6f33" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="44d8-bced-205a-2708" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="2657-51a4-cea5-be46" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
-    <entryLink id="5213-d143-4913-79d0" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8731-1db0-6aee-9d3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c79b-d713-273a-ea2d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
-    <entryLink id="8748-3b55-7bf5-e2c0" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="c571-11e3-7014-e476" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="c127-4ea2-ac32-0533" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
-    <entryLink id="bff1-7771-3d8d-e5c5" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="ba9e-9237-7cf0-2cdf" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="bc05-9542-2277-62a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
-    <entryLink id="6610-b4bd-958a-7c83" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8042-9564-5467-e404" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="bf7d-39dc-51f3-47a1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
-    <entryLink id="7db3-340c-ba11-4a1e" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b9ac-3a35-2624-bacc" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="173c-273f-cb7d-86b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5f72-ca1e-15d3-fea5" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="3aa7-404f-d499-041c" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup" />
-        <entryLink id="1d93-4a37-42b4-fbda" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
-    <entryLink id="1acd-d0b1-d78d-68bc" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="bd89-d9ef-4a18-7b84" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="b3ce-1178-7096-4527" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a163-1629-a0db-e90a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="6991-cb22-811f-3935" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup" />
-        <entryLink id="89d9-43d8-856e-d1e0" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
-    <entryLink id="da7d-be52-7812-61bb" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="79ec-28c1-ec3b-4210" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="482e-828e-7fa4-07f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="af3b-c056-7a37-8ab1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="1c15-2119-4405-ad03" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup" />
-        <entryLink id="4946-1cb8-219b-c505" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
-    <entryLink id="44a2-f6df-fc05-0f43" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9681-ed26-675b-936e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="34df-50a4-147b-7f8e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
-    <entryLink id="bfdc-b6f8-3138-8993" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="b042-556b-affd-a549" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="bbc8-4a63-f7da-3277" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
-    <entryLink id="04be-2dc8-bf31-92c7" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9e53-bf1b-df8d-242b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7f71-49ae-a8cc-92c6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
-    <entryLink id="7654-4428-0eaf-2bb3" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8310-c7f7-2c1d-81f6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="a750-723e-d54c-55f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
-    <entryLink id="71c8-b9c3-03b7-5e46" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="94bf-9f97-a6cc-bdbd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="b499-29d1-1084-9c1b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
-    <entryLink id="55e3-53f8-aff1-56f0" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b654-0713-dbcb-fac2" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="396b-66cf-fde7-6b45" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
-    <entryLink id="7cad-f100-ccda-a2c1" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b87e-e496-5d32-636a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a617-6b7d-855f-51d4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
-    <entryLink id="1905-93de-51a5-c39a" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="f754-2f56-75b8-39bf" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="6736-d5b0-cac5-f893" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
-    <entryLink id="4fff-23a6-e0ad-0040" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9ec9-a831-8230-aed1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d162-0b9b-3468-ffc7" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
-    <entryLink id="d44f-c5aa-43fe-f35a" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3f6c-1b86-d49a-81cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ef92-356d-bb25-4a7d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
-    <entryLink id="279f-7714-301f-2ccb" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1007-272e-be59-3e53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="04a2-9cc9-83f4-a3f6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
-    <entryLink id="b5ed-8cb8-70d7-d337" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="58a6-399b-95e2-fba4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="532e-6998-04cb-82d5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
-    <entryLink id="5738-89d2-d898-dd43" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5f74-6f21-6cc9-20fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1e39-1810-c70a-7a3a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
-    <entryLink id="d5e8-eda5-2bba-8981" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="58d1-ba27-3195-3d6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ee32-1f6f-8f4f-742d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
-    <entryLink id="b2d9-6f4a-cc5f-e78c" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1cb1-7fa2-7338-4df6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7d4b-dd38-5a01-a103" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
-    <entryLink id="8e34-be48-fc63-1061" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e242-af15-f16b-99f0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="44c7-56d4-0c47-31af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
-    <entryLink id="28e1-088a-a00b-14a5" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9808-f361-416c-03d1" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="a743-dc77-7516-e95c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
-    <entryLink id="e5f8-9815-7d06-4090" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="01b2-fd1e-2294-5d82" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="2f4e-1098-6b0e-b788" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
-    <entryLink id="9223-b6a2-72c3-f158" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink><entryLink id="19bd-cdfd-0295-3a7d" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_8ed4-376d-4030-9439</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_8a11-c2a0-4335-99ef</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_fa8e-1af7-4d41-ac8c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_94bd-c771-4a85-8581</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3bea-73b6-8ffe-4dca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0eb7-2d24-5c4f-7b36" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="77b5-2752-298a-c4a9" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="1496-307f-4945-a0dc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_361e-fb90-4b0e-ac3d</comment></categoryLink>
+        <categoryLink id="6514-e5f0-4870-bbfd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d4ef-1074-45a9-959e</comment></categoryLink>
+        <categoryLink id="bcf2-01f5-4646-8558" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_febb-f536-4d25-a8ab</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
-    <entryLink id="ef99-24bb-258b-d38c" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0512-465f-44fa-31a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="14ff-8be5-1fe9-c875" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink><entryLink id="eef1-e56b-4752-b723" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="80cc-f566-427e-bd5d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_473b-e812-4158-9416</comment></categoryLink>
+        <categoryLink id="69fa-bb22-4f28-b83a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_00a2-63ff-4698-a35b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
-    <entryLink id="e182-b167-658c-777d" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink><entryLink id="13c7-f976-5bce-99e3" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7cf3-8a72-4f82-8cdc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_228c-5681-4ce8-b726</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_01bb-8abd-4253-9a4d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8f9f-20c5-d188-6895" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="140b-5729-a0b5-22e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7be5-6d3f-44b0-9aa1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2a08-4432-42ad-bfdb</comment></categoryLink>
+        <categoryLink id="09f3-072c-4641-b9ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_422e-0808-4897-8630</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
-    <entryLink id="d9d6-f726-7d7b-1ffb" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink><entryLink id="877a-d43b-10d1-f561" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1af8-4459-4717-8e3b</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_06b4-92b9-438c-b1a5</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6c8d-8b28-417b-9a7c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_715d-8186-4aa6-b40c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_390e-358c-4f8e-ade8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="cd37-4063-e2a5-338c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f59c-c588-3941-1bbd" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="8846-ea24-4848-951e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f4c0-4396-4f39-a34f</comment></categoryLink>
+        <categoryLink id="c4db-81c0-48c9-bc6c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1301-8415-490e-8f06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
-    <entryLink id="7b7b-2196-728e-38b0" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink><entryLink id="cd1d-73b9-ba01-2166" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d0c9-9a26-4324-b030</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4e9e-a61d-42f2-bacb</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ed9e-b634-4bec-9eb0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4614-ad0f-4fba-adaf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_8d08-24f6-41be-8931</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a067-d86b-4ac7-a71c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_caf6-5548-4b89-8102</comment></categoryLink>
+        <categoryLink id="d396-b44b-47ce-b4a8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_63a3-be61-428d-ab29</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink><entryLink id="4282-f953-0998-4a79" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f318-4b03-4767-8c7f</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b8ef-7245-4df8-a8c4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_6bce-ec44-48cb-873a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3918-1f63-4672-97d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0678-4fdd-48e6-8f61</comment></categoryLink>
+        <categoryLink id="4d12-adea-479d-87f6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0d82-10a9-4de2-8ad7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink><entryLink id="815c-31c8-b4a1-6f10" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ada1-1e18-4cbc-9598</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b1d1-ac44-47dd-9159</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5d64-f00c-4464-891b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25f0-f825-4a83-8f0d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_64b1-9e36-44da-b36a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="46ae-7a73-4b06-926d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_d53e-113f-4a40-a3d5</comment></categoryLink>
+        <categoryLink id="b9da-1e07-4a3d-8bd0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1939-76b5-4279-9f8c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink><entryLink id="0e62-b141-65fa-29a7" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d765-3bb2-4b48-bd12</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_0ca1-cfb4-4a56-ab3b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f80a-83c5-663b-bb6e" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="669a-3be3-1c78-94ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c0ce-092c-4f65-89e0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e6f7-a6ca-4825-bfc5</comment></categoryLink>
+        <categoryLink id="e6be-f33b-4b5b-8f8b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dbec-e027-4ec1-8514</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
-    <entryLink id="f91b-17f1-641e-4f44" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink><entryLink id="f424-c704-68e1-64f2" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d8ee-81ed-45f9-8b79</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_8f4e-e8cb-4ac9-a415</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e934-c99a-4eda-91ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_cefb-cfd7-4dc8-99c4</comment></categoryLink>
+        <categoryLink id="ef73-a9db-483f-a9eb" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a9fd-9d16-4a5e-855c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink><entryLink id="536b-275d-4547-f363" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e76b-46ca-4ab8-a93d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8035-75b8-43bb-97c9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_71a4-31e7-4927-a0ab</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6606-dbb1-42ef-840a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_a56d-347b-4b09-a918</comment></categoryLink>
+        <categoryLink id="b0fb-505b-4e3f-a93e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_96e5-4531-4213-903e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink><entryLink id="e3ea-2f97-1420-cda3" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1fb5-2375-4c22-b41e</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7d7c-255d-49b6-96b9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5321-254b-4890-9bf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ddf8-b8b7-4afb-b6dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d754-4c0f-4f7c-a9e8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9441-d79b-4720-9667</comment></categoryLink>
+        <categoryLink id="36d8-7297-4bc8-9764" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7d7e-32d3-4692-b401</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink><entryLink id="8d1a-e08c-09a1-c590" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_99fc-5fe7-4b37-a62f</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_25f4-f6b8-4b44-8350</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_81f7-2311-4cce-95bc</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_09aa-af2a-4012-91d1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_00ae-fad3-4df6-9cb9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6656-86b1-4cda-8ebd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f65b-8958-49b3-92a5</comment></categoryLink>
+        <categoryLink id="dc31-5e3c-470a-86e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0451-1929-4942-8c3f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink><entryLink id="fea4-16d5-7648-03a8" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_edc4-4915-40ba-bbf0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_105f-ba26-4146-bc54</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7a2c-a76c-421c-a8a2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_05c9-0543-47ee-ba81</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e6ad-f0d7-4627-921b</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="18ac-f3d1-428d-99d1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c6a8-22a8-4d41-b969</comment></categoryLink>
+        <categoryLink id="b025-4b35-454b-a556" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03ca-12cc-4e0a-b628</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink><entryLink id="9693-4501-d924-2b12" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ae67-ef52-4cac-958c</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fc61-7306-4d99-acde</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1be0-67e7-45a1-bdbb</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_42a8-7fda-4e05-af0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ff21-7e68-4a1a-9287" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_565a-1592-491f-8b9b</comment></categoryLink>
+        <categoryLink id="3d19-26e1-4c90-a763" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_81d5-c14a-42ab-bdde</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink><entryLink id="b4ec-d19d-a8f1-50c0" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1ae7-c41b-4818-be71</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_08a5-b1bb-4ba1-ba42</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d677-b5ad-4838-8746</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_537f-bc1f-4aaa-b0dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2750-bb7f-44e3-8cc1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bc67-ce1f-4004-aeb7</comment></categoryLink>
+        <categoryLink id="f03b-c06e-4ff2-97c3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_9a45-9699-4475-aeef</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink><entryLink id="adb2-4de8-afe3-91e8" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_c28f-4109-44c4-ab64</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fdc1-a894-48bc-9e7c</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_4936-a68c-4524-9088</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb37-ac0c-49ae-9d6f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a025-8572-4f20-b247" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3afe-cfc0-4da6-a985</comment></categoryLink>
+        <categoryLink id="4082-1c7b-42ec-bacf" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_04a8-6aae-45ae-bd4c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink><entryLink id="9358-fb65-0ca9-ebc2" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ae19-30c0-43c5-920e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_6ebe-1bf3-4d78-9dd0</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1887-152d-48b7-b13f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_a7c4-ee6a-4f0b-8ab0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bd85-fa90-47ff-9f84</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_7bd6-9043-4d7e-ba37</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="01ec-d0cc-487b-867c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3610-c975-4d55-bdfe</comment></categoryLink>
+        <categoryLink id="cdb7-5d12-45b0-a845" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2fc2-f636-4c80-9608</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink><entryLink id="3e47-03f4-f686-e15e" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_85c5-d4d9-4b23-9e4d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_80e8-d50b-4906-8153</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_b93b-d4f1-45eb-8a69</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e183-f183-4db7-83b5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0f39-204a-4217-b896</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_eee9-7bfd-4fea-a1bd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="69ca-f7f0-4929-ac23" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f81d-9435-4f11-99c1</comment></categoryLink>
+        <categoryLink id="b335-75fc-482a-85ea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9568-6142-4fdd-be3a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink><entryLink id="591f-5a82-e2ba-37da" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_005e-6607-4e2c-8dd2</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_7745-260c-4c36-b719</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_ba25-a4b2-4ba9-b023</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ddeb-f4c8-4091-9153</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4904-fd2f-429f-9cf7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_faea-b21b-43c5-b918</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="71e8-7a48-4046-abdf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_b24f-3ae0-4cbb-b016</comment></categoryLink>
+        <categoryLink id="272b-0b4b-42b4-ae10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fd26-8e6b-4521-92b9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink><entryLink id="1632-273a-4ab9-745b" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6ecb-28e2-43ed-a6a0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_c067-1118-4d96-b28b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_250e-23c0-4e43-bf74</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1553-a6e6-4291-853f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_aab6-797b-427a-9fd8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2705-a4d2-4d22-b8d8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c77f-0819-473b-a8a2</comment></categoryLink>
+        <categoryLink id="478b-8a8b-489c-9b7e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_89fb-c924-4daf-923d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink><entryLink id="3899-9a92-0dc8-0554" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d72c-519a-451f-81b6</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_3d16-444c-42c9-aad1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_f4b2-6371-494b-863a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_797f-a84b-42f6-8e66</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0d78-fe38-4829-9b12</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ed4b-75d9-42bd-8ded" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0397-c837-4fea-a527</comment></categoryLink>
+        <categoryLink id="44ac-7162-498d-b82c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_060b-bccb-4776-bd83</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink><entryLink id="a37d-f3d2-c0ee-e902" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3c84-6d74-4c42-b38d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_5b15-7aa4-4897-aaf1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_3326-31ed-4151-9b37</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6a0e-1b65-4057-ba5d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f8c7-abc9-45ec-955f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_2538-8dc5-446c-8344</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2e72-864f-4422-99a9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_c1cf-cea4-4278-8f27</comment></categoryLink>
+        <categoryLink id="ebfe-e386-404e-a965" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5f51-2734-4a46-9f72</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink><entryLink id="f3d7-db2a-86be-e0d4" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af71-f3ff-49b1-83e9</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_1c9e-b3bf-4e88-a43f</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_6d0d-1b1d-4065-89cf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d0b7-8686-491e-9d33</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_7db8-0874-487a-be6f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1034-29a0-44b1-a85f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6d6e-e57c-4e9a-83be" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_0c16-6841-42b2-b02d</comment></categoryLink>
+        <categoryLink id="6c1c-ab26-4aa4-b0af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_602d-2d2d-4ff4-a82a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink><entryLink id="359d-0a15-9916-9c24" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_22bd-baae-45f9-b366</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_52bd-55de-4d53-ba55</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_df1b-7476-4ab8-8d2f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_49fa-0dcf-4a61-a5b1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0ea-1443-4993-86e7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2a8-3fbe-448c-9902</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="41dd-ba00-4196-a48f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3632-0b5d-4622-ae33</comment></categoryLink>
+        <categoryLink id="46ae-1740-4210-9293" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_da44-7815-4fdd-981c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink><entryLink id="6b9d-c046-31f7-df14" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2bfa-b203-47e2-a828</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a39b-8a3c-49cf-bf62</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2a05-07b3-49c5-8145</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f730-87fb-44bd-b68e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_2d0e-6c49-4493-a022</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2e2-50c1-40c3-b4dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a243-71d1-4cc9-80ed" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_5ad5-8701-42cd-b2b6</comment></categoryLink>
+        <categoryLink id="5886-339c-4144-878d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_20a4-4346-4a3b-a7d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink><entryLink id="eb80-0c80-2a5d-444d" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_773a-1ea4-41a0-b766</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_9d4d-6fb8-4131-a5a3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e3bc-02f8-4ece-a5ea</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c371-76d9-4a4d-bc00</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b4c6-d4ba-4b2e-9b99</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="79fc-6a5c-43a2-89d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6ea9-a7e5-437d-9e35</comment></categoryLink>
+        <categoryLink id="e648-5737-490e-86d3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_3cec-f053-42ab-a6eb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink><entryLink id="f385-591a-76ae-6c96" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1e60-42ba-4c8b-9077</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9860-f593-425e-b89b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_c842-10e8-4509-8eda</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ea52-ff41-40f6-8cf3</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_51e6-c5e1-4003-96bc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="145b-94c6-4a23-af84" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4d7c-201f-4c99-b89a</comment></categoryLink>
+        <categoryLink id="7b99-7def-4474-91bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_10f9-4718-4e07-bb32</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink><entryLink id="66a1-77c7-24f2-6f33" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d6ef-0e36-4863-8074" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4e52-ad1b-48d4-8eed</comment></categoryLink>
+        <categoryLink id="4723-fbbc-4254-8aca" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_6979-1ed3-4f1f-a025</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink><entryLink id="5213-d143-4913-79d0" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry"><categoryLinks>
+        <categoryLink id="b8bc-0d89-41f0-8249" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6140-2404-46f9-bd42</comment></categoryLink>
+        <categoryLink id="1103-70b8-4b8d-bc94" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_1c86-fad8-46ec-a0b0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink><entryLink id="8748-3b55-7bf5-e2c0" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4729-bc86-456b-b73d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_cf0f-e3f4-4fb4-989d</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1cc8-5611-4d9a-9218</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_2e32-ca02-48f0-a8dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="416c-072a-4747-80c4" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_0af1-d052-4bd7-aab6</comment></categoryLink>
+        <categoryLink id="a4f9-3b02-467e-b17b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_45ce-e338-43c9-b63e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink><entryLink id="bff1-7771-3d8d-e5c5" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4dce-8632-4f7c-813e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_8a71-3995-4155-ac33</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d206-f2ce-41b8-945a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan">
+                  <comment>    node_id_2e02-cf1c-4a71-861c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ec81-bd33-45a8-8550</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_3344-743c-45d3-b930</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7286-858d-7b12-757d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="f6f5-060e-5033-5561" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ff76-5613-4e5f-8595" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4272-9b9d-4c59-95f0</comment></categoryLink>
+        <categoryLink id="0f31-b64d-4032-8eca" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_d85b-1ae7-40d5-9341</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
-    <entryLink id="86ed-08f1-a8ec-dc32" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2a39-857d-f54d-9c2c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="a647-e450-e635-41ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink><entryLink id="6610-b4bd-958a-7c83" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry"><categoryLinks>
+        <categoryLink id="e6fc-b1af-43bd-a58c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ff9f-01cb-41b9-800e</comment></categoryLink>
+        <categoryLink id="eabd-24ca-4bcb-ba26" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_1315-6051-4a46-b070</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
-    <entryLink id="88d1-f74f-1ce1-b28b" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink><entryLink id="7db3-340c-ba11-4a1e" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry"><categoryLinks>
+        <categoryLink id="7bc5-049e-45bd-b4c0" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_b084-df23-4f99-812f</comment></categoryLink>
+        <categoryLink id="a1ba-0bee-4b82-b4a8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_84fc-9304-4e9e-ab78</comment></categoryLink>
+        <categoryLink id="a775-a822-4195-a5df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d06a-7939-4691-9aed</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="1ca1-50f9-49fb-a3b0" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup"><comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+        <entryLink id="5df1-3761-4aba-901e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup"><comment>    template_id_741d-8c09-4211-ada6    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink><entryLink id="1acd-d0b1-d78d-68bc" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_54a4-6ec8-4c61-9c3e</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_f7fd-2d16-4603-a065</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="736d-dea2-e8c1-5a0c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="17db-f60d-520a-d6e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="710f-c946-4069-9f5a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_c0ac-4b8c-421c-a21b</comment></categoryLink>
+        <categoryLink id="2093-0faf-4fa8-9b09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8db9-079e-4482-b200</comment></categoryLink>
+        <categoryLink id="ea6e-3eee-419a-88d6" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_413c-9273-4308-b546</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
-    <entryLink id="1f94-02a7-c8b1-904a" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f032-b807-395c-20c2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="6452-0568-f373-36ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      <entryLinks>
+        <entryLink id="f8af-9984-4409-bc71" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup"><comment>    template_id_bbc4-33fc-4664-a18e    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="40bc-ebb8-4525-be9e" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup"><comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink><entryLink id="da7d-be52-7812-61bb" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry"><categoryLinks>
+        <categoryLink id="6129-f6a6-458b-8c96" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_4c8d-96f6-48f9-9590</comment></categoryLink>
+        <categoryLink id="9db0-429a-4a9a-a411" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_049c-0fa5-4575-8fa8</comment></categoryLink>
+        <categoryLink id="f305-0fda-470f-9ed4" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_7358-52d7-4aae-8e07</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
-    <entryLink id="1191-d33e-b4cd-60a9" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+      <entryLinks>
+        <entryLink id="d6b6-de12-4034-a967" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4ef8-ecc8-b821-c604" type="selectionEntryGroup"><comment>    template_id_4784-b370-444b-93ae    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="5065-1d67-4582-b6e9" name="Retinue" hidden="false" collective="false" import="true" targetId="ec53-0911-52b7-dafa" type="selectionEntryGroup"><comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink><entryLink id="44a2-f6df-fc05-0f43" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_3c03-a823-4466-9bd6</comment>
           <conditionGroups>
-            <conditionGroup type="and">
+            <conditionGroup type="or">
+              <comment>    node_id_8bbb-f95b-413f-b6f4</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_41b0-6b0a-482a-919e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e1f7-3cc6-4794-8b6d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1215-3850-b799-00dd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="9e71-7304-0a04-c353" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="da86-9f25-47b3-ad3a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_05ce-cc31-40ad-9320</comment></categoryLink>
+        <categoryLink id="5392-622d-43ce-bccb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f13c-f8e1-4a50-bfe3</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
-    <entryLink id="2260-bbe6-a8c2-1d7d" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="832e-3147-9188-d333" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="2205-836c-f187-f54e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
-    <entryLink id="1042-91c1-17c2-50e5" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="590a-64f1-a0fc-7f28" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2f58-074e-4b84-d0b5" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
-        <categoryLink id="3931-9a80-26ee-1472" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
-    <entryLink id="59f9-fb6b-cbcc-603f" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="30ad-d5ba-6803-4c1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7c04-f138-c644-d921" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
-    <entryLink id="75fa-5312-9b7b-4254" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink><entryLink id="bfdc-b6f8-3138-8993" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_db78-4d49-42ab-954a</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_f14d-9943-47b6-866c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a95-938f-4a07-9727</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_7775-78e1-44cc-87c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1faf-7c3f-4ad2-afa1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_b822-3417-4613-be37</comment></categoryLink>
+        <categoryLink id="0359-ab9a-40e4-b348" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_25db-b03f-4881-b310</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink><entryLink id="04be-2dc8-bf31-92c7" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry"><categoryLinks>
+        <categoryLink id="c231-43da-4bdf-ad6d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_75a7-dc06-445b-b2dc</comment></categoryLink>
+        <categoryLink id="59c6-9d76-4eeb-8c0a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_e21a-c03b-4885-ac46</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink><entryLink id="7654-4428-0eaf-2bb3" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9a08-5fe6-4010-bbc3</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_72cf-cfce-4e02-b379</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fa87-a330-0a86-a6d4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="be46-4a53-ce54-1b0a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2d02-539b-4fd4-8199" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_f55b-7555-444b-beee</comment></categoryLink>
+        <categoryLink id="49d9-93dc-4855-b053" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3386-c9ad-4d74-9474</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
-    <entryLink id="4d2e-1b91-bb2c-ec0e" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a154-dcf6-2800-217f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3de0-b87a-7b60-7eb7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
-    <entryLink id="46fb-2fd0-838e-7eea" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink><entryLink id="71c8-b9c3-03b7-5e46" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_a0f6-9606-4b75-a2f8</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_94b3-1331-474b-885b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b46b-8f20-ae5f-adcf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="dc72-17d7-73c1-6a95" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="ba8a-068c-4551-94a4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_79fa-3370-4ae0-9e12</comment></categoryLink>
+        <categoryLink id="bd26-56ea-4a13-9d13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bb53-4e65-4fb6-9dd7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
-  </entryLinks>
-  <sharedSelectionEntries>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink><entryLink id="55e3-53f8-aff1-56f0" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f8cc-833a-4ac1-bf89</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+              <comment>    node_id_5988-c012-4dad-9a66</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="65c9-fe5f-486d-b4ee" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_8d82-3279-4481-84bb</comment></categoryLink>
+        <categoryLink id="2a63-4514-418d-bd54" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e25c-925e-4b96-8bb3</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink><entryLink id="7cad-f100-ccda-a2c1" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6b73-b21c-4e2b-9d14</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_a7fe-cc62-4a6f-a781</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5be1-1937-4964-a455</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_da1d-b2bc-4117-82a4</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6ead-3a6f-4149-b385" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7010-be56-4709-b058</comment></categoryLink>
+        <categoryLink id="9f21-e814-4265-8f36" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7379-a740-47ba-a054</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink><entryLink id="1905-93de-51a5-c39a" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_dd34-83cf-47d7-b557</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_be88-afef-49b3-bd1e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d894-2f95-472a-b711" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_944f-7420-4982-8ea9</comment></categoryLink>
+        <categoryLink id="2e2d-ea81-47fb-9f43" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ea80-0efe-457d-a450</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink><entryLink id="4fff-23a6-e0ad-0040" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><categoryLinks>
+        <categoryLink id="cdfa-b12f-46df-a8e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9a36-f261-43cc-9bd1</comment></categoryLink>
+        <categoryLink id="bc4a-7222-4c6e-974b" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a648-8396-442a-af59</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink><entryLink id="d44f-c5aa-43fe-f35a" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_cb81-0303-4b88-ae53</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9648-31e3-43aa-8cf3</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_0507-da81-4023-bfcf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0e84-54ff-488d-b066</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ab19-fc5c-4a42-92e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6ff-0977-4c92-bb28</comment></categoryLink>
+        <categoryLink id="4507-3c66-489e-b780" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f555-7d39-458f-84c9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink><entryLink id="279f-7714-301f-2ccb" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8203-5b00-497b-b939</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_40ee-3e71-4978-b1e4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f6a8-f660-46dc-b3c5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_d988-3af6-48bf-b0a8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="817a-c93f-45b0-bcd2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_39e5-eda5-45d1-a643</comment></categoryLink>
+        <categoryLink id="5e8a-79ac-4504-b09c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_6416-21bb-4df4-9de8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink><entryLink id="b5ed-8cb8-70d7-d337" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b03e-5d91-4be3-8adc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_0443-29c0-46e9-ad1d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f2c9-7356-4c27-a22f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0e9-4a9e-4b2b-a9d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2256-10e8-43dd-adbd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5528-2dac-4be5-900c</comment></categoryLink>
+        <categoryLink id="36bc-8b75-4922-8308" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_dc8f-d888-4585-991d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink><entryLink id="5738-89d2-d898-dd43" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1d3c-8e17-489f-9002</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5725-8bee-4bcc-878d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_be47-0d6f-49f2-9f4b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_863c-f3a4-4802-b80c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e82f-6d5f-4922-b22f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_899e-b052-4d5b-8c18</comment></categoryLink>
+        <categoryLink id="ba44-9d38-42ff-baa0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f5e9-cff6-41d2-a016</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink><entryLink id="d5e8-eda5-2bba-8981" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_72da-1513-4e02-b595</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7a48-a3b0-4a26-849b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e232-25f3-4cb7-8ab2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_9aa4-5660-4697-8ab2</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="562c-08de-4b1b-a309" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_09cd-2176-40af-bba6</comment></categoryLink>
+        <categoryLink id="5877-e84f-47de-b33a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_05e6-7c63-4a35-9ba0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink><entryLink id="b2d9-6f4a-cc5f-e78c" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry"><categoryLinks>
+        <categoryLink id="5d7b-d511-4ebe-a057" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0dfa-4004-4751-8022</comment></categoryLink>
+        <categoryLink id="a8c8-3399-4fde-90f7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a669-0f5d-4fd3-811b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink><entryLink id="8e34-be48-fc63-1061" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_09b5-4e3b-4c84-a574</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_32e5-ebba-41fb-9ff2</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_838e-0ccf-4d3a-aabd</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_dfef-0ec2-49fb-a534</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6c74-00b7-4662-b4df" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4f60-472b-45a9-ab9e</comment></categoryLink>
+        <categoryLink id="e216-561d-443b-a51e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e2e3-af36-45a6-a955</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink><entryLink id="28e1-088a-a00b-14a5" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_936f-1ef7-472e-840e</comment>
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+              <comment>    node_id_d73d-d52e-4c75-8ac0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5c57-38bf-4c0c-adc6" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_7a55-ecb4-4e5d-b955</comment></categoryLink>
+        <categoryLink id="6096-b0ef-44eb-9ebe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f28c-710e-4ff8-9810</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink><entryLink id="e5f8-9815-7d06-4090" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_a743-0cc2-45ae-a7eb</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2721-e88d-41f7-bedc</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_e10f-1390-4b33-8fcc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7f62-be9a-433f-94fc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2008-f1c4-4285-a14f</comment></categoryLink>
+        <categoryLink id="4735-ce4d-4885-8839" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e88b-a95a-4647-af3b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink><entryLink id="9223-b6a2-72c3-f158" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_25d8-330b-4574-b515</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7836-6878-47a8-8827</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_5ea9-46dd-4a11-9410</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_ab5d-961b-4924-a705</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0f80-3dd8-4f99-b565" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9189-836c-475d-a52e</comment></categoryLink>
+        <categoryLink id="b020-df82-470f-bc13" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_e1fa-b7d8-47b0-a88a</comment></categoryLink>
+        <categoryLink id="6350-9690-4a19-9ad6" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_a137-e3c0-4d63-a48c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink><entryLink id="ef99-24bb-258b-d38c" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry"><categoryLinks>
+        <categoryLink id="5407-509b-49cf-9215" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b1d5-fd75-4f17-bbf4</comment></categoryLink>
+        <categoryLink id="1e6d-cbd1-45ac-9f3d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_f221-bf81-4045-849b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink><entryLink id="e182-b167-658c-777d" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_b743-7a00-43e4-beb8</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d12f-2c98-4e62-a716</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d4d7-ba67-47aa-962f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+                  <comment>    node_id_1637-edee-457a-bb0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dd18-fa3b-40dc-be53" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_f203-bc26-421f-b79e</comment></categoryLink>
+        <categoryLink id="ebe8-898a-4a90-8536" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_a53e-59d9-4ac2-a21f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink><entryLink id="d9d6-f726-7d7b-1ffb" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry"><categoryLinks>
+        <categoryLink id="b74e-3965-4ca6-98f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_51af-a137-4a1c-97a4</comment></categoryLink>
+        <categoryLink id="684b-63ac-46c0-bf6c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ec1f-c326-40a8-9d1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink><entryLink id="7b7b-2196-728e-38b0" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_c111-feb0-4012-98cd</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_63d7-8427-431d-9ae6</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7498-8645-48cf-b177" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_e707-fde1-457f-91c4</comment></categoryLink>
+        <categoryLink id="90e0-8c7d-4c87-acd9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ec67-8573-4460-89db</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink><entryLink id="f91b-17f1-641e-4f44" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3348-16e4-4a9a-a549</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_bea4-c4a8-4843-b9fe</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2970-17ff-4be1-91e5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_503a-46e7-40e7-bd07</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_4555-15e1-43ff-80a0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8adc-ba37-4b11-a3ce" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_fce3-801c-49c8-85d4</comment></categoryLink>
+        <categoryLink id="81cf-2649-4a75-8912" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0c2d-2349-44b6-9831</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink><entryLink id="86ed-08f1-a8ec-dc32" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry"><categoryLinks>
+        <categoryLink id="f080-7b36-41e2-8c93" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ac1c-b3bf-4011-918a</comment></categoryLink>
+        <categoryLink id="fede-89c6-4290-8196" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_589c-1d0e-4b7d-be6b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink><entryLink id="88d1-f74f-1ce1-b28b" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2f46-a0b6-48a5-a0ee</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_636f-0f8a-43f1-910b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c883-39c8-4a74-aeaa</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_0796-e467-4438-89b3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="669a-f74f-4673-99cd" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_5a04-9847-4c91-a49a</comment></categoryLink>
+        <categoryLink id="cec4-5a61-463d-9fcc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b4b4-daeb-483c-a306</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink><entryLink id="1f94-02a7-c8b1-904a" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6087-a5e5-4d3c-9ebd</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c7e1-5f42-4528-bf07</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1950-08dc-4544-ab01</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_daf3-31ed-42c0-85dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5778-c398-4077-8e3e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_7d4f-547c-43ed-a520</comment></categoryLink>
+        <categoryLink id="8d61-b60a-494f-bd73" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f04e-04e8-4891-9b1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink><entryLink id="1191-d33e-b4cd-60a9" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_dfdc-f6f6-49d2-a7b3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_354c-c71f-472f-b268</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1127-c974-4663-874d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_0843-bef2-4767-8307</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b173-c139-4503-947a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_28e0-91e7-4ada-9fac</comment></categoryLink>
+        <categoryLink id="dda5-59dd-4d84-a33d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4448-a712-4dd7-bf6d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink><entryLink id="2260-bbe6-a8c2-1d7d" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d512-fd07-4a29-863a</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_55c6-a35f-485a-9f0d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d89e-cf1f-4ceb-b3de</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e2c9-0d01-403c-900e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_a7b8-c835-4cb2-b3d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="aea1-4aa2-4fcc-84ea" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_e22a-c5f8-4825-a45f</comment></categoryLink>
+        <categoryLink id="7d9a-5044-44d5-84a5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03fc-6a7f-45a5-bcb8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink><entryLink id="1042-91c1-17c2-50e5" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry"><categoryLinks>
+        <categoryLink id="e023-5242-4082-852f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0aff-4f6e-4b03-a23c</comment></categoryLink>
+        <categoryLink id="a9bf-b170-4fa6-8a89" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"><comment>    template_id_7d5a-62e7-43ee-b79b</comment></categoryLink>
+        <categoryLink id="91fe-6998-4b02-ae9f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_4986-9157-49f2-b670</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink><entryLink id="59f9-fb6b-cbcc-603f" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_319e-90d4-44a3-8e83</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_28db-d943-4099-9abd</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1a45-a592-49df-9465</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb31-d0b2-4677-928e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ee3d-9435-44e3-9306" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1b86-0977-4a8b-adac</comment></categoryLink>
+        <categoryLink id="f9b4-8aad-400c-9ed9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_b449-403a-4e42-9239</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink><entryLink id="75fa-5312-9b7b-4254" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafa-470f-4c2c-8be3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_e2ba-a855-4de2-9f46</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_0171-b30d-44ee-9389</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fdfb-119b-4774-934a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_3891-9a00-4f8f-b95f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0165-d443-4635-8f07" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e5df-17d4-4521-9d5b</comment></categoryLink>
+        <categoryLink id="d89f-91cd-4b66-bc06" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"><comment>    template_id_0ecd-4873-4d3a-b28b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink><entryLink id="4d2e-1b91-bb2c-ec0e" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_fbfa-8d78-4d6d-8a05</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_21f2-0916-46bf-b75a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_4fbd-633b-4dd6-9fdd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="76d9-46cd-4e06-a4fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4f71-446f-4cff-afda</comment></categoryLink>
+        <categoryLink id="2e16-c0a3-498b-850c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_3f44-8647-43a4-ac22</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink><entryLink id="46fb-2fd0-838e-7eea" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af15-2c71-4f8b-833e</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_d95a-80b9-4463-af55</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0516-c7ef-446e-8d09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6b1-886e-4194-8bcd</comment></categoryLink>
+        <categoryLink id="0d06-495a-4c6a-9dc4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_51b5-f9c1-4587-8fc7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink><entryLink id="9b0b-9782-4bd8-91d6" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
+    <entryLink id="be0a-50d8-47d2-a6e8" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
+    <entryLink id="49b5-d091-422e-ba8f" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
+    <entryLink id="cee8-28d4-492f-b2bf" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <entryLink id="106d-ae42-4136-8e9f" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3531-57d1-4081-882d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_f233-2361-4177-8ba7</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b932-667a-4b43-8331</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <entryLink id="7a76-6c0e-4a6d-9a8d" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <entryLink id="c025-ed50-44c5-adbd" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3129-6f59-4365-906b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2bcb-0af1-4aea-9191" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <entryLink id="5d60-49aa-47dc-85f9" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ede2-d453-4e34-8cda</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2907-3215-4b01-96ff</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_c90c-959f-40fb-a4cb</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ba2d-50ad-45f1-91c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0e88-485e-43c2-8bef" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <entryLink id="5112-fe65-4b4a-9ca4" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_409c-0a5d-4ef8-a871</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7078-c1c7-4af2-b43d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_9a69-0fdc-4957-8982</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1a4c-69b5-4219-8502" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fba0-3ea7-4eaf-b33a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <entryLink id="a6f6-0b55-4712-81a4" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
+    <entryLink id="cf25-b990-42dd-8b7b" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
+    <entryLink id="0ff5-e228-411f-980b" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
+    <entryLink id="e6f5-b7d7-483e-aaa1" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+  </entryLinks><sharedSelectionEntries>
     <selectionEntry id="8c74-40b1-5019-f4d4" name="Vulkan" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65d8-0392-0de1-6820" type="max" />

--- a/2022 - LA - Salamanders.cat
+++ b/2022 - LA - Salamanders.cat
@@ -2161,7 +2161,7 @@
       <entryLinks>
         <entryLink id="a684-5ee4-dec2-31ba" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_7dee-602c-4b47-be09</comment></selectionEntryGroup>
     <selectionEntryGroup id="ec53-0911-52b7-dafa" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="467b-133a-c09c-b969" type="max" />
@@ -2183,7 +2183,7 @@
         <entryLink id="f7b0-e209-7d07-e62c" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
         <entryLink id="9d06-d7bf-1138-373a" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_be38-a066-4f8e-ae54</comment></selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
     <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />

--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -1,6 +1,5 @@
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="62c7-42f4-5523-af1b" name="LA -  XVI: Sons of Horus" revision="15" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26">
-  <entryLinks>
-    <entryLink id="c2a2-9b6d-b384-3f43" name="  XVI: Sons of Horus" hidden="false" collective="false" import="false" targetId="01b4-57c7-bf61-2abf" type="selectionEntry">
+  <entryLinks><entryLink id="c2a2-9b6d-b384-3f43" name="  XVI: Sons of Horus" hidden="false" collective="false" import="false" targetId="01b4-57c7-bf61-2abf" type="selectionEntry">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57a1-d021-4da4-093e" type="min" />
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17ce-5398-8e0c-9aa7" type="max" />
@@ -149,939 +148,1695 @@
         <categoryLink id="d429-527d-c73b-bddc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="6405-c1c7-8dba-8ae0" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1e9f-1cb6-da66-b237" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4346-1e41-b3fc-208f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <entryLink id="6405-c1c7-8dba-8ae0" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="f03f-2f11-4672-ad15" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6d4-581f-4746-bec3</comment></categoryLink>
+        <categoryLink id="fa55-54b1-43e9-b9fa" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_2489-ee2a-45dd-b384</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
-    <entryLink id="7b18-b50c-59a0-265f" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="bb97-d2c9-cd3a-c0e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="edd6-2dc1-5c4f-a591" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
-    <entryLink id="976e-1e33-d989-1476" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink><entryLink id="7b18-b50c-59a0-265f" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b02f-e65f-4a88-a175</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_b87b-bf35-4238-b7c6</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1aff-27af-435e-8102</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_fdf9-4906-4180-a39d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e196-f30f-88af-6df7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="3d4b-f740-fb15-8228" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7e31-cb05-92eb-e48c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="2400-f7db-433d-bd90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8378-ede4-476d-b657</comment></categoryLink>
+        <categoryLink id="99cf-c093-4060-a35e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_d64f-ad19-426c-adf7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
-    <entryLink id="5931-079a-7236-2747" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="43f1-2d99-fcf6-4032" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="4742-2329-2f94-d568" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
-    <entryLink id="3d2a-7e13-20ef-2f2a" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="248e-c85a-b6d6-857e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="3ac8-8ff3-8100-72de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
-    <entryLink id="7ae0-abf2-9c89-7c46" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink><entryLink id="976e-1e33-d989-1476" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_7fd1-8ce8-4d10-82e7</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_eaae-8c43-4d30-898c</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_f67d-8cf3-424f-b491</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_b949-6414-4f3d-b268</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="023d-25b3-af63-4ed6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="6b08-cdb7-c559-6ad7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4ff3-b061-aa45-08b3" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="b599-cb2d-4179-9fed" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_ac26-e639-4d53-9b8b</comment></categoryLink>
+        <categoryLink id="f8a8-7e1f-41e5-b530" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_49af-0d08-4c7e-8ce6</comment></categoryLink>
+        <categoryLink id="a983-0dcc-4794-a2c8" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_b606-de16-4659-95cd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
-    <entryLink id="87b1-8092-dca7-2c37" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink><entryLink id="5931-079a-7236-2747" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="38df-3a93-cdf2-b777" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="e1e7-54c0-5562-9478" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
-    <entryLink id="7a59-42d0-94a9-8e83" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7583-6fa0-4089-a19e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_0e5c-99ab-41d3-a42e</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c296-e8e8-4a7a-989a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_8868-5bcb-4604-ba8e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="60d5-a2ee-44bc-9e7a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a009-a597-4b51-b228</comment></categoryLink>
+        <categoryLink id="4d6d-e02b-4b66-a75c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_24f4-9145-4016-80d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink><entryLink id="3d2a-7e13-20ef-2f2a" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_e732-7499-47bf-9748</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_81a5-a959-46b7-baa4</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7ec3-447a-4644-b012</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_71e2-c430-4c99-a559</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_df7b-3fb9-4f65-9165</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4533-378f-411d-a983" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c165-3906-463a-9c73</comment></categoryLink>
+        <categoryLink id="79ed-a409-4311-a0d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6d1-d14c-473f-be09</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink><entryLink id="7ae0-abf2-9c89-7c46" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_27a3-1e4c-4b76-a594</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_d59a-dcd0-44fd-b866</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_0c8b-2b92-49ed-98c7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_bafe-f799-41d9-ac85</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_6369-288c-4fec-a640</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_fe53-8858-41dc-8ec4</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b460-e474-5655-72cb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="e265-87d2-1088-c7e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a0b0-4f18-46aa-a695" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_3a22-caae-4eea-9bc5</comment></categoryLink>
+        <categoryLink id="cfa8-b2dd-4514-b984" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f759-f33e-4698-9f8a</comment></categoryLink>
+        <categoryLink id="abc3-6a77-4231-a08c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_c624-3ae0-46c0-9b06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
-    <entryLink id="e36c-83cf-3188-9e63" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7ff1-d82f-d17e-3ed5" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="ddb7-718e-db49-7597" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b31a-9085-dff0-ede7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="8c21-e292-7178-6a1a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup" />
-        <entryLink id="74fa-f7e8-4f16-b6b8" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink><entryLink id="87b1-8092-dca7-2c37" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_13b3-ce1e-4f9d-8319</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d681-9d81-4abd-b11b</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a57-e48b-4534-bca5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_1859-5641-4674-9097</comment>
+                </condition>
               </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
-    <entryLink id="fe52-c4e3-2387-07b6" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
-      <modifiers>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8e3a-9a3f-4252-be5a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_251a-df5b-4bfd-ad63</comment></categoryLink>
+        <categoryLink id="6559-b2ac-4150-aec2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4644-98ab-4e3f-b1fd</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink><entryLink id="7a59-42d0-94a9-8e83" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_591d-d028-4663-918d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_0482-c5f9-4c95-9597</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_75a7-971d-4978-a83f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_a7d5-2bfe-4621-ac0c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9f13-b460-4f27-b0cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_31fc-e265-45a7-bb5b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9306-035c-b8ec-3972" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6cb4-9c57-4a8e-db99" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="7f25-8120-3321-fb5f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="c668-fa82-4239-9528" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_67c2-df43-44fc-92d1</comment></categoryLink>
+        <categoryLink id="167d-b0ab-4a62-910c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4136-bb4e-4dd4-99f9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink><entryLink id="e36c-83cf-3188-9e63" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry"><categoryLinks>
+        <categoryLink id="ccea-04e0-42b0-b324" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_2599-24e3-44e5-9568</comment></categoryLink>
+        <categoryLink id="9d66-18cd-47e5-b8bc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_285f-6e56-473b-b2fe</comment></categoryLink>
+        <categoryLink id="498d-a6e6-43cc-bf26" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_685e-022f-4e2f-a568</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="5789-ff4a-ef4b-edfb" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup" />
-        <entryLink id="777a-56cd-8dfb-5a68" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup">
+        <entryLink id="6a45-af65-4f00-9cd2" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup"><comment>    template_id_2a38-6544-4267-b584    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="69fd-bb5a-46f8-a894" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_8287-16ff-46ba-9838</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_81c1-fca9-44dc-ba4c</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_6e59-4592-47ef-b76d    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
-    <entryLink id="9ba0-00ac-e866-e5d9" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d9f0-59e4-35e7-bb4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f432-8613-0453-cb30" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="db76-fdd3-3600-5aed" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="67bc-10b1-2a33-8b36" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup" />
-        <entryLink id="d83b-fe6d-b9fd-2864" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
-    <entryLink id="ee70-f549-a838-fc80" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2247-5478-7e06-c3ca" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="d51f-2d4a-31e2-9366" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
-    <entryLink id="298a-7e54-6282-d112" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b6cb-fdc3-227d-177c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1362-7754-a43b-c501" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
-    <entryLink id="9230-f176-32b2-7d8d" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink><entryLink id="fe52-c4e3-2387-07b6" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ad5d-3c79-4239-9116</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_60b1-049b-4a5f-85c2</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="46e0-7c29-6d37-16ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a07c-df2c-0031-c36b" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="147b-8a43-401f-9c63" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bd6a-0cda-4e0f-80ae</comment></categoryLink>
+        <categoryLink id="0b33-d83b-4b5b-9db8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_ae75-7cca-4701-9d56</comment></categoryLink>
+        <categoryLink id="4b45-474f-4647-8372" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_e517-62d4-48f7-8174</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
-    <entryLink id="391b-a79f-876c-4c33" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
+      <entryLinks>
+        <entryLink id="d7cd-cbcd-4bb7-8b13" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup"><comment>    template_id_fafb-6414-474a-8a09    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="8bbf-f0b6-475e-bed5" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_1e43-c980-4508-8ec2</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_4140-36a7-4203-b5e9</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_a6a6-9bc7-4d4e-86a7    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink><entryLink id="9ba0-00ac-e866-e5d9" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry"><categoryLinks>
+        <categoryLink id="9be8-257d-4e98-838d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fc9d-03d1-4bbd-a1c4</comment></categoryLink>
+        <categoryLink id="9499-2ce8-44a7-be45" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_f51c-73d7-4f29-be1c</comment></categoryLink>
+        <categoryLink id="2123-b1f8-456e-8c90" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_257d-78c0-4bab-ba65</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="dd33-f4ba-4b31-83c8" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup"><comment>    template_id_ac26-33db-40a7-bdba    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="f693-3253-449b-920b" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_189b-db75-4db6-9fe9</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_cbdb-2500-4e13-876a</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_dc8e-2801-46d6-84f8    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink><entryLink id="ee70-f549-a838-fc80" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b43b-547f-472e-9076</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8ff9-0498-4540-8552</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fbfe-931a-489b-a589</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f4c3-5aa6-4caa-abf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_17f8-f055-4c9c-b757</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="bc19-9ee8-bfab-8436" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5944-f85c-a636-db84" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="0409-0ca7-4110-8df9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f1c8-27fd-4f98-8527</comment></categoryLink>
+        <categoryLink id="0ce3-a809-4add-8a1d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2b20-1a8b-4753-b657</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
-    <entryLink id="46ee-7083-fc7a-c22e" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink><entryLink id="298a-7e54-6282-d112" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry"><categoryLinks>
+        <categoryLink id="8a51-62aa-44c4-92a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4207-8d8f-4b1a-836b</comment></categoryLink>
+        <categoryLink id="cf72-ca21-4571-bba2" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_2b34-077f-4279-86fb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink><entryLink id="9230-f176-32b2-7d8d" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="7fcb-d2bb-ddf3-cf38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9f4e-77db-9581-ec72" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="9ec8-2731-4ca4-bc1d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6577-e0fb-4fda-834e</comment></categoryLink>
+        <categoryLink id="c437-5a23-42ae-905f" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_5d59-09bf-4566-b7e1</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
-    <entryLink id="70d1-1da3-af70-f8b4" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink><entryLink id="391b-a79f-876c-4c33" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"><categoryLinks>
+        <categoryLink id="82c8-4dd0-46d7-b491" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_aa93-057d-42f6-82d7</comment></categoryLink>
+        <categoryLink id="c9c6-3fe8-4e33-85d3" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_403c-4e9c-4af5-84ec</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink><entryLink id="46ee-7083-fc7a-c22e" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_23fa-06dd-49f9-a7db</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5b26-059e-40b3-9d93</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f7bf-3a1c-4103-aed8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="2707-323f-d4f7-d83c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="1c40-efc2-b737-fe75" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="267b-0b05-4e6a-bda5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dd44-e0a8-42a8-bdcc</comment></categoryLink>
+        <categoryLink id="704e-a9cf-4e39-af22" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_c5b0-f9ae-468d-924a</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
-    <entryLink id="f8ba-0406-a964-e89d" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink><entryLink id="70d1-1da3-af70-f8b4" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8396-e51c-4e2b-bada</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_13bb-9fb5-4580-92cf</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_bfb8-8125-4548-92f5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25e3-b8f5-4448-a7c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="46cb-a436-45c5-947a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_f926-27fd-4a92-97a1</comment></categoryLink>
+        <categoryLink id="093a-ac5c-4f07-9baf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_82e3-36e1-4e85-8fcb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink><entryLink id="f8ba-0406-a964-e89d" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0812-2a99-32b8-cfc8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
         <categoryLink id="0d0d-89a7-4ae2-a798" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="5326-0dc2-99cd-5a7b" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
-      <modifiers>
+    <entryLink id="5326-0dc2-99cd-5a7b" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_658f-b1ad-4347-a998</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_12bc-3db2-4d28-abce</comment>
+            </condition>
           </conditions>
         </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="2fe0-daee-3736-c8b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a4a2-9b7d-fcd8-ceb8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
-    <entryLink id="50cc-1a98-d330-f811" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_9d83-7691-41d6-8dad</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_add7-ba48-46d4-8a02</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_1fb0-2421-40a4-9e49</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0c45-ab68-ca05-a713" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="221a-fead-fb30-7766" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9c7e-673d-c5bb-5c74" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="8b91-dbe7-4b52-9538" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7004-b00d-481f-b740</comment></categoryLink>
+        <categoryLink id="13ea-a9e5-4a65-8d41" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4f88-2fc3-491c-bfb7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
-    <entryLink id="d0c1-0ce8-23d9-291d" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="05c1-048e-dd58-95b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="db55-be7a-6ca0-993f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
-    <entryLink id="f892-38ef-43ef-b485" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="726e-1741-0e17-257d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="af6f-8fa1-be8d-ab53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
-    <entryLink id="cd69-d7e1-281d-92c2" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c9e3-c57e-07b4-430a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="f04f-29e8-f562-6aaf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
-    <entryLink id="a686-3572-9648-f413" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="210d-4413-aa5b-f52d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="021c-3d91-163a-7a1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
-    <entryLink id="a1bb-eca2-1b35-c3b8" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ac85-ba77-de25-6801" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c9e0-f198-62ee-6559" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
-    <entryLink id="ef9b-780f-2c71-9129" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3796-2f84-9305-de64" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="4db5-b750-90e7-cb26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
-    <entryLink id="5f51-164d-60e0-ab13" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="b34a-111f-7c43-2ba6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="9070-08d2-40cf-0ad8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
-    <entryLink id="a340-af9c-0234-641c" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="4ca7-6a06-e4b4-0159" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0ed2-d09d-c159-f05b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
-    <entryLink id="8aa0-c430-bf92-3960" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2dbb-2ee5-a9c1-7fc0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="01c3-0b7a-6939-34f9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
-    <entryLink id="227f-e0ff-0d7b-6f13" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="cc3c-77b8-f57c-61e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0854-8252-2da8-8134" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
-    <entryLink id="14d3-6123-8d3c-d540" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="5944-0a79-2728-83a2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="2e77-be6f-f86d-cc37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
-    <entryLink id="d57b-2de7-7e2d-1a11" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9b79-85e2-ca6c-83e1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="80ec-ba11-6e27-7546" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
-    <entryLink id="7adb-fe67-ec60-d8da" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="00ce-9ec3-91e1-2aeb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="8a3f-00ad-5369-637a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
-    <entryLink id="9e8c-3d53-6db8-bd35" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6b42-43d3-cad6-733e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7a33-25cb-e445-a261" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
-    <entryLink id="235c-143e-dcbe-611f" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="027a-a147-a3eb-c57e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="dd96-3e87-0d98-2dcd" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
-    <entryLink id="9cea-481c-2a16-8b08" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="cdab-8bac-d1bc-4605" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="2906-825a-29a1-a60b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
-    <entryLink id="b455-e6ed-ddea-9480" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="4baa-3a1c-ec3b-a526" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="f1c4-c235-f6f1-2894" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
-    <entryLink id="132f-94b6-52aa-df0a" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1cd3-8f79-a919-82fa" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="8ac4-9a55-fa56-2947" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
-    <entryLink id="947f-1ab5-b634-c170" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="f9b9-a2cf-8383-4708" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="344a-677e-3b71-8b43" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
-    <entryLink id="2140-c0f2-e5fc-909e" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="2cc6-1d3b-a458-0ae5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="8e9f-931d-ee47-b4df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
-    <entryLink id="44a5-b487-c296-ba15" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0a0c-38fb-f78c-803d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="65a0-2d58-e86c-8d53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
-    <entryLink id="2ae3-0e12-6739-1757" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1214-471f-5840-45b9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="7a4d-edac-c3fd-cc13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
-    <entryLink id="0d89-f094-1e9f-0ffc" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="985e-3071-f56d-fe2f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="9f54-3016-179e-351f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
-    <entryLink id="a0b7-2afc-187c-072c" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="a73f-3887-68be-61c9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="4dc9-64b1-cd49-6f65" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
-    <entryLink id="a70c-faf4-f59d-47c1" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1675-a822-213a-f49e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d698-4626-b245-cf7a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
-    <entryLink id="9574-3763-b54a-dc08" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="332c-f396-7746-b882" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="5dbc-94c2-bd54-119f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
-    <entryLink id="10af-636e-0fcc-30de" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="2c9b-7448-07f8-146c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="1f32-cda0-5ee1-cd35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
-    <entryLink id="1597-f21c-1ec0-35b3" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a330-1e6e-66d0-e975" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c6ca-d7f1-1653-53ee" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
-    <entryLink id="1392-2d22-a57e-3b86" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0e88-775b-2eff-df80" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="7b28-18b8-1a97-bb4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
-    <entryLink id="9bdc-3415-095f-861e" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3373-ea50-6c85-f1ab" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="6541-8d6e-6c27-7846" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
-    <entryLink id="2aca-ce33-1bbb-061a" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="04a3-e2e8-f20a-1f6f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6016-f133-be7c-5153" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
-    <entryLink id="3930-0089-f27e-cd7c" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="20b7-7a46-bebe-7273" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="9b99-c6ac-ce5a-a757" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ee4a-26ae-1138-2c27" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="2027-afd3-6eba-ecb3" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup" />
-        <entryLink id="1300-170f-0263-d0bc" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
-    <entryLink id="b5c1-305a-2799-adc0" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1a6a-b273-5f16-c4a0" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="1b08-9276-71bb-50c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="16c0-0209-25df-8043" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="5a22-9a37-892f-6462" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup" />
-        <entryLink id="2e93-e68a-5522-ade9" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
-    <entryLink id="d2a4-2d48-b694-6b53" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2ff3-f549-637d-1449" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="61bc-112b-6174-dded" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ea44-e73e-7e88-9bdc" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="6de7-675a-af19-1da7" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup" />
-        <entryLink id="6840-495c-d3b5-9df6" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
-    <entryLink id="072c-e66d-6103-4070" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7ef3-214d-3d2a-af4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="473b-5fad-f640-4c68" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
-    <entryLink id="09b7-f3c2-c74b-ba7f" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="b99d-fd38-1573-b275" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="cddc-b8d8-e2e7-94a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
-    <entryLink id="287f-4f3c-5407-06a6" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9ad9-c2b3-d3a5-a8e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="738f-13cd-fc9c-50e0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
-    <entryLink id="c076-17e8-8918-b464" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="562e-6510-08c3-97b1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="32cb-ed8c-1150-3c3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
-    <entryLink id="2446-ab14-6e35-6d1e" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="76aa-00e6-9797-61bd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="cd64-2c1f-637e-1e4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
-    <entryLink id="af59-4e3e-9177-aa52" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="fa1e-e57e-fe64-a832" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="ae8a-255f-1e7e-a42a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
-    <entryLink id="e3ef-ce1f-d480-fc6b" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="380b-47c8-094a-0eef" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9bed-c37e-14de-732d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
-    <entryLink id="c2a3-8fb0-4ad3-549f" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d122-28b5-e796-7fda" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="dff8-9a3d-6b04-ac0f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
-    <entryLink id="cb6d-aeb1-bea4-df7b" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1d95-12aa-9c16-33d6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3c1c-d3dd-a987-8173" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
-    <entryLink id="a159-873b-f843-b18e" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b9b3-68c5-ab61-5c02" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="fbe7-2425-dbb4-66ad" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
-    <entryLink id="389c-ce86-89a2-3776" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="abe7-4be2-eed3-9971" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9527-c78b-175c-0594" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
-    <entryLink id="5b55-c65d-087d-b84f" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3ef7-3530-30d4-65c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2443-43b5-239c-2553" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
-    <entryLink id="0547-6d52-1f3f-ac18" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="cecd-2fd2-c4cb-eaa7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5786-dde9-1b3e-c114" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
-    <entryLink id="8f46-ec72-492b-3578" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="91b1-a34b-b760-dfca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="411d-14aa-6e09-a22d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
-    <entryLink id="4e7d-a15a-ea60-4f0b" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1214-fac9-7990-1358" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="47bf-3493-af53-d564" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
-    <entryLink id="00bb-4210-6011-0544" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2601-e6bb-a438-f56f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="9346-8593-8ae7-2102" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
-    <entryLink id="c8c3-c970-b364-eb7d" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="462a-b975-5f48-5b8d" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="8088-3487-4b42-2991" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
-    <entryLink id="7730-3dcf-bb6e-ec1f" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="aef3-aa0e-aff3-69a7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="347e-65e6-c5e8-5334" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
-    <entryLink id="4781-3622-8679-be54" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink><entryLink id="50cc-1a98-d330-f811" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_8ed4-376d-4030-9439</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_8a11-c2a0-4335-99ef</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_fa8e-1af7-4d41-ac8c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_94bd-c771-4a85-8581</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="85ff-623d-8cf0-df89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="228a-e216-3f8c-727a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="5b13-d956-3328-00b8" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="8b85-3de7-4c7e-9687" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_361e-fb90-4b0e-ac3d</comment></categoryLink>
+        <categoryLink id="72e8-a3f9-4258-a35b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d4ef-1074-45a9-959e</comment></categoryLink>
+        <categoryLink id="6167-3453-49a6-a017" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_febb-f536-4d25-a8ab</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
-    <entryLink id="780e-5eaf-5516-471e" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="69c3-3c08-9e7d-286d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9bab-10fe-7410-247b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink><entryLink id="d0c1-0ce8-23d9-291d" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="b354-3d58-4c35-ade4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_473b-e812-4158-9416</comment></categoryLink>
+        <categoryLink id="de15-6897-4fbe-bc4f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_00a2-63ff-4698-a35b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
-    <entryLink id="3800-5e59-a995-b32d" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink><entryLink id="f892-38ef-43ef-b485" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7cf3-8a72-4f82-8cdc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_228c-5681-4ce8-b726</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_01bb-8abd-4253-9a4d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b8cb-40c9-c1c7-b573" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="93f5-ce69-d670-5421" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="23df-87d4-483d-9fa8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2a08-4432-42ad-bfdb</comment></categoryLink>
+        <categoryLink id="5540-fc5a-4879-aa33" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_422e-0808-4897-8630</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
-    <entryLink id="b38b-92a2-1f92-b780" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink><entryLink id="cd69-d7e1-281d-92c2" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1af8-4459-4717-8e3b</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_06b4-92b9-438c-b1a5</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6c8d-8b28-417b-9a7c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_715d-8186-4aa6-b40c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_390e-358c-4f8e-ade8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="6f31-643c-3333-afa2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7ff0-ca96-8d3b-c392" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="d3bf-7cd3-490e-8f98" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f4c0-4396-4f39-a34f</comment></categoryLink>
+        <categoryLink id="5861-d8d1-414c-8984" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1301-8415-490e-8f06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
-    <entryLink id="f5ff-653e-2803-6fff" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink><entryLink id="a686-3572-9648-f413" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d0c9-9a26-4324-b030</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4e9e-a61d-42f2-bacb</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ed9e-b634-4bec-9eb0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4614-ad0f-4fba-adaf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_8d08-24f6-41be-8931</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3e71-3c0f-47de-8692" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_caf6-5548-4b89-8102</comment></categoryLink>
+        <categoryLink id="dbd9-7ccb-4ec0-b48d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_63a3-be61-428d-ab29</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink><entryLink id="a1bb-eca2-1b35-c3b8" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f318-4b03-4767-8c7f</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b8ef-7245-4df8-a8c4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_6bce-ec44-48cb-873a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="057c-f7c9-4597-9968" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0678-4fdd-48e6-8f61</comment></categoryLink>
+        <categoryLink id="a2ce-9d3f-425c-bb6c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0d82-10a9-4de2-8ad7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink><entryLink id="ef9b-780f-2c71-9129" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ada1-1e18-4cbc-9598</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b1d1-ac44-47dd-9159</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5d64-f00c-4464-891b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25f0-f825-4a83-8f0d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_64b1-9e36-44da-b36a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="913a-86b0-4c48-a1b5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_d53e-113f-4a40-a3d5</comment></categoryLink>
+        <categoryLink id="b9d3-be16-4aa8-a007" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1939-76b5-4279-9f8c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink><entryLink id="5f51-164d-60e0-ab13" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d765-3bb2-4b48-bd12</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_0ca1-cfb4-4a56-ab3b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2d26-6b64-fea1-1a46" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="cbc4-6cc1-5cee-3517" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="31b7-3726-48d3-9cfa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e6f7-a6ca-4825-bfc5</comment></categoryLink>
+        <categoryLink id="28c5-8018-41ca-8365" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dbec-e027-4ec1-8514</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
-    <entryLink id="8f38-399f-db76-c24d" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink><entryLink id="a340-af9c-0234-641c" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d8ee-81ed-45f9-8b79</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_8f4e-e8cb-4ac9-a415</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="516d-e3a7-4c58-8a1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_cefb-cfd7-4dc8-99c4</comment></categoryLink>
+        <categoryLink id="e88d-d858-4081-82d1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a9fd-9d16-4a5e-855c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink><entryLink id="8aa0-c430-bf92-3960" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e76b-46ca-4ab8-a93d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8035-75b8-43bb-97c9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_71a4-31e7-4927-a0ab</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7667-d417-4c91-bb88" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_a56d-347b-4b09-a918</comment></categoryLink>
+        <categoryLink id="5b04-3409-49d0-96c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_96e5-4531-4213-903e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink><entryLink id="227f-e0ff-0d7b-6f13" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1fb5-2375-4c22-b41e</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7d7c-255d-49b6-96b9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5321-254b-4890-9bf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ddf8-b8b7-4afb-b6dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5014-fa8e-4b5b-89ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9441-d79b-4720-9667</comment></categoryLink>
+        <categoryLink id="908b-600c-423e-bf71" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7d7e-32d3-4692-b401</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink><entryLink id="14d3-6123-8d3c-d540" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_99fc-5fe7-4b37-a62f</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_25f4-f6b8-4b44-8350</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_81f7-2311-4cce-95bc</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_09aa-af2a-4012-91d1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_00ae-fad3-4df6-9cb9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9915-3dbb-459b-8aab" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f65b-8958-49b3-92a5</comment></categoryLink>
+        <categoryLink id="2a73-5d83-4492-b4ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0451-1929-4942-8c3f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink><entryLink id="d57b-2de7-7e2d-1a11" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_edc4-4915-40ba-bbf0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_105f-ba26-4146-bc54</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7a2c-a76c-421c-a8a2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_05c9-0543-47ee-ba81</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e6ad-f0d7-4627-921b</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2c83-8a08-45e7-a2ad" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c6a8-22a8-4d41-b969</comment></categoryLink>
+        <categoryLink id="5c0b-02d3-4cdf-ae26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03ca-12cc-4e0a-b628</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink><entryLink id="7adb-fe67-ec60-d8da" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ae67-ef52-4cac-958c</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fc61-7306-4d99-acde</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1be0-67e7-45a1-bdbb</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_42a8-7fda-4e05-af0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="31ed-02f5-4369-8df2" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_565a-1592-491f-8b9b</comment></categoryLink>
+        <categoryLink id="5da7-504f-4415-9ab6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_81d5-c14a-42ab-bdde</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink><entryLink id="9e8c-3d53-6db8-bd35" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1ae7-c41b-4818-be71</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_08a5-b1bb-4ba1-ba42</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d677-b5ad-4838-8746</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_537f-bc1f-4aaa-b0dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="89c1-45ea-49a2-bf58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bc67-ce1f-4004-aeb7</comment></categoryLink>
+        <categoryLink id="aa3b-8566-4f98-b76a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_9a45-9699-4475-aeef</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink><entryLink id="235c-143e-dcbe-611f" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_c28f-4109-44c4-ab64</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fdc1-a894-48bc-9e7c</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_4936-a68c-4524-9088</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb37-ac0c-49ae-9d6f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ca77-7ad1-4b42-b151" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3afe-cfc0-4da6-a985</comment></categoryLink>
+        <categoryLink id="bdc4-7e02-4ad7-9777" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_04a8-6aae-45ae-bd4c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink><entryLink id="9cea-481c-2a16-8b08" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ae19-30c0-43c5-920e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_6ebe-1bf3-4d78-9dd0</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1887-152d-48b7-b13f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_a7c4-ee6a-4f0b-8ab0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bd85-fa90-47ff-9f84</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_7bd6-9043-4d7e-ba37</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="10be-47f3-4451-87db" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3610-c975-4d55-bdfe</comment></categoryLink>
+        <categoryLink id="369a-7560-49a3-b167" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2fc2-f636-4c80-9608</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink><entryLink id="b455-e6ed-ddea-9480" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_85c5-d4d9-4b23-9e4d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_80e8-d50b-4906-8153</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_b93b-d4f1-45eb-8a69</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e183-f183-4db7-83b5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0f39-204a-4217-b896</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_eee9-7bfd-4fea-a1bd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f9e4-2eed-4940-8e85" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f81d-9435-4f11-99c1</comment></categoryLink>
+        <categoryLink id="14ed-fc51-4960-bb59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9568-6142-4fdd-be3a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink><entryLink id="132f-94b6-52aa-df0a" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_005e-6607-4e2c-8dd2</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_7745-260c-4c36-b719</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_ba25-a4b2-4ba9-b023</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ddeb-f4c8-4091-9153</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4904-fd2f-429f-9cf7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_faea-b21b-43c5-b918</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="66e9-176d-4684-a526" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_b24f-3ae0-4cbb-b016</comment></categoryLink>
+        <categoryLink id="a91a-0b08-408a-a7ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fd26-8e6b-4521-92b9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink><entryLink id="947f-1ab5-b634-c170" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6ecb-28e2-43ed-a6a0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_c067-1118-4d96-b28b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_250e-23c0-4e43-bf74</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1553-a6e6-4291-853f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_aab6-797b-427a-9fd8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fcfb-0106-4410-8d3b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c77f-0819-473b-a8a2</comment></categoryLink>
+        <categoryLink id="50ae-9aa7-4afc-9044" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_89fb-c924-4daf-923d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink><entryLink id="2140-c0f2-e5fc-909e" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d72c-519a-451f-81b6</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_3d16-444c-42c9-aad1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_f4b2-6371-494b-863a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_797f-a84b-42f6-8e66</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0d78-fe38-4829-9b12</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="226b-2575-4498-93c4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0397-c837-4fea-a527</comment></categoryLink>
+        <categoryLink id="de39-3781-4648-9e63" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_060b-bccb-4776-bd83</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink><entryLink id="44a5-b487-c296-ba15" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3c84-6d74-4c42-b38d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_5b15-7aa4-4897-aaf1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_3326-31ed-4151-9b37</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6a0e-1b65-4057-ba5d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f8c7-abc9-45ec-955f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_2538-8dc5-446c-8344</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a711-323d-42a3-b623" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_c1cf-cea4-4278-8f27</comment></categoryLink>
+        <categoryLink id="bc5d-8b72-41a4-88f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5f51-2734-4a46-9f72</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink><entryLink id="2ae3-0e12-6739-1757" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af71-f3ff-49b1-83e9</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_1c9e-b3bf-4e88-a43f</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_6d0d-1b1d-4065-89cf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d0b7-8686-491e-9d33</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_7db8-0874-487a-be6f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1034-29a0-44b1-a85f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="92c5-551d-4ce3-b922" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_0c16-6841-42b2-b02d</comment></categoryLink>
+        <categoryLink id="6865-5b63-46dd-a2b7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_602d-2d2d-4ff4-a82a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink><entryLink id="0d89-f094-1e9f-0ffc" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_22bd-baae-45f9-b366</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_52bd-55de-4d53-ba55</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_df1b-7476-4ab8-8d2f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_49fa-0dcf-4a61-a5b1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0ea-1443-4993-86e7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2a8-3fbe-448c-9902</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9058-32f4-4d72-8c00" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3632-0b5d-4622-ae33</comment></categoryLink>
+        <categoryLink id="b857-8ae3-4130-a8fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_da44-7815-4fdd-981c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink><entryLink id="a0b7-2afc-187c-072c" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2bfa-b203-47e2-a828</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a39b-8a3c-49cf-bf62</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2a05-07b3-49c5-8145</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f730-87fb-44bd-b68e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_2d0e-6c49-4493-a022</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2e2-50c1-40c3-b4dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ecd7-bdb5-452f-bb1f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_5ad5-8701-42cd-b2b6</comment></categoryLink>
+        <categoryLink id="1bfe-0836-4a7e-9c0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_20a4-4346-4a3b-a7d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink><entryLink id="a70c-faf4-f59d-47c1" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_773a-1ea4-41a0-b766</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_9d4d-6fb8-4131-a5a3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e3bc-02f8-4ece-a5ea</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c371-76d9-4a4d-bc00</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b4c6-d4ba-4b2e-9b99</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="70fb-0b39-405b-b039" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6ea9-a7e5-437d-9e35</comment></categoryLink>
+        <categoryLink id="73e6-36ba-4ce9-83b6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_3cec-f053-42ab-a6eb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink><entryLink id="9574-3763-b54a-dc08" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1e60-42ba-4c8b-9077</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9860-f593-425e-b89b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_c842-10e8-4509-8eda</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ea52-ff41-40f6-8cf3</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_51e6-c5e1-4003-96bc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d632-8c66-4ebe-bd0e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4d7c-201f-4c99-b89a</comment></categoryLink>
+        <categoryLink id="c5f3-9933-46f7-bba7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_10f9-4718-4e07-bb32</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink><entryLink id="10af-636e-0fcc-30de" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="bf1c-9c0a-4945-bca5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4e52-ad1b-48d4-8eed</comment></categoryLink>
+        <categoryLink id="eba3-d636-472c-b62c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_6979-1ed3-4f1f-a025</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink><entryLink id="1597-f21c-1ec0-35b3" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry"><categoryLinks>
+        <categoryLink id="28d9-dd4e-4da4-9bf8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6140-2404-46f9-bd42</comment></categoryLink>
+        <categoryLink id="1886-cc41-4e0f-aa95" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_1c86-fad8-46ec-a0b0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink><entryLink id="1392-2d22-a57e-3b86" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4729-bc86-456b-b73d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_cf0f-e3f4-4fb4-989d</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1cc8-5611-4d9a-9218</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_2e32-ca02-48f0-a8dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0052-2fdd-434d-9e86" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_0af1-d052-4bd7-aab6</comment></categoryLink>
+        <categoryLink id="e82a-10cc-47f4-9afd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_45ce-e338-43c9-b63e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink><entryLink id="9bdc-3415-095f-861e" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4dce-8632-4f7c-813e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_8a71-3995-4155-ac33</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d206-f2ce-41b8-945a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan">
+                  <comment>    node_id_2e02-cf1c-4a71-861c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ec81-bd33-45a8-8550</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_3344-743c-45d3-b930</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ae20-d0c4-70c7-f9f7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="59eb-fecc-0376-f1c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1d1f-4110-42ea-9f59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4272-9b9d-4c59-95f0</comment></categoryLink>
+        <categoryLink id="34bc-412a-4e0a-879d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_d85b-1ae7-40d5-9341</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
-    <entryLink id="6470-f57a-424d-00c6" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3577-609f-5b84-028f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="6da1-2109-1f37-2e38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink><entryLink id="2aca-ce33-1bbb-061a" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry"><categoryLinks>
+        <categoryLink id="3acc-9a1f-4c56-8568" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ff9f-01cb-41b9-800e</comment></categoryLink>
+        <categoryLink id="1d0d-3339-4e5a-8e44" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_1315-6051-4a46-b070</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
-    <entryLink id="3cd2-a32f-b28f-009f" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink><entryLink id="3930-0089-f27e-cd7c" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry"><categoryLinks>
+        <categoryLink id="a504-c02b-40d5-b166" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_b084-df23-4f99-812f</comment></categoryLink>
+        <categoryLink id="765f-fd33-41e9-b71b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_84fc-9304-4e9e-ab78</comment></categoryLink>
+        <categoryLink id="367c-35ca-4bcb-bbf1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d06a-7939-4691-9aed</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="1513-f9d5-4101-a102" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup"><comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+        <entryLink id="96c4-bb85-4b75-9548" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup"><comment>    template_id_741d-8c09-4211-ada6    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink><entryLink id="b5c1-305a-2799-adc0" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_54a4-6ec8-4c61-9c3e</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_f7fd-2d16-4603-a065</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3037-a8ca-20d3-534d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="c73d-9891-71e7-76a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b15f-d434-46f3-ae64" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_c0ac-4b8c-421c-a21b</comment></categoryLink>
+        <categoryLink id="0bc2-529a-4cbb-9c5b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8db9-079e-4482-b200</comment></categoryLink>
+        <categoryLink id="b929-d071-4123-b6a7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_413c-9273-4308-b546</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
-    <entryLink id="d011-3de2-3cc6-0f35" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="16ad-24e9-b153-8bb6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="27b1-e3c2-60b1-516c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      <entryLinks>
+        <entryLink id="8457-cc17-4c0d-9a8f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup"><comment>    template_id_bbc4-33fc-4664-a18e    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="9b95-1a4a-4a12-b0a2" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup"><comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink><entryLink id="d2a4-2d48-b694-6b53" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry"><categoryLinks>
+        <categoryLink id="e872-89f8-4f22-94ee" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_4c8d-96f6-48f9-9590</comment></categoryLink>
+        <categoryLink id="f916-2243-4aa3-985a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_049c-0fa5-4575-8fa8</comment></categoryLink>
+        <categoryLink id="b80f-bc94-48e7-b5af" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_7358-52d7-4aae-8e07</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
-    <entryLink id="7837-a28a-8209-3530" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+      <entryLinks>
+        <entryLink id="73df-e919-4f8e-b582" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup"><comment>    template_id_4784-b370-444b-93ae    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="fc1c-ed6b-4eca-9724" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup"><comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink><entryLink id="072c-e66d-6103-4070" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_3c03-a823-4466-9bd6</comment>
           <conditionGroups>
-            <conditionGroup type="and">
+            <conditionGroup type="or">
+              <comment>    node_id_8bbb-f95b-413f-b6f4</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_41b0-6b0a-482a-919e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e1f7-3cc6-4794-8b6d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="09ed-1e8e-eef3-ceb4" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="10ca-8de9-e591-102c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5446-e890-4221-9762" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_05ce-cc31-40ad-9320</comment></categoryLink>
+        <categoryLink id="98f5-bf03-4ea7-9a76" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f13c-f8e1-4a50-bfe3</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
-    <entryLink id="ac10-3866-dc00-e9b0" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2cca-2349-9505-003b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="50cd-7946-c0d5-8494" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
-    <entryLink id="cba8-a086-7cdd-032a" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f546-9ba5-1604-7105" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="af79-c917-a7e9-d25d" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
-        <categoryLink id="a0d2-0e6e-61e6-e10c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
-    <entryLink id="423d-7836-a117-197a" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7a04-38f5-5a1d-c040" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d389-4af2-8e95-f9e6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
-    <entryLink id="4020-e726-939d-8199" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink><entryLink id="09b7-f3c2-c74b-ba7f" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_db78-4d49-42ab-954a</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_f14d-9943-47b6-866c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a95-938f-4a07-9727</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_7775-78e1-44cc-87c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="989f-34a1-4486-aa64" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_b822-3417-4613-be37</comment></categoryLink>
+        <categoryLink id="3b57-1bfd-415a-99bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_25db-b03f-4881-b310</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink><entryLink id="287f-4f3c-5407-06a6" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry"><categoryLinks>
+        <categoryLink id="ac37-d870-4ed7-98e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_75a7-dc06-445b-b2dc</comment></categoryLink>
+        <categoryLink id="ab08-c979-458a-85dc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_e21a-c03b-4885-ac46</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink><entryLink id="c076-17e8-8918-b464" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9a08-5fe6-4010-bbc3</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_72cf-cfce-4e02-b379</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="97e8-8e9d-08f5-3fd4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="4f40-d9d5-9b24-358b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5b6f-d425-4087-a8be" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_f55b-7555-444b-beee</comment></categoryLink>
+        <categoryLink id="864a-3067-4bb2-b5bd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3386-c9ad-4d74-9474</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
-    <entryLink id="c517-a723-bc6e-81ea" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d06f-9f45-80cc-fa70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f1ae-df7c-541f-3f77" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
-    <entryLink id="89a5-01f5-b9de-bd46" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink><entryLink id="2446-ab14-6e35-6d1e" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_a0f6-9606-4b75-a2f8</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_94b3-1331-474b-885b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
-      <infoLinks>
-        <infoLink id="dbda-3c87-a8c3-c89f" name="Legiones Astartes (Sons of Hours) " hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule" />
-      </infoLinks>
       <categoryLinks>
-        <categoryLink id="bfeb-c007-501f-09d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="28cc-a586-d1a5-07d4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="431a-57a0-4a66-ba7f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_79fa-3370-4ae0-9e12</comment></categoryLink>
+        <categoryLink id="0ff8-977b-46b2-aa43" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bb53-4e65-4fb6-9dd7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
-    <entryLink id="0e1d-fa87-3467-c137" name="Reaver Agressor Squad" hidden="false" collective="false" import="true" targetId="af3a-334f-152f-d55f" type="selectionEntry">
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink><entryLink id="af59-4e3e-9177-aa52" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f8cc-833a-4ac1-bf89</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+              <comment>    node_id_5988-c012-4dad-9a66</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ff7b-13a9-48d7-b964" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_8d82-3279-4481-84bb</comment></categoryLink>
+        <categoryLink id="0608-37fa-4568-855c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e25c-925e-4b96-8bb3</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink><entryLink id="e3ef-ce1f-d480-fc6b" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6b73-b21c-4e2b-9d14</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_a7fe-cc62-4a6f-a781</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5be1-1937-4964-a455</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_da1d-b2bc-4117-82a4</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="545c-556e-43fe-9f9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7010-be56-4709-b058</comment></categoryLink>
+        <categoryLink id="a7c1-8628-43e3-a862" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7379-a740-47ba-a054</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink><entryLink id="c2a3-8fb0-4ad3-549f" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_dd34-83cf-47d7-b557</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_be88-afef-49b3-bd1e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9de8-9cfc-4a6c-a179" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_944f-7420-4982-8ea9</comment></categoryLink>
+        <categoryLink id="c7cf-9d42-4215-903a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ea80-0efe-457d-a450</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink><entryLink id="cb6d-aeb1-bea4-df7b" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><categoryLinks>
+        <categoryLink id="486b-70ef-4ecb-91b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9a36-f261-43cc-9bd1</comment></categoryLink>
+        <categoryLink id="bf1e-238a-4062-ac01" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a648-8396-442a-af59</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink><entryLink id="a159-873b-f843-b18e" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_cb81-0303-4b88-ae53</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9648-31e3-43aa-8cf3</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_0507-da81-4023-bfcf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0e84-54ff-488d-b066</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9fed-7606-429e-aee8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6ff-0977-4c92-bb28</comment></categoryLink>
+        <categoryLink id="b184-22bb-4d0d-be4a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f555-7d39-458f-84c9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink><entryLink id="389c-ce86-89a2-3776" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8203-5b00-497b-b939</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_40ee-3e71-4978-b1e4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f6a8-f660-46dc-b3c5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_d988-3af6-48bf-b0a8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="528e-ed4e-4960-bd7b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_39e5-eda5-45d1-a643</comment></categoryLink>
+        <categoryLink id="a97e-077c-4f2d-815c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_6416-21bb-4df4-9de8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink><entryLink id="5b55-c65d-087d-b84f" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b03e-5d91-4be3-8adc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_0443-29c0-46e9-ad1d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f2c9-7356-4c27-a22f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0e9-4a9e-4b2b-a9d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8062-a307-438b-be9e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5528-2dac-4be5-900c</comment></categoryLink>
+        <categoryLink id="25d3-d15a-4177-b769" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_dc8f-d888-4585-991d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink><entryLink id="0547-6d52-1f3f-ac18" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1d3c-8e17-489f-9002</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5725-8bee-4bcc-878d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_be47-0d6f-49f2-9f4b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_863c-f3a4-4802-b80c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ad55-8a6f-4957-ad0a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_899e-b052-4d5b-8c18</comment></categoryLink>
+        <categoryLink id="777c-7a95-42fe-8285" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f5e9-cff6-41d2-a016</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink><entryLink id="8f46-ec72-492b-3578" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_72da-1513-4e02-b595</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7a48-a3b0-4a26-849b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e232-25f3-4cb7-8ab2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_9aa4-5660-4697-8ab2</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="44bf-e48f-4d9c-9f78" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_09cd-2176-40af-bba6</comment></categoryLink>
+        <categoryLink id="2b7f-80cf-471a-b526" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_05e6-7c63-4a35-9ba0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink><entryLink id="4e7d-a15a-ea60-4f0b" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry"><categoryLinks>
+        <categoryLink id="5057-5dc9-44f7-9413" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0dfa-4004-4751-8022</comment></categoryLink>
+        <categoryLink id="7cb5-ba02-4e41-95ad" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a669-0f5d-4fd3-811b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink><entryLink id="00bb-4210-6011-0544" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_09b5-4e3b-4c84-a574</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_32e5-ebba-41fb-9ff2</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_838e-0ccf-4d3a-aabd</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_dfef-0ec2-49fb-a534</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="72f7-f4aa-4a5a-912b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4f60-472b-45a9-ab9e</comment></categoryLink>
+        <categoryLink id="f58b-d647-4a5c-8f47" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e2e3-af36-45a6-a955</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink><entryLink id="c8c3-c970-b364-eb7d" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_936f-1ef7-472e-840e</comment>
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+              <comment>    node_id_d73d-d52e-4c75-8ac0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="08a0-7b9f-4b7d-86b2" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_7a55-ecb4-4e5d-b955</comment></categoryLink>
+        <categoryLink id="656a-2d57-4d70-b1df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f28c-710e-4ff8-9810</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink><entryLink id="7730-3dcf-bb6e-ec1f" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_a743-0cc2-45ae-a7eb</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2721-e88d-41f7-bedc</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_e10f-1390-4b33-8fcc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="31f9-df51-46fd-ae5a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2008-f1c4-4285-a14f</comment></categoryLink>
+        <categoryLink id="763b-aed3-4e26-8396" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e88b-a95a-4647-af3b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink><entryLink id="4781-3622-8679-be54" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_25d8-330b-4574-b515</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7836-6878-47a8-8827</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_5ea9-46dd-4a11-9410</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_ab5d-961b-4924-a705</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="795b-8968-465f-8fcf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9189-836c-475d-a52e</comment></categoryLink>
+        <categoryLink id="10c3-a1f3-42b4-b74f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_e1fa-b7d8-47b0-a88a</comment></categoryLink>
+        <categoryLink id="8d14-6614-4bf2-bcab" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_a137-e3c0-4d63-a48c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink><entryLink id="780e-5eaf-5516-471e" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry"><categoryLinks>
+        <categoryLink id="b443-1acf-4ff9-a18e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b1d5-fd75-4f17-bbf4</comment></categoryLink>
+        <categoryLink id="5008-22e0-4a28-addf" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_f221-bf81-4045-849b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink><entryLink id="3800-5e59-a995-b32d" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_b743-7a00-43e4-beb8</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d12f-2c98-4e62-a716</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d4d7-ba67-47aa-962f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+                  <comment>    node_id_1637-edee-457a-bb0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0c5-001d-4ffc-abc9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_f203-bc26-421f-b79e</comment></categoryLink>
+        <categoryLink id="ce07-a5dd-45e6-a102" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_a53e-59d9-4ac2-a21f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink><entryLink id="b38b-92a2-1f92-b780" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry"><categoryLinks>
+        <categoryLink id="108c-636c-4c4c-a2ad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_51af-a137-4a1c-97a4</comment></categoryLink>
+        <categoryLink id="3176-3d4b-487e-9b82" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ec1f-c326-40a8-9d1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink><entryLink id="f5ff-653e-2803-6fff" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_c111-feb0-4012-98cd</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_63d7-8427-431d-9ae6</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="aebe-c348-4298-b80e" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_e707-fde1-457f-91c4</comment></categoryLink>
+        <categoryLink id="20ef-39af-426d-830e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ec67-8573-4460-89db</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink><entryLink id="8f38-399f-db76-c24d" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3348-16e4-4a9a-a549</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_bea4-c4a8-4843-b9fe</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2970-17ff-4be1-91e5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_503a-46e7-40e7-bd07</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_4555-15e1-43ff-80a0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6e39-c3b5-438a-b9e7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_fce3-801c-49c8-85d4</comment></categoryLink>
+        <categoryLink id="09e3-fdd4-45b4-9505" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0c2d-2349-44b6-9831</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink><entryLink id="6470-f57a-424d-00c6" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry"><categoryLinks>
+        <categoryLink id="7ffe-a8e7-4c79-a35e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ac1c-b3bf-4011-918a</comment></categoryLink>
+        <categoryLink id="900b-a555-4893-8993" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_589c-1d0e-4b7d-be6b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink><entryLink id="3cd2-a32f-b28f-009f" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2f46-a0b6-48a5-a0ee</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_636f-0f8a-43f1-910b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c883-39c8-4a74-aeaa</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_0796-e467-4438-89b3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a0c5-8ec7-43ff-a702" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_5a04-9847-4c91-a49a</comment></categoryLink>
+        <categoryLink id="4924-13cb-408b-a0e3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b4b4-daeb-483c-a306</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink><entryLink id="d011-3de2-3cc6-0f35" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6087-a5e5-4d3c-9ebd</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c7e1-5f42-4528-bf07</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1950-08dc-4544-ab01</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_daf3-31ed-42c0-85dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="77ef-880e-4a0e-a4f2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_7d4f-547c-43ed-a520</comment></categoryLink>
+        <categoryLink id="bd85-a007-43c6-8dfc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f04e-04e8-4891-9b1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink><entryLink id="7837-a28a-8209-3530" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_dfdc-f6f6-49d2-a7b3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_354c-c71f-472f-b268</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1127-c974-4663-874d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_0843-bef2-4767-8307</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d0af-dc84-4d20-a213" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_28e0-91e7-4ada-9fac</comment></categoryLink>
+        <categoryLink id="cf56-18e9-49eb-8afe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4448-a712-4dd7-bf6d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink><entryLink id="ac10-3866-dc00-e9b0" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d512-fd07-4a29-863a</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_55c6-a35f-485a-9f0d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d89e-cf1f-4ceb-b3de</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e2c9-0d01-403c-900e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_a7b8-c835-4cb2-b3d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="719f-868c-46cc-a33d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_e22a-c5f8-4825-a45f</comment></categoryLink>
+        <categoryLink id="6028-1cb6-41f6-a547" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03fc-6a7f-45a5-bcb8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink><entryLink id="cba8-a086-7cdd-032a" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry"><categoryLinks>
+        <categoryLink id="4fd9-cbe5-420a-9229" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0aff-4f6e-4b03-a23c</comment></categoryLink>
+        <categoryLink id="580e-5100-4881-a488" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"><comment>    template_id_7d5a-62e7-43ee-b79b</comment></categoryLink>
+        <categoryLink id="8ff0-8adc-48aa-be20" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_4986-9157-49f2-b670</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink><entryLink id="423d-7836-a117-197a" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_319e-90d4-44a3-8e83</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_28db-d943-4099-9abd</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1a45-a592-49df-9465</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb31-d0b2-4677-928e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="774d-349f-4b8f-9806" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1b86-0977-4a8b-adac</comment></categoryLink>
+        <categoryLink id="481b-9d6a-4177-b699" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_b449-403a-4e42-9239</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink><entryLink id="4020-e726-939d-8199" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafa-470f-4c2c-8be3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_e2ba-a855-4de2-9f46</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_0171-b30d-44ee-9389</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fdfb-119b-4774-934a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_3891-9a00-4f8f-b95f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f6f7-d5da-469b-86ba" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e5df-17d4-4521-9d5b</comment></categoryLink>
+        <categoryLink id="610a-c2bf-4e64-80ba" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"><comment>    template_id_0ecd-4873-4d3a-b28b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink><entryLink id="c517-a723-bc6e-81ea" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_fbfa-8d78-4d6d-8a05</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_21f2-0916-46bf-b75a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_4fbd-633b-4dd6-9fdd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3e04-2b63-4d57-bf53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4f71-446f-4cff-afda</comment></categoryLink>
+        <categoryLink id="57aa-86c0-4c4c-91bd" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_3f44-8647-43a4-ac22</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink><entryLink id="89a5-01f5-b9de-bd46" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af15-2c71-4f8b-833e</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_d95a-80b9-4463-af55</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0e2c-336e-4841-a340" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6b1-886e-4194-8bcd</comment></categoryLink>
+        <categoryLink id="5caa-165c-457e-b567" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_51b5-f9c1-4587-8fc7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink><entryLink id="0e1d-fa87-3467-c137" name="Reaver Agressor Squad" hidden="false" collective="false" import="true" targetId="af3a-334f-152f-d55f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -1105,8 +1860,269 @@
         <categoryLink id="c490-800c-2c91-6890" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
     </entryLink>
-  </entryLinks>
-  <sharedSelectionEntries>
+  <entryLink id="88c9-c7b9-42f5-8af8" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
+    <entryLink id="82a4-8478-49aa-89b6" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
+    <entryLink id="cec3-fef3-48b5-af49" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
+    <entryLink id="c3f4-8754-44c8-8e6e" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <entryLink id="9ff9-8907-4e68-9d24" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3531-57d1-4081-882d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_f233-2361-4177-8ba7</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b932-667a-4b43-8331</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <entryLink id="0071-30d3-40e6-acd5" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <entryLink id="b113-e149-4c1b-ad2b" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3129-6f59-4365-906b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2bcb-0af1-4aea-9191" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <entryLink id="49bc-43a4-4520-9274" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ede2-d453-4e34-8cda</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2907-3215-4b01-96ff</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_c90c-959f-40fb-a4cb</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ba2d-50ad-45f1-91c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0e88-485e-43c2-8bef" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <entryLink id="380d-31d1-417d-ae07" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_409c-0a5d-4ef8-a871</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7078-c1c7-4af2-b43d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_9a69-0fdc-4957-8982</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1a4c-69b5-4219-8502" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fba0-3ea7-4eaf-b33a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <entryLink id="2ad6-3f18-4add-b8a8" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
+    <entryLink id="e827-f2b3-421a-b04f" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
+    <entryLink id="f5fd-bb36-4efb-a1c6" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
+    <entryLink id="240d-8914-458c-8982" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+  </entryLinks><sharedSelectionEntries>
     <selectionEntry id="0c73-9141-d1b4-6a40" name="Chieftain Squad" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="805b-0e2e-edfb-fcac" name="Kingslayers" hidden="false" typeId="b46c-270c-d29e-f0ff" typeName="Ability">

--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -1,13 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="62c7-42f4-5523-af1b" name="LA -  XVI: Sons of Horus" revision="15" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="62c7-42f4-5523-af1b" name="LA -  XVI: Sons of Horus" revision="15" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26">
   <entryLinks>
     <entryLink id="c2a2-9b6d-b384-3f43" name="  XVI: Sons of Horus" hidden="false" collective="false" import="false" targetId="01b4-57c7-bf61-2abf" type="selectionEntry">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57a1-d021-4da4-093e" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17ce-5398-8e0c-9aa7" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57a1-d021-4da4-093e" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17ce-5398-8e0c-9aa7" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="77a4-df1d-7fb6-75ec" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="77a4-df1d-7fb6-75ec" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="e2c3-2fb9-ad2e-c424" name="Chieftain Squad" hidden="true" collective="false" import="false" targetId="0c73-9141-d1b4-6a40" type="selectionEntry">
@@ -16,34 +15,34 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="114d-f93f-d7a5-80d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f195-05cd-45e6-70af" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="114d-f93f-d7a5-80d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f195-05cd-45e6-70af" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="7742-6ac2-9a35-df68" name="Maloghurst the Twisted" hidden="false" collective="false" import="false" targetId="0b37-0420-b06a-fcc5" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b32e-3835-5d7e-6f91" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="bd61-dd1a-5314-ed85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="126c-a234-df65-26be" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="b32e-3835-5d7e-6f91" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="bd61-dd1a-5314-ed85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="126c-a234-df65-26be" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="bb45-67fc-bc65-c082" name="Tybalt Marr" hidden="true" collective="false" import="false" targetId="c3db-b014-dfaa-d189" type="selectionEntry">
@@ -52,39 +51,39 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="aa5f-6290-d3fb-abdc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0929-6baa-85a0-1f92" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="c2bd-dc92-2e11-b309" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="aa5f-6290-d3fb-abdc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0929-6baa-85a0-1f92" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c2bd-dc92-2e11-b309" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0" />
       </costs>
     </entryLink>
     <entryLink id="79f4-181d-3ce9-f37b" name="Reaver Agressor Squad" hidden="false" collective="false" import="false" targetId="af3a-334f-152f-d55f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0bfe-b991-37d7-ae6d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="d2f9-3965-25e2-eaff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0bfe-b991-37d7-ae6d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="d2f9-3965-25e2-eaff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="24ed-4463-3ad8-4da7" name="Reaver Attack Squad" hidden="false" collective="false" import="false" targetId="8b29-bf2a-a814-5642" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0789-bb51-f100-dd5e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="77a5-bc2d-91c4-f76e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0789-bb51-f100-dd5e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="77a5-bc2d-91c4-f76e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="bcf7-3f90-c06a-5208" name="Ezekyle Abaddon" hidden="false" collective="false" import="false" targetId="09df-6357-0a00-80a6" type="selectionEntry">
@@ -93,1017 +92,1017 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f3d1-a002-2b03-4847" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="020a-df9f-429e-a84a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6e66-b81f-4d44-a873" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="f3d1-a002-2b03-4847" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="020a-df9f-429e-a84a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6e66-b81f-4d44-a873" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="97be-411c-8c15-dfd2" name="Horus Lupercal" hidden="false" collective="false" import="false" targetId="f0a3-4ae4-e07a-91b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2fe4-5c5c-bead-f06e" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
-        <categoryLink id="734c-b12a-678e-ad6a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2fe4-5c5c-bead-f06e" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true" />
+        <categoryLink id="734c-b12a-678e-ad6a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="f092-385d-cb95-de74" name="Garviel Loken" hidden="false" collective="false" import="false" targetId="44bf-8a69-f21a-dfba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8cab-2c82-02c7-7545" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="faf8-056b-cd6a-94e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1272-35e1-e6fe-f231" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="8cab-2c82-02c7-7545" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="faf8-056b-cd6a-94e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1272-35e1-e6fe-f231" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="c121-2d4a-e85e-14c7" name="Justaerin Terminator Squad" hidden="false" collective="false" import="false" targetId="c45d-ade3-6b28-68a2" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1d7a-0e25-aa2d-ac68" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="d429-527d-c73b-bddc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1d7a-0e25-aa2d-ac68" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="d429-527d-c73b-bddc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="6405-c1c7-8dba-8ae0" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1e9f-1cb6-da66-b237" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4346-1e41-b3fc-208f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1e9f-1cb6-da66-b237" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4346-1e41-b3fc-208f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
     <entryLink id="7b18-b50c-59a0-265f" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="bb97-d2c9-cd3a-c0e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="edd6-2dc1-5c4f-a591" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="bb97-d2c9-cd3a-c0e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="edd6-2dc1-5c4f-a591" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
     <entryLink id="976e-1e33-d989-1476" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e196-f30f-88af-6df7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="3d4b-f740-fb15-8228" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7e31-cb05-92eb-e48c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="e196-f30f-88af-6df7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="3d4b-f740-fb15-8228" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7e31-cb05-92eb-e48c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="5931-079a-7236-2747" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="43f1-2d99-fcf6-4032" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="4742-2329-2f94-d568" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="43f1-2d99-fcf6-4032" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="4742-2329-2f94-d568" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
     <entryLink id="3d2a-7e13-20ef-2f2a" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="248e-c85a-b6d6-857e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="3ac8-8ff3-8100-72de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="248e-c85a-b6d6-857e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="3ac8-8ff3-8100-72de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
     <entryLink id="7ae0-abf2-9c89-7c46" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="023d-25b3-af63-4ed6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="6b08-cdb7-c559-6ad7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4ff3-b061-aa45-08b3" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="023d-25b3-af63-4ed6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="6b08-cdb7-c559-6ad7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4ff3-b061-aa45-08b3" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
     <entryLink id="87b1-8092-dca7-2c37" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="38df-3a93-cdf2-b777" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="e1e7-54c0-5562-9478" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="38df-3a93-cdf2-b777" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="e1e7-54c0-5562-9478" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
     <entryLink id="7a59-42d0-94a9-8e83" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b460-e474-5655-72cb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="e265-87d2-1088-c7e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b460-e474-5655-72cb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="e265-87d2-1088-c7e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
     <entryLink id="e36c-83cf-3188-9e63" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7ff1-d82f-d17e-3ed5" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="ddb7-718e-db49-7597" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b31a-9085-dff0-ede7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="7ff1-d82f-d17e-3ed5" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="ddb7-718e-db49-7597" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b31a-9085-dff0-ede7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="8c21-e292-7178-6a1a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup"/>
+        <entryLink id="8c21-e292-7178-6a1a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup" />
         <entryLink id="74fa-f7e8-4f16-b6b8" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
     <entryLink id="fe52-c4e3-2387-07b6" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9306-035c-b8ec-3972" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6cb4-9c57-4a8e-db99" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="7f25-8120-3321-fb5f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="9306-035c-b8ec-3972" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6cb4-9c57-4a8e-db99" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="7f25-8120-3321-fb5f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="5789-ff4a-ef4b-edfb" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup"/>
+        <entryLink id="5789-ff4a-ef4b-edfb" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup" />
         <entryLink id="777a-56cd-8dfb-5a68" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
     <entryLink id="9ba0-00ac-e866-e5d9" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d9f0-59e4-35e7-bb4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f432-8613-0453-cb30" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="db76-fdd3-3600-5aed" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="d9f0-59e4-35e7-bb4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f432-8613-0453-cb30" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="db76-fdd3-3600-5aed" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="67bc-10b1-2a33-8b36" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup"/>
+        <entryLink id="67bc-10b1-2a33-8b36" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup" />
         <entryLink id="d83b-fe6d-b9fd-2864" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
     <entryLink id="ee70-f549-a838-fc80" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2247-5478-7e06-c3ca" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="d51f-2d4a-31e2-9366" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2247-5478-7e06-c3ca" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="d51f-2d4a-31e2-9366" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
     <entryLink id="298a-7e54-6282-d112" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b6cb-fdc3-227d-177c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1362-7754-a43b-c501" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="b6cb-fdc3-227d-177c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1362-7754-a43b-c501" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
     <entryLink id="9230-f176-32b2-7d8d" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="46e0-7c29-6d37-16ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a07c-df2c-0031-c36b" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="46e0-7c29-6d37-16ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a07c-df2c-0031-c36b" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
     <entryLink id="391b-a79f-876c-4c33" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="bc19-9ee8-bfab-8436" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5944-f85c-a636-db84" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="bc19-9ee8-bfab-8436" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5944-f85c-a636-db84" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
     <entryLink id="46ee-7083-fc7a-c22e" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7fcb-d2bb-ddf3-cf38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9f4e-77db-9581-ec72" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="7fcb-d2bb-ddf3-cf38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9f4e-77db-9581-ec72" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
     <entryLink id="70d1-1da3-af70-f8b4" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2707-323f-d4f7-d83c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="1c40-efc2-b737-fe75" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2707-323f-d4f7-d83c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="1c40-efc2-b737-fe75" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
     <entryLink id="f8ba-0406-a964-e89d" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0812-2a99-32b8-cfc8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="0d0d-89a7-4ae2-a798" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0812-2a99-32b8-cfc8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="0d0d-89a7-4ae2-a798" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="5326-0dc2-99cd-5a7b" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2fe0-daee-3736-c8b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a4a2-9b7d-fcd8-ceb8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="2fe0-daee-3736-c8b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a4a2-9b7d-fcd8-ceb8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
     <entryLink id="50cc-1a98-d330-f811" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0c45-ab68-ca05-a713" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="221a-fead-fb30-7766" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9c7e-673d-c5bb-5c74" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="0c45-ab68-ca05-a713" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="221a-fead-fb30-7766" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9c7e-673d-c5bb-5c74" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="d0c1-0ce8-23d9-291d" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="05c1-048e-dd58-95b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="db55-be7a-6ca0-993f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="05c1-048e-dd58-95b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="db55-be7a-6ca0-993f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="f892-38ef-43ef-b485" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="726e-1741-0e17-257d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="af6f-8fa1-be8d-ab53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="726e-1741-0e17-257d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="af6f-8fa1-be8d-ab53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
     <entryLink id="cd69-d7e1-281d-92c2" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c9e3-c57e-07b4-430a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="f04f-29e8-f562-6aaf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c9e3-c57e-07b4-430a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="f04f-29e8-f562-6aaf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
     <entryLink id="a686-3572-9648-f413" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="210d-4413-aa5b-f52d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="021c-3d91-163a-7a1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="210d-4413-aa5b-f52d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="021c-3d91-163a-7a1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
     <entryLink id="a1bb-eca2-1b35-c3b8" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ac85-ba77-de25-6801" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c9e0-f198-62ee-6559" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="ac85-ba77-de25-6801" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c9e0-f198-62ee-6559" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
     <entryLink id="ef9b-780f-2c71-9129" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3796-2f84-9305-de64" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="4db5-b750-90e7-cb26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3796-2f84-9305-de64" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="4db5-b750-90e7-cb26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
     <entryLink id="5f51-164d-60e0-ab13" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b34a-111f-7c43-2ba6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="9070-08d2-40cf-0ad8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b34a-111f-7c43-2ba6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="9070-08d2-40cf-0ad8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
     <entryLink id="a340-af9c-0234-641c" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4ca7-6a06-e4b4-0159" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0ed2-d09d-c159-f05b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="4ca7-6a06-e4b4-0159" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0ed2-d09d-c159-f05b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
     <entryLink id="8aa0-c430-bf92-3960" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2dbb-2ee5-a9c1-7fc0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="01c3-0b7a-6939-34f9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2dbb-2ee5-a9c1-7fc0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="01c3-0b7a-6939-34f9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
     <entryLink id="227f-e0ff-0d7b-6f13" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="cc3c-77b8-f57c-61e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0854-8252-2da8-8134" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="cc3c-77b8-f57c-61e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0854-8252-2da8-8134" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="14d3-6123-8d3c-d540" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5944-0a79-2728-83a2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="2e77-be6f-f86d-cc37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5944-0a79-2728-83a2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="2e77-be6f-f86d-cc37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
     <entryLink id="d57b-2de7-7e2d-1a11" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9b79-85e2-ca6c-83e1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="80ec-ba11-6e27-7546" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9b79-85e2-ca6c-83e1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="80ec-ba11-6e27-7546" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
     <entryLink id="7adb-fe67-ec60-d8da" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="00ce-9ec3-91e1-2aeb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="8a3f-00ad-5369-637a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="00ce-9ec3-91e1-2aeb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="8a3f-00ad-5369-637a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
     <entryLink id="9e8c-3d53-6db8-bd35" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6b42-43d3-cad6-733e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7a33-25cb-e445-a261" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6b42-43d3-cad6-733e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7a33-25cb-e445-a261" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
     <entryLink id="235c-143e-dcbe-611f" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="027a-a147-a3eb-c57e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dd96-3e87-0d98-2dcd" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="027a-a147-a3eb-c57e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="dd96-3e87-0d98-2dcd" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
     <entryLink id="9cea-481c-2a16-8b08" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cdab-8bac-d1bc-4605" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="2906-825a-29a1-a60b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="cdab-8bac-d1bc-4605" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="2906-825a-29a1-a60b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
     <entryLink id="b455-e6ed-ddea-9480" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4baa-3a1c-ec3b-a526" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="f1c4-c235-f6f1-2894" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4baa-3a1c-ec3b-a526" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="f1c4-c235-f6f1-2894" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
     <entryLink id="132f-94b6-52aa-df0a" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1cd3-8f79-a919-82fa" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="8ac4-9a55-fa56-2947" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1cd3-8f79-a919-82fa" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="8ac4-9a55-fa56-2947" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
     <entryLink id="947f-1ab5-b634-c170" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f9b9-a2cf-8383-4708" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="344a-677e-3b71-8b43" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f9b9-a2cf-8383-4708" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="344a-677e-3b71-8b43" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
     <entryLink id="2140-c0f2-e5fc-909e" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2cc6-1d3b-a458-0ae5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="8e9f-931d-ee47-b4df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2cc6-1d3b-a458-0ae5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="8e9f-931d-ee47-b4df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
     <entryLink id="44a5-b487-c296-ba15" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0a0c-38fb-f78c-803d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="65a0-2d58-e86c-8d53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0a0c-38fb-f78c-803d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="65a0-2d58-e86c-8d53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
     <entryLink id="2ae3-0e12-6739-1757" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1214-471f-5840-45b9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="7a4d-edac-c3fd-cc13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1214-471f-5840-45b9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="7a4d-edac-c3fd-cc13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
     <entryLink id="0d89-f094-1e9f-0ffc" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="985e-3071-f56d-fe2f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="9f54-3016-179e-351f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="985e-3071-f56d-fe2f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="9f54-3016-179e-351f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
     <entryLink id="a0b7-2afc-187c-072c" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a73f-3887-68be-61c9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="4dc9-64b1-cd49-6f65" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a73f-3887-68be-61c9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="4dc9-64b1-cd49-6f65" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
     <entryLink id="a70c-faf4-f59d-47c1" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1675-a822-213a-f49e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d698-4626-b245-cf7a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="1675-a822-213a-f49e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d698-4626-b245-cf7a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
     <entryLink id="9574-3763-b54a-dc08" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="332c-f396-7746-b882" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="5dbc-94c2-bd54-119f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="332c-f396-7746-b882" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="5dbc-94c2-bd54-119f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
     <entryLink id="10af-636e-0fcc-30de" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2c9b-7448-07f8-146c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="1f32-cda0-5ee1-cd35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2c9b-7448-07f8-146c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="1f32-cda0-5ee1-cd35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
     <entryLink id="1597-f21c-1ec0-35b3" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a330-1e6e-66d0-e975" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c6ca-d7f1-1653-53ee" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="a330-1e6e-66d0-e975" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c6ca-d7f1-1653-53ee" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="1392-2d22-a57e-3b86" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0e88-775b-2eff-df80" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="7b28-18b8-1a97-bb4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0e88-775b-2eff-df80" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="7b28-18b8-1a97-bb4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
     <entryLink id="9bdc-3415-095f-861e" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3373-ea50-6c85-f1ab" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="6541-8d6e-6c27-7846" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3373-ea50-6c85-f1ab" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="6541-8d6e-6c27-7846" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="2aca-ce33-1bbb-061a" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="04a3-e2e8-f20a-1f6f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6016-f133-be7c-5153" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="04a3-e2e8-f20a-1f6f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6016-f133-be7c-5153" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="3930-0089-f27e-cd7c" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="20b7-7a46-bebe-7273" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="9b99-c6ac-ce5a-a757" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ee4a-26ae-1138-2c27" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="20b7-7a46-bebe-7273" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="9b99-c6ac-ce5a-a757" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ee4a-26ae-1138-2c27" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="2027-afd3-6eba-ecb3" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup"/>
-        <entryLink id="1300-170f-0263-d0bc" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup"/>
+        <entryLink id="2027-afd3-6eba-ecb3" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup" />
+        <entryLink id="1300-170f-0263-d0bc" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
     <entryLink id="b5c1-305a-2799-adc0" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1a6a-b273-5f16-c4a0" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="1b08-9276-71bb-50c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="16c0-0209-25df-8043" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="1a6a-b273-5f16-c4a0" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="1b08-9276-71bb-50c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="16c0-0209-25df-8043" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="5a22-9a37-892f-6462" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup"/>
-        <entryLink id="2e93-e68a-5522-ade9" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup"/>
+        <entryLink id="5a22-9a37-892f-6462" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup" />
+        <entryLink id="2e93-e68a-5522-ade9" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
     <entryLink id="d2a4-2d48-b694-6b53" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2ff3-f549-637d-1449" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="61bc-112b-6174-dded" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ea44-e73e-7e88-9bdc" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="2ff3-f549-637d-1449" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="61bc-112b-6174-dded" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ea44-e73e-7e88-9bdc" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="6de7-675a-af19-1da7" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup"/>
-        <entryLink id="6840-495c-d3b5-9df6" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup"/>
+        <entryLink id="6de7-675a-af19-1da7" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="9c74-1002-8103-2848" type="selectionEntryGroup" />
+        <entryLink id="6840-495c-d3b5-9df6" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
     <entryLink id="072c-e66d-6103-4070" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7ef3-214d-3d2a-af4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="473b-5fad-f640-4c68" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="7ef3-214d-3d2a-af4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="473b-5fad-f640-4c68" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="09b7-f3c2-c74b-ba7f" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b99d-fd38-1573-b275" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="cddc-b8d8-e2e7-94a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b99d-fd38-1573-b275" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="cddc-b8d8-e2e7-94a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
     <entryLink id="287f-4f3c-5407-06a6" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9ad9-c2b3-d3a5-a8e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="738f-13cd-fc9c-50e0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="9ad9-c2b3-d3a5-a8e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="738f-13cd-fc9c-50e0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="c076-17e8-8918-b464" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="562e-6510-08c3-97b1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="32cb-ed8c-1150-3c3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="562e-6510-08c3-97b1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="32cb-ed8c-1150-3c3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
     <entryLink id="2446-ab14-6e35-6d1e" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="76aa-00e6-9797-61bd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="cd64-2c1f-637e-1e4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="76aa-00e6-9797-61bd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="cd64-2c1f-637e-1e4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
     <entryLink id="af59-4e3e-9177-aa52" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fa1e-e57e-fe64-a832" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="ae8a-255f-1e7e-a42a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fa1e-e57e-fe64-a832" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="ae8a-255f-1e7e-a42a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
     <entryLink id="e3ef-ce1f-d480-fc6b" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="380b-47c8-094a-0eef" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9bed-c37e-14de-732d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="380b-47c8-094a-0eef" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9bed-c37e-14de-732d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
     <entryLink id="c2a3-8fb0-4ad3-549f" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d122-28b5-e796-7fda" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="dff8-9a3d-6b04-ac0f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d122-28b5-e796-7fda" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="dff8-9a3d-6b04-ac0f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
     <entryLink id="cb6d-aeb1-bea4-df7b" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1d95-12aa-9c16-33d6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3c1c-d3dd-a987-8173" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="1d95-12aa-9c16-33d6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3c1c-d3dd-a987-8173" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
     <entryLink id="a159-873b-f843-b18e" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b9b3-68c5-ab61-5c02" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fbe7-2425-dbb4-66ad" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="b9b3-68c5-ab61-5c02" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="fbe7-2425-dbb4-66ad" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
     <entryLink id="389c-ce86-89a2-3776" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="abe7-4be2-eed3-9971" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9527-c78b-175c-0594" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="abe7-4be2-eed3-9971" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9527-c78b-175c-0594" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
     <entryLink id="5b55-c65d-087d-b84f" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3ef7-3530-30d4-65c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2443-43b5-239c-2553" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3ef7-3530-30d4-65c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2443-43b5-239c-2553" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
     <entryLink id="0547-6d52-1f3f-ac18" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="cecd-2fd2-c4cb-eaa7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5786-dde9-1b3e-c114" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="cecd-2fd2-c4cb-eaa7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5786-dde9-1b3e-c114" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="8f46-ec72-492b-3578" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="91b1-a34b-b760-dfca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="411d-14aa-6e09-a22d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="91b1-a34b-b760-dfca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="411d-14aa-6e09-a22d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
     <entryLink id="4e7d-a15a-ea60-4f0b" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1214-fac9-7990-1358" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="47bf-3493-af53-d564" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="1214-fac9-7990-1358" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="47bf-3493-af53-d564" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="00bb-4210-6011-0544" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2601-e6bb-a438-f56f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="9346-8593-8ae7-2102" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2601-e6bb-a438-f56f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="9346-8593-8ae7-2102" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
     <entryLink id="c8c3-c970-b364-eb7d" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="462a-b975-5f48-5b8d" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="8088-3487-4b42-2991" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="462a-b975-5f48-5b8d" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="8088-3487-4b42-2991" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
     <entryLink id="7730-3dcf-bb6e-ec1f" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="aef3-aa0e-aff3-69a7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="347e-65e6-c5e8-5334" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="aef3-aa0e-aff3-69a7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="347e-65e6-c5e8-5334" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
     <entryLink id="4781-3622-8679-be54" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="85ff-623d-8cf0-df89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="228a-e216-3f8c-727a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="5b13-d956-3328-00b8" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="85ff-623d-8cf0-df89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="228a-e216-3f8c-727a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="5b13-d956-3328-00b8" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="780e-5eaf-5516-471e" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="69c3-3c08-9e7d-286d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9bab-10fe-7410-247b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="69c3-3c08-9e7d-286d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9bab-10fe-7410-247b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
     <entryLink id="3800-5e59-a995-b32d" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b8cb-40c9-c1c7-b573" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="93f5-ce69-d670-5421" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b8cb-40c9-c1c7-b573" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="93f5-ce69-d670-5421" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
     <entryLink id="b38b-92a2-1f92-b780" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6f31-643c-3333-afa2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7ff0-ca96-8d3b-c392" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6f31-643c-3333-afa2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7ff0-ca96-8d3b-c392" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
     <entryLink id="f5ff-653e-2803-6fff" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2d26-6b64-fea1-1a46" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="cbc4-6cc1-5cee-3517" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2d26-6b64-fea1-1a46" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="cbc4-6cc1-5cee-3517" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="8f38-399f-db76-c24d" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ae20-d0c4-70c7-f9f7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="59eb-fecc-0376-f1c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ae20-d0c4-70c7-f9f7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="59eb-fecc-0376-f1c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
     <entryLink id="6470-f57a-424d-00c6" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3577-609f-5b84-028f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="6da1-2109-1f37-2e38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3577-609f-5b84-028f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="6da1-2109-1f37-2e38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="3cd2-a32f-b28f-009f" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3037-a8ca-20d3-534d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="c73d-9891-71e7-76a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3037-a8ca-20d3-534d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="c73d-9891-71e7-76a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
     <entryLink id="d011-3de2-3cc6-0f35" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="16ad-24e9-b153-8bb6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="27b1-e3c2-60b1-516c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="16ad-24e9-b153-8bb6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="27b1-e3c2-60b1-516c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
     <entryLink id="7837-a28a-8209-3530" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="09ed-1e8e-eef3-ceb4" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="10ca-8de9-e591-102c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="09ed-1e8e-eef3-ceb4" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="10ca-8de9-e591-102c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
     <entryLink id="ac10-3866-dc00-e9b0" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2cca-2349-9505-003b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="50cd-7946-c0d5-8494" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2cca-2349-9505-003b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="50cd-7946-c0d5-8494" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
     <entryLink id="cba8-a086-7cdd-032a" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f546-9ba5-1604-7105" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="af79-c917-a7e9-d25d" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="a0d2-0e6e-61e6-e10c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f546-9ba5-1604-7105" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="af79-c917-a7e9-d25d" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
+        <categoryLink id="a0d2-0e6e-61e6-e10c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="423d-7836-a117-197a" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7a04-38f5-5a1d-c040" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d389-4af2-8e95-f9e6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="7a04-38f5-5a1d-c040" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d389-4af2-8e95-f9e6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
     <entryLink id="4020-e726-939d-8199" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="97e8-8e9d-08f5-3fd4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="4f40-d9d5-9b24-358b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="97e8-8e9d-08f5-3fd4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="4f40-d9d5-9b24-358b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
     <entryLink id="c517-a723-bc6e-81ea" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d06f-9f45-80cc-fa70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f1ae-df7c-541f-3f77" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="d06f-9f45-80cc-fa70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f1ae-df7c-541f-3f77" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
     <entryLink id="89a5-01f5-b9de-bd46" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <infoLinks>
-        <infoLink id="dbda-3c87-a8c3-c89f" name="Legiones Astartes (Sons of Hours) " hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
+        <infoLink id="dbda-3c87-a8c3-c89f" name="Legiones Astartes (Sons of Hours) " hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="bfeb-c007-501f-09d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="28cc-a586-d1a5-07d4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="bfeb-c007-501f-09d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="28cc-a586-d1a5-07d4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
     <entryLink id="0e1d-fa87-3467-c137" name="Reaver Agressor Squad" hidden="false" collective="false" import="true" targetId="af3a-334f-152f-d55f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6ec-f3e6-760c-f9bb" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6ec-f3e6-760c-f9bb" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="add" field="category" value="6399-5c65-7833-1025">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6ec-f3e6-760c-f9bb" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6ec-f3e6-760c-f9bb" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e12d-b822-47b3-4e92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="317c-51b9-5bce-4d12" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
-        <categoryLink id="c490-800c-2c91-6890" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="e12d-b822-47b3-4e92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="317c-51b9-5bce-4d12" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="c490-800c-2c91-6890" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -1112,37 +1111,37 @@
       <profiles>
         <profile id="805b-0e2e-edfb-fcac" name="Kingslayers" hidden="false" typeId="b46c-270c-d29e-f0ff" typeName="Ability">
           <characteristics>
-            <characteristic name="Description" typeId="0982-427b-1d4a-d07c">When any models with this special rule are used to make Melee Attacks against an enemy unit that includes any models with the Independent Character special rule or the Primarch Unit Type, all failed To Hit rolls of ‘1’ may be re-rolled. When a model with this special rule that is Engaged in a Challenge is used to make Melee  Attacks against a model with the Independent Character special rule or the Primarch Unit Type, all failed To Hit rolls may be re-rolled.</characteristic>
+            <characteristic name="Description" typeId="0982-427b-1d4a-d07c">When any models with this special rule are used to make Melee Attacks against an enemy unit that includes any models with the Independent Character special rule or the Primarch Unit Type, all failed To Hit rolls of &#8216;1&#8217; may be re-rolled. When a model with this special rule that is Engaged in a Challenge is used to make Melee  Attacks against a model with the Independent Character special rule or the Primarch Unit Type, all failed To Hit rolls may be re-rolled.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <rules>
         <rule id="7612-00a4-0f95-1d31" name="Chieftain Retinue" hidden="true">
-          <description>A Chieftain Squad in a Detachment that includes at least one model with both the Master of the Legion and Legiones Astartes (Sons of Horus) special rules may be selected as a Retinue Squad instead of as an HQ choice. The model with both the Master of the Legion and Legiones Astartes (Sons of Horus) special rules is referred to as the Retinue Squad’s Leader for the purposes of this special rule (if the Detachment includes more than one model with both the Master of the Legion and Legiones Astartes (Sons of Horus) special rules then the controlling player selects one as the unit’s Leader). A Chieftain Squad selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. A Chieftain Squad selected as a Retinue Squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Retinue Squad during play.</description>
+          <description>A Chieftain Squad in a Detachment that includes at least one model with both the Master of the Legion and Legiones Astartes (Sons of Horus) special rules may be selected as a Retinue Squad instead of as an HQ choice. The model with both the Master of the Legion and Legiones Astartes (Sons of Horus) special rules is referred to as the Retinue Squad&#8217;s Leader for the purposes of this special rule (if the Detachment includes more than one model with both the Master of the Legion and Legiones Astartes (Sons of Horus) special rules then the controlling player selects one as the unit&#8217;s Leader). A Chieftain Squad selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. A Chieftain Squad selected as a Retinue Squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Retinue Squad during play.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="cdad-84ae-8cf9-e37e" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
-        <infoLink id="0e0e-3a0b-4a09-5014" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="1cf2-f06c-9b38-96ea" name="Legiones Astartes (Sons of Hours) " hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
+        <infoLink id="cdad-84ae-8cf9-e37e" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
+        <infoLink id="0e0e-3a0b-4a09-5014" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="1cf2-f06c-9b38-96ea" name="Legiones Astartes (Sons of Hours) " hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="74fd-91d7-6d1c-8edd" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="8cac-3a0b-8f04-2877" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="ed45-fc62-5dd5-769f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="74fd-91d7-6d1c-8edd" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="8cac-3a0b-8f04-2877" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="ed45-fc62-5dd5-769f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d566-70f1-05bc-642c" name="Chieftain" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="710d-84d2-92a3-d877" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39dd-72cc-71a0-745b" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="710d-84d2-92a3-d877" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39dd-72cc-71a0-745b" type="min" />
           </constraints>
           <profiles>
             <profile id="5534-37ba-0ebb-cb5d" name="Chieftain" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="0c73-9141-d1b4-6a40" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                    <condition field="selections" scope="0c73-9141-d1b4-6a40" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1164,44 +1163,44 @@
           <selectionEntryGroups>
             <selectionEntryGroup id="42c3-658b-e3c8-b90f" name="Chainsword Option:" hidden="false" collective="false" import="true" defaultSelectionEntryId="64da-0270-ba24-a4e5">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e130-60ad-e0a1-21fb" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f721-e9ee-bf16-803f" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e130-60ad-e0a1-21fb" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f721-e9ee-bf16-803f" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="64da-0270-ba24-a4e5" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+                <entryLink id="64da-0270-ba24-a4e5" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
                 <entryLink id="d284-72b8-da08-65a5" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="f99c-e595-5d49-c5bb" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="d6ad-8de3-ce45-bf2b" name="Chainaxe" hidden="false" collective="false" import="true" targetId="85b9-4e50-af11-c295" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="b188-d053-c577-d35f" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="6e32-2558-306b-9f76" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="c4ad-0f49-eaaf-be9a" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="fac5-a684-f4e3-75f1" name="Carsoran Power Axe" hidden="false" collective="false" import="true" targetId="fa70-f0d0-b06d-5413" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1210,26 +1209,26 @@
           <entryLinks>
             <entryLink id="71ab-a10e-6757-4644" name="Banestrike Bolter" hidden="false" collective="false" import="true" targetId="6865-354c-0880-ee5f" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0638-b4cb-7d40-8852" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a89e-7a5a-cfbd-564c" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0638-b4cb-7d40-8852" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a89e-7a5a-cfbd-564c" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="0ca4-f397-e1f8-2afe" name="Standard Bearer" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f955-100b-e49c-57d4" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3657-7248-73d5-32f7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f955-100b-e49c-57d4" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3657-7248-73d5-32f7" type="max" />
           </constraints>
           <profiles>
             <profile id="cdb8-bdeb-4815-705a" name="Standard Bearer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="0c73-9141-d1b4-6a40" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                    <condition field="selections" scope="0c73-9141-d1b4-6a40" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1251,44 +1250,44 @@
           <selectionEntryGroups>
             <selectionEntryGroup id="84c8-59bf-6f20-ce85" name="Chainsword Option:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a068-fea8-775d-7f75">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="911a-d4c1-40bb-42d9" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05de-a119-b8b4-b0ed" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="911a-d4c1-40bb-42d9" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05de-a119-b8b4-b0ed" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="a068-fea8-775d-7f75" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+                <entryLink id="a068-fea8-775d-7f75" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
                 <entryLink id="14f3-251d-d9e1-4b7e" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="98c6-7bf1-d726-92ef" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="ba0d-c39d-ac23-dba4" name="Chainaxe" hidden="false" collective="false" import="true" targetId="85b9-4e50-af11-c295" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="0f5c-cf40-86cd-dc7b" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="fe8a-7386-a94f-777b" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="2ed3-6ad7-b882-3570" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="a5a0-0f64-8ed7-ec05" name="Carsoran Power Axe" hidden="false" collective="false" import="true" targetId="fa70-f0d0-b06d-5413" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1297,98 +1296,98 @@
           <entryLinks>
             <entryLink id="413e-aa31-e7c6-9916" name="Legion Standard" hidden="false" collective="false" import="true" targetId="7e13-cc1f-6bd7-7ac6" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0940-ab0e-7725-2705" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c82-4531-f78a-1582" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0940-ab0e-7725-2705" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c82-4531-f78a-1582" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="c2f1-59e7-aa0f-daec" name="The entire unit may exchange its power armour for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5404-76bf-fd5e-27d6">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9067-254b-a2f2-46d7" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07ed-187c-663a-03da" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9067-254b-a2f2-46d7" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07ed-187c-663a-03da" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="8f78-11c3-991a-d322" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="0c73-9141-d1b4-6a40" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="0c73-9141-d1b4-6a40" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="882d-d106-88d6-b062" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="882d-d106-88d6-b062" type="max" />
               </constraints>
             </entryLink>
-            <entryLink id="5404-76bf-fd5e-27d6" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry"/>
+            <entryLink id="5404-76bf-fd5e-27d6" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="6771-6397-3fa0-edff" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7de7-9921-66c5-43bf" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25da-81c5-11d1-3fa1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7de7-9921-66c5-43bf" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25da-81c5-11d1-3fa1" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="f4b8-6cef-15ef-1468" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7190-5562-ba3c-122a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52f0-486f-25ed-af62" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7190-5562-ba3c-122a" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52f0-486f-25ed-af62" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="615f-361c-7ee2-8880" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1591-36e0-ab0f-cd09" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ca5-54ca-350c-3fa8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1591-36e0-ab0f-cd09" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ca5-54ca-350c-3fa8" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="a4c4-91a5-c886-a8bc" name="Boarding Shield" hidden="false" collective="false" import="true" targetId="0c0f-f751-cc4e-4951" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cde4-b192-5c90-ca28" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a53d-ec69-da6d-44a6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cde4-b192-5c90-ca28" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a53d-ec69-da6d-44a6" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="f0a3-4ae4-e07a-91b8" name="Horus Lupercal" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="6438-a713-c788-02e4" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="be89-a0c6-b0cb-b46e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="6438-a713-c788-02e4" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="be89-a0c6-b0cb-b46e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="28c5-de31-09e9-9a57" name="The Serpent&apos;s Scales" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="28c5-de31-09e9-9a57" name="The Serpent's Scales" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7473-da29-c5e8-2c41" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f91-041f-beb7-8445" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7473-da29-c5e8-2c41" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f91-041f-beb7-8445" type="min" />
           </constraints>
           <profiles>
-            <profile id="ded9-f55f-df24-0505" name="The Serpent&apos;s Scales" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+            <profile id="ded9-f55f-df24-0505" name="The Serpent's Scales" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
               <characteristics>
-                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">The Serpent&apos;s Scales provide 2+ Armour Save and a 3+ Invulnerable Save.</characteristic>
+                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">The Serpent's Scales provide 2+ Armour Save and a 3+ Invulnerable Save.</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
-        <selectionEntry id="bc32-bea3-06d2-338d" name="The Warmaster&apos;s Talon" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="bc32-bea3-06d2-338d" name="The Warmaster's Talon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc8e-0524-73f4-41eb" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed14-fc69-c511-0ec7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc8e-0524-73f4-41eb" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed14-fc69-c511-0ec7" type="max" />
           </constraints>
           <profiles>
-            <profile id="44ef-30cd-a29e-5fc7" name="The Warmaster&apos;s Talon (Melee)" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="44ef-30cd-a29e-5fc7" name="The Warmaster's Talon (Melee)" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">User</characteristic>
@@ -1396,9 +1395,9 @@
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Shred, Deflagrate</characteristic>
               </characteristics>
             </profile>
-            <profile id="7ea2-6480-8a45-60bd" name="The Warmaster&apos;s Talon (Shooting)" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="7ea2-6480-8a45-60bd" name="The Warmaster's Talon (Shooting)" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">24"</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 3, Twin-linked</characteristic>
@@ -1406,18 +1405,18 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="d5f6-c201-6be9-29b9" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
-            <infoLink id="52e3-c93b-1b55-76a1" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
-            <infoLink id="9696-333a-f9bb-535d" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
+            <infoLink id="d5f6-c201-6be9-29b9" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
+            <infoLink id="52e3-c93b-1b55-76a1" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule" />
+            <infoLink id="9696-333a-f9bb-535d" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="ae00-4cb3-fc75-80de" name="Worldbreaker" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6337-a300-a2d3-573b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8b1-f349-f67f-c19f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6337-a300-a2d3-573b" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8b1-f349-f67f-c19f" type="max" />
           </constraints>
           <profiles>
             <profile id="38f7-03d2-8858-0049" name="Worldbreaker" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1430,30 +1429,30 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="23c4-6c0e-b178-baca" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="23c4-6c0e-b178-baca" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
             <infoLink id="1723-b746-1b08-a0e8" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Brutal (2)"/>
+                <modifier type="set" field="name" value="Brutal (2)" />
               </modifiers>
             </infoLink>
-            <infoLink id="0b04-e9fc-242c-694b" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
-            <infoLink id="6db7-9837-a7f0-466b" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+            <infoLink id="0b04-e9fc-242c-694b" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule" />
+            <infoLink id="6db7-9837-a7f0-466b" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="6eef-889c-3277-7e9d" name="Horus" hidden="false" collective="false" import="true" defaultSelectionEntryId="e577-a40b-3770-17a6">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3301-91b4-4b51-e5cd" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="927d-00e6-c2a7-6aee" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3301-91b4-4b51-e5cd" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="927d-00e6-c2a7-6aee" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="e577-a40b-3770-17a6" name="Horus Lupercal" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0ab-1f0c-5f0d-16db" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0ab-1f0c-5f0d-16db" type="max" />
               </constraints>
               <profiles>
                 <profile id="57ec-4b1f-426b-d539" name="Horus Lupercal" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -1474,22 +1473,22 @@
               </profiles>
               <rules>
                 <rule id="5651-2420-0871-121f" name="Master of War" hidden="false">
-                  <description>Once per battle, at the start of any turn where Horus Lupercal’s controlling player is the Reactive player, this special rule may be activated. For the duration of the turn on which this special rule is activated, the Reaction Allotment of the army that includes Horus is increased by +1 in every Phase.</description>
+                  <description>Once per battle, at the start of any turn where Horus Lupercal&#8217;s controlling player is the Reactive player, this special rule may be activated. For the duration of the turn on which this special rule is activated, the Reaction Allotment of the army that includes Horus is increased by +1 in every Phase.</description>
                 </rule>
                 <rule id="2f6b-7800-e71c-ed83" name="Master of Weapons" hidden="false">
                   <description>During the Assault phase Horus Lupercal can never be hit by a Melee Attack on a score of better than 4+, regardless of the Weapon Skill of his opponent. In addition, during the Assault phase Horus Lupercal may choose to split his Attacks between any of the weapons he is equipped with, declaring which attacks will be used with which weaponprofiles before any of his attacks are rolled.</description>
                 </rule>
               </rules>
               <infoLinks>
-                <infoLink id="cd95-c533-b08f-b9db" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+                <infoLink id="cd95-c533-b08f-b9db" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="4a11-c7c1-e1a1-d067" name="Horus Ascended" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3b5-10bc-7885-c908" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3b5-10bc-7885-c908" type="max" />
               </constraints>
               <profiles>
                 <profile id="7152-ae03-3008-4647" name="Horus Ascended" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -1510,18 +1509,18 @@
               </profiles>
               <rules>
                 <rule id="dd1b-0330-aab1-7188" name="A Dark Fate" hidden="false">
-                  <description>The first time in any battle that Horus Ascended loses his last Wound, or is otherwise removed from play as a casualty, the model is instead placed into Reserves with a single Wound remaining – any unit Horus Ascended was part of remains in play, even a Retinue or other unit that would normally not allow the removal of a model from the unit. After having been placed in Reserves due to this special rule, Horus Ascended may choose to re-enter play, with the controlling player making Reserves rolls for the model as per the normal rules. If the Slay the Warlord objective, or any other objective that requires the enemy Warlord be removed as a casualty to score Victory points, is in effect then it is still triggered when Horus Ascended is moved into Reserves due to this special rule – and may be triggered a second time if Horus Ascended returns to play and is removed as a casualty again</description>
+                  <description>The first time in any battle that Horus Ascended loses his last Wound, or is otherwise removed from play as a casualty, the model is instead placed into Reserves with a single Wound remaining &#8211; any unit Horus Ascended was part of remains in play, even a Retinue or other unit that would normally not allow the removal of a model from the unit. After having been placed in Reserves due to this special rule, Horus Ascended may choose to re-enter play, with the controlling player making Reserves rolls for the model as per the normal rules. If the Slay the Warlord objective, or any other objective that requires the enemy Warlord be removed as a casualty to score Victory points, is in effect then it is still triggered when Horus Ascended is moved into Reserves due to this special rule &#8211; and may be triggered a second time if Horus Ascended returns to play and is removed as a casualty again</description>
                 </rule>
                 <rule id="3f6d-8e47-55b5-3f8b" name="The Power of Chaos Eternal" hidden="false">
-                  <description>Once per battle, at the start of any Assault phase (whether Horus Ascended’s controlling player is the Active or Reactive player), Horus Ascended’s controlling player
-may choose to activate the Power of Chaos Eternal. Onc eactivated, Horus Ascended increases his Strength and Toughness Characteristics to 10 for the duration of the Assault phase and ignores all the effects of the Unwieldy special rule on attacks made with Worldbreaker. Once the Assault phase is ended, all combats being fought have been resolved and the effects of the Power of Chaos Eternal have ended, Horus Ascended automatically suffers Perils of the Warp – but any Wounds caused must be allocated to friendly models in the same unit as Horus Ascended, if any such models exist, before they are allocated to Horus Ascended</description>
+                  <description>Once per battle, at the start of any Assault phase (whether Horus Ascended&#8217;s controlling player is the Active or Reactive player), Horus Ascended&#8217;s controlling player
+may choose to activate the Power of Chaos Eternal. Onc eactivated, Horus Ascended increases his Strength and Toughness Characteristics to 10 for the duration of the Assault phase and ignores all the effects of the Unwieldy special rule on attacks made with Worldbreaker. Once the Assault phase is ended, all combats being fought have been resolved and the effects of the Power of Chaos Eternal have ended, Horus Ascended automatically suffers Perils of the Warp &#8211; but any Wounds caused must be allocated to friendly models in the same unit as Horus Ascended, if any such models exist, before they are allocated to Horus Ascended</description>
                 </rule>
                 <rule id="d859-aa19-1907-0790" name="The Spreading Corruption" hidden="false">
-                  <description>All models in a unit made up entirely of models withthe Infantry, Cavalry or Dreadnought Unit Types inthesame Detachment as Horus Ascended may be giiven the Corrupted Unit Sub-type at a cost of +25 points per unit . If this upgrade is selected for a unit then all models in the unit must gain the Corrupted Sub-type – models that are attached to units, such as Apothecaries or Techmarines, must be upgraded separately. For Apothecary Detachments, Techmarine Covenants and other units which are bought as a single Force Organisation slot and then separated, divided or attached to other units (including units bought using the Retinue special rule or any variant of that rule which allows a unit to be counted as part of the same Force Organisation slot as a Leader model), the upgrade is bought once for
+                  <description>All models in a unit made up entirely of models withthe Infantry, Cavalry or Dreadnought Unit Types inthesame Detachment as Horus Ascended may be giiven the Corrupted Unit Sub-type at a cost of +25 points per unit . If this upgrade is selected for a unit then all models in the unit must gain the Corrupted Sub-type &#8211; models that are attached to units, such as Apothecaries or Techmarines, must be upgraded separately. For Apothecary Detachments, Techmarine Covenants and other units which are bought as a single Force Organisation slot and then separated, divided or attached to other units (including units bought using the Retinue special rule or any variant of that rule which allows a unit to be counted as part of the same Force Organisation slot as a Leader model), the upgrade is bought once for
 the entire set of models before they are separated and must be applied to all models chosen as part of that Force Organisation slot.</description>
                 </rule>
                 <rule id="9445-c0b8-f082-54cb" name="Master of War" hidden="false">
-                  <description>Once per battle, at the start of any turn where Horus Lupercal’s controlling player is the Reactive player, this special rule may be activated. For the duration of the turn on which this special rule is activated, the Reaction Allotment of the army that includes Horus is increased by +1 in every Phase.</description>
+                  <description>Once per battle, at the start of any turn where Horus Lupercal&#8217;s controlling player is the Reactive player, this special rule may be activated. For the duration of the turn on which this special rule is activated, the Reaction Allotment of the army that includes Horus is increased by +1 in every Phase.</description>
                 </rule>
                 <rule id="ade0-2be2-4fad-a2b9" name="Master of Weapons" hidden="false">
                   <description>During the Assault phase Horus Lupercal can never be hit by a Melee Attack on a score of better than 4+, regardless of the Weapon Skill of his opponent. In addition, during the Assault phase Horus Lupercal may choose to split his Attacks between any of the weapons he is equipped with, declaring which attacks will be used with which weaponprofiles before any of his attacks are rolled.</description>
@@ -1530,18 +1529,18 @@ the entire set of models before they are separated and must be applied to all mo
               <infoLinks>
                 <infoLink id="6ecc-afc9-a699-ce44" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Feel No Pain (4+)"/>
+                    <modifier type="set" field="name" value="Feel No Pain (4+)" />
                   </modifiers>
                 </infoLink>
                 <infoLink id="6bfb-c229-3493-acb0" name="Rage (X)" hidden="false" targetId="564d-3550-ae44-2f99" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Rage (3)"/>
+                    <modifier type="set" field="name" value="Rage (3)" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="63c5-a1e6-28a4-8fab" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+                <infoLink id="63c5-a1e6-28a4-8fab" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="400.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="400.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1550,26 +1549,26 @@ the entire set of models before they are separated and must be applied to all mo
       <entryLinks>
         <entryLink id="2f3f-8bef-916f-bb9a" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b8a-86b3-166d-3ba1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e35a-06a7-2457-0dd1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b8a-86b3-166d-3ba1" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e35a-06a7-2457-0dd1" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="a075-487c-3b98-e8aa" name="Cognis-Signum" hidden="false" collective="false" import="true" targetId="93b3-2d66-f7a3-be42" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6ed-7f5a-2208-6aaf" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d080-41a8-483b-0753" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6ed-7f5a-2208-6aaf" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d080-41a8-483b-0753" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="6c67-67b9-f9cb-1485" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="254c-71b4-dd86-7f35" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5a1-aac3-84e1-b65f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="254c-71b4-dd86-7f35" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5a1-aac3-84e1-b65f" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="f8a4-123d-bab3-2847" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17f2-8cec-334a-82ca" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25ef-87d3-336e-0824" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17f2-8cec-334a-82ca" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25ef-87d3-336e-0824" type="min" />
           </constraints>
           <profiles>
             <profile id="2902-12cc-7ca8-fb07" name="Sire of the Sons of Horus" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
@@ -1581,51 +1580,51 @@ the entire set of models before they are separated and must be applied to all mo
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="600.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="600.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="8b29-bf2a-a814-5642" name="Reaver Attack Squad" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="75f8-aafa-4322-7748" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="2e29-50f0-b4bc-8fbe" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
+        <infoLink id="75f8-aafa-4322-7748" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="2e29-50f0-b4bc-8fbe" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
         <infoLink id="75c4-d82f-ede3-14b9" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Counter-Attack (1)"/>
+            <modifier type="set" field="name" value="Counter-Attack (1)" />
           </modifiers>
         </infoLink>
         <infoLink id="6fc5-e673-2dbf-f18e" name="Precision Shots (X)" hidden="false" targetId="4b71-81ee-31f4-fa09" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Precision Shots (6+)"/>
+            <modifier type="set" field="name" value="Precision Shots (6+)" />
           </modifiers>
         </infoLink>
         <infoLink id="80d6-e6f7-e6ce-bbd1" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Precision Strikes (6+)"/>
+            <modifier type="set" field="name" value="Precision Strikes (6+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4caa-933a-6c61-0c7a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="d534-6f34-1da7-062d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="4caa-933a-6c61-0c7a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="d534-6f34-1da7-062d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8e5a-163d-6dcf-8f4a" name=" Reaver Chieftain" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07e5-477f-23a4-438f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbe7-9334-987a-0b36" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07e5-477f-23a4-438f" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbe7-9334-987a-0b36" type="min" />
           </constraints>
           <profiles>
             <profile id="59da-9721-f96d-4ebd" name="Reaver Chieftain" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="8b29-bf2a-a814-5642" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9d64-3950-9bfb-e312" type="equalTo"/>
+                    <condition field="selections" scope="8b29-bf2a-a814-5642" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9d64-3950-9bfb-e312" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1639,144 +1638,144 @@ the entire set of models before they are separated and must be applied to all mo
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="9e64-6058-50b6-2676" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="9e64-6058-50b6-2676" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="366f-f67d-382b-7a6f" name="Bolt Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d4bd-a4c8-1282-0a0d">
               <modifiers>
                 <modifier type="set" field="881c-0f64-ed3b-8eba" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="8e5a-163d-6dcf-8f4a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d24-803f-8f30-316b" type="equalTo"/>
+                    <condition field="selections" scope="8e5a-163d-6dcf-8f4a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d24-803f-8f30-316b" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="d1cd-8aa3-ab43-2f68" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="8e5a-163d-6dcf-8f4a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d24-803f-8f30-316b" type="equalTo"/>
+                    <condition field="selections" scope="8e5a-163d-6dcf-8f4a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d24-803f-8f30-316b" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1cd-8aa3-ab43-2f68" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="881c-0f64-ed3b-8eba" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1cd-8aa3-ab43-2f68" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="881c-0f64-ed3b-8eba" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="d4bd-a4c8-1282-0a0d" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22c1-055e-c2e3-af08" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22c1-055e-c2e3-af08" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="6730-5f84-fa68-b8ef" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61ce-18b2-b975-37fd" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61ce-18b2-b975-37fd" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="3bd2-0780-e27b-bec4" name="Chainaxe:" hidden="false" collective="false" import="true" defaultSelectionEntryId="974b-cafd-675d-822c">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="637e-d5e1-af2d-dfc6" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bc7-5650-d4c5-dece" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="637e-d5e1-af2d-dfc6" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bc7-5650-d4c5-dece" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="974b-cafd-675d-822c" name="Chainaxe" hidden="false" collective="false" import="true" targetId="85b9-4e50-af11-c295" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="694d-b737-ed78-5cab" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="694d-b737-ed78-5cab" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="1d24-803f-8f30-316b" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9018-34ed-65e8-73c6" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9018-34ed-65e8-73c6" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="6227-81e5-42d6-1e96" name="Melee Options:" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52ca-7c89-b94e-b456" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52ca-7c89-b94e-b456" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="76ef-4798-5739-b4a7" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2848-03e5-0f1f-0029" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2848-03e5-0f1f-0029" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="52b7-4be0-5587-d174" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6b5-0c2c-13dd-3597" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6b5-0c2c-13dd-3597" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="95e7-b45d-a745-603d" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d5b-eb68-ceb4-3371" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d5b-eb68-ceb4-3371" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="65cf-81d7-eaa7-b987" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9df-c23b-cf40-c4b7" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9df-c23b-cf40-c4b7" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="aa97-5d5b-c85f-1466" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7862-8524-4450-2f63" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7862-8524-4450-2f63" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="4fb9-bde6-ed2c-0583" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="698f-0ae7-2992-95b5" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="698f-0ae7-2992-95b5" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="2681-506f-fad0-8077" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eca4-a40c-bf64-15a8" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eca4-a40c-bf64-15a8" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="b164-423e-5d3f-1039" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56fc-998b-ed47-968e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56fc-998b-ed47-968e" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="2cbd-2132-5a0d-1c83" name="Power Armor:" hidden="false" collective="false" import="true" defaultSelectionEntryId="6146-cf27-9715-3181">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be7c-0b56-b7c5-d2d0" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d41-b75b-7cee-29f8" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be7c-0b56-b7c5-d2d0" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d41-b75b-7cee-29f8" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="6146-cf27-9715-3181" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry"/>
+                <entryLink id="6146-cf27-9715-3181" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry" />
                 <entryLink id="9d64-3950-9bfb-e312" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1785,15 +1784,15 @@ the entire set of models before they are separated and must be applied to all mo
           <entryLinks>
             <entryLink id="6e40-4be0-f222-03d2" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45b2-d301-04ac-80fc" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45b2-d301-04ac-80fc" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1802,29 +1801,29 @@ the entire set of models before they are separated and must be applied to all mo
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="8b29-bf2a-a814-5642" value="11.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
+                <condition field="selections" scope="8b29-bf2a-a814-5642" value="11.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2c4-34b4-fc09-3827" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2c4-34b4-fc09-3827" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="4dea-e681-494c-97f0" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="d6de-bb45-7504-48eb" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="true" targetId="bbe8-818d-3068-d79c" type="selectionEntry"/>
+            <entryLink id="d6de-bb45-7504-48eb" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="true" targetId="bbe8-818d-3068-d79c" type="selectionEntry" />
             <entryLink id="0083-9c8d-a1b2-fdb0" name="Storm Eagle Gunship" hidden="true" collective="false" import="true" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1833,8 +1832,8 @@ the entire set of models before they are separated and must be applied to all mo
         </selectionEntryGroup>
         <selectionEntryGroup id="8754-b93d-33ac-fb7c" name=" Reavers:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9a78-22bd-c5e6-f60b">
           <constraints>
-            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="736a-f717-4ae9-88e4" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a23-8c6e-49f9-3268" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="736a-f717-4ae9-88e4" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a23-8c6e-49f9-3268" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="9a78-22bd-c5e6-f60b" name=" Reavers (Collective)" hidden="false" collective="false" import="true" type="model">
@@ -1842,7 +1841,7 @@ the entire set of models before they are separated and must be applied to all mo
                 <profile id="1592-ade6-005a-add2" name="Reaver" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1860,130 +1859,130 @@ the entire set of models before they are separated and must be applied to all mo
                   <modifiers>
                     <modifier type="set" field="dbc7-664a-65d8-a123" value="0.0">
                       <conditions>
-                        <condition field="selections" scope="9a78-22bd-c5e6-f60b" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6262-4892-f340-6fea" type="greaterThan"/>
+                        <condition field="selections" scope="9a78-22bd-c5e6-f60b" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6262-4892-f340-6fea" type="greaterThan" />
                       </conditions>
                     </modifier>
                     <modifier type="set" field="b472-ea78-6e7b-457b" value="0.0">
                       <conditions>
-                        <condition field="selections" scope="9a78-22bd-c5e6-f60b" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6262-4892-f340-6fea" type="greaterThan"/>
+                        <condition field="selections" scope="9a78-22bd-c5e6-f60b" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6262-4892-f340-6fea" type="greaterThan" />
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbc7-664a-65d8-a123" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b472-ea78-6e7b-457b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbc7-664a-65d8-a123" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b472-ea78-6e7b-457b" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="ffb6-d9af-ced1-89bf" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d867-7766-66d5-b377" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d867-7766-66d5-b377" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="5e95-90f5-faef-5ee7" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="6b5f-d62d-7568-38b6" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a467-11b3-4767-7c7c" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a467-11b3-4767-7c7c" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="50d7-e83b-c50e-7fa7" name="Melee Options:" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40e2-1848-d8f1-95d2" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40e2-1848-d8f1-95d2" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="a351-2563-959f-bc3e" name="Power Fist" hidden="false" collective="false" import="true" targetId="a472-3ded-51a3-44a0" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99c0-df87-c485-99da" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99c0-df87-c485-99da" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="a2c0-3477-47b9-e053" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="11c8-0876-80b1-cecd" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1784-e6ad-0f2e-2378" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1784-e6ad-0f2e-2378" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="a7f9-fd95-c7ce-4ff3" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="20d9-83b9-c533-7048" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4463-92f9-2225-0dcf" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4463-92f9-2225-0dcf" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="6714-9260-487c-26c6" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="6f53-4c43-ba83-4b2f" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7431-7932-4840-e790" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7431-7932-4840-e790" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="5392-95b9-10b8-e9e7" name="Power Maul" hidden="false" collective="false" import="true" targetId="98e8-f217-dea9-0493" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99ef-00c7-57fb-0f0c" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99ef-00c7-57fb-0f0c" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="d0db-5011-370f-f359" name="Power Sword" hidden="false" collective="false" import="true" targetId="fa06-cac0-3d98-125e" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d24-2eec-e826-8541" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d24-2eec-e826-8541" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="1115-f321-30cf-aa1a" name="Power Lance" hidden="false" collective="false" import="true" targetId="fca3-4ec1-c581-1ba3" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1703-358e-f129-18c5" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1703-358e-f129-18c5" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="ecbe-3b11-861d-7b14" name="Power Axe" hidden="false" collective="false" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a55-6eac-81c5-138c" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a55-6eac-81c5-138c" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="6240-ce0c-aeb7-77f5" name="Chainaxe:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4fe8-921e-3e0a-e142">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bf5-42ae-e452-274b" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e06a-e658-5772-14a7" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bf5-42ae-e452-274b" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e06a-e658-5772-14a7" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="4fe8-921e-3e0a-e142" name="Chainaxe" hidden="false" collective="false" import="true" targetId="3a0d-c3bb-dc59-a4c3" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a7c-b601-37f3-a6b5" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a7c-b601-37f3-a6b5" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="6262-4892-f340-6fea" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2ad-b4b8-3c61-b01a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2ad-b4b8-3c61-b01a" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="2fc2-12f4-a68f-111d" name=" Reaver w/ Options" hidden="false" collective="false" import="true" type="model">
@@ -1991,7 +1990,7 @@ the entire set of models before they are separated and must be applied to all mo
                 <profile id="c465-d069-d874-1381" name="Reaver" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2009,56 +2008,56 @@ the entire set of models before they are separated and must be applied to all mo
                   <modifiers>
                     <modifier type="set" field="4c4d-e37c-d769-752a" value="0.0">
                       <conditions>
-                        <condition field="selections" scope="2fc2-12f4-a68f-111d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="478a-54bc-b61b-924d" type="equalTo"/>
+                        <condition field="selections" scope="2fc2-12f4-a68f-111d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="478a-54bc-b61b-924d" type="equalTo" />
                       </conditions>
                     </modifier>
                     <modifier type="set" field="c137-50c4-5513-b15b" value="0.0">
                       <conditions>
-                        <condition field="selections" scope="2fc2-12f4-a68f-111d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="478a-54bc-b61b-924d" type="equalTo"/>
+                        <condition field="selections" scope="2fc2-12f4-a68f-111d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="478a-54bc-b61b-924d" type="equalTo" />
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c137-50c4-5513-b15b" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c4d-e37c-d769-752a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c137-50c4-5513-b15b" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c4d-e37c-d769-752a" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="565a-a9c4-c431-282b" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0054-2c79-a0ce-88de" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0054-2c79-a0ce-88de" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="95cc-3fa2-7caf-ea19" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="376d-e988-5e65-23a9" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="376d-e988-5e65-23a9" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="7ea0-4014-4002-c484" name="May Take:" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d278-f7ac-9b28-91f5" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d278-f7ac-9b28-91f5" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="f7aa-75e5-1692-e5b0" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7988-c9ac-7adf-d0ac" type="max"/>
-                        <constraint field="selections" scope="8b29-bf2a-a814-5642" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1abf-a295-d420-e614" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7988-c9ac-7adf-d0ac" type="max" />
+                        <constraint field="selections" scope="8b29-bf2a-a814-5642" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1abf-a295-d420-e614" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="e8fb-5174-8ef0-cb3a" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0488-dba6-740f-3cee" type="max"/>
-                        <constraint field="selections" scope="8b29-bf2a-a814-5642" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1383-9f08-11fd-654d" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0488-dba6-740f-3cee" type="max" />
+                        <constraint field="selections" scope="8b29-bf2a-a814-5642" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1383-9f08-11fd-654d" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -2067,144 +2066,144 @@ the entire set of models before they are separated and must be applied to all mo
                   <modifiers>
                     <modifier type="increment" field="1fac-4537-4d2a-dd7a" value="1.0">
                       <repeats>
-                        <repeat field="selections" scope="8b29-bf2a-a814-5642" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                        <repeat field="selections" scope="8b29-bf2a-a814-5642" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                       </repeats>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="8b29-bf2a-a814-5642" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1fac-4537-4d2a-dd7a" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c615-b03c-ea16-dbc9" type="max"/>
+                    <constraint field="selections" scope="8b29-bf2a-a814-5642" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1fac-4537-4d2a-dd7a" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c615-b03c-ea16-dbc9" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="68cc-a1cd-030d-804f" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5db7-4d1a-c5c3-b0e7" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5db7-4d1a-c5c3-b0e7" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="e9f7-d43e-bcbc-ea7f" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1694-e3fa-4804-b520" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1694-e3fa-4804-b520" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="db2e-a32b-a6a0-4fe6" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e46-cd3f-1455-a07b" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e46-cd3f-1455-a07b" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="2eff-e5d1-e67c-7980" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf9b-7095-9778-9b36" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf9b-7095-9778-9b36" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="8b97-b007-8723-6975" name="Chainaxe:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4a11-b7fc-8bfd-40e1">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="424c-841f-ead6-56f5" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c848-0fa4-a6db-c67e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="424c-841f-ead6-56f5" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c848-0fa4-a6db-c67e" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="4a11-b7fc-8bfd-40e1" name="Chainaxe" hidden="false" collective="false" import="true" targetId="85b9-4e50-af11-c295" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5951-65b3-b9ca-a994" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5951-65b3-b9ca-a994" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="478a-54bc-b61b-924d" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c23-482b-86d0-43d6" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c23-482b-86d0-43d6" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="de42-6a34-0125-2ab0" name="Melee Options:" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8abf-9d53-fd20-548d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8abf-9d53-fd20-548d" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="f94b-12d0-7114-bf7f" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf6b-fd2e-eb9a-0e1d" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf6b-fd2e-eb9a-0e1d" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="2e36-2490-0633-cf36" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11b9-6ad5-cfff-290e" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11b9-6ad5-cfff-290e" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="e878-3017-bb3e-63d6" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06b3-c8b6-14fd-99a7" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06b3-c8b6-14fd-99a7" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="cbdd-a3dd-b6f4-e417" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd4f-7f7d-c364-b858" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd4f-7f7d-c364-b858" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="0f9e-7335-7338-ea74" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eaec-b8ac-c4f6-7334" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eaec-b8ac-c4f6-7334" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="3d5a-cbc3-b864-82d1" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d50a-d246-9477-58c4" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d50a-d246-9477-58c4" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="bf7a-9f23-ec53-7f4e" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6270-2b58-fa50-63f4" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6270-2b58-fa50-63f4" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="d1cf-fcd1-ce0e-551e" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d920-c3a1-6229-f4f7" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d920-c3a1-6229-f4f7" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2213,49 +2212,49 @@ the entire set of models before they are separated and must be applied to all mo
       <entryLinks>
         <entryLink id="ba70-498c-3d20-7e03" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4eba-f912-112f-030a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96f8-ac0b-200d-c914" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4eba-f912-112f-030a" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96f8-ac0b-200d-c914" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="c8f1-8b4e-8041-0e5e" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ad4-493a-5464-4ff6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bab-44eb-1d7c-2d74" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ad4-493a-5464-4ff6" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bab-44eb-1d7c-2d74" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="b77b-8e3a-d77e-0c1b" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e0a-de29-b2ea-be4c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="499d-cd39-402f-a07a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e0a-de29-b2ea-be4c" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="499d-cd39-402f-a07a" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="47.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="47.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="0b37-0420-b06a-fcc5" name="Maloghurst the Twisted" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e111-8b2f-68b0-e75d" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e111-8b2f-68b0-e75d" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="1f57-7f73-c9f6-c78c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="008c-4ae3-4bb8-7464" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="0a8b-db6e-ba23-26ec" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
-        <categoryLink id="18b7-46e4-9b59-2827" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="1f57-7f73-c9f6-c78c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="008c-4ae3-4bb8-7464" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="0a8b-db6e-ba23-26ec" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+        <categoryLink id="18b7-46e4-9b59-2827" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e879-1248-f5b3-ae24" name="Maloghurst the Twisted" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a38-b73d-dcc4-4c59" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6af2-5fc7-a9e3-3f37" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a38-b73d-dcc4-4c59" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6af2-5fc7-a9e3-3f37" type="max" />
           </constraints>
           <profiles>
             <profile id="0621-2f2e-e1bc-3455" name="Maloghurst the Twisted" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">(Character, Line, Unique)
 </characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2274,78 +2273,78 @@ the entire set of models before they are separated and must be applied to all mo
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="73ca-7b51-5381-6eed" name="Legiones Astartes (Sons of Hours) " hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
-            <infoLink id="b33d-d628-cdc3-9482" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
-            <infoLink id="56f5-f635-8f53-97f9" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+            <infoLink id="73ca-7b51-5381-6eed" name="Legiones Astartes (Sons of Hours) " hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule" />
+            <infoLink id="b33d-d628-cdc3-9482" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule" />
+            <infoLink id="56f5-f635-8f53-97f9" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
             <infoLink id="16ad-203d-8847-4534" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Adamantium Will (5+)"/>
+                <modifier type="set" field="name" value="Adamantium Will (5+)" />
               </modifiers>
             </infoLink>
             <infoLink id="aa64-c3fe-3470-74ba" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="It Will Not Die (5+)"/>
+                <modifier type="set" field="name" value="It Will Not Die (5+)" />
               </modifiers>
             </infoLink>
-            <infoLink id="e98c-8773-4421-8985" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
+            <infoLink id="e98c-8773-4421-8985" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="f36d-e4bf-df87-90eb" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2503-cfa4-aae7-8512" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="912b-a42e-97b2-59cc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2503-cfa4-aae7-8512" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="912b-a42e-97b2-59cc" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="722d-2230-2452-9b5d" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fab-1d69-9590-ef7f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d594-40f8-0a2d-8509" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fab-1d69-9590-ef7f" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d594-40f8-0a2d-8509" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="aad5-0ff0-c0c3-19cf" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50bd-5338-4abf-e913" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="215d-b02b-d1fe-8364" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50bd-5338-4abf-e913" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="215d-b02b-d1fe-8364" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="22ef-e21f-bb40-3b4f" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abf3-557b-52f5-b516" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6601-e331-6d35-02ee" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abf3-557b-52f5-b516" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6601-e331-6d35-02ee" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="a816-81df-e29a-0f53" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d33c-acb5-1adc-742e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c932-61a2-b95e-0bc8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d33c-acb5-1adc-742e" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c932-61a2-b95e-0bc8" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="3395-36a7-67ea-d87e" name="Banestrike Bolter" hidden="false" collective="false" import="true" targetId="6865-354c-0880-ee5f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdf7-8ba9-6683-65c2" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dc9-18fa-4552-98a3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdf7-8ba9-6683-65c2" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dc9-18fa-4552-98a3" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="4b16-7d4a-249f-63f7" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac31-4e2a-3fd2-dcc1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07c1-06c4-f0e0-62a3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac31-4e2a-3fd2-dcc1" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07c1-06c4-f0e0-62a3" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="8342-df5c-e270-9e43" name="Legion Standard" hidden="false" collective="false" import="true" targetId="7e13-cc1f-6bd7-7ac6" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbaa-9fcb-c5bf-e93e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d91e-4590-9f46-b80a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbaa-9fcb-c5bf-e93e" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d91e-4590-9f46-b80a" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="095f-65b3-f721-0b20" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ada3-79ac-e227-f963" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ada3-79ac-e227-f963" type="max" />
           </constraints>
           <profiles>
             <profile id="92ae-bca5-5ad8-45b1" name="Warlord: Bearer of the Eye" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
@@ -2355,27 +2354,27 @@ the entire set of models before they are separated and must be applied to all mo
             </profile>
           </profiles>
         </entryLink>
-        <entryLink id="cdd3-63e5-5cb7-7f49" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup"/>
+        <entryLink id="cdd3-63e5-5cb7-7f49" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup" />
         <entryLink id="64ed-1fac-1213-aa97" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8001-21ca-e4e8-ae81" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f665-e1d6-aa8f-9550" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8001-21ca-e4e8-ae81" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f665-e1d6-aa8f-9550" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="140.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="140.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="09df-6357-0a00-80a6" name="Ezekyle Abaddon" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e3ed-3bd7-17d5-5c60" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e3ed-3bd7-17d5-5c60" type="max" />
       </constraints>
       <profiles>
         <profile id="9b3e-2eed-06a2-050b" name="Ezekyle Abaddon" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character, Unique)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">7</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2391,35 +2390,35 @@ the entire set of models before they are separated and must be applied to all mo
       <infoLinks>
         <infoLink id="500e-a65f-ae88-964d" name="Battle-Hardened (X)" hidden="false" targetId="5c3b-ed0b-4ad0-d547" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Battle-hardened (1)"/>
+            <modifier type="set" field="name" value="Battle-hardened (1)" />
           </modifiers>
         </infoLink>
         <infoLink id="79ba-70cf-c3a9-88bd" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="1799-0d1a-e91d-0f9d" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
-        <infoLink id="9468-1e48-8fc4-bf4c" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
-        <infoLink id="235e-c0a7-d465-00cc" name="Legiones Astartes (Sons of Hours) " hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
+        <infoLink id="1799-0d1a-e91d-0f9d" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule" />
+        <infoLink id="9468-1e48-8fc4-bf4c" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule" />
+        <infoLink id="235e-c0a7-d465-00cc" name="Legiones Astartes (Sons of Hours) " hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule" />
         <infoLink id="50ed-6313-7966-b1b5" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Precision Strikes (4+)"/>
+            <modifier type="set" field="name" value="Precision Strikes (4+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="aea7-24d3-925e-74c2" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="aea7-24d3-925e-74c2" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="6cdb-94f4-0716-aa82" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="4897-8773-245a-fd7e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="fa52-b947-779c-4a2b" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="ea4e-2199-7ddc-8cb8" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="6cdb-94f4-0716-aa82" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="4897-8773-245a-fd7e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="fa52-b947-779c-4a2b" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="ea4e-2199-7ddc-8cb8" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="30f5-0018-958d-9e99" name="Cthonic power claw" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4623-5cc1-3ec4-f144" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26b7-ad69-cc51-8349" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4623-5cc1-3ec4-f144" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26b7-ad69-cc51-8349" type="max" />
           </constraints>
           <profiles>
             <profile id="1ffe-1743-88a9-914c" name="Cthonic power claw" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2432,45 +2431,45 @@ the entire set of models before they are separated and must be applied to all mo
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="8294-4618-c12a-c61b" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
-            <infoLink id="56ed-7946-8553-84ee" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
-            <infoLink id="7f28-8b5b-7d74-7d31" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
-            <infoLink id="cd62-82fa-63db-7f10" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="8294-4618-c12a-c61b" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
+            <infoLink id="56ed-7946-8553-84ee" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule" />
+            <infoLink id="7f28-8b5b-7d74-7d31" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
+            <infoLink id="cd62-82fa-63db-7f10" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="5bb2-42bc-dfc8-01a1" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="216b-de86-dad8-0d1f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="669d-f1ec-91bf-d9bf" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="216b-de86-dad8-0d1f" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="669d-f1ec-91bf-d9bf" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="681e-c5cb-1a2f-7497" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a49-6e72-d288-08ef" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e03-550c-4309-1154" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a49-6e72-d288-08ef" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e03-550c-4309-1154" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="0c03-36bc-20c4-f546" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d400-ff52-9cf2-3b1c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f84f-3d2f-8693-a9bd" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d400-ff52-9cf2-3b1c" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f84f-3d2f-8693-a9bd" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="0c79-b670-22af-34b1" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="2ab9-0e45-405e-056b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0525-9671-fb9d-6d8e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c10f-86af-ac28-4659" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0525-9671-fb9d-6d8e" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c10f-86af-ac28-4659" type="min" />
           </constraints>
         </entryLink>
-        <entryLink id="7651-956e-11f3-f994" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup"/>
+        <entryLink id="7651-956e-11f3-f994" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup" />
         <entryLink id="61b2-faf9-6930-9f3a" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fafd-2200-42ec-eda1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fafd-2200-42ec-eda1" type="max" />
           </constraints>
           <profiles>
             <profile id="f860-1d2b-1915-a74d" name="The Vengeful Spirit" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
@@ -2482,25 +2481,25 @@ the entire set of models before they are separated and must be applied to all mo
         </entryLink>
         <entryLink id="5e2d-5d5d-0d0f-7541" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="578f-5645-1cbe-3921" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6331-d95e-82c9-09bd" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="578f-5645-1cbe-3921" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6331-d95e-82c9-09bd" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="250.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="250.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="44bf-8a69-f21a-dfba" name="Garviel Loken" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ee89-21f5-174e-4fe4" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ee89-21f5-174e-4fe4" type="max" />
       </constraints>
       <profiles>
         <profile id="aabe-2dfc-085c-f3c7" name="Garviel Loken" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">(Character, Unique)
 </characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">6</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2523,54 +2522,54 @@ remains in play and regains 1D3 Wounds.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="486d-d2b0-1c78-9d56" name="Legiones Astartes (Sons of Hours) " hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
-        <infoLink id="1603-a22b-5c84-710e" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="486d-d2b0-1c78-9d56" name="Legiones Astartes (Sons of Hours) " hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule" />
+        <infoLink id="1603-a22b-5c84-710e" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="fcef-9b8a-6c3f-4fbe" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="6aca-3f5f-eceb-bb6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="4dff-4a2a-cd14-2871" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="fcef-9b8a-6c3f-4fbe" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="6aca-3f5f-eceb-bb6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="4dff-4a2a-cd14-2871" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <entryLinks>
         <entryLink id="3f9e-3f03-7de9-9919" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="648d-a2d7-3773-9c40" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c2b-86c2-f8b3-302b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="648d-a2d7-3773-9c40" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c2b-86c2-f8b3-302b" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="e615-1559-5729-bfce" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="178c-951f-7899-f035" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c85-5ec9-a5a8-b9ec" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="178c-951f-7899-f035" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c85-5ec9-a5a8-b9ec" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="66eb-6a1d-b144-735f" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb05-dcbb-1c7f-20ce" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37c3-c7be-161f-2072" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb05-dcbb-1c7f-20ce" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37c3-c7be-161f-2072" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="da61-52a0-88d1-b804" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69d1-8d7e-87de-e843" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e93-08eb-51da-0346" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69d1-8d7e-87de-e843" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e93-08eb-51da-0346" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="82ea-c025-6831-e022" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4436-621e-8ade-b98a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec8f-4091-be7c-21d6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4436-621e-8ade-b98a" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec8f-4091-be7c-21d6" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="0a6d-3060-7125-55f4" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="2ab9-0e45-405e-056b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de77-264e-bdea-35ce" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="350b-ecc5-2fda-6467" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de77-264e-bdea-35ce" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="350b-ecc5-2fda-6467" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="d476-ad29-0a41-707e" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9200-4f65-64e8-4fd6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9200-4f65-64e8-4fd6" type="max" />
           </constraints>
           <profiles>
             <profile id="3f4f-0288-3d43-f0f8" name="Wolf of Luna" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
@@ -2580,51 +2579,51 @@ remains in play and regains 1D3 Wounds.</description>
             </profile>
           </profiles>
         </entryLink>
-        <entryLink id="1001-50f5-7ab3-1c6f" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup"/>
+        <entryLink id="1001-50f5-7ab3-1c6f" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup" />
         <entryLink id="921b-793b-73d1-9f87" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c50-cbdd-9cb9-709b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44ad-8431-2e8b-b65a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c50-cbdd-9cb9-709b" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44ad-8431-2e8b-b65a" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="c45d-ade3-6b28-68a2" name="Justaerin Terminator Squad" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="7c0d-6e3e-9350-dc1c" name="Justaerin Retinue" hidden="true">
-          <description>A Justaerin Terminator Squad may be selected as a Retinue Squad in a Detachment that includes one model with both the Master of the Legion and the Legiones Astartes (Sons of Horus) special rules, instead of as an Elites choice, A unit selected a a Retinue Squad must have one model with both the Master of the Legion and Legiones Astartes (Sons of Horus) special rules from the same Detachment selected by the controlling player as the Justaerin Terminator Squad&apos;s Leader for the purposes of this special rule. A Justaerin Terminator Squad selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. A Justearin Terminator Squad selected as a Retinue Squad must be deployed with the model selected as its Leader as part of the unit and the Leader may not voluntarly leave the Retinue Squad during play. If that Leader has the Deep Strike special rule then all models in the Justaerin Terminator Squad selected as a Retinue Squad gain the Deep Strike special rule as well. One Justaerin in a Justaerin Terminator Squad selected as a Retinue may exchange a Banestrike combi-weapon for a Legion standard for +15 points.</description>
+          <description>A Justaerin Terminator Squad may be selected as a Retinue Squad in a Detachment that includes one model with both the Master of the Legion and the Legiones Astartes (Sons of Horus) special rules, instead of as an Elites choice, A unit selected a a Retinue Squad must have one model with both the Master of the Legion and Legiones Astartes (Sons of Horus) special rules from the same Detachment selected by the controlling player as the Justaerin Terminator Squad's Leader for the purposes of this special rule. A Justaerin Terminator Squad selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. A Justearin Terminator Squad selected as a Retinue Squad must be deployed with the model selected as its Leader as part of the unit and the Leader may not voluntarly leave the Retinue Squad during play. If that Leader has the Deep Strike special rule then all models in the Justaerin Terminator Squad selected as a Retinue Squad gain the Deep Strike special rule as well. One Justaerin in a Justaerin Terminator Squad selected as a Retinue may exchange a Banestrike combi-weapon for a Legion standard for +15 points.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="c675-f415-df8c-9198" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="15fc-6476-1058-2444" name="Legiones Astartes (Sons of Hours) " hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
+        <infoLink id="c675-f415-df8c-9198" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="15fc-6476-1058-2444" name="Legiones Astartes (Sons of Hours) " hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule" />
         <infoLink id="fbdd-00cb-3008-825b" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
         <infoLink id="6820-2952-d130-011b" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Furious Charge (1)"/>
+            <modifier type="set" field="name" value="Furious Charge (1)" />
           </modifiers>
         </infoLink>
-        <infoLink id="3b6a-af09-446f-d659" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
-        <infoLink id="835b-d027-2f68-140a" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="3b6a-af09-446f-d659" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
+        <infoLink id="835b-d027-2f68-140a" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="705b-da26-7a7c-2f8c" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="9f47-8b3b-90cc-998d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="5156-399a-3fcc-8ca9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="fbc7-2ac6-fa36-63d9" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="705b-da26-7a7c-2f8c" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="9f47-8b3b-90cc-998d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="5156-399a-3fcc-8ca9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="fbc7-2ac6-fa36-63d9" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="43c6-ca0f-65dd-f2cb" name="1) Justaerin" hidden="false" collective="false" import="true" defaultSelectionEntryId="d9c2-8eaa-a071-6524">
           <constraints>
-            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3f3-0462-7998-2fa0" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f9f-dd8a-e34d-b713" type="min"/>
+            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3f3-0462-7998-2fa0" type="max" />
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f9f-dd8a-e34d-b713" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="d9c2-8eaa-a071-6524" name="Justaerin" hidden="false" collective="false" import="true" type="model">
@@ -2648,134 +2647,134 @@ remains in play and regains 1D3 Wounds.</description>
               <selectionEntryGroups>
                 <selectionEntryGroup id="6691-b178-4930-7f35" name="1) Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="76d1-3491-8cfa-c785">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e56-5118-ef41-bb66" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6449-6ab0-5918-a67c" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e56-5118-ef41-bb66" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6449-6ab0-5918-a67c" type="min" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="bc36-5c7a-12c9-ecd5" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry"/>
+                    <entryLink id="bc36-5c7a-12c9-ecd5" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry" />
                     <entryLink id="63b1-a8b2-fc77-98eb" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="a380-2e79-f118-ffbf" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="1511-bd7d-cf0d-2ff9" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
-                    <entryLink id="76d1-3491-8cfa-c785" name="Carsoran Power Axe" hidden="false" collective="false" import="true" targetId="fa70-f0d0-b06d-5413" type="selectionEntry"/>
-                    <entryLink id="dbbd-7478-e600-97b8" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
-                    <entryLink id="e911-e67b-a091-b914" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
-                    <entryLink id="5287-b139-05ee-fefb" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
+                    <entryLink id="76d1-3491-8cfa-c785" name="Carsoran Power Axe" hidden="false" collective="false" import="true" targetId="fa70-f0d0-b06d-5413" type="selectionEntry" />
+                    <entryLink id="dbbd-7478-e600-97b8" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
+                    <entryLink id="e911-e67b-a091-b914" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry" />
+                    <entryLink id="5287-b139-05ee-fefb" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry" />
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="3e88-c2b2-4533-6814" name="2) Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="ceda-447f-57bf-0406">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a0f-e448-deaa-9ba4" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6475-312e-f2bc-8ce3" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a0f-e448-deaa-9ba4" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6475-312e-f2bc-8ce3" type="min" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="292a-bee9-5ace-e173" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry"/>
-                    <entryLink id="ceda-447f-57bf-0406" name="Banestrike Combi-Bolter" hidden="false" collective="false" import="true" targetId="d3eb-73ae-7b59-c348" type="selectionEntry"/>
+                    <entryLink id="292a-bee9-5ace-e173" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry" />
+                    <entryLink id="ceda-447f-57bf-0406" name="Banestrike Combi-Bolter" hidden="false" collective="false" import="true" targetId="d3eb-73ae-7b59-c348" type="selectionEntry" />
                     <entryLink id="df3f-c2e3-4555-c3c1" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="9d2f-1220-0ce0-c430" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
-                    <entryLink id="e9ca-0a6b-b8fb-b628" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry"/>
-                    <entryLink id="4dbd-995a-886d-aa11" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry"/>
-                    <entryLink id="ae2d-66c0-86d3-ce69" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry"/>
+                    <entryLink id="e9ca-0a6b-b8fb-b628" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry" />
+                    <entryLink id="4dbd-995a-886d-aa11" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry" />
+                    <entryLink id="ae2d-66c0-86d3-ce69" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry" />
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="76dd-bd99-d050-4772" name="3) Wargear" hidden="false" collective="false" import="true">
                   <entryLinks>
                     <entryLink id="d301-233e-6e2e-e5f0" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4846-7391-9321-670e" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4846-7391-9321-670e" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="a1f2-efc6-9ff7-3323" name="Justaerin w/Heavy Weapon (1 in 5)" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="9292-4c64-a125-adc0" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="c45d-ade3-6b28-68a2" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="c45d-ade3-6b28-68a2" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9292-4c64-a125-adc0" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9292-4c64-a125-adc0" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="abe0-c112-95a4-eb37" name="Justaerin" hidden="false" targetId="46b2-7f6f-7859-c042" type="profile"/>
+                <infoLink id="abe0-c112-95a4-eb37" name="Justaerin" hidden="false" targetId="46b2-7f6f-7859-c042" type="profile" />
               </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="2c01-4f2c-4719-5c37" name="1) Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="ac79-e75c-c4be-e1b6">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e060-b139-1cda-6ccc" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a445-94e7-3e92-a61b" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e060-b139-1cda-6ccc" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a445-94e7-3e92-a61b" type="min" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="287b-ddd3-7405-6e98" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry"/>
+                    <entryLink id="287b-ddd3-7405-6e98" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry" />
                     <entryLink id="fcf3-2835-0cd6-5833" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="b07c-59d4-8ba4-4529" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="0f0e-3a07-2f78-ebd5" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
-                    <entryLink id="ac79-e75c-c4be-e1b6" name="Carsoran Power Axe" hidden="false" collective="false" import="true" targetId="fa70-f0d0-b06d-5413" type="selectionEntry"/>
-                    <entryLink id="433b-a67a-ebd5-5075" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
-                    <entryLink id="17bc-dcc1-947b-d14f" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
-                    <entryLink id="b1c8-544c-60b2-1667" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
+                    <entryLink id="ac79-e75c-c4be-e1b6" name="Carsoran Power Axe" hidden="false" collective="false" import="true" targetId="fa70-f0d0-b06d-5413" type="selectionEntry" />
+                    <entryLink id="433b-a67a-ebd5-5075" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
+                    <entryLink id="17bc-dcc1-947b-d14f" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry" />
+                    <entryLink id="b1c8-544c-60b2-1667" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry" />
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="e7d0-e2b2-0cc5-43d7" name="2) Heavy Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="f401-1e90-af5b-e2d7">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="455d-f04a-9c2a-8793" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b40d-844e-57f4-e473" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="455d-f04a-9c2a-8793" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b40d-844e-57f4-e473" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="f401-1e90-af5b-e2d7" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="f3c9-465b-65eb-b382" name="Reaper Autocannon" hidden="false" collective="false" import="true" targetId="b87f-48de-6ced-043b" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="5722-3b12-b37f-da84" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -2784,121 +2783,121 @@ remains in play and regains 1D3 Wounds.</description>
                   <entryLinks>
                     <entryLink id="393d-7616-b987-7c68" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e390-816a-7ac0-03da" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e390-816a-7ac0-03da" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="3c6e-f814-9806-3453" name="Justaerin w/Pair of Lightning Claws" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
-                <infoLink id="bf5d-56de-8ae4-0d95" name="Justaerin" hidden="false" targetId="46b2-7f6f-7859-c042" type="profile"/>
+                <infoLink id="bf5d-56de-8ae4-0d95" name="Justaerin" hidden="false" targetId="46b2-7f6f-7859-c042" type="profile" />
               </infoLinks>
               <entryLinks>
                 <entryLink id="522d-390c-6cdb-25a3" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3308-be71-03bb-c740" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f933-0594-a47e-3c6e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3308-be71-03bb-c740" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f933-0594-a47e-3c6e" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="3856-ef30-d865-30a6" name="Justaerin w/Pair of Lightning Claws, Grenade Harness" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
-                <infoLink id="d2da-f8b0-57f3-787f" name="Justaerin" hidden="false" targetId="46b2-7f6f-7859-c042" type="profile"/>
+                <infoLink id="d2da-f8b0-57f3-787f" name="Justaerin" hidden="false" targetId="46b2-7f6f-7859-c042" type="profile" />
               </infoLinks>
               <entryLinks>
                 <entryLink id="cb03-ad32-953a-ec74" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1953-26fd-0121-99fa" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c81-8bdc-c334-d79e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1953-26fd-0121-99fa" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c81-8bdc-c334-d79e" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="02f6-40f3-e986-1049" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb31-6e5c-80f4-b0b3" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a1e-6eea-cc05-4983" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb31-6e5c-80f4-b0b3" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a1e-6eea-cc05-4983" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="b02f-0bac-63d0-6dc6" name="Justaerin w/Legion Standard" hidden="true" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b574-7838-ac21-b8f6" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b574-7838-ac21-b8f6" type="instanceOf" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad28-34fd-94b7-29a0" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad28-34fd-94b7-29a0" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="42ce-b7b3-b834-a6f6" name="Justaerin" hidden="false" targetId="46b2-7f6f-7859-c042" type="profile"/>
+                <infoLink id="42ce-b7b3-b834-a6f6" name="Justaerin" hidden="false" targetId="46b2-7f6f-7859-c042" type="profile" />
               </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="0b9d-0946-e85d-9b63" name="1) Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="b7a6-016d-899f-c0cf">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d44d-6484-0fe1-6d62" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a105-b1b7-67b9-aacd" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d44d-6484-0fe1-6d62" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a105-b1b7-67b9-aacd" type="min" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="efd5-64d0-51a8-7cd6" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry"/>
+                    <entryLink id="efd5-64d0-51a8-7cd6" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry" />
                     <entryLink id="0902-0da0-630a-3f70" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="b7f8-bdc1-61ab-71c4" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="3a13-12ee-7c6b-abe5" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
-                    <entryLink id="b7a6-016d-899f-c0cf" name="Carsoran Power Axe" hidden="false" collective="false" import="true" targetId="fa70-f0d0-b06d-5413" type="selectionEntry"/>
-                    <entryLink id="52af-ec0c-d7c4-57e2" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
-                    <entryLink id="658c-6646-ad88-5620" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
-                    <entryLink id="1bfb-39b3-6006-8fb6" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
+                    <entryLink id="b7a6-016d-899f-c0cf" name="Carsoran Power Axe" hidden="false" collective="false" import="true" targetId="fa70-f0d0-b06d-5413" type="selectionEntry" />
+                    <entryLink id="52af-ec0c-d7c4-57e2" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
+                    <entryLink id="658c-6646-ad88-5620" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry" />
+                    <entryLink id="1bfb-39b3-6006-8fb6" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry" />
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="807c-f222-3aac-75e0" name="2) Wargear" hidden="false" collective="false" import="true">
                   <entryLinks>
                     <entryLink id="ae03-a6d8-a217-6d1a" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2ae-9ee5-f478-c089" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2ae-9ee5-f478-c089" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="17c3-d902-98be-8b55" name="Legion Standard" hidden="false" collective="false" import="true" targetId="7e13-cc1f-6bd7-7ac6" type="selectionEntry"/>
+                <entryLink id="17c3-d902-98be-8b55" name="Legion Standard" hidden="false" collective="false" import="true" targetId="7e13-cc1f-6bd7-7ac6" type="selectionEntry" />
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2907,26 +2906,26 @@ remains in play and regains 1D3 Wounds.</description>
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="c45d-ade3-6b28-68a2" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                <condition field="selections" scope="c45d-ade3-6b28-68a2" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
               </conditions>
             </modifier>
           </modifiers>
           <entryLinks>
-            <entryLink id="2bfa-ade8-2fc1-e615" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry"/>
-            <entryLink id="18d5-41ad-421d-6a92" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="true" targetId="bbe8-818d-3068-d79c" type="selectionEntry"/>
+            <entryLink id="2bfa-ade8-2fc1-e615" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry" />
+            <entryLink id="18d5-41ad-421d-6a92" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="true" targetId="bbe8-818d-3068-d79c" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="b445-5f56-6379-d473" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry"/>
+        <entryLink id="b445-5f56-6379-d473" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="c3db-b014-dfaa-d189" name="Tybalt Marr" publicationId="d0df-7166-5cd3-89fd" page="92" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ecb0-3e9c-e3b6-fde7" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ecb0-3e9c-e3b6-fde7" type="max" />
       </constraints>
       <profiles>
         <profile id="f462-014b-dfb4-b367" name="Tybalt Marr" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2946,18 +2945,18 @@ remains in play and regains 1D3 Wounds.</description>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="8b6d-35f3-191d-2ae6" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="8b6d-35f3-191d-2ae6" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="773d-17eb-9834-2e2a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="d4f8-7cfd-49ff-ca02" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="5dc1-6807-ef11-1755" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="773d-17eb-9834-2e2a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="d4f8-7cfd-49ff-ca02" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="5dc1-6807-ef11-1755" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2095-6d87-7bf5-f840" name="The Culling Blade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b3a-542c-9f64-43fd" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6677-0feb-f086-8037" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b3a-542c-9f64-43fd" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6677-0feb-f086-8037" type="min" />
           </constraints>
           <profiles>
             <profile id="5472-3591-df1c-a996" name="The Culling Blade" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2965,132 +2964,132 @@ remains in play and regains 1D3 Wounds.</description>
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Breaching (5+)., Murderous Strike (5+), Duellist&apos;s Edge (1), Master-crafted</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Breaching (5+)., Murderous Strike (5+), Duellist's Edge (1), Master-crafted</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="70dd-29b5-f2ac-7708" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="70dd-29b5-f2ac-7708" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
             <infoLink id="1a2d-c26e-cea1-2765" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Breaching (5+)"/>
+                <modifier type="set" field="name" value="Breaching (5+)" />
               </modifiers>
             </infoLink>
             <infoLink id="877d-a1ab-2147-6daf" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Murderous Strike (5+)"/>
+                <modifier type="set" field="name" value="Murderous Strike (5+)" />
               </modifiers>
             </infoLink>
-            <infoLink id="2be1-f255-4992-5f54" name="Duellist’s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule">
+            <infoLink id="2be1-f255-4992-5f54" name="Duellist&#8217;s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Duellist’s Edge (1)"/>
+                <modifier type="set" field="name" value="Duellist&#8217;s Edge (1)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="3d80-bb4b-a338-1dfd" name="Banestrike Bolter" hidden="false" collective="false" import="true" targetId="6865-354c-0880-ee5f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a844-395b-2fc8-778a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d165-ac5d-f854-3f4e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a844-395b-2fc8-778a" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d165-ac5d-f854-3f4e" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="4b62-a476-4e9c-aaf4" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7af3-a824-7d02-d2f9" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfb4-ca62-5028-c016" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7af3-a824-7d02-d2f9" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfb4-ca62-5028-c016" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="dac0-477b-9e13-a353" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a115-8f9f-39a0-30ad" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="897b-6f25-e7f8-e75a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a115-8f9f-39a0-30ad" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="897b-6f25-e7f8-e75a" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="674e-472c-04d3-bf50" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="125d-6670-0228-4400" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c783-5790-0c2b-ccb9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="125d-6670-0228-4400" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c783-5790-0c2b-ccb9" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="513d-254f-0c57-77ec" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82b4-e53e-8e87-58fa" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6574-afa2-ff46-b34c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82b4-e53e-8e87-58fa" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6574-afa2-ff46-b34c" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="11d9-cec7-c3b1-7a6e" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f38-ca61-86e7-b1a5" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa27-d393-180e-c5e7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f38-ca61-86e7-b1a5" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa27-d393-180e-c5e7" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="3fc5-0ceb-c9f6-ab2b" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c7d-51de-08ef-ce26" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c7d-51de-08ef-ce26" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="7a0e-8ef9-0003-ad42" name="The Armour of Pride" hidden="false" collective="false" import="true" targetId="5cda-4256-f20a-9764" type="selectionEntry"/>
+            <entryLink id="7a0e-8ef9-0003-ad42" name="The Armour of Pride" hidden="false" collective="false" import="true" targetId="5cda-4256-f20a-9764" type="selectionEntry" />
           </entryLinks>
         </entryLink>
-        <entryLink id="4383-2955-67f1-bb4c" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup"/>
+        <entryLink id="4383-2955-67f1-bb4c" name="Retinue" hidden="false" collective="false" import="true" targetId="b574-7838-ac21-b8f6" type="selectionEntryGroup" />
         <entryLink id="c58c-b25c-fefb-9473" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5373-c654-c7da-365e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1aeb-0b67-eb5d-6269" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5373-c654-c7da-365e" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1aeb-0b67-eb5d-6269" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="af3a-334f-152f-d55f" name="Reaver Agressor Squad" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="30fa-9b63-8ecb-6a86" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="164a-6447-95d6-7e7c" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
+        <infoLink id="30fa-9b63-8ecb-6a86" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="164a-6447-95d6-7e7c" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
         <infoLink id="79c9-48f2-82d3-9b63" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Counter-Attack (1)"/>
+            <modifier type="set" field="name" value="Counter-Attack (1)" />
           </modifiers>
         </infoLink>
         <infoLink id="f73c-1216-bdbb-c9c4" name="Precision Shots (X)" hidden="false" targetId="4b71-81ee-31f4-fa09" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Precision Shots (6+)"/>
+            <modifier type="set" field="name" value="Precision Shots (6+)" />
           </modifiers>
         </infoLink>
         <infoLink id="adcd-defd-bd48-d6e0" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Precision Strikes (6+)"/>
+            <modifier type="set" field="name" value="Precision Strikes (6+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="38b8-bc47-ee4f-baef" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="6480-d33b-811b-a7fe" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="38b8-bc47-ee4f-baef" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="6480-d33b-811b-a7fe" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ce86-cb58-16b1-219d" name=" Reaver Chieftain" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="975e-c126-4bc7-1d3b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d9c-9d39-06b9-43e5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="975e-c126-4bc7-1d3b" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d9c-9d39-06b9-43e5" type="min" />
           </constraints>
           <profiles>
             <profile id="ae0f-6324-22a8-d06f" name="Reaver Chieftain" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="ce86-cb58-16b1-219d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7651-9307-69ad-00ae" type="equalTo"/>
+                    <condition field="selections" scope="ce86-cb58-16b1-219d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7651-9307-69ad-00ae" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -3104,144 +3103,144 @@ remains in play and regains 1D3 Wounds.</description>
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="32f6-2c22-d0e4-c548" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="32f6-2c22-d0e4-c548" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="4c88-3a9a-a466-eb56" name="Bolt Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="e645-7b6f-6e68-6d11">
               <modifiers>
                 <modifier type="set" field="55e3-dc8b-569f-13a0" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="ce86-cb58-16b1-219d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e0d-7d96-8142-100e" type="equalTo"/>
+                    <condition field="selections" scope="ce86-cb58-16b1-219d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e0d-7d96-8142-100e" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="3107-81fb-aa5b-d08c" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="ce86-cb58-16b1-219d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e0d-7d96-8142-100e" type="equalTo"/>
+                    <condition field="selections" scope="ce86-cb58-16b1-219d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e0d-7d96-8142-100e" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55e3-dc8b-569f-13a0" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3107-81fb-aa5b-d08c" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55e3-dc8b-569f-13a0" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3107-81fb-aa5b-d08c" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="e645-7b6f-6e68-6d11" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9edf-a1f1-2703-791a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9edf-a1f1-2703-791a" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="ba65-b834-c883-3e26" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa6e-8953-b7d4-c6df" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa6e-8953-b7d4-c6df" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="bb46-afe6-d43e-8b86" name="Chainaxe:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b493-ef06-0b8e-8af5">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39bd-f575-1213-0464" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71a5-7198-6cf2-5702" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39bd-f575-1213-0464" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71a5-7198-6cf2-5702" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="b493-ef06-0b8e-8af5" name="Chainaxe" hidden="false" collective="false" import="true" targetId="85b9-4e50-af11-c295" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="110a-be16-0350-73dc" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="110a-be16-0350-73dc" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="2e0d-7d96-8142-100e" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2193-a74e-4ca0-0a8b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2193-a74e-4ca0-0a8b" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="4902-da5e-c752-6b69" name="Melee Options:" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9472-1e08-3ef8-205a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9472-1e08-3ef8-205a" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="37ba-3905-9eef-bf44" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e230-eecf-46a0-d3ab" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e230-eecf-46a0-d3ab" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="fec0-935f-e7f5-ccb7" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd36-293f-2e21-a1be" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd36-293f-2e21-a1be" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="91e4-c372-6577-e616" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8635-6eff-27b0-f731" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8635-6eff-27b0-f731" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="79ab-9d38-f571-61d3" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b61-321b-c3fd-80b4" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b61-321b-c3fd-80b4" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="6ebb-a7ed-8d58-a850" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ea6-7ca3-6794-2d9c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ea6-7ca3-6794-2d9c" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="c016-8cd9-264f-f786" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a40-759b-fd4b-9a44" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a40-759b-fd4b-9a44" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="6816-4fef-8524-bf97" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e5e-79b9-3987-a477" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e5e-79b9-3987-a477" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="6b97-eca9-7368-0b88" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dc5-4885-bf33-404d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dc5-4885-bf33-404d" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="7db8-ffff-9048-c1cc" name="Power Armor:" hidden="false" collective="false" import="true" defaultSelectionEntryId="7f5f-20f9-64b5-a6fd">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0289-78b4-dcc6-4030" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea0d-be62-58f2-a865" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0289-78b4-dcc6-4030" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea0d-be62-58f2-a865" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="7f5f-20f9-64b5-a6fd" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry"/>
+                <entryLink id="7f5f-20f9-64b5-a6fd" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry" />
                 <entryLink id="7651-9307-69ad-00ae" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -3250,23 +3249,23 @@ remains in play and regains 1D3 Wounds.</description>
           <entryLinks>
             <entryLink id="6517-6496-5a22-4772" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43d0-6c11-41f0-3f25" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43d0-6c11-41f0-3f25" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="9f32-e9af-d271-26a8" name=" Reavers:" hidden="false" collective="false" import="true" defaultSelectionEntryId="e0c0-8529-c8e5-310e">
           <constraints>
-            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee8c-1fc6-5ab8-9d82" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f941-c4ee-0ba4-0d5b" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee8c-1fc6-5ab8-9d82" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f941-c4ee-0ba4-0d5b" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="e0c0-8529-c8e5-310e" name=" Reavers (Collective)" hidden="false" collective="false" import="true" type="model">
@@ -3274,7 +3273,7 @@ remains in play and regains 1D3 Wounds.</description>
                 <profile id="5ba1-244a-e6f0-9727" name="Reaver" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -3292,130 +3291,130 @@ remains in play and regains 1D3 Wounds.</description>
                   <modifiers>
                     <modifier type="set" field="5dcd-6f49-81fa-2a3c" value="0.0">
                       <conditions>
-                        <condition field="selections" scope="e0c0-8529-c8e5-310e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c6be-c1b7-5cb4-4598" type="greaterThan"/>
+                        <condition field="selections" scope="e0c0-8529-c8e5-310e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c6be-c1b7-5cb4-4598" type="greaterThan" />
                       </conditions>
                     </modifier>
                     <modifier type="set" field="83e4-cbd6-26ea-0420" value="0.0">
                       <conditions>
-                        <condition field="selections" scope="e0c0-8529-c8e5-310e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c6be-c1b7-5cb4-4598" type="greaterThan"/>
+                        <condition field="selections" scope="e0c0-8529-c8e5-310e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c6be-c1b7-5cb4-4598" type="greaterThan" />
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83e4-cbd6-26ea-0420" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dcd-6f49-81fa-2a3c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83e4-cbd6-26ea-0420" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dcd-6f49-81fa-2a3c" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="a86c-a2f6-a87d-7d68" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a052-24cb-7985-9b96" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a052-24cb-7985-9b96" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="7984-6702-b14e-2004" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="6b5f-d62d-7568-38b6" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ac0-aec9-43d7-0d00" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ac0-aec9-43d7-0d00" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="95e9-b970-f51d-60fb" name="Melee Options:" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31a2-474b-c6b7-1be9" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31a2-474b-c6b7-1be9" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="62e6-874f-775d-c07d" name="Power Fist" hidden="false" collective="false" import="true" targetId="a472-3ded-51a3-44a0" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5a8-ae45-65e7-d353" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5a8-ae45-65e7-d353" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="537d-e24e-1b75-05f7" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="11c8-0876-80b1-cecd" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9708-4dc9-9145-a41b" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9708-4dc9-9145-a41b" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="ed39-859a-cb79-cb48" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="20d9-83b9-c533-7048" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="719d-3ca3-83a9-c0a3" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="719d-3ca3-83a9-c0a3" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="449a-6b47-9a3c-f197" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="6f53-4c43-ba83-4b2f" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4047-ec21-ad23-6b51" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4047-ec21-ad23-6b51" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="3e3e-091b-2b04-b662" name="Power Maul" hidden="false" collective="false" import="true" targetId="98e8-f217-dea9-0493" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad5e-640b-3c64-67d9" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad5e-640b-3c64-67d9" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="9d3c-05e1-f655-83d4" name="Power Sword" hidden="false" collective="false" import="true" targetId="fa06-cac0-3d98-125e" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a53c-8e0c-1c78-2743" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a53c-8e0c-1c78-2743" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="ca51-7aa7-b893-4382" name="Power Lance" hidden="false" collective="false" import="true" targetId="fca3-4ec1-c581-1ba3" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5729-380b-852c-771a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5729-380b-852c-771a" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="4acf-1d83-746b-ef04" name="Power Axe" hidden="false" collective="false" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d034-2339-edaa-7444" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d034-2339-edaa-7444" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="1173-05cd-f843-5620" name="Chainaxe:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5ceb-53fa-ff47-908f">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92c4-abd8-ca3f-4257" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e91-13e5-c32d-967c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92c4-abd8-ca3f-4257" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e91-13e5-c32d-967c" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="5ceb-53fa-ff47-908f" name="Chainaxe" hidden="false" collective="false" import="true" targetId="3a0d-c3bb-dc59-a4c3" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e841-68e5-7b15-8cf8" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e841-68e5-7b15-8cf8" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="c6be-c1b7-5cb4-4598" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee68-c4f1-e31b-9d3b" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee68-c4f1-e31b-9d3b" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="8149-8fa6-c6b9-c3db" name=" Reaver w/ Options" hidden="false" collective="false" import="true" type="model">
@@ -3423,7 +3422,7 @@ remains in play and regains 1D3 Wounds.</description>
                 <profile id="31e2-14f5-6668-8811" name="Reaver" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -3441,56 +3440,56 @@ remains in play and regains 1D3 Wounds.</description>
                   <modifiers>
                     <modifier type="set" field="e121-f2fb-d8e0-ad94" value="0.0">
                       <conditions>
-                        <condition field="selections" scope="8149-8fa6-c6b9-c3db" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ff2c-755a-88b3-26a6" type="equalTo"/>
+                        <condition field="selections" scope="8149-8fa6-c6b9-c3db" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ff2c-755a-88b3-26a6" type="equalTo" />
                       </conditions>
                     </modifier>
                     <modifier type="set" field="f4cc-a592-76da-0c29" value="0.0">
                       <conditions>
-                        <condition field="selections" scope="8149-8fa6-c6b9-c3db" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ff2c-755a-88b3-26a6" type="equalTo"/>
+                        <condition field="selections" scope="8149-8fa6-c6b9-c3db" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ff2c-755a-88b3-26a6" type="equalTo" />
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e121-f2fb-d8e0-ad94" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4cc-a592-76da-0c29" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e121-f2fb-d8e0-ad94" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4cc-a592-76da-0c29" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="2feb-5e81-0480-0450" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79cc-7c81-f6b7-88f0" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79cc-7c81-f6b7-88f0" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="db36-7c61-f74c-42dc" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cba8-d9b6-234c-e8e0" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cba8-d9b6-234c-e8e0" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="cd2f-c040-cb24-3586" name="May Take:" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3ea-0fe8-a467-df0a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3ea-0fe8-a467-df0a" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="e0f4-7b94-cdd9-fe20" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a9c-a5f1-bdb6-5d2b" type="max"/>
-                        <constraint field="selections" scope="af3a-334f-152f-d55f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="888c-70b3-8554-0805" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a9c-a5f1-bdb6-5d2b" type="max" />
+                        <constraint field="selections" scope="af3a-334f-152f-d55f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="888c-70b3-8554-0805" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="8962-8127-2d66-7427" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0324-b27f-08c5-cedb" type="max"/>
-                        <constraint field="selections" scope="af3a-334f-152f-d55f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="787a-98f6-09c7-8298" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0324-b27f-08c5-cedb" type="max" />
+                        <constraint field="selections" scope="af3a-334f-152f-d55f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="787a-98f6-09c7-8298" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -3499,144 +3498,144 @@ remains in play and regains 1D3 Wounds.</description>
                   <modifiers>
                     <modifier type="increment" field="1f69-bada-e5bb-252e" value="1.0">
                       <repeats>
-                        <repeat field="selections" scope="af3a-334f-152f-d55f" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                        <repeat field="selections" scope="af3a-334f-152f-d55f" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                       </repeats>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="af3a-334f-152f-d55f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1f69-bada-e5bb-252e" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb21-e253-cfc7-f8b4" type="max"/>
+                    <constraint field="selections" scope="af3a-334f-152f-d55f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1f69-bada-e5bb-252e" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb21-e253-cfc7-f8b4" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="b264-03d6-e515-44fc" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="819e-5067-420f-42d4" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="819e-5067-420f-42d4" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="8cb7-5b11-b343-5008" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db62-f0ba-704e-3f39" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db62-f0ba-704e-3f39" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="47bd-6735-7fd0-209d" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45ae-365f-2afa-09ce" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45ae-365f-2afa-09ce" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="552d-2eb5-3dac-584d" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="297b-fb6c-6059-c0a6" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="297b-fb6c-6059-c0a6" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="82c9-d11f-6342-fb9c" name="Chainaxe:" hidden="false" collective="false" import="true" defaultSelectionEntryId="768d-bb27-e6e9-48ae">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39cb-d7de-6d20-1730" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4b7-8e10-52c1-ebb2" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39cb-d7de-6d20-1730" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4b7-8e10-52c1-ebb2" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="768d-bb27-e6e9-48ae" name="Chainaxe" hidden="false" collective="false" import="true" targetId="85b9-4e50-af11-c295" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="430c-9c82-632c-73a8" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="430c-9c82-632c-73a8" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="ff2c-755a-88b3-26a6" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee5c-2b78-3c0f-7f3a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee5c-2b78-3c0f-7f3a" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="2b34-d70c-f6f6-2440" name="Melee Options:" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce50-434d-d6f0-38f4" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce50-434d-d6f0-38f4" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="02cf-114d-85e9-abb7" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d488-2521-02da-be2f" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d488-2521-02da-be2f" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="fbdc-0960-0a0f-bf5f" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d69-3431-b794-4f6a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d69-3431-b794-4f6a" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="d3ef-660c-0039-e3ef" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f82-6b0f-df6a-e3d9" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f82-6b0f-df6a-e3d9" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="7a90-36b2-0777-95f0" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9aa-dd07-7f96-4f2e" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9aa-dd07-7f96-4f2e" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="4269-3680-bcb1-189e" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="871b-ca2f-50aa-3902" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="871b-ca2f-50aa-3902" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="fb45-d866-84e8-4093" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0009-5add-e994-fd5a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0009-5add-e994-fd5a" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="2a1d-7abb-b856-f907" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9493-2d94-9916-2e32" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9493-2d94-9916-2e32" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="4f87-5b9b-ede1-a67e" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f00-809e-eac9-d604" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f00-809e-eac9-d604" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3645,47 +3644,47 @@ remains in play and regains 1D3 Wounds.</description>
       <entryLinks>
         <entryLink id="103f-297d-dba4-3628" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21ad-e6d5-9e08-cbbb" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ead-5586-5e86-9d5e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21ad-e6d5-9e08-cbbb" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ead-5586-5e86-9d5e" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="a41b-2569-865f-6087" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f79a-9f95-c015-c8f2" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59fb-0e93-6651-7081" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f79a-9f95-c015-c8f2" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59fb-0e93-6651-7081" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="df73-ae1d-3f1f-803a" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee3b-eb87-5694-6710" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10cc-e627-34ca-8c16" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee3b-eb87-5694-6710" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10cc-e627-34ca-8c16" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="c35a-4e1f-b524-1889" name="Warhawk Jump Pack" hidden="false" collective="false" import="true" targetId="a298-8584-70ed-18ce" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b80f-2237-ed1d-865a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9993-f103-e8b1-6a6d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b80f-2237-ed1d-865a" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9993-f103-e8b1-6a6d" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="b574-7838-ac21-b8f6" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8601-e12f-064d-ca77" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8601-e12f-064d-ca77" type="max" />
       </constraints>
       <entryLinks>
-        <entryLink id="e953-7a39-2608-827f" name="Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
-        <entryLink id="8a6b-c862-f210-ef44" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="e953-7a39-2608-827f" name="Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
+        <entryLink id="8a6b-c862-f210-ef44" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
         <entryLink id="1d47-f8b8-ca8f-f960" name="Command Squad, Cataphractii" hidden="false" collective="false" import="true" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -3694,7 +3693,7 @@ remains in play and regains 1D3 Wounds.</description>
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -3703,7 +3702,7 @@ remains in play and regains 1D3 Wounds.</description>
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -3714,106 +3713,106 @@ remains in play and regains 1D3 Wounds.</description>
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="3a20-a888-7f54-7286" value="1.0">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="783e-d904-abb7-00dc" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a20-a888-7f54-7286" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="783e-d904-abb7-00dc" type="max" />
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a20-a888-7f54-7286" type="min" />
       </constraints>
       <selectionEntryGroups>
         <selectionEntryGroup id="8ad0-7437-7c83-4d76" name=" XVI: Sons of Horus" publicationId="09c5-eeae-f398-b653" page="282" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01b4-57c7-bf61-2abf" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01b4-57c7-bf61-2abf" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6f6b-5878-a4e7-1903" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bf85-bd3e-d108-2d2a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6f6b-5878-a4e7-1903" type="max" />
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bf85-bd3e-d108-2d2a" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="6116-f678-f510-65f1" name="Chosen by Dark Gods (Traitor only)" publicationId="09c5-eeae-f398-b653" page="282" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6ac2-8254-3278-b927" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a2a4-c897-567c-c653" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6ac2-8254-3278-b927" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a2a4-c897-567c-c653" type="max" />
               </constraints>
               <profiles>
                 <profile id="fe6e-18d8-eb98-cca0" name="Chosen by Dark Gods" publicationId="09c5-eeae-f398-b653" page="282" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Traitor Allegiance.
-The controlling player of a Warlord with this Trait may choose to roll a D6 at the start of each of that player’s turns. On the roll of a 2-5, the Warlord’s Strength and Toughness Characteristics are increased by +1 until the start of the controlling player’s next turn, and on the roll of a 6 the Warlord may also regain a single Wound (this may not take that model’s Wound score above its starting amount). However, on the roll of a 1 the Warlord suffers a single Wound instead which cannot be negated by any Saving Throw (including Invulnerable Saves) or Damage Mitigation roll (but can be regained as normal, either by this Trait or another special rule that restores Wounds). In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
+The controlling player of a Warlord with this Trait may choose to roll a D6 at the start of each of that player&#8217;s turns. On the roll of a 2-5, the Warlord&#8217;s Strength and Toughness Characteristics are increased by +1 until the start of the controlling player&#8217;s next turn, and on the roll of a 6 the Warlord may also regain a single Wound (this may not take that model&#8217;s Wound score above its starting amount). However, on the roll of a 1 the Warlord suffers a single Wound instead which cannot be negated by any Saving Throw (including Invulnerable Saves) or Damage Mitigation roll (but can be regained as normal, either by this Trait or another special rule that restores Wounds). In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="aa24-7e1b-dde3-f009" name="Wolf of Luna (Loyalist only)" publicationId="09c5-eeae-f398-b653" page="282" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0851-f10f-47f1-66ac" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f7ed-7ab2-894a-c565" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0851-f10f-47f1-66ac" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f7ed-7ab2-894a-c565" type="max" />
               </constraints>
               <profiles>
                 <profile id="ae38-1eb0-7eb1-c94a" name="Wolf of Luna" publicationId="09c5-eeae-f398-b653" page="282" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Loyalist Allegiance.
-A Warlord with this Trait may only join a unit composed entirely of models with both the Legiones Astartes (Sons of Horus) special rule and the Loyalist Allegiance. Both the Warlord and any unit it joins gain +1 Attack on any turn in which they successfully Charge, or are successfully charged by, an enemy unit that includes any models with both the Legiones Astartes (X) special rule and the Traitor Allegiance. These increases are in addition to any other bonuses granted by other special rules. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty. </characteristic>
+A Warlord with this Trait may only join a unit composed entirely of models with both the Legiones Astartes (Sons of Horus) special rule and the Loyalist Allegiance. Both the Warlord and any unit it joins gain +1 Attack on any turn in which they successfully Charge, or are successfully charged by, an enemy unit that includes any models with both the Legiones Astartes (X) special rule and the Traitor Allegiance. These increases are in addition to any other bonuses granted by other special rules. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Assault phase as long as the Warlord has not been removed as a casualty. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="5cda-4256-f20a-9764" name="The Armour of Pride" publicationId="09c5-eeae-f398-b653" page="282" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="33e8-8a33-d94f-fe2e" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9b61-5843-2499-22c4" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="33e8-8a33-d94f-fe2e" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9b61-5843-2499-22c4" type="max" />
               </constraints>
               <profiles>
                 <profile id="8d15-a646-f085-96aa" name="The Armour of Pride" publicationId="09c5-eeae-f398-b653" page="282" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">The first time in any battle when a Warlord with this Trait is reduced to 0 Wounds for any reason, the controlling player must immediately make a Leadership test for that model. If the Test is failed then the Warlord is removed as a casualty as normal, but if the Test is passed then the Warlord is not removed as a casualty, remains in play and regains D3 Wounds. This has no effect against attacks or rules which remove the model as a casualty without inflicting Wounds or against attacks with the Instant Death special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Shooting phase as long as the Warlord has not been removed as a casualty. </characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">The first time in any battle when a Warlord with this Trait is reduced to 0 Wounds for any reason, the controlling player must immediately make a Leadership test for that model. If the Test is failed then the Warlord is removed as a casualty as normal, but if the Test is passed then the Warlord is not removed as a casualty, remains in play and regains D3 Wounds. This has no effect against attacks or rules which remove the model as a casualty without inflicting Wounds or against attacks with the Instant Death special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Shooting phase as long as the Warlord has not been removed as a casualty. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="9714-3b10-54a0-01a4" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+        <entryLink id="9714-3b10-54a0-01a4" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -358,7 +358,7 @@
         <categoryLink id="7fcb-d2bb-ddf3-cf38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="9f4e-77db-9581-ec72" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
     <entryLink id="70d1-1da3-af70-f8b4" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2707-323f-d4f7-d83c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
@@ -786,7 +786,7 @@
         <categoryLink id="9ad9-c2b3-d3a5-a8e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="738f-13cd-fc9c-50e0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
     <entryLink id="c076-17e8-8918-b464" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
@@ -867,7 +867,7 @@
         <categoryLink id="cecd-2fd2-c4cb-eaa7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="5786-dde9-1b3e-c114" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
     <entryLink id="8f46-ec72-492b-3578" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="91b1-a34b-b760-dfca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -879,7 +879,7 @@
         <categoryLink id="1214-fac9-7990-1358" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="47bf-3493-af53-d564" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
     <entryLink id="00bb-4210-6011-0544" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2601-e6bb-a438-f56f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -961,7 +961,7 @@
         <categoryLink id="2d26-6b64-fea1-1a46" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="cbc4-6cc1-5cee-3517" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
     <entryLink id="8f38-399f-db76-c24d" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -989,7 +989,7 @@
         <categoryLink id="3577-609f-5b84-028f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="6da1-2109-1f37-2e38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
     <entryLink id="3cd2-a32f-b28f-009f" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -1039,7 +1039,7 @@
         <categoryLink id="af79-c917-a7e9-d25d" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
         <categoryLink id="a0d2-0e6e-61e6-e10c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
     <entryLink id="423d-7836-a117-197a" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7a04-38f5-5a1d-c040" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />

--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -3708,7 +3708,7 @@ remains in play and regains 1D3 Wounds.</description>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_be38-a066-4f8e-ae54</comment></selectionEntryGroup>
     <selectionEntryGroup id="9c74-1002-8103-2848" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -3810,7 +3810,7 @@ A Warlord with this Trait may only join a unit composed entirely of models with 
       <entryLinks>
         <entryLink id="9714-3b10-54a0-01a4" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_7dee-602c-4b47-be09</comment></selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
     <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />

--- a/2022 - LA - Space Wolves.cat
+++ b/2022 - LA - Space Wolves.cat
@@ -383,7 +383,7 @@
         <categoryLink id="32b7-0e98-c965-80a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="aa46-ab99-ca1d-d982" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
     <entryLink id="96a4-98a1-d338-3f29" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d338-30bf-599c-51da" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
@@ -811,7 +811,7 @@
         <categoryLink id="ed7c-c6ef-bd7a-ae22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="0511-9ade-d4f4-6f77" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
     <entryLink id="cd2c-8f8d-c0c7-1898" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
@@ -892,7 +892,7 @@
         <categoryLink id="5adc-e50d-7ba6-196b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="4826-382e-c68a-ec41" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
     <entryLink id="d6cf-a3dd-6f9a-c387" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f724-5371-cd99-9a3a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -904,7 +904,7 @@
         <categoryLink id="3c8a-32f6-3a0f-3f3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="0a2b-76a3-44a3-4ed9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
     <entryLink id="5b98-7257-55a6-1c70" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d273-5150-7505-021e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -986,7 +986,7 @@
         <categoryLink id="d691-db2f-243f-21c1" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="353f-9781-1a42-355a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
     <entryLink id="0128-944f-c876-31b0" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -1015,7 +1015,7 @@
         <categoryLink id="35b2-e100-5f07-093b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="376d-3b99-7653-20f9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
     <entryLink id="bf65-1ff7-f962-26b5" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -1065,7 +1065,7 @@
         <categoryLink id="65ed-1dc6-9c7f-0c1b" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
         <categoryLink id="e3cb-0d6f-62b7-5297" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
     <entryLink id="3623-c92a-36d6-f65a" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="cff0-5f02-eb91-8d00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />

--- a/2022 - LA - Space Wolves.cat
+++ b/2022 - LA - Space Wolves.cat
@@ -1,53 +1,52 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ca15-13de-89cb-bbb2" name="LA -   VI: Space Wolves" revision="17" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="28" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="ca15-13de-89cb-bbb2" name="LA -   VI: Space Wolves" revision="17" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="28">
   <entryLinks>
     <entryLink id="ff53-69d9-ec0b-9caa" name="   VI: Space Wolves" hidden="false" collective="false" import="false" targetId="4916-965e-8339-44f6" type="selectionEntry">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c8c-8356-e2e2-0b04" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1d3-74cd-b6b9-0bf2" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c8c-8356-e2e2-0b04" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1d3-74cd-b6b9-0bf2" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="d95c-fe4e-9f85-5c49" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="d95c-fe4e-9f85-5c49" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="1c86-f3f7-7462-c9a1" name="Deathsworn Pack" hidden="false" collective="false" import="false" targetId="3fa0-d6ed-981b-e361" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="afb7-b32a-da09-ad2f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="90f3-333e-c096-a39d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="afb7-b32a-da09-ad2f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="90f3-333e-c096-a39d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="8eb8-d620-5aae-d5ff" name="Fenrisian Wolf Pack" hidden="true" collective="false" import="false" targetId="f47e-c270-b62a-4205" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ecf9-012f-8171-c36a" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
-        <categoryLink id="026f-5075-581f-d0fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ecf9-012f-8171-c36a" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="026f-5075-581f-d0fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="145a-e620-0394-c8e6" name="Geigor Fell-Hand" hidden="false" collective="false" import="false" targetId="b4c7-4f96-122b-7ade" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6535-c9ec-ed83-7d89" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="1147-77ac-040c-ff0f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e2f9-db44-a72b-c576" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="6535-c9ec-ed83-7d89" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="1147-77ac-040c-ff0f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e2f9-db44-a72b-c576" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="7a57-b5be-d2e5-93f1" name="Grey Slayer Pack" hidden="false" collective="false" import="false" targetId="4bbf-f3df-7b18-4a49" type="selectionEntry">
@@ -56,17 +55,17 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="37a5-e559-aa6f-a23d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="9fab-f8f9-82e9-e115" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a657-599b-10e2-1ae1" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="37a5-e559-aa6f-a23d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="9fab-f8f9-82e9-e115" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a657-599b-10e2-1ae1" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="2e36-c0e4-643d-7f4e" name="Grey Stalker Pack" hidden="false" collective="false" import="false" targetId="4dbc-6266-853a-5114" type="selectionEntry">
@@ -75,207 +74,207 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c550-0f2f-8b47-f6ed" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="cc44-9321-b02a-11a5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9dee-400e-17b5-10cf" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="c550-0f2f-8b47-f6ed" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="cc44-9321-b02a-11a5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9dee-400e-17b5-10cf" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="ff22-4cd4-671e-7ec0" name="Hvarl Red-Blade" hidden="false" collective="false" import="false" targetId="31b6-168b-3c08-14b0" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="76e8-88e7-36d9-7a91" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="f177-b333-d0fd-981c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f78b-4136-ea01-903f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="76e8-88e7-36d9-7a91" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="f177-b333-d0fd-981c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f78b-4136-ea01-903f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="7313-b16a-cb0c-47a4" name="Jorlund Hunter Pack" hidden="true" collective="false" import="false" targetId="fcc8-bc3c-e443-eb3f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2b8c-b008-2f79-76cb" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="6596-a629-9cda-0b3b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2b8c-b008-2f79-76cb" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="6596-a629-9cda-0b3b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="912f-464e-f011-8a3c" name="Leman Russ" hidden="false" collective="false" import="false" targetId="c028-dc90-e4b6-8b43" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="02d9-6d81-e872-d7b7" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
-        <categoryLink id="1b8f-f807-3d22-80df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="02d9-6d81-e872-d7b7" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true" />
+        <categoryLink id="1b8f-f807-3d22-80df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="89e7-9749-8180-3d09" name="The Wolf-kin of Russ" hidden="false" collective="false" import="false" targetId="3bb9-4637-e963-b36f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1194-4568-72cb-9521" name="New CategoryLink" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="true"/>
-        <categoryLink id="a879-10d5-44fa-e515" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1194-4568-72cb-9521" name="New CategoryLink" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="true" />
+        <categoryLink id="a879-10d5-44fa-e515" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="1928-6d13-b015-a13f" name="Varagyr Wolf Guard Terminator Squad" hidden="false" collective="false" import="false" targetId="9359-61a5-fcdb-c28e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2286-5f51-f705-f752" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="071a-b942-24b6-7962" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2286-5f51-f705-f752" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="071a-b942-24b6-7962" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="c875-ee84-11d8-4a4a" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d381-b3e5-f4f3-bbf5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d9a7-e6d3-71e4-c8b4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="d381-b3e5-f4f3-bbf5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d9a7-e6d3-71e4-c8b4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
     <entryLink id="1b97-ffd5-a00e-d1c6" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2232-0a88-c640-9737" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="589b-60ee-12ba-45be" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="2232-0a88-c640-9737" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="589b-60ee-12ba-45be" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
     <entryLink id="7d0a-baa4-fef8-2fb6" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9579-1448-0161-c917" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="74d2-3be1-9300-e5f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="756a-f619-7e21-024b" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="9579-1448-0161-c917" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="74d2-3be1-9300-e5f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="756a-f619-7e21-024b" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="eb51-6d1f-6a43-2a87" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8413-d84d-5496-f2d4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="a66d-6a51-283b-59ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8413-d84d-5496-f2d4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="a66d-6a51-283b-59ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
     <entryLink id="4368-a60c-a96f-de3a" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9548-32a6-cd08-0fe4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="e7ff-e224-3b47-5afb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9548-32a6-cd08-0fe4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="e7ff-e224-3b47-5afb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
     <entryLink id="46ca-3578-3252-5279" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6eb0-486f-577e-5627" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="739a-bfcc-85bb-c8aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7094-3caa-ee44-76e4" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="6eb0-486f-577e-5627" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="739a-bfcc-85bb-c8aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7094-3caa-ee44-76e4" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
     <entryLink id="2ff8-6ccd-f1f4-1cc7" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cfdc-b894-8560-7a5d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="6823-a6fe-bab9-a971" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="cfdc-b894-8560-7a5d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="6823-a6fe-bab9-a971" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
     <entryLink id="b81f-cbff-a999-972a" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2c4b-a1e5-77f2-5345" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="007d-e4b1-66ef-f29a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2c4b-a1e5-77f2-5345" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="007d-e4b1-66ef-f29a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
     <entryLink id="b056-11c6-65e2-4864" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e2d2-2e5d-196a-8ba0" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="1f0d-3ea4-7135-c01a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bbb1-2e28-a895-2773" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="e2d2-2e5d-196a-8ba0" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="1f0d-3ea4-7135-c01a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bbb1-2e28-a895-2773" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="a048-525e-9d11-0913" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup"/>
+        <entryLink id="a048-525e-9d11-0913" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup" />
         <entryLink id="e59d-0e97-9d74-e9e4" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
@@ -286,13 +285,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b625-1cef-3057-156c" type="equalTo"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e9ab-2cc5-4507-eded" type="equalTo"/>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b625-1cef-3057-156c" type="equalTo" />
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e9ab-2cc5-4507-eded" type="equalTo" />
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -302,834 +301,834 @@
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
     <entryLink id="0080-caee-e018-2221" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7e17-cec5-beeb-64fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5bbb-6981-bbb6-b22e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="3211-e977-b4b3-e574" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="7e17-cec5-beeb-64fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5bbb-6981-bbb6-b22e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="3211-e977-b4b3-e574" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="e994-869a-97db-bfa3" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup"/>
+        <entryLink id="e994-869a-97db-bfa3" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup" />
         <entryLink id="1030-323d-58c6-593b" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
     <entryLink id="ec0e-c9eb-67cb-f9d8" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c9b7-d77f-9416-29a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ba91-3515-281a-aff7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="d43b-bebe-d264-5cfc" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="c9b7-d77f-9416-29a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ba91-3515-281a-aff7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="d43b-bebe-d264-5cfc" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="5dda-f970-b0ed-d799" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup"/>
+        <entryLink id="5dda-f970-b0ed-d799" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup" />
         <entryLink id="e808-f640-509e-7e80" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
     <entryLink id="2c9a-afc1-adf7-ca0a" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1afd-1b9e-18de-c80f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="2055-fb8d-2a40-b95b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1afd-1b9e-18de-c80f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="2055-fb8d-2a40-b95b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
     <entryLink id="00cf-817e-bd67-0e6d" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="00b6-7a51-ca72-92cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8fe1-aa3a-5a0a-abf2" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="00b6-7a51-ca72-92cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8fe1-aa3a-5a0a-abf2" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
     <entryLink id="d269-cb1c-f9a7-05a9" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7f01-b48c-4827-5fad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1b83-f323-38b4-92b7" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="7f01-b48c-4827-5fad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1b83-f323-38b4-92b7" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
     <entryLink id="1b2e-e05b-a2b3-5362" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="301c-085a-e2bf-6a9d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ee9e-2f37-d8ee-d7ff" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="301c-085a-e2bf-6a9d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ee9e-2f37-d8ee-d7ff" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
     <entryLink id="de04-9e9f-bdef-b73f" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="32b7-0e98-c965-80a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="aa46-ab99-ca1d-d982" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="32b7-0e98-c965-80a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="aa46-ab99-ca1d-d982" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
     <entryLink id="96a4-98a1-d338-3f29" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d338-30bf-599c-51da" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="1226-be2f-2291-9f64" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d338-30bf-599c-51da" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="1226-be2f-2291-9f64" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
     <entryLink id="3b55-ae51-3e2e-1cfb" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a7fe-cc33-a15d-5e87" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="7814-2b4d-9ca5-67f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a7fe-cc33-a15d-5e87" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="7814-2b4d-9ca5-67f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="987c-fcb5-d720-5551" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e4d0-8af0-393c-561a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="17b0-90f5-294f-e909" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="e4d0-8af0-393c-561a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="17b0-90f5-294f-e909" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
     <entryLink id="908b-c742-7cba-5421" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="15f3-c336-e9e6-adbb" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="bf2f-6245-0fd7-e32a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8691-3f54-d9b8-5da5" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="15f3-c336-e9e6-adbb" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="bf2f-6245-0fd7-e32a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8691-3f54-d9b8-5da5" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="e4fd-db7f-0da8-27f1" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="75ca-a855-c8d6-8bdc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7d2c-675b-fd5f-df4a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="75ca-a855-c8d6-8bdc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7d2c-675b-fd5f-df4a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="42f1-f479-531e-d27c" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4bad-9e6e-11a9-c5e8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="03a9-09d2-055e-e1c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4bad-9e6e-11a9-c5e8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="03a9-09d2-055e-e1c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
     <entryLink id="e640-d1e0-f223-6ae0" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a620-4554-c1bf-9675" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="efe0-5bc8-d758-1037" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a620-4554-c1bf-9675" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="efe0-5bc8-d758-1037" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
     <entryLink id="f552-5192-a1ad-3567" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5e37-217a-fc08-955c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="daa5-581f-6bde-0d64" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5e37-217a-fc08-955c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="daa5-581f-6bde-0d64" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
     <entryLink id="7951-37ba-ea97-1fbf" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8e1f-3d06-c16f-92bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6dc9-b166-08bf-9f29" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="8e1f-3d06-c16f-92bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6dc9-b166-08bf-9f29" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
     <entryLink id="4ce1-afcb-a998-139b" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e916-03bd-32d8-4be5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="7890-7142-1f66-e71d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e916-03bd-32d8-4be5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="7890-7142-1f66-e71d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
     <entryLink id="147f-e6f3-1e59-d1bd" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="42dd-26b2-8549-70f4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="95b9-72ea-e6e8-a5d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="42dd-26b2-8549-70f4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="95b9-72ea-e6e8-a5d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
     <entryLink id="4b91-3302-2321-8f73" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a587-db17-1128-1fea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="eaba-5d84-966d-b027" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="a587-db17-1128-1fea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="eaba-5d84-966d-b027" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
     <entryLink id="7d27-f014-42c7-959a" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ca7a-1c7e-26f3-1b35" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="d730-98de-27b8-1dc9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ca7a-1c7e-26f3-1b35" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="d730-98de-27b8-1dc9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
     <entryLink id="ccbd-0180-6d11-2b2f" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2fb0-88d0-8fa7-1d55" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="91e0-882d-c9ea-cb04" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="2fb0-88d0-8fa7-1d55" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="91e0-882d-c9ea-cb04" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="da43-7b82-1390-31c7" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c0e3-fd94-b038-e378" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="4d53-6abe-4314-1078" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c0e3-fd94-b038-e378" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="4d53-6abe-4314-1078" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
     <entryLink id="f17c-af0f-f367-1a2d" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f5ff-b22c-073c-a1ab" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="1091-c2c4-a4e5-c977" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f5ff-b22c-073c-a1ab" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="1091-c2c4-a4e5-c977" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
     <entryLink id="2448-3b6a-1eb5-3893" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d7fb-7744-61be-0566" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="2383-9cb4-55c4-4a39" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d7fb-7744-61be-0566" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="2383-9cb4-55c4-4a39" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
     <entryLink id="7a9b-0add-54e5-d7d2" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5f45-8b44-6274-6ec6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f60e-36a0-9cd8-9a5a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="5f45-8b44-6274-6ec6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f60e-36a0-9cd8-9a5a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
     <entryLink id="892d-221b-1bc4-c9a9" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="939e-fc28-3576-7a8f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1049-44d6-18cb-2e84" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="939e-fc28-3576-7a8f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1049-44d6-18cb-2e84" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
     <entryLink id="023a-80b2-012b-c1cb" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="df0b-d5b9-a329-79f8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="8eeb-eed3-1ba3-2abb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="df0b-d5b9-a329-79f8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="8eeb-eed3-1ba3-2abb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
     <entryLink id="40eb-8d27-4e31-9ea7" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d672-c540-c41b-1144" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="524d-6b64-9e34-ba14" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d672-c540-c41b-1144" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="524d-6b64-9e34-ba14" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
     <entryLink id="2187-7689-25c3-8c0f" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7128-ca59-44b3-4ddd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="606d-c437-12c0-b161" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7128-ca59-44b3-4ddd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="606d-c437-12c0-b161" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
     <entryLink id="55ab-e092-3970-348a" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0f02-9cfc-e7b7-17cd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="adb9-c576-f4a8-1f66" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0f02-9cfc-e7b7-17cd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="adb9-c576-f4a8-1f66" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
     <entryLink id="9dca-1c0b-ac10-a5ab" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="78f4-bc8d-0973-cbde" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="f31d-6560-9b3d-a4dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="78f4-bc8d-0973-cbde" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="f31d-6560-9b3d-a4dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
     <entryLink id="26f0-1c70-6b8f-2527" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1cef-7792-976c-030a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c974-917f-8f19-a199" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1cef-7792-976c-030a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="c974-917f-8f19-a199" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
     <entryLink id="a748-8ade-d505-9718" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7112-795a-da10-6412" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="a416-8088-db2f-998c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7112-795a-da10-6412" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="a416-8088-db2f-998c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
     <entryLink id="8b7c-7ea0-397c-bd00" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a632-972c-b2e7-c4a4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="9d6d-c576-79d7-f3ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a632-972c-b2e7-c4a4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="9d6d-c576-79d7-f3ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
     <entryLink id="9cba-fa2b-41e3-1816" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="84e7-3b48-82f5-a34e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="77b8-a56e-9978-a3a8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="84e7-3b48-82f5-a34e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="77b8-a56e-9978-a3a8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
     <entryLink id="69c5-c19e-f63a-8b1a" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8cc2-2db5-c63f-0a66" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bc9f-2f0c-cb50-2cc8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="8cc2-2db5-c63f-0a66" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bc9f-2f0c-cb50-2cc8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
     <entryLink id="866b-22df-9377-8855" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b129-db81-daf0-788a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c906-2a18-cfc2-fdd8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b129-db81-daf0-788a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="c906-2a18-cfc2-fdd8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
     <entryLink id="5077-05bd-eafc-1dfd" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8522-1958-3938-5d6a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="d61b-2776-448a-61b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8522-1958-3938-5d6a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="d61b-2776-448a-61b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
     <entryLink id="9438-c576-3b7f-9b59" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6538-afdf-33fd-cbf7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a713-1243-387c-339a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6538-afdf-33fd-cbf7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a713-1243-387c-339a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="1240-b7cf-81bd-dfd4" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7690-7c01-df17-0d1b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="8939-91f4-c635-aaed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7690-7c01-df17-0d1b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="8939-91f4-c635-aaed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
     <entryLink id="5a00-8d61-a643-6566" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d313-44e3-e5a3-f365" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="e673-1a76-b248-687d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d313-44e3-e5a3-f365" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="e673-1a76-b248-687d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="f8f1-c14a-7b0a-3590" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4dec-8968-767d-ff54" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8c70-da6c-df95-38a8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="4dec-8968-767d-ff54" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8c70-da6c-df95-38a8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="4e43-5156-847b-8c66" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2818-d9aa-4665-38d3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="e7e2-bb0c-3c4a-0320" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4f47-8982-3457-e4c4" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="2818-d9aa-4665-38d3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="e7e2-bb0c-3c4a-0320" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4f47-8982-3457-e4c4" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="c1d2-7ba9-e47e-7428" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup"/>
-        <entryLink id="ac31-1fdf-49e6-08d0" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup"/>
+        <entryLink id="c1d2-7ba9-e47e-7428" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup" />
+        <entryLink id="ac31-1fdf-49e6-08d0" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
     <entryLink id="4492-fa79-5b0b-e40d" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="08f4-136a-4976-1eaf" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="2efe-eb0d-b81b-2d13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ccfd-336b-882c-094a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="08f4-136a-4976-1eaf" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="2efe-eb0d-b81b-2d13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ccfd-336b-882c-094a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="350f-07c0-7445-5d21" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup"/>
-        <entryLink id="ab8a-99b0-c8fd-1597" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup"/>
+        <entryLink id="350f-07c0-7445-5d21" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup" />
+        <entryLink id="ab8a-99b0-c8fd-1597" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
     <entryLink id="3bb3-146d-dabd-3a2d" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e002-1378-0466-6b09" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="4cb7-2028-74ba-e85d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="05ec-97d6-2b39-daea" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="e002-1378-0466-6b09" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="4cb7-2028-74ba-e85d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="05ec-97d6-2b39-daea" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="544c-b6ec-b730-826e" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup"/>
-        <entryLink id="44e8-69eb-9e8b-ef37" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup"/>
+        <entryLink id="544c-b6ec-b730-826e" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup" />
+        <entryLink id="44e8-69eb-9e8b-ef37" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
     <entryLink id="6902-9449-3896-09d7" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="879c-0510-a1b8-7b67" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f971-7a09-f435-5f91" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="879c-0510-a1b8-7b67" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f971-7a09-f435-5f91" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="e473-af51-1016-4171" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5cfc-92f3-531c-d9cc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="2ca2-d227-0c40-e67f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5cfc-92f3-531c-d9cc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="2ca2-d227-0c40-e67f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
     <entryLink id="6e50-e22e-2dac-d62b" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ed7c-c6ef-bd7a-ae22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0511-9ade-d4f4-6f77" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="ed7c-c6ef-bd7a-ae22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0511-9ade-d4f4-6f77" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="cd2c-8f8d-c0c7-1898" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b555-f7b7-5d06-b82e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="6f96-121e-4c10-7560" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b555-f7b7-5d06-b82e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="6f96-121e-4c10-7560" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
     <entryLink id="1041-1b38-81e8-e66d" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="023e-71c2-8c55-09be" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="70b5-db33-6588-0cd7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="023e-71c2-8c55-09be" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="70b5-db33-6588-0cd7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
     <entryLink id="d982-a7bc-c170-28af" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ef7d-458c-0f51-f990" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="dd7d-df7c-a816-2acb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ef7d-458c-0f51-f990" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="dd7d-df7c-a816-2acb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
     <entryLink id="727e-bf5c-484d-3964" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2155-1f53-593a-ae03" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="eac3-dadd-28e3-0abb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="2155-1f53-593a-ae03" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="eac3-dadd-28e3-0abb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
     <entryLink id="e3ec-76e5-e3eb-e644" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bd76-63cb-6fa9-40eb" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="650f-4395-8d57-116a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bd76-63cb-6fa9-40eb" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="650f-4395-8d57-116a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
     <entryLink id="040c-ad2c-82dc-b606" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6eae-1a8a-d099-520a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c84c-de97-d069-ee48" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="6eae-1a8a-d099-520a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c84c-de97-d069-ee48" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
     <entryLink id="2dbf-8f01-ee5e-4e05" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a0f0-da7b-1a9f-fda1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fac4-5b03-1aa5-eee0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="a0f0-da7b-1a9f-fda1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="fac4-5b03-1aa5-eee0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
     <entryLink id="1bfc-59f7-21fc-9522" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fe28-67c6-1d19-8b59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="30dc-d245-86c7-92bf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="fe28-67c6-1d19-8b59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="30dc-d245-86c7-92bf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
     <entryLink id="a685-aac6-ae7f-56ff" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="15ee-4fd1-7633-8bee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5f73-1651-76e6-4403" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="15ee-4fd1-7633-8bee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5f73-1651-76e6-4403" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
     <entryLink id="ae13-45b3-410d-db09" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5adc-e50d-7ba6-196b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4826-382e-c68a-ec41" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="5adc-e50d-7ba6-196b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4826-382e-c68a-ec41" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="d6cf-a3dd-6f9a-c387" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f724-5371-cd99-9a3a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5502-960d-729a-013a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="f724-5371-cd99-9a3a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5502-960d-729a-013a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
     <entryLink id="154c-33e7-c019-5776" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3c8a-32f6-3a0f-3f3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0a2b-76a3-44a3-4ed9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="3c8a-32f6-3a0f-3f3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0a2b-76a3-44a3-4ed9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="5b98-7257-55a6-1c70" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d273-5150-7505-021e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="08a6-064b-bb57-b5a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d273-5150-7505-021e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="08a6-064b-bb57-b5a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
     <entryLink id="5faf-84f9-b693-f012" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="912b-f1b7-16cd-fbb2" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="6e0a-37aa-a8e4-ce75" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="912b-f1b7-16cd-fbb2" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="6e0a-37aa-a8e4-ce75" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
     <entryLink id="2edd-54be-4991-b1fb" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d672-0687-6d82-5a52" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="15c1-78a0-7544-4ba5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d672-0687-6d82-5a52" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="15c1-78a0-7544-4ba5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
     <entryLink id="4fcb-24e5-0465-48f5" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d289-5834-1624-39ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="21b4-3d77-64bd-30f9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="fc73-94b2-f659-179c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="d289-5834-1624-39ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="21b4-3d77-64bd-30f9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fc73-94b2-f659-179c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="dafc-d557-9714-d453" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="41fd-85fb-7f01-3ebc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b8e0-0c1d-e3a3-97da" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="41fd-85fb-7f01-3ebc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b8e0-0c1d-e3a3-97da" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
     <entryLink id="96c6-9762-bd80-4224" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="89d2-f9bd-e35d-4876" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="15d8-8e3e-60ab-789a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="89d2-f9bd-e35d-4876" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="15d8-8e3e-60ab-789a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
     <entryLink id="8682-cae9-19c7-632a" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5ca7-507e-b21e-81cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2b0b-4d09-84dd-afc0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="5ca7-507e-b21e-81cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2b0b-4d09-84dd-afc0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
     <entryLink id="c9e1-64bd-499d-4779" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d691-db2f-243f-21c1" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="353f-9781-1a42-355a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d691-db2f-243f-21c1" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="353f-9781-1a42-355a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="0128-944f-c876-31b0" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e48c-8501-977d-d4f4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="285b-28b3-e711-7201" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e48c-8501-977d-d4f4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="285b-28b3-e711-7201" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
     <entryLink id="1b00-d14d-b1b4-38aa" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="35b2-e100-5f07-093b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="376d-3b99-7653-20f9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="35b2-e100-5f07-093b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="376d-3b99-7653-20f9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="bf65-1ff7-f962-26b5" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3366-7d0f-cee2-a67a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="bd50-4ba4-2cc3-80b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3366-7d0f-cee2-a67a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="bd50-4ba4-2cc3-80b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
     <entryLink id="8a3b-87e9-09e0-3e53" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1680-22c8-6098-2e71" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="0093-5702-39e7-da16" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1680-22c8-6098-2e71" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="0093-5702-39e7-da16" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
     <entryLink id="8cf1-c85b-4c68-6ef4" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4eb2-022b-cd69-6152" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="9523-a7ba-a4b6-326b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4eb2-022b-cd69-6152" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="9523-a7ba-a4b6-326b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
     <entryLink id="30fc-7395-212a-8799" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b3d4-4d1a-a01a-4bf5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="3604-8de1-1c45-a66c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b3d4-4d1a-a01a-4bf5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="3604-8de1-1c45-a66c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
     <entryLink id="0ad2-daf8-8b18-c43b" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3774-a720-3191-578c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="65ed-1dc6-9c7f-0c1b" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="e3cb-0d6f-62b7-5297" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="3774-a720-3191-578c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="65ed-1dc6-9c7f-0c1b" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
+        <categoryLink id="e3cb-0d6f-62b7-5297" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="3623-c92a-36d6-f65a" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="cff0-5f02-eb91-8d00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4082-670a-a9ca-8ac1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="cff0-5f02-eb91-8d00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4082-670a-a9ca-8ac1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
     <entryLink id="72d1-2201-1bf6-c35a" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1947-04fa-1624-fe75" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="6a2d-9e0c-4dc1-4b00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1947-04fa-1624-fe75" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="6a2d-9e0c-4dc1-4b00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
     <entryLink id="7232-6f4c-c3e1-6191" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="bd3c-2782-2231-8c9a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bb47-9aee-ad52-615e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="bd3c-2782-2231-8c9a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bb47-9aee-ad52-615e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
     <entryLink id="4001-533a-8998-a443" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c198-3c27-918d-30c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6da4-ab27-5487-d257" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="c198-3c27-918d-30c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6da4-ab27-5487-d257" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="c028-dc90-e4b6-8b43" name="Leman Russ" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="00ed-3f49-ad36-075e" name="Howl of the Death Wolf" hidden="false">
-          <description>Once per battle, Leman Russ&apos; controlling plaer may declare the use of this special rule at the start of their turn. For the duration of that player turn only, all friendly models with the Legiones Astartes (Space Wolves) special rule gain a bonus of +1 to their Movement Characteristic and any enemy units that include one or more models with the Legiones Astartes (Space Wolves) special rule must take an an immediate Pinning test.</description>
+          <description>Once per battle, Leman Russ' controlling plaer may declare the use of this special rule at the start of their turn. For the duration of that player turn only, all friendly models with the Legiones Astartes (Space Wolves) special rule gain a bonus of +1 to their Movement Characteristic and any enemy units that include one or more models with the Legiones Astartes (Space Wolves) special rule must take an an immediate Pinning test.</description>
         </rule>
       </rules>
       <infoLinks>
         <infoLink id="c03d-f37e-7bff-cbdd" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Counter-attack (2)"/>
+            <modifier type="set" field="name" value="Counter-attack (2)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0c18-6f90-811e-6f2d" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="935c-5280-2665-ebbe" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="94c4-d1c1-31a4-0cce" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="0c18-6f90-811e-6f2d" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="935c-5280-2665-ebbe" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="94c4-d1c1-31a4-0cce" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1c95-89ac-6ffc-46f3" name="Leman Russ" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be06-ab6d-e9cb-2713" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51eb-0153-8238-943d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be06-ab6d-e9cb-2713" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51eb-0153-8238-943d" type="min" />
           </constraints>
           <profiles>
             <profile id="7ad2-4b1d-6d07-8f2c" name="Leman Russ" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -1151,19 +1150,19 @@
           <entryLinks>
             <entryLink id="125f-4af2-edd8-1515" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da57-dc97-9a86-e2e3" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="913f-e3b3-3582-88b1" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da57-dc97-9a86-e2e3" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="913f-e3b3-3582-88b1" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="3533-53d6-976c-05f1" name="The Armour Elavagar" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f489-4eb8-679e-79d8" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="556b-ced7-aa72-6cf9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f489-4eb8-679e-79d8" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="556b-ced7-aa72-6cf9" type="max" />
           </constraints>
           <profiles>
             <profile id="271d-f10d-c131-700d" name="The Armour Elavagar" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
@@ -1173,13 +1172,13 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="d50f-2d25-e508-bcdd" name="The Axe of Helwinter" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ed7-ac5b-376d-1c36" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e1d-3431-7eb1-4d24" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ed7-ac5b-376d-1c36" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e1d-3431-7eb1-4d24" type="max" />
           </constraints>
           <profiles>
             <profile id="c190-0634-f65b-b798" name="The Axe of Helwinter" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1192,22 +1191,22 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="5c71-09b8-5c60-1511" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
-            <infoLink id="fb62-d6db-b610-5c0e" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="5c71-09b8-5c60-1511" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule" />
+            <infoLink id="fb62-d6db-b610-5c0e" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
             <infoLink id="c898-7b08-6d2d-dfda" name="Reaping Blow (X)" hidden="false" targetId="bd8c-4f52-d682-1b40" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Reaping Blow (1)"/>
+                <modifier type="set" field="name" value="Reaping Blow (1)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="8698-6c8a-f742-a3cd" name="The Sword of Balenight" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="030e-0375-e5b0-785c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad6a-e257-cacd-9fde" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="030e-0375-e5b0-785c" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad6a-e257-cacd-9fde" type="max" />
           </constraints>
           <profiles>
             <profile id="7b1d-7752-6f41-5e2e" name="The Sword of Balenight" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1225,31 +1224,31 @@
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="a07d-5fee-9f0e-3165" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="a07d-5fee-9f0e-3165" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
             <infoLink id="a800-e538-1155-3b73" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Murderous Strike (4+)"/>
+                <modifier type="set" field="name" value="Murderous Strike (4+)" />
               </modifiers>
             </infoLink>
             <infoLink id="61c2-eb24-7896-43f3" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Brutal (2)"/>
+                <modifier type="set" field="name" value="Brutal (2)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="75d0-45ea-6f63-a352" name="Scornspitter" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c87-9e35-8b1a-306b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21c8-5e4e-ccd5-0321" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c87-9e35-8b1a-306b" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21c8-5e4e-ccd5-0321" type="max" />
           </constraints>
           <profiles>
             <profile id="b08c-0503-6441-2b45" name="Scornspitter" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;	</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">12"	</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 3, Rending (6+)</characteristic>
@@ -1259,43 +1258,43 @@
           <infoLinks>
             <infoLink id="c117-d426-2d15-e051" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Rending *6+)"/>
+                <modifier type="set" field="name" value="Rending *6+)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="49b2-1a04-298a-7df8" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6205-fe19-0747-253d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a13e-1ad6-3488-b0db" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6205-fe19-0747-253d" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a13e-1ad6-3488-b0db" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="c507-ff44-48a0-4b23" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3887-ea03-14c2-f856" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8203-7357-667b-2641" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3887-ea03-14c2-f856" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8203-7357-667b-2641" type="min" />
           </constraints>
           <profiles>
             <profile id="c33b-517f-4347-f8c1" name="Sire of the Space Wolves" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All models with the Legiones Astartes (Space Wolves) special rule in the same army as Leman Russ gain a bonus of +1 to their Strength for the duration of any turn in which such a unit successfully Charges an enemy unit.In addition, an army with Leman Russ as it&apos;s Warlord may make an additional Reaction in the opposing player&apos;s Assault phase as long as Leman Russ has not been removed as a casualty. </characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All models with the Legiones Astartes (Space Wolves) special rule in the same army as Leman Russ gain a bonus of +1 to their Strength for the duration of any turn in which such a unit successfully Charges an enemy unit.In addition, an army with Leman Russ as it's Warlord may make an additional Reaction in the opposing player's Assault phase as long as Leman Russ has not been removed as a casualty. </characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="450.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="450.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="3bb9-4637-e963-b36f" name="The Wolf-kin of Russ" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d1c-d50c-bc98-97a5" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d1c-d50c-bc98-97a5" type="max" />
       </constraints>
       <rules>
         <rule id="a94a-903b-1755-ce9d" name="Wolf-kin of Russ" hidden="false">
@@ -1303,22 +1302,22 @@
         </rule>
       </rules>
       <categoryLinks>
-        <categoryLink id="a231-01f6-2c07-1d34" name="Skirmish:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
-        <categoryLink id="aa46-1901-68ca-1c6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="e1f3-747e-4b46-0a8e" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-        <categoryLink id="f919-6f26-e787-b770" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="a231-01f6-2c07-1d34" name="Skirmish:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false" />
+        <categoryLink id="aa46-1901-68ca-1c6f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="e1f3-747e-4b46-0a8e" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false" />
+        <categoryLink id="f919-6f26-e787-b770" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="cdb9-9230-2585-94c5" name="Freki" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dcc-713f-67e8-9817" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a82-ce89-81f1-709e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dcc-713f-67e8-9817" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a82-ce89-81f1-709e" type="max" />
           </constraints>
           <profiles>
             <profile id="d9f4-df74-418f-43d3" name="Freki" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish, Light, Unique)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">10&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">10"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">0</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">5</characteristic>
@@ -1332,38 +1331,38 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="67f2-7e42-bb4f-58d8" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
+            <infoLink id="67f2-7e42-bb4f-58d8" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule" />
             <infoLink id="a8cd-08d5-1696-0066" name="Fear (X)" hidden="false" targetId="21f6-7842-df5c-d2e7" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Fear (1)"/>
+                <modifier type="set" field="name" value="Fear (1)" />
               </modifiers>
             </infoLink>
             <infoLink id="8831-0ed2-552a-28c1" name="Rampage (X)" hidden="false" targetId="3efb-2a2c-2d0b-92fc" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Rampage (2)"/>
+                <modifier type="set" field="name" value="Rampage (2)" />
               </modifiers>
             </infoLink>
             <infoLink id="47a2-1b7f-64b4-ccfb" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+                <modifier type="set" field="name" value="Hammer of Wrath (1)" />
               </modifiers>
             </infoLink>
             <infoLink id="b230-ec29-b9be-5ed5" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+                <modifier type="set" field="name" value="Feel No Pain (5+)" />
               </modifiers>
             </infoLink>
             <infoLink id="f42d-0660-b6e1-e4ec" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Bulky 4"/>
+                <modifier type="set" field="name" value="Bulky 4" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="20e3-5bc9-c50e-701d" name="Tooth &amp; Claw" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad11-5a3b-64ea-6b37" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2670-f077-99ec-0ba6" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad11-5a3b-64ea-6b37" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2670-f077-99ec-0ba6" type="max" />
               </constraints>
               <profiles>
                 <profile id="4dd5-183d-e7ca-40a9" name="Tooth &amp; Claw" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1376,27 +1375,27 @@
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="be3c-e80c-0eed-1d72" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule"/>
+                <infoLink id="be3c-e80c-0eed-1d72" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="35f2-f7ef-b668-1962" name="Geri" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc07-9758-0681-1c93" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1b3-6472-b78a-266e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc07-9758-0681-1c93" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1b3-6472-b78a-266e" type="max" />
           </constraints>
           <profiles>
             <profile id="4176-e237-72b2-3472" name="Geri" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish, Light, Unique)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">10&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">10"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">7</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">0</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">5</characteristic>
@@ -1412,36 +1411,36 @@
           <infoLinks>
             <infoLink id="2af5-af5f-5728-b099" name="Rampage (X)" hidden="false" targetId="3efb-2a2c-2d0b-92fc" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Rampage (2)"/>
+                <modifier type="set" field="name" value="Rampage (2)" />
               </modifiers>
             </infoLink>
             <infoLink id="a6be-a034-9a33-2564" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+                <modifier type="set" field="name" value="Hammer of Wrath (1)" />
               </modifiers>
             </infoLink>
             <infoLink id="df19-bdb8-3662-d1c8" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+                <modifier type="set" field="name" value="Feel No Pain (5+)" />
               </modifiers>
             </infoLink>
-            <infoLink id="2e55-b860-71d0-4d05" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
+            <infoLink id="2e55-b860-71d0-4d05" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule" />
             <infoLink id="f69f-c1bf-3ec8-1266" name="Fear (X)" hidden="false" targetId="21f6-7842-df5c-d2e7" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Fear (1)"/>
+                <modifier type="set" field="name" value="Fear (1)" />
               </modifiers>
             </infoLink>
             <infoLink id="6eda-b140-825e-230f" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Bulky 4"/>
+                <modifier type="set" field="name" value="Bulky 4" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="024e-6aa5-9ac0-10b9" name="Tooth &amp; Claw" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d98e-6bf1-e0c1-9b96" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50d8-515a-b62f-8038" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d98e-6bf1-e0c1-9b96" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50d8-515a-b62f-8038" type="max" />
               </constraints>
               <profiles>
                 <profile id="e720-c3e9-32ab-4be4" name="Tooth &amp; Claw" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1454,20 +1453,20 @@
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="e758-5001-f3b3-bf27" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule"/>
+                <infoLink id="e758-5001-f3b3-bf27" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="3fa0-d6ed-981b-e361" name="Deathsworn Pack" hidden="false" collective="false" import="true" type="unit">
@@ -1480,30 +1479,30 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="daf2-8f35-a6b7-4d1c" name="Legiones Astartes (Space Wolves) " hidden="false" targetId="f806-8d12-07ab-fdaf" type="rule"/>
+        <infoLink id="daf2-8f35-a6b7-4d1c" name="Legiones Astartes (Space Wolves) " hidden="false" targetId="f806-8d12-07ab-fdaf" type="rule" />
         <infoLink id="8929-038e-d235-dbc6" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Counter Attack (1)"/>
+            <modifier type="set" field="name" value="Counter Attack (1)" />
           </modifiers>
         </infoLink>
-        <infoLink id="0fbd-20ec-9b4a-b6ae" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="0fbd-20ec-9b4a-b6ae" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="e579-d4c0-6f64-2eb2" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="1ebc-e9e5-35d4-88c3" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="81a2-f758-8265-d1a6" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="e579-d4c0-6f64-2eb2" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="1ebc-e9e5-35d4-88c3" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="81a2-f758-8265-d1a6" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="70ee-9357-f7f6-2275" name="Deathsworn" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2fb-2647-c6bc-16dd" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d59e-7bac-0b11-2529" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2fb-2647-c6bc-16dd" type="max" />
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d59e-7bac-0b11-2529" type="min" />
           </constraints>
           <profiles>
             <profile id="859d-927d-32d1-8db8" name="Deathsworn" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1517,40 +1516,40 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="8fbd-8f9c-1880-dc48" name="Ymira Class Stasis Bombs" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d36-173b-aaef-e588" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d5d-9afd-4639-b6c7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d36-173b-aaef-e588" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d5d-9afd-4639-b6c7" type="max" />
           </constraints>
           <profiles>
             <profile id="ad6c-64b3-35cf-c8eb" name="Ymira Class Stasis Bombs" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
               <characteristics>
-                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Any units which successfully Charges a unit that includes one or more models with Ymira Class Stasis Bombs must make a Disordered Charge. In addition, the controlling player of a unit that includes any models with Ymira Class Stasis Bombs may choose to activate the Ymira Class Stasis Bombs when declaring a Charge for that unit, before any dice are rolled to determine Charge Distance. The Ymira Class Stasis Bombs remain activated until the start of the controlling player&apos;s next turn, and may be activated again if another Charge is later declared for that unit. Whilst activated, all models with Ymira Class Stasis Bombs must add both Fleshbane and Gets Hot special rule to all attacks made during the Fight Sub-phase. All Wounds inflicted by the Gets Hot special rule on a model with an activated Ymira Class Stasis Bomb are resolved using the AP value of the weapon the model with Ymira Class Stasis Bombs is using to attack.</characteristic>
+                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Any units which successfully Charges a unit that includes one or more models with Ymira Class Stasis Bombs must make a Disordered Charge. In addition, the controlling player of a unit that includes any models with Ymira Class Stasis Bombs may choose to activate the Ymira Class Stasis Bombs when declaring a Charge for that unit, before any dice are rolled to determine Charge Distance. The Ymira Class Stasis Bombs remain activated until the start of the controlling player's next turn, and may be activated again if another Charge is later declared for that unit. Whilst activated, all models with Ymira Class Stasis Bombs must add both Fleshbane and Gets Hot special rule to all attacks made during the Fight Sub-phase. All Wounds inflicted by the Gets Hot special rule on a model with an activated Ymira Class Stasis Bomb are resolved using the AP value of the weapon the model with Ymira Class Stasis Bombs is using to attack.</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="3cd5-bf0d-9f6a-ab2b" name="The entire squad may take:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bde-a8d5-99e0-417c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bde-a8d5-99e0-417c" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="9a66-f226-c9f8-1ec8" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
               </costs>
             </entryLink>
             <entryLink id="3941-9867-37e0-b7ca" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -1559,34 +1558,34 @@
           <modifiers>
             <modifier type="increment" field="e235-1cd8-4c5e-6fbd" value="1.0">
               <repeats>
-                <repeat field="selections" scope="3fa0-d6ed-981b-e361" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70ee-9357-f7f6-2275" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="3fa0-d6ed-981b-e361" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70ee-9357-f7f6-2275" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e235-1cd8-4c5e-6fbd" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e235-1cd8-4c5e-6fbd" type="max" />
           </constraints>
           <selectionEntryGroups>
             <selectionEntryGroup id="618d-0a81-0fff-ddb9" name="One in five models may exchange their Power Axe for:" hidden="false" collective="false" import="true">
               <modifiers>
                 <modifier type="increment" field="c45c-62c9-b771-136a" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="3fa0-d6ed-981b-e361" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70ee-9357-f7f6-2275" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="3fa0-d6ed-981b-e361" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70ee-9357-f7f6-2275" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c45c-62c9-b771-136a" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c45c-62c9-b771-136a" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="6c34-8deb-33ef-6c52" name="Great Frost Blade" hidden="false" collective="false" import="true" targetId="49f0-b021-37b6-fc8a" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="9e13-26cb-7006-8144" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1595,21 +1594,21 @@
           <entryLinks>
             <entryLink id="bace-2178-054a-9e1b" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="221b-ce0b-5dd1-d555" name="Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1157-1303-3b3f-1ef5" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1157-1303-3b3f-1ef5" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="d939-00a5-000c-6528" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1618,7 +1617,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1627,7 +1626,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1638,37 +1637,37 @@
       <entryLinks>
         <entryLink id="0019-3b95-65ee-5a37" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95a2-1260-622e-cb6f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8b6-beb4-0a35-d4b8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95a2-1260-622e-cb6f" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8b6-beb4-0a35-d4b8" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="eaa8-acd5-2302-d5f9" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0856-d7d6-db8d-7d9e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="459e-f9bb-cf76-21f9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0856-d7d6-db8d-7d9e" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="459e-f9bb-cf76-21f9" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="8cf9-c431-4919-8263" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a4b-5ef4-8666-fb6c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="817b-324d-fb80-fc47" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a4b-5ef4-8666-fb6c" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="817b-324d-fb80-fc47" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="d2c5-d1fa-7c94-03e6" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca3e-112a-326d-6564" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6614-29ac-ac84-de7c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca3e-112a-326d-6564" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6614-29ac-ac84-de7c" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="99d1-d8c5-04db-bb2b" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c83-3226-2f1e-f074" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56b8-1ee0-5a5b-a11b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c83-3226-2f1e-f074" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56b8-1ee0-5a5b-a11b" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="9359-61a5-fcdb-c28e" name="Varagyr Wolf Guard Terminator Squad" hidden="false" collective="false" import="true" type="unit">
@@ -1678,47 +1677,47 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="4112-2bbe-38a5-76f5" name="Legiones Astartes (Space Wolves) " hidden="false" targetId="f806-8d12-07ab-fdaf" type="rule"/>
+        <infoLink id="4112-2bbe-38a5-76f5" name="Legiones Astartes (Space Wolves) " hidden="false" targetId="f806-8d12-07ab-fdaf" type="rule" />
         <infoLink id="b783-d078-7768-9e9d" name="Fear (X)" hidden="false" targetId="21f6-7842-df5c-d2e7" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Fear (1)"/>
+            <modifier type="set" field="name" value="Fear (1)" />
           </modifiers>
         </infoLink>
-        <infoLink id="d251-966b-6eb8-7835" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="671b-c1b2-a4b1-3e55" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="d251-966b-6eb8-7835" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="671b-c1b2-a4b1-3e55" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
         <infoLink id="b72b-e2a5-632a-fdb5" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Counter-attack (1)"/>
+            <modifier type="set" field="name" value="Counter-attack (1)" />
           </modifiers>
         </infoLink>
         <infoLink id="a309-1e02-b324-4f95" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (2)"/>
+            <modifier type="set" field="name" value="Hammer of Wrath (2)" />
           </modifiers>
         </infoLink>
         <infoLink id="ef7c-d099-24ed-429d" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="2ee4-2abc-3c87-55e6" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="7469-45b8-1b62-5427" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="0ef2-5d12-a22c-7300" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="38da-50e3-302b-8975" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="2ee4-2abc-3c87-55e6" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="7469-45b8-1b62-5427" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="0ef2-5d12-a22c-7300" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
+        <categoryLink id="38da-50e3-302b-8975" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="075a-c65e-c1eb-2ca9" name="Varagyr" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9444-e11b-ade3-2cba" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c17a-30ff-ab42-8b52" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9444-e11b-ade3-2cba" type="min" />
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c17a-30ff-ab42-8b52" type="max" />
           </constraints>
           <profiles>
             <profile id="f565-590b-f5ce-6959" name="Varagyr" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1734,104 +1733,104 @@
           <selectionEntryGroups>
             <selectionEntryGroup id="7871-c7ea-1fc6-b37a" name="1st Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="516e-3ae3-8334-98c7">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08e2-3413-082f-a1cc" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b48f-dda7-7d3c-e3f8" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08e2-3413-082f-a1cc" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b48f-dda7-7d3c-e3f8" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="516e-3ae3-8334-98c7" name="Frost Axe" hidden="false" collective="false" import="true" targetId="dba2-6933-b915-6196" type="selectionEntry"/>
-                <entryLink id="5365-26e3-1123-13e2" name="Frost Sword" hidden="false" collective="false" import="true" targetId="ee1c-6b24-699a-ef1e" type="selectionEntry"/>
-                <entryLink id="14a7-cc9f-500e-c793" name="Frost Claw" hidden="false" collective="false" import="true" targetId="e919-d961-d007-ad34" type="selectionEntry"/>
+                <entryLink id="516e-3ae3-8334-98c7" name="Frost Axe" hidden="false" collective="false" import="true" targetId="dba2-6933-b915-6196" type="selectionEntry" />
+                <entryLink id="5365-26e3-1123-13e2" name="Frost Sword" hidden="false" collective="false" import="true" targetId="ee1c-6b24-699a-ef1e" type="selectionEntry" />
+                <entryLink id="14a7-cc9f-500e-c793" name="Frost Claw" hidden="false" collective="false" import="true" targetId="e919-d961-d007-ad34" type="selectionEntry" />
                 <entryLink id="f904-18a6-db78-1fdf" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="1255-a3d3-a413-c8a5" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="018d-6a11-819a-0e0a" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="1e96-ad8f-c47d-3296" name="2nd Melee/Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="96a3-dc2d-a073-c43a">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="672c-1154-6bd9-2c18" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e472-03e1-8442-9f32" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="672c-1154-6bd9-2c18" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e472-03e1-8442-9f32" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="96a3-dc2d-a073-c43a" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                <entryLink id="96a3-dc2d-a073-c43a" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry" />
                 <entryLink id="58af-39f6-a102-fd57" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="5749-353c-9469-7c50" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="bcc5-b6a0-5fa8-a692" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="4.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="4.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="0869-9597-bee0-98f1" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="3ff4-773d-f99b-013e" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="2b45-410f-3642-e75d" name="Reaper Autocannon" hidden="false" collective="false" import="true" targetId="b87f-48de-6ced-043b" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="40da-c1e8-44d7-17b4" name="Frost Axe" hidden="false" collective="false" import="true" targetId="dba2-6933-b915-6196" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="ec8a-8c4c-7b80-a56e" name="Frost Claw" hidden="false" collective="false" import="true" targetId="e919-d961-d007-ad34" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="3003-3c2e-6706-d2a3" name="Frost Sword" hidden="false" collective="false" import="true" targetId="ee1c-6b24-699a-ef1e" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="5db6-d3eb-227c-118d" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="9977-8907-aebb-d864" name="Thegn" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bcc-529f-a4fa-473b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df3f-7b6d-4d74-c40c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bcc-529f-a4fa-473b" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df3f-7b6d-4d74-c40c" type="min" />
           </constraints>
           <profiles>
             <profile id="3c7e-c2c4-eba7-bfa2" name="Thegn" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1845,36 +1844,36 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="72ed-7d96-0940-a70d" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="72ed-7d96-0940-a70d" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="123a-39a8-1b6e-8e3e" name="1st Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="6d1f-4f34-170b-58a9">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f97e-cb9c-7247-9a58" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c937-7c0b-bdd7-d788" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f97e-cb9c-7247-9a58" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c937-7c0b-bdd7-d788" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="6d1f-4f34-170b-58a9" name="Frost Axe" hidden="false" collective="false" import="true" targetId="dba2-6933-b915-6196" type="selectionEntry"/>
-                <entryLink id="8048-8751-9c7e-ab2e" name="Frost Claw" hidden="false" collective="false" import="true" targetId="e919-d961-d007-ad34" type="selectionEntry"/>
-                <entryLink id="c60e-7dad-d2d1-c9f7" name="Frost Sword" hidden="false" collective="false" import="true" targetId="ee1c-6b24-699a-ef1e" type="selectionEntry"/>
+                <entryLink id="6d1f-4f34-170b-58a9" name="Frost Axe" hidden="false" collective="false" import="true" targetId="dba2-6933-b915-6196" type="selectionEntry" />
+                <entryLink id="8048-8751-9c7e-ab2e" name="Frost Claw" hidden="false" collective="false" import="true" targetId="e919-d961-d007-ad34" type="selectionEntry" />
+                <entryLink id="c60e-7dad-d2d1-c9f7" name="Frost Sword" hidden="false" collective="false" import="true" targetId="ee1c-6b24-699a-ef1e" type="selectionEntry" />
                 <entryLink id="40bb-a50b-f2e8-fb96" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="9481-4c04-8ab8-f4af" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="eb49-64d5-dc8f-009f" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="339a-7c26-37ff-1de7" name="Great Frost Blade" hidden="false" collective="false" import="true" targetId="49f0-b021-37b6-fc8a" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1883,154 +1882,154 @@
               <entryLinks>
                 <entryLink id="cfe8-2f1a-3457-370b" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c001-a09d-9502-8161" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c001-a09d-9502-8161" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="2664-72e5-084a-3407" name="2nd Melee/Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="a73a-8b73-e4cb-b597">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bd3-4ae0-4c41-bb2a" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d41f-ea94-9fa0-9ccc" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bd3-4ae0-4c41-bb2a" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d41f-ea94-9fa0-9ccc" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="a73a-8b73-e4cb-b597" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                <entryLink id="a73a-8b73-e4cb-b597" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry" />
                 <entryLink id="b0f0-04d1-87d8-ee83" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="29ff-51e3-b047-c272" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="b085-9f30-0972-0358" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="4d2d-683e-7e07-d3c9" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="4.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="4.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="f034-55dc-3456-0a20" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="24dc-23af-b31d-3018" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="c90c-7213-18c2-6734" name="Reaper Autocannon" hidden="false" collective="false" import="true" targetId="b87f-48de-6ced-043b" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="ac63-fd32-3dfd-7789" name="Frost Axe" hidden="false" collective="false" import="true" targetId="dba2-6933-b915-6196" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="d3af-bc5d-0114-b650" name="Frost Claw" hidden="false" collective="false" import="true" targetId="e919-d961-d007-ad34" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="1e56-430c-9c22-bb55" name="Frost Sword" hidden="false" collective="false" import="true" targetId="ee1c-6b24-699a-ef1e" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="1ee9-5292-7560-083a" name="1) One Varagyr may take:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="094e-9a19-c9c5-5b6b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="094e-9a19-c9c5-5b6b" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="405f-36b9-5e78-6bb1" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fda7-5e8d-3a5c-8293" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fda7-5e8d-3a5c-8293" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="15eb-5d0d-2691-9283" name="2) Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c4c-af4a-58c3-14c3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c4c-af4a-58c3-14c3" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="575c-a529-2c44-7d7a" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="9359-61a5-fcdb-c28e" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="selections" scope="9359-61a5-fcdb-c28e" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="a48f-8638-d56c-edef" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"/>
+            <entryLink id="a48f-8638-d56c-edef" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="db05-98c2-3719-2118" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry"/>
+        <entryLink id="db05-98c2-3719-2118" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="4bbf-f3df-7b18-4a49" name="Grey Slayer Pack" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="93fd-8b85-2340-ab02" name="Heart of the Legion" hidden="false" targetId="c0dd-9002-2ebd-f96d" type="rule"/>
-        <infoLink id="d615-5cfc-48ae-91e1" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="93fd-8b85-2340-ab02" name="Heart of the Legion" hidden="false" targetId="c0dd-9002-2ebd-f96d" type="rule" />
+        <infoLink id="d615-5cfc-48ae-91e1" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="5234-c678-2b0f-0557" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Counter-Attack (1)"/>
+            <modifier type="set" field="name" value="Counter-Attack (1)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="bbe7-7ff2-451e-b829" name="New CategoryLink" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="b448-e7f9-63a5-1209" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="1b8f-457a-d55c-4e91" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
-        <categoryLink id="1d25-440b-a838-dfd4" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="bbe7-7ff2-451e-b829" name="New CategoryLink" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="b448-e7f9-63a5-1209" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="1b8f-457a-d55c-4e91" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false" />
+        <categoryLink id="1d25-440b-a838-dfd4" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2429-5700-81ec-f055" name="  Huscarl" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85dd-3fb3-7d19-70da" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5269-10b1-4553-422e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85dd-3fb3-7d19-70da" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5269-10b1-4553-422e" type="min" />
           </constraints>
           <profiles>
             <profile id="bcee-a24c-39ef-4127" name="Huscarl" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="4bbf-f3df-7b18-4a49" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                    <condition field="selections" scope="4bbf-f3df-7b18-4a49" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Skirmish, Line)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2044,17 +2043,17 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="a17a-08c9-3929-eb98" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="a17a-08c9-3929-eb98" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="b309-5e5b-0e38-3a11" name="3) May exchange his Bolt Pistol and Fenrisian Axe for:" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="536b-3e6f-5250-9230" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="536b-3e6f-5250-9230" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="0465-ca6a-124f-209d" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -2063,101 +2062,101 @@
               <modifiers>
                 <modifier type="set" field="fb6c-b751-79ee-88d1" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="2429-5700-81ec-f055" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b309-5e5b-0e38-3a11" type="equalTo"/>
+                    <condition field="selections" scope="2429-5700-81ec-f055" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b309-5e5b-0e38-3a11" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="53e4-06cb-4cac-0222" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="2429-5700-81ec-f055" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b309-5e5b-0e38-3a11" type="equalTo"/>
+                    <condition field="selections" scope="2429-5700-81ec-f055" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b309-5e5b-0e38-3a11" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="53e4-06cb-4cac-0222" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fb6c-b751-79ee-88d1" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="53e4-06cb-4cac-0222" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fb6c-b751-79ee-88d1" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="3133-1be5-8c07-a7a3" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="2c24-689e-e6e0-b531" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="1f4b-6771-0f9b-0e7d" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+                <entryLink id="1f4b-6771-0f9b-0e7d" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="5269-1810-eeb0-2cf4" name="1) May exchange his Fenrisian Axe for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="bbcb-c9bc-3433-6889">
               <modifiers>
                 <modifier type="set" field="6a95-9b57-cb97-2b06" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="2429-5700-81ec-f055" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b309-5e5b-0e38-3a11" type="equalTo"/>
+                    <condition field="selections" scope="2429-5700-81ec-f055" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b309-5e5b-0e38-3a11" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="ca41-11c6-3c0c-2a19" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="2429-5700-81ec-f055" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b309-5e5b-0e38-3a11" type="equalTo"/>
+                    <condition field="selections" scope="2429-5700-81ec-f055" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b309-5e5b-0e38-3a11" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6a95-9b57-cb97-2b06" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ca41-11c6-3c0c-2a19" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6a95-9b57-cb97-2b06" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ca41-11c6-3c0c-2a19" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="5610-d71e-909e-4b0f" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+                <entryLink id="5610-d71e-909e-4b0f" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
                 <entryLink id="2292-9d2f-ce2a-da8d" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="e2b3-f5e8-e91a-0443" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="534f-377a-57a4-966c" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="bbcb-c9bc-3433-6889" name="Fenrisian Axe" hidden="false" collective="false" import="true" targetId="72ba-d2df-d98b-8b5d" type="selectionEntry"/>
+                <entryLink id="bbcb-c9bc-3433-6889" name="Fenrisian Axe" hidden="false" collective="false" import="true" targetId="72ba-d2df-d98b-8b5d" type="selectionEntry" />
                 <entryLink id="e46b-2d16-6319-333b" name="Frost Claw" hidden="false" collective="false" import="true" targetId="e919-d961-d007-ad34" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="876e-674d-daf1-b829" name="Frost Sword" hidden="false" collective="false" import="true" targetId="ee1c-6b24-699a-ef1e" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="2437-e7ff-31b9-eb16" name="Frost Axe" hidden="false" collective="false" import="true" targetId="dba2-6933-b915-6196" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="fb7e-ae9d-aa65-63fb" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="aaf8-3be3-a5be-2515" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="841c-23de-1ab4-47b8" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="dd82-bd06-8963-7020" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -2166,38 +2165,38 @@
               <entryLinks>
                 <entryLink id="8ec7-8256-9afc-6cf0" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e220-9d1b-1098-7031" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e220-9d1b-1098-7031" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="4fbc-0bd9-ba0d-e8a1" name="5) Armor" hidden="false" collective="false" import="true" defaultSelectionEntryId="15d6-9386-8033-723d">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f65-94c2-ac9c-3a0b" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be56-90ae-d4c3-fcd5" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f65-94c2-ac9c-3a0b" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be56-90ae-d4c3-fcd5" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="b196-d3d9-df25-bcbb" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e668-66da-cd6a-29af" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e668-66da-cd6a-29af" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="15d6-9386-8033-723d" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da80-0e58-96a0-ab7a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da80-0e58-96a0-ab7a" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2206,19 +2205,19 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="4bbf-f3df-7b18-4a49" value="11.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast"/>
+                <condition field="selections" scope="4bbf-f3df-7b18-4a49" value="11.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47fd-5d87-5fc5-fb4e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47fd-5d87-5fc5-fb4e" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="e660-ad77-0628-6eaa" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -2227,7 +2226,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -2236,7 +2235,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -2245,87 +2244,87 @@
         </selectionEntryGroup>
         <selectionEntryGroup id="7eed-7c35-10cb-c1dd" name="1) Grey Slayers" hidden="false" collective="false" import="true" defaultSelectionEntryId="3817-4281-fe35-c72e">
           <constraints>
-            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e294-a914-7f6c-f4d0" type="max"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79a7-3f45-06f3-beec" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e294-a914-7f6c-f4d0" type="max" />
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79a7-3f45-06f3-beec" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="3817-4281-fe35-c72e" name=" Grey Slayer w/Combat Shield, Fenrisian Axe" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3e4-1fe7-4f21-d3b1" type="max"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3e4-1fe7-4f21-d3b1" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="5a66-18dc-57cb-deff" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+                <infoLink id="5a66-18dc-57cb-deff" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile" />
               </infoLinks>
               <entryLinks>
                 <entryLink id="9427-5ae1-4dbf-78f6" name="Fenrisian Axe" hidden="false" collective="false" import="true" targetId="394d-2287-e1bc-2ba1" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4957-23b7-dcf2-0e55" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f13f-7ec4-0c7b-f8c6" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4957-23b7-dcf2-0e55" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f13f-7ec4-0c7b-f8c6" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="9733-960c-71bd-fec2" name="Combat Shield" hidden="false" collective="true" import="true" targetId="7f4a-84b2-f992-4558" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6ae-3661-8d9a-26b0" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7414-6453-5515-19e2" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6ae-3661-8d9a-26b0" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7414-6453-5515-19e2" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="859f-9945-1a77-2d77" name=" Grey Slayer w/Combat Shield, Power Axe" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0591-2e71-4bc7-c0f2" type="max"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0591-2e71-4bc7-c0f2" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="93c3-ce1a-2f86-0620" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+                <infoLink id="93c3-ce1a-2f86-0620" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile" />
               </infoLinks>
               <entryLinks>
                 <entryLink id="9afa-1e8c-f2fb-95b9" name="Combat Shield" hidden="false" collective="false" import="true" targetId="7f4a-84b2-f992-4558" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e73f-a252-dd36-0b26" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e5d-bb79-2d6f-f404" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e73f-a252-dd36-0b26" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e5d-bb79-2d6f-f404" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="a299-e104-59e1-b324" name="Power Axe" hidden="false" collective="false" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2955-63af-73d5-6ebe" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d23b-1841-6398-dc15" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2955-63af-73d5-6ebe" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d23b-1841-6398-dc15" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="ed00-a72f-bbb4-429d" name=" Grey Slayer w/Bolter, Power Sword" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f469-4a17-5017-6460" type="max"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f469-4a17-5017-6460" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="0c0a-f2a8-bd18-00b8" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+                <infoLink id="0c0a-f2a8-bd18-00b8" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile" />
               </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="01fe-956a-8c5b-ad37" name="Bayonet:" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ce5-8d93-e0c6-dc1e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ce5-8d93-e0c6-dc1e" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="059f-4905-ef17-a1f6" name="Bayonet" hidden="false" collective="false" import="true" targetId="8413-55c8-60ce-e9bf" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32bb-f88e-3ebd-a0ca" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32bb-f88e-3ebd-a0ca" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="ec10-dae2-7375-322d" name="Chain Bayonet" hidden="false" collective="false" import="true" targetId="45bb-31b1-8ed3-7c95" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93f0-b08b-5bd2-dd8c" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93f0-b08b-5bd2-dd8c" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -2334,112 +2333,112 @@
               <entryLinks>
                 <entryLink id="7080-9ced-0f34-5c4c" name="Power Sword" hidden="false" collective="true" import="true" targetId="fa06-cac0-3d98-125e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1056-701d-2289-1e38" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a852-ade7-7de0-f1ca" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1056-701d-2289-1e38" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a852-ade7-7de0-f1ca" type="min" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="0450-d715-3c18-4f3f" name="Power Sword" hidden="false" collective="true" import="true" targetId="fa06-cac0-3d98-125e" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e03-f4b6-2689-b463" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7fe-928f-15af-991e" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e03-f4b6-2689-b463" type="max" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7fe-928f-15af-991e" type="min" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="dc4f-bed8-6b42-c180" name="Bolter" hidden="false" collective="false" import="true" targetId="a080-c391-6083-5e5d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0449-2ae7-3f89-05b5" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eae2-8852-4045-61ca" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0449-2ae7-3f89-05b5" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eae2-8852-4045-61ca" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="fc48-8eea-bc4e-f014" name="Grey Slayer w/ Options" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
-                <infoLink id="e480-d8fd-c483-ab4c" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+                <infoLink id="e480-d8fd-c483-ab4c" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile" />
               </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="9c8b-06cd-57f8-921a" name="4) May take:" hidden="false" collective="false" import="true">
                   <entryLinks>
                     <entryLink id="cda8-bb14-4fca-8692" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf38-4431-7de3-e486" type="max"/>
-                        <constraint field="selections" scope="4bbf-f3df-7b18-4a49" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0730-148c-a481-0718" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf38-4431-7de3-e486" type="max" />
+                        <constraint field="selections" scope="4bbf-f3df-7b18-4a49" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0730-148c-a481-0718" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="5343-4a66-5c51-9020" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1939-1f0c-d4e0-555d" type="max"/>
-                        <constraint field="selections" scope="4bbf-f3df-7b18-4a49" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b876-7a58-b9b2-344c" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1939-1f0c-d4e0-555d" type="max" />
+                        <constraint field="selections" scope="4bbf-f3df-7b18-4a49" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b876-7a58-b9b2-344c" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="c388-fd8d-3c79-988c" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="4bbf-f3df-7b18-4a49" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fd6b-6711-c618-27f5" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05e4-4ca8-c17e-fa78" type="max"/>
+                        <constraint field="selections" scope="4bbf-f3df-7b18-4a49" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fd6b-6711-c618-27f5" type="max" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05e4-4ca8-c17e-fa78" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="eab9-00c1-865d-7b0e" name="2) Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="cef9-cc05-66fc-915b">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b80-dca0-a3b1-460e" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cad1-d1a6-c3d7-5155" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b80-dca0-a3b1-460e" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cad1-d1a6-c3d7-5155" type="max" />
                   </constraints>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="a4a9-eb1f-8b46-6701" name="One in Five may take:" hidden="false" collective="false" import="true">
                       <modifiers>
                         <modifier type="increment" field="a565-9f21-a76e-58cf" value="1.0">
                           <repeats>
-                            <repeat field="selections" scope="4bbf-f3df-7b18-4a49" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                            <repeat field="selections" scope="4bbf-f3df-7b18-4a49" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                           </repeats>
                         </modifier>
                       </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="be92-8d23-28bb-854d" type="max"/>
-                        <constraint field="selections" scope="4bbf-f3df-7b18-4a49" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a565-9f21-a76e-58cf" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="be92-8d23-28bb-854d" type="max" />
+                        <constraint field="selections" scope="4bbf-f3df-7b18-4a49" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a565-9f21-a76e-58cf" type="max" />
                       </constraints>
                       <entryLinks>
                         <entryLink id="25c4-377d-5a6f-92d3" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eae5-b396-2987-e7a7" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eae5-b396-2987-e7a7" type="max" />
                           </constraints>
                           <costs>
-                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                           </costs>
                         </entryLink>
                         <entryLink id="7232-bb03-f480-a0d9" name="Heavy Chainsword" hidden="false" collective="false" import="true" targetId="ba92-3eda-3a71-dabb" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cfd-6fb3-4f29-c1cf" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cfd-6fb3-4f29-c1cf" type="max" />
                           </constraints>
                           <costs>
-                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                           </costs>
                         </entryLink>
                         <entryLink id="42f8-d5ac-400c-221a" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc08-4607-7a8e-bc8a" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc08-4607-7a8e-bc8a" type="max" />
                           </constraints>
                           <costs>
-                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                           </costs>
                         </entryLink>
                       </entryLinks>
@@ -2448,70 +2447,70 @@
                   <entryLinks>
                     <entryLink id="cef9-cc05-66fc-915b" name="Fenrisian Axe" hidden="false" collective="false" import="true" targetId="72ba-d2df-d98b-8b5d" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92ff-c1c8-b127-7a5b" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92ff-c1c8-b127-7a5b" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="20d5-88be-2cde-77d4" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c154-7326-14c8-14df" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c154-7326-14c8-14df" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="b197-8529-1b80-c712" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20e9-0524-4f88-7234" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20e9-0524-4f88-7234" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="0a29-0761-ce94-f299" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17ae-f3ff-2d03-b6e4" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17ae-f3ff-2d03-b6e4" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="83e6-4734-118e-0748" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ca8-22b5-897d-3a11" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ca8-22b5-897d-3a11" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="d543-e85c-64b3-ecd8" name="3) Pistol Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d6ee-cefb-93a1-9fb2">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6edc-b5ba-8e07-dba1" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae9e-5766-9972-d9f7" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6edc-b5ba-8e07-dba1" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae9e-5766-9972-d9f7" type="min" />
                   </constraints>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="8fc4-5397-dc86-9f16" name="One in Five may take:" hidden="false" collective="false" import="true">
                       <modifiers>
                         <modifier type="increment" field="631e-bc1c-d1d5-56ae" value="1.0">
                           <repeats>
-                            <repeat field="selections" scope="4bbf-f3df-7b18-4a49" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                            <repeat field="selections" scope="4bbf-f3df-7b18-4a49" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                           </repeats>
                         </modifier>
                       </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e47a-d9f6-8d02-f40a" type="max"/>
-                        <constraint field="selections" scope="4bbf-f3df-7b18-4a49" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="631e-bc1c-d1d5-56ae" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e47a-d9f6-8d02-f40a" type="max" />
+                        <constraint field="selections" scope="4bbf-f3df-7b18-4a49" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="631e-bc1c-d1d5-56ae" type="max" />
                       </constraints>
                       <entryLinks>
                         <entryLink id="0aa3-32c2-8664-56a1" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
                           <costs>
-                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                           </costs>
                         </entryLink>
                         <entryLink id="8baa-4c7f-d68e-ff1f" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                           <costs>
-                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                           </costs>
                         </entryLink>
                       </entryLinks>
@@ -2520,53 +2519,53 @@
                   <entryLinks>
                     <entryLink id="d6ee-cefb-93a1-9fb2" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3156-e23b-074b-9b16" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3156-e23b-074b-9b16" type="max" />
                       </constraints>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="5ae3-f552-811e-6462" name="1) Shield or Bolter" hidden="false" collective="false" import="true" defaultSelectionEntryId="d95d-82be-5371-4f68">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5f0-36f8-acee-727a" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c1c-dbdd-515c-5474" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5f0-36f8-acee-727a" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c1c-dbdd-515c-5474" type="max" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="d95d-82be-5371-4f68" name="Combat Shield" hidden="false" collective="false" import="true" targetId="472a-8297-2c71-3a9c" type="selectionEntry"/>
-                    <entryLink id="9e40-5252-e440-ba1f" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry"/>
+                    <entryLink id="d95d-82be-5371-4f68" name="Combat Shield" hidden="false" collective="false" import="true" targetId="472a-8297-2c71-3a9c" type="selectionEntry" />
+                    <entryLink id="9e40-5252-e440-ba1f" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry" />
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="c830-ff75-317f-45c1" name=" Grey Slayer w/Bolter, Power Axe" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eafc-d323-e557-addc" type="max"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eafc-d323-e557-addc" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="2755-3657-0ca6-05b4" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+                <infoLink id="2755-3657-0ca6-05b4" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile" />
               </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="0672-8a8b-a371-3cf6" name="Bayonet:" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="425d-a2c5-5b25-ca13" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="425d-a2c5-5b25-ca13" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="2faf-10a7-6aa4-e548" name="Bayonet" hidden="false" collective="false" import="true" targetId="8413-55c8-60ce-e9bf" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81b7-128c-9a63-f3ac" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81b7-128c-9a63-f3ac" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="1d52-e42b-2a5b-6d5b" name="Chain Bayonet" hidden="false" collective="false" import="true" targetId="45bb-31b1-8ed3-7c95" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70fc-23a2-b8ac-3e83" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70fc-23a2-b8ac-3e83" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -2575,51 +2574,51 @@
               <entryLinks>
                 <entryLink id="9d3e-7773-2d17-ff16" name="Power Axe" hidden="false" collective="false" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9548-149f-a775-aaa8" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="570e-acaa-0eaf-efc4" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9548-149f-a775-aaa8" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="570e-acaa-0eaf-efc4" type="min" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="6886-fb54-3a4a-4be6" name="Bolter" hidden="false" collective="false" import="true" targetId="a080-c391-6083-5e5d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f25-356a-9053-731f" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfa6-73ab-2d13-f936" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f25-356a-9053-731f" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfa6-73ab-2d13-f936" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="98f2-784e-6eeb-9940" name=" Grey Slayer w/Bolter, Power Maul" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed71-d9e1-d05d-9917" type="max"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed71-d9e1-d05d-9917" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="638d-f604-5753-d1b9" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+                <infoLink id="638d-f604-5753-d1b9" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile" />
               </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="0d0d-54d2-e990-aba6" name="Bayonet:" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2751-4c99-eb26-f03a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2751-4c99-eb26-f03a" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="8325-082d-e31e-91c0" name="Bayonet" hidden="false" collective="false" import="true" targetId="8413-55c8-60ce-e9bf" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5088-018d-329f-6ffb" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5088-018d-329f-6ffb" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="02d4-67f5-2f11-c1ad" name="Chain Bayonet" hidden="false" collective="false" import="true" targetId="45bb-31b1-8ed3-7c95" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97a4-4dda-71e0-e288" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97a4-4dda-71e0-e288" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -2628,51 +2627,51 @@
               <entryLinks>
                 <entryLink id="9256-9972-90ed-be1b" name="Bolter" hidden="false" collective="false" import="true" targetId="a080-c391-6083-5e5d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6cf-c811-1497-f461" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bb0-c24c-beba-7746" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6cf-c811-1497-f461" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bb0-c24c-beba-7746" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="7a36-a5b2-8f48-7d08" name="Power Maul" hidden="false" collective="true" import="true" targetId="98e8-f217-dea9-0493" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1278-aff4-3812-6c4d" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5c8-6cd0-534e-7f65" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1278-aff4-3812-6c4d" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5c8-6cd0-534e-7f65" type="min" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="31e0-f58c-85d7-d5f2" name=" Grey Slayer w/Bolter, Fenrisian Axe" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f3b-8b30-4203-600f" type="max"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f3b-8b30-4203-600f" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="a584-c907-0e0c-d75c" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+                <infoLink id="a584-c907-0e0c-d75c" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile" />
               </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="788a-76c9-78fa-ba60" name="Bayonet:" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="974d-7b8e-41c0-79ef" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="974d-7b8e-41c0-79ef" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="aa67-38b4-8412-eac6" name="Bayonet" hidden="false" collective="false" import="true" targetId="8413-55c8-60ce-e9bf" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df2c-b405-8bbd-1c5f" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df2c-b405-8bbd-1c5f" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="e3b3-414d-95f4-514c" name="Chain Bayonet" hidden="false" collective="false" import="true" targetId="45bb-31b1-8ed3-7c95" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb4d-5940-7850-9890" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb4d-5940-7850-9890" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -2681,48 +2680,48 @@
               <entryLinks>
                 <entryLink id="8d94-e6cd-6bb6-82b2" name="Fenrisian Axe" hidden="false" collective="false" import="true" targetId="394d-2287-e1bc-2ba1" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e72e-9b81-19d1-f268" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac1e-f5c6-57bc-1d93" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e72e-9b81-19d1-f268" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac1e-f5c6-57bc-1d93" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="bdc4-2c1f-1cd6-16bd" name="Bolter" hidden="false" collective="false" import="true" targetId="a080-c391-6083-5e5d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5a0-29b9-b71a-1698" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8c8-1871-8795-2733" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5a0-29b9-b71a-1698" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8c8-1871-8795-2733" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="cc8a-51a3-99db-3e78" name=" Grey Slayer w/Bolter, Power Lance" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41d6-34e1-bd03-fc0c" type="max"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41d6-34e1-bd03-fc0c" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="f865-bc19-79bc-2288" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+                <infoLink id="f865-bc19-79bc-2288" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile" />
               </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="ae61-bacb-8d80-bf2d" name="Bayonet:" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfc9-4f6b-fbf6-b610" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfc9-4f6b-fbf6-b610" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="a3cd-b7d3-e51c-8b76" name="Bayonet" hidden="false" collective="false" import="true" targetId="8413-55c8-60ce-e9bf" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fa3-cfcb-3918-5aaf" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fa3-cfcb-3918-5aaf" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="84e2-e5ca-2a87-a96b" name="Chain Bayonet" hidden="false" collective="false" import="true" targetId="45bb-31b1-8ed3-7c95" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa4c-874a-9349-e02b" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa4c-874a-9349-e02b" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -2731,97 +2730,97 @@
               <entryLinks>
                 <entryLink id="d6a7-89af-9d02-d27b" name="Power Lance" hidden="false" collective="false" import="true" targetId="fca3-4ec1-c581-1ba3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31cf-ea4b-4655-6ae2" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03b8-60b4-7590-e48b" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31cf-ea4b-4655-6ae2" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03b8-60b4-7590-e48b" type="min" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="2d48-73ea-a312-d1eb" name="Bolter" hidden="false" collective="false" import="true" targetId="a080-c391-6083-5e5d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b310-b30e-8a38-b445" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9156-a7c3-dc9a-10a0" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b310-b30e-8a38-b445" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9156-a7c3-dc9a-10a0" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="1f48-0084-7908-cc26" name=" Grey Slayer w/Combat Shield, Power Maul" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2fb-6c4f-bcb5-6f33" type="max"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2fb-6c4f-bcb5-6f33" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="8978-8d5a-a65f-c77b" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+                <infoLink id="8978-8d5a-a65f-c77b" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile" />
               </infoLinks>
               <entryLinks>
                 <entryLink id="680f-5aac-26db-cee1" name="Combat Shield" hidden="false" collective="false" import="true" targetId="7f4a-84b2-f992-4558" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49c0-2a68-b3d2-1977" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3934-76aa-30d3-d0dc" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49c0-2a68-b3d2-1977" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3934-76aa-30d3-d0dc" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="bc33-d031-f1aa-b6a6" name="Power Maul" hidden="false" collective="false" import="true" targetId="98e8-f217-dea9-0493" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ffc-fda0-9ebe-5374" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1be-c891-1265-6638" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ffc-fda0-9ebe-5374" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1be-c891-1265-6638" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="bd6a-c128-08d2-8627" name=" Grey Slayer w/Combat Shield, Power Lance" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d55-8c38-1df0-216f" type="max"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d55-8c38-1df0-216f" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="37e9-d97d-1da8-6edc" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+                <infoLink id="37e9-d97d-1da8-6edc" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile" />
               </infoLinks>
               <entryLinks>
                 <entryLink id="a0ed-8766-a1e7-13af" name="Combat Shield" hidden="false" collective="false" import="true" targetId="7f4a-84b2-f992-4558" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9db-3d33-ec61-65c9" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d421-16b3-59f2-7d5b" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9db-3d33-ec61-65c9" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d421-16b3-59f2-7d5b" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="3326-643e-2ade-7115" name="Power Lance" hidden="false" collective="false" import="true" targetId="fca3-4ec1-c581-1ba3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a98c-8fc7-4890-4082" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a00c-8d09-1472-f62d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a98c-8fc7-4890-4082" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a00c-8d09-1472-f62d" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="0f4d-43c5-f0bd-ea25" name=" Grey Slayer w/Combat Shield, Power Sword" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c526-40b9-27a3-5d74" type="max"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c526-40b9-27a3-5d74" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="6eae-1d7d-02ab-9d95" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile"/>
+                <infoLink id="6eae-1d7d-02ab-9d95" name="Grey Slayer" hidden="false" targetId="a9da-5857-c0e5-aa5c" type="profile" />
               </infoLinks>
               <entryLinks>
                 <entryLink id="fe10-d98a-3819-ed0d" name="Combat Shield" hidden="false" collective="false" import="true" targetId="7f4a-84b2-f992-4558" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="233c-a861-bea3-1892" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bce-c417-1d47-86f4" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="233c-a861-bea3-1892" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bce-c417-1d47-86f4" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="476d-f33f-7577-4d27" name="Power Sword" hidden="false" collective="false" import="true" targetId="fa06-cac0-3d98-125e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d127-c217-524a-4194" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e93-76ef-b675-1e56" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d127-c217-524a-4194" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e93-76ef-b675-1e56" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="17.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2830,61 +2829,61 @@
       <entryLinks>
         <entryLink id="adf1-5261-0138-f50a" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dd5-8cb8-0729-e8ff" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f6e-1c5b-b655-19c3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dd5-8cb8-0729-e8ff" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f6e-1c5b-b655-19c3" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="0df2-f714-4c59-35f0" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="febb-504b-6d67-abd2" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04c6-0a47-2ef6-faea" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="febb-504b-6d67-abd2" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04c6-0a47-2ef6-faea" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="7113-34df-7006-7f65" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e04-d23f-a579-6b6e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e618-d93c-cc00-2318" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e04-d23f-a579-6b6e" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e618-d93c-cc00-2318" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="37.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="37.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="4dbc-6266-853a-5114" name="Grey Stalker Pack" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="32a3-4015-d07a-3db1" name="Heart of the Legion" hidden="false" targetId="c0dd-9002-2ebd-f96d" type="rule"/>
-        <infoLink id="cb15-1672-0494-dfde" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="32a3-4015-d07a-3db1" name="Heart of the Legion" hidden="false" targetId="c0dd-9002-2ebd-f96d" type="rule" />
+        <infoLink id="cb15-1672-0494-dfde" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="9096-601c-a072-2c87" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Counter-Attack (1)"/>
+            <modifier type="set" field="name" value="Counter-Attack (1)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b526-a925-98fa-3c1b" name="New CategoryLink" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="4d9c-b591-869f-72e1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="cebe-84b9-86a9-ad58" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
-        <categoryLink id="b50f-33ce-bd61-3d78" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="b526-a925-98fa-3c1b" name="New CategoryLink" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="4d9c-b591-869f-72e1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="cebe-84b9-86a9-ad58" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false" />
+        <categoryLink id="b50f-33ce-bd61-3d78" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="de06-5384-4447-33ee" name="  Huscarl" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="823e-0135-6fe9-b78a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d0c-bf5e-d824-73b1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="823e-0135-6fe9-b78a" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d0c-bf5e-d824-73b1" type="min" />
           </constraints>
           <profiles>
             <profile id="e877-5c80-b4d5-92c9" name="Huscarl" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="4dbc-6266-853a-5114" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                    <condition field="selections" scope="4dbc-6266-853a-5114" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Skirmish, Line)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2898,29 +2897,29 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="45f3-17a2-f2de-7958" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="45f3-17a2-f2de-7958" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a31a-a800-9e97-7e77" name="4) Wargear" hidden="false" collective="false" import="true">
               <entryLinks>
                 <entryLink id="a0f6-4b27-a43d-bd54" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fd7-f75b-9e54-c41a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fd7-f75b-9e54-c41a" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="9fd4-dedd-0c98-6944" name="3) May exchange his bolt pistol and chainsword for:" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="401e-2a66-c04c-eb0f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="401e-2a66-c04c-eb0f" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="c605-af6e-c224-6146" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -2929,128 +2928,128 @@
               <modifiers>
                 <modifier type="set" field="c91c-5560-09e0-fb70" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="de06-5384-4447-33ee" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9fd4-dedd-0c98-6944" type="equalTo"/>
+                    <condition field="selections" scope="de06-5384-4447-33ee" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9fd4-dedd-0c98-6944" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="e269-4e04-848a-7755" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="de06-5384-4447-33ee" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9fd4-dedd-0c98-6944" type="equalTo"/>
+                    <condition field="selections" scope="de06-5384-4447-33ee" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9fd4-dedd-0c98-6944" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e269-4e04-848a-7755" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c91c-5560-09e0-fb70" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e269-4e04-848a-7755" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c91c-5560-09e0-fb70" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="fa2a-4456-7dc2-c1af" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="ebfb-f5f2-9d64-0c94" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="c610-649b-5621-5183" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+                <entryLink id="c610-649b-5621-5183" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="f668-639d-5a8f-94b6" name="1) Melee Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="e0ec-57a8-8dc7-d16f">
               <modifiers>
                 <modifier type="set" field="4ca1-790e-dfed-51bd" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="de06-5384-4447-33ee" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9fd4-dedd-0c98-6944" type="equalTo"/>
+                    <condition field="selections" scope="de06-5384-4447-33ee" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9fd4-dedd-0c98-6944" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="c346-2ce9-b817-1f10" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="de06-5384-4447-33ee" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9fd4-dedd-0c98-6944" type="equalTo"/>
+                    <condition field="selections" scope="de06-5384-4447-33ee" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9fd4-dedd-0c98-6944" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c346-2ce9-b817-1f10" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ca1-790e-dfed-51bd" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c346-2ce9-b817-1f10" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ca1-790e-dfed-51bd" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="e0ec-57a8-8dc7-d16f" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+                <entryLink id="e0ec-57a8-8dc7-d16f" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
                 <entryLink id="5477-0b75-ff23-c299" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="dbaa-5350-7b61-e0a7" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="e511-4f4d-26ec-2c07" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="7d4a-4b39-0534-6dee" name="Frost Axe" hidden="false" collective="false" import="true" targetId="dba2-6933-b915-6196" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="c2dc-c180-b1c4-9229" name="Frost Claw" hidden="false" collective="false" import="true" targetId="e919-d961-d007-ad34" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="1347-f29c-79ae-8a15" name="Frost Sword" hidden="false" collective="false" import="true" targetId="ee1c-6b24-699a-ef1e" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="5954-423c-8d49-c74e" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="6e51-ddaf-6bbc-f424" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="4d41-f64c-6a5e-c188" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="6caf-800b-35db-535a" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="c8e9-7a5c-bb82-acdc" name="5) Armor" hidden="false" collective="false" import="true" defaultSelectionEntryId="e5d0-b3df-36c7-ab43">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03b7-ac66-6d10-eef2" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0820-63ac-f05b-a474" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03b7-ac66-6d10-eef2" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0820-63ac-f05b-a474" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="0e1b-de41-4c71-76c8" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f53a-1e6f-ec75-c5fe" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f53a-1e6f-ec75-c5fe" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="e5d0-b3df-36c7-ab43" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4733-037a-328a-3c00" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4733-037a-328a-3c00" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -3059,19 +3058,19 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="4dbc-6266-853a-5114" value="11.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast"/>
+                <condition field="selections" scope="4dbc-6266-853a-5114" value="11.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a4d-7e82-5342-320b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a4d-7e82-5342-320b" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="251b-fdf1-6bab-8994" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -3080,7 +3079,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -3089,7 +3088,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -3098,14 +3097,14 @@
         </selectionEntryGroup>
         <selectionEntryGroup id="8394-4c83-24a2-e0ca" name="2) The entire unit may take one of the following options:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1783-bf7c-feb8-d7aa" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1783-bf7c-feb8-d7aa" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="b519-0ff5-0434-12aa" name="Combat Shield" hidden="false" collective="false" import="true" targetId="472a-8297-2c71-3a9c" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="4dbc-6266-853a-5114" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="4dbc-6266-853a-5114" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
@@ -3114,7 +3113,7 @@
               <modifiers>
                 <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="4dbc-6266-853a-5114" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="4dbc-6266-853a-5114" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
@@ -3123,197 +3122,197 @@
         </selectionEntryGroup>
         <selectionEntryGroup id="d553-ff08-9139-822b" name="1) Grey Stalkers" hidden="false" collective="false" import="true" defaultSelectionEntryId="2472-8f6f-6df0-19b9">
           <constraints>
-            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ab2-6b29-93f3-b5b3" type="max"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf05-da1d-123e-1e5e" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ab2-6b29-93f3-b5b3" type="max" />
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf05-da1d-123e-1e5e" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="8f76-5bfd-9088-e7cb" name=" Grey Stalker w/ Fenrisian Axe" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3cad-2fed-f34d-2086" type="max"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3cad-2fed-f34d-2086" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="ba37-3162-9ca2-dd99" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile"/>
+                <infoLink id="ba37-3162-9ca2-dd99" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile" />
               </infoLinks>
               <entryLinks>
                 <entryLink id="1fd5-5f60-6c78-24dc" name="Fenrisian Axe" hidden="false" collective="false" import="true" targetId="394d-2287-e1bc-2ba1" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="365f-e02e-8021-2687" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd0e-148f-dbaa-545e" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="365f-e02e-8021-2687" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd0e-148f-dbaa-545e" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="14.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="14.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="7861-5220-928a-3c81" name=" Grey Stalker w/ Power Axe" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06fe-b505-2913-2ada" type="max"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06fe-b505-2913-2ada" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="bde1-b7f5-43e2-3d7a" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile"/>
+                <infoLink id="bde1-b7f5-43e2-3d7a" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile" />
               </infoLinks>
               <entryLinks>
                 <entryLink id="cfa0-87a3-89be-a6fa" name="Power Axe" hidden="false" collective="true" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcde-fb7f-d082-adf6" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cda-e787-6eef-7c39" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcde-fb7f-d082-adf6" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cda-e787-6eef-7c39" type="min" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="fcdb-5adc-1d89-aac7" name=" Grey Stalker w/ Power Lance" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3372-06f2-49c4-d52e" type="max"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3372-06f2-49c4-d52e" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="054d-10f1-067c-cead" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile"/>
+                <infoLink id="054d-10f1-067c-cead" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile" />
               </infoLinks>
               <entryLinks>
                 <entryLink id="6094-5a13-4f61-0c12" name="Power Lance" hidden="false" collective="false" import="true" targetId="fca3-4ec1-c581-1ba3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a813-b63a-cfce-9136" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81a6-4cd5-70c0-6ec4" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a813-b63a-cfce-9136" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81a6-4cd5-70c0-6ec4" type="min" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="b157-449e-0ddb-6d47" name=" Grey Stalker w/ Power Maul" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f44-8552-2534-7e07" type="max"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f44-8552-2534-7e07" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="cc0d-24a3-a431-9545" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile"/>
+                <infoLink id="cc0d-24a3-a431-9545" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile" />
               </infoLinks>
               <entryLinks>
                 <entryLink id="94c7-d414-bd2e-aadc" name="Power Maul" hidden="false" collective="true" import="true" targetId="98e8-f217-dea9-0493" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f360-7517-c85f-0d2c" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d95-d1af-cbdd-c3d9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f360-7517-c85f-0d2c" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d95-d1af-cbdd-c3d9" type="min" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="af66-5795-41ff-afdb" name=" Grey Stalker w/ Power Sword" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="797a-f56d-70f9-4116" type="max"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="797a-f56d-70f9-4116" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="c169-f0af-b78a-2482" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile"/>
+                <infoLink id="c169-f0af-b78a-2482" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile" />
               </infoLinks>
               <entryLinks>
                 <entryLink id="6b9f-f342-9711-6d3f" name="Power Sword" hidden="false" collective="true" import="true" targetId="fa06-cac0-3d98-125e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f9d-0254-de58-2942" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fb8-f875-4d6e-4f13" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f9d-0254-de58-2942" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fb8-f875-4d6e-4f13" type="min" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="a482-de3c-4324-a64f" name="Grey Stalker w/ Options" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
-                <infoLink id="854e-4e5c-ad06-96ca" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile"/>
+                <infoLink id="854e-4e5c-ad06-96ca" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile" />
               </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="5e09-8755-2cb5-f9d3" name="4) May take:" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43d3-383e-df4e-bf75" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43d3-383e-df4e-bf75" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="d549-7eb5-5b79-6fa1" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d691-708b-c46b-2f7c" type="max"/>
-                        <constraint field="selections" scope="4dbc-6266-853a-5114" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="33cc-96d5-3ab7-3fa6" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d691-708b-c46b-2f7c" type="max" />
+                        <constraint field="selections" scope="4dbc-6266-853a-5114" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="33cc-96d5-3ab7-3fa6" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="19c9-d689-6495-1a82" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1461-e7e8-575f-1b93" type="max"/>
-                        <constraint field="selections" scope="4dbc-6266-853a-5114" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="feb9-ef97-e342-8305" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1461-e7e8-575f-1b93" type="max" />
+                        <constraint field="selections" scope="4dbc-6266-853a-5114" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="feb9-ef97-e342-8305" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="ad50-9550-209a-7c6f" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="4dbc-6266-853a-5114" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d2ff-cb02-9ebd-9c60" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f42-e206-8eb6-78ad" type="max"/>
+                        <constraint field="selections" scope="4dbc-6266-853a-5114" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d2ff-cb02-9ebd-9c60" type="max" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f42-e206-8eb6-78ad" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="26a9-2607-a964-ed94" name="1) Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="fe60-df61-7f5c-00f0">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd35-4c93-3144-e5f0" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1916-8f6e-f160-f336" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd35-4c93-3144-e5f0" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1916-8f6e-f160-f336" type="max" />
                   </constraints>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="61c1-146c-36a9-0ac4" name="One in Five may take:" hidden="false" collective="false" import="true">
                       <modifiers>
                         <modifier type="increment" field="ceb1-d204-ca35-e068" value="1.0">
                           <repeats>
-                            <repeat field="selections" scope="4dbc-6266-853a-5114" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                            <repeat field="selections" scope="4dbc-6266-853a-5114" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                           </repeats>
                         </modifier>
                       </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="773f-52e4-83b0-7de0" type="max"/>
-                        <constraint field="selections" scope="4dbc-6266-853a-5114" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ceb1-d204-ca35-e068" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="773f-52e4-83b0-7de0" type="max" />
+                        <constraint field="selections" scope="4dbc-6266-853a-5114" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ceb1-d204-ca35-e068" type="max" />
                       </constraints>
                       <entryLinks>
                         <entryLink id="df18-e783-bf4e-7c40" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b44-f115-ef2c-14f0" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b44-f115-ef2c-14f0" type="max" />
                           </constraints>
                           <costs>
-                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                           </costs>
                         </entryLink>
                         <entryLink id="26ef-e725-6a58-d454" name="Heavy Chainsword" hidden="false" collective="false" import="true" targetId="ba92-3eda-3a71-dabb" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f498-8ad4-b047-f657" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f498-8ad4-b047-f657" type="max" />
                           </constraints>
                           <costs>
-                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                           </costs>
                         </entryLink>
                         <entryLink id="7af6-e661-2086-2b6b" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b0c-5423-1496-2f57" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b0c-5423-1496-2f57" type="max" />
                           </constraints>
                           <costs>
-                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                           </costs>
                         </entryLink>
                       </entryLinks>
@@ -3322,78 +3321,78 @@
                   <entryLinks>
                     <entryLink id="fe60-df61-7f5c-00f0" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fda-0662-b86f-7f7a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fda-0662-b86f-7f7a" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="d6a2-11f9-cbd4-c70a" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e096-c05f-d4f4-d40f" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e096-c05f-d4f4-d40f" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="5f57-5cb2-e0f8-a4a5" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a087-61ec-9add-296b" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a087-61ec-9add-296b" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="7c1a-2243-e8dd-7e24" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5323-c306-8a8d-5e09" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5323-c306-8a8d-5e09" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="9803-a7a8-5722-be71" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f843-9aad-aaf7-3686" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f843-9aad-aaf7-3686" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="d513-a534-3af0-797f" name="Fenrisian Axe" hidden="false" collective="false" import="true" targetId="72ba-d2df-d98b-8b5d" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2a3-4278-b56d-2b26" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2a3-4278-b56d-2b26" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="40bd-43db-c9d7-4c20" name="2) Pistol Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="eeed-bc3a-bfe5-9417">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3b1-4c85-ed8d-24bc" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="837d-34ec-7a92-e130" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3b1-4c85-ed8d-24bc" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="837d-34ec-7a92-e130" type="min" />
                   </constraints>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="d861-c7ca-77ac-f16b" name="One in Five may take:" hidden="false" collective="false" import="true">
                       <modifiers>
                         <modifier type="increment" field="ced1-65b1-ae5a-05fd" value="1.0">
                           <repeats>
-                            <repeat field="selections" scope="4dbc-6266-853a-5114" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                            <repeat field="selections" scope="4dbc-6266-853a-5114" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                           </repeats>
                         </modifier>
                       </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ec4-d19f-6095-3e87" type="max"/>
-                        <constraint field="selections" scope="4dbc-6266-853a-5114" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ced1-65b1-ae5a-05fd" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ec4-d19f-6095-3e87" type="max" />
+                        <constraint field="selections" scope="4dbc-6266-853a-5114" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ced1-65b1-ae5a-05fd" type="max" />
                       </constraints>
                       <entryLinks>
                         <entryLink id="8ad4-9ec3-724b-90d3" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
                           <costs>
-                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                           </costs>
                         </entryLink>
                         <entryLink id="4fff-0750-704b-06fc" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                           <costs>
-                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                           </costs>
                         </entryLink>
                       </entryLinks>
@@ -3402,7 +3401,7 @@
                   <entryLinks>
                     <entryLink id="eeed-bc3a-bfe5-9417" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8ca-7ffe-5924-e3dc" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8ca-7ffe-5924-e3dc" type="max" />
                       </constraints>
                     </entryLink>
                   </entryLinks>
@@ -3411,127 +3410,127 @@
                   <modifiers>
                     <modifier type="increment" field="2874-ab94-349e-a17b" value="1.0">
                       <repeats>
-                        <repeat field="selections" scope="4dbc-6266-853a-5114" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                        <repeat field="selections" scope="4dbc-6266-853a-5114" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                       </repeats>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="4dbc-6266-853a-5114" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2874-ab94-349e-a17b" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b16-3134-3261-460e" type="max"/>
+                    <constraint field="selections" scope="4dbc-6266-853a-5114" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2874-ab94-349e-a17b" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b16-3134-3261-460e" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="b76e-cebe-fbc4-5897" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71a3-efcd-b938-5dfc" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71a3-efcd-b938-5dfc" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="02a7-ceeb-8689-2273" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e259-5059-ad19-8df9" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e259-5059-ad19-8df9" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="c089-bca0-12d5-467c" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59ba-2ee9-8c0f-857a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59ba-2ee9-8c0f-857a" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="59f5-5a7f-ade3-d088" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e63-c12b-a5a1-4c8d" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e63-c12b-a5a1-4c8d" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="0021-3fef-d4b8-9492" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfac-0723-440c-5b60" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfac-0723-440c-5b60" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="529a-a6b5-ece3-4e6d" name="Volkite Caliver" hidden="false" collective="false" import="true" targetId="9250-490f-abeb-b901" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad47-0173-92be-ff88" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad47-0173-92be-ff88" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="6b9d-8160-a50c-7938" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2685-5d08-a7ce-813a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2685-5d08-a7ce-813a" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="cb36-2e10-ce49-56c3" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="119b-6f37-59e9-043b" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="119b-6f37-59e9-043b" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="4028-65b0-b728-66ab" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1748-3f58-d618-9e77" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1748-3f58-d618-9e77" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="8db5-380a-9862-c66b" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="323c-a298-5a99-7d91" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="323c-a298-5a99-7d91" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="9bb7-1e48-c249-ccef" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f02-07b7-dce9-251e" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f02-07b7-dce9-251e" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="2472-8f6f-6df0-19b9" name=" Grey Stalker w/ Chainsword" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2bb-3a7a-fd75-ed17" type="max"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2bb-3a7a-fd75-ed17" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="d6b4-2d12-4915-90ba" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile"/>
+                <infoLink id="d6b4-2d12-4915-90ba" name="Grey Stalker" hidden="false" targetId="4d62-74ee-7111-a22c" type="profile" />
               </infoLinks>
               <entryLinks>
                 <entryLink id="5139-5148-36db-7ddd" name="Chainsword" hidden="false" collective="false" import="true" targetId="b5b7-b50a-ac86-9173" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cbf-900a-811a-c49d" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="089f-7c35-b77a-75ad" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cbf-900a-811a-c49d" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="089f-7c35-b77a-75ad" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3540,48 +3539,48 @@
       <entryLinks>
         <entryLink id="c04b-6003-771b-a1b7" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7997-f2d6-1d9f-cf40" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c81-9fcf-8938-427e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7997-f2d6-1d9f-cf40" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c81-9fcf-8938-427e" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="0b32-aca6-5152-f9ba" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11c1-a659-bcad-e296" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d371-1231-d98e-bd7d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11c1-a659-bcad-e296" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d371-1231-d98e-bd7d" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="66de-d2f3-f04b-c2a6" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f9c-ae14-c7fa-a171" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="659a-34ee-9b61-692f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f9c-ae14-c7fa-a171" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="659a-34ee-9b61-692f" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="37.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="37.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="b4c7-4f96-122b-7ade" name="Geigor Fell-Hand" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="855f-f43d-fd08-ea00" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="855f-f43d-fd08-ea00" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="d60f-4d22-ec3a-4ff4" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="d837-ea6b-4c27-6d28" name="Skirmish:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
-        <categoryLink id="630f-3af2-6436-6e5f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="ed4d-3332-70b3-36a0" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="d60f-4d22-ec3a-4ff4" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="d837-ea6b-4c27-6d28" name="Skirmish:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false" />
+        <categoryLink id="630f-3af2-6436-6e5f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="ed4d-3332-70b3-36a0" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b7a3-a947-16cc-f6ac" name="Geigor Fell-Hand" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cbd-8789-5ecb-5852" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a45-b6f0-5cec-a469" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cbd-8789-5ecb-5852" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a45-b6f0-5cec-a469" type="max" />
           </constraints>
           <profiles>
             <profile id="de49-5dab-06c5-628f" name="Geigor Fell-Hand" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Skirmish, Unique)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -3595,19 +3594,19 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="6e89-5920-b7b2-13d4" name="Legiones Astartes (Space Wolves) " hidden="false" targetId="f806-8d12-07ab-fdaf" type="rule"/>
-            <infoLink id="f1a9-e3d2-0be3-6591" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+            <infoLink id="6e89-5920-b7b2-13d4" name="Legiones Astartes (Space Wolves) " hidden="false" targetId="f806-8d12-07ab-fdaf" type="rule" />
+            <infoLink id="f1a9-e3d2-0be3-6591" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
             <infoLink id="1f91-dfa6-413c-71b2" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Counter-attack (1)"/>
+                <modifier type="set" field="name" value="Counter-attack (1)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="f0ed-14f1-5946-9a5f" name="The Fell Hand" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cb7-a603-7761-3c2f" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="378d-a031-c386-2f98" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cb7-a603-7761-3c2f" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="378d-a031-c386-2f98" type="max" />
               </constraints>
               <profiles>
                 <profile id="e83a-8757-7a8b-2a7b" name="The Fell Hand" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -3620,113 +3619,113 @@
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="ea26-4733-e457-1736" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="ea26-4733-e457-1736" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
                 <infoLink id="d4e0-578d-a357-075e" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Rending (5+)"/>
+                    <modifier type="set" field="name" value="Rending (5+)" />
                   </modifiers>
                 </infoLink>
                 <infoLink id="5ed8-3e05-1827-9261" name="Reaping Blow (X)" hidden="false" targetId="bd8c-4f52-d682-1b40" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Reaping Blow (1)"/>
+                    <modifier type="set" field="name" value="Reaping Blow (1)" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="910a-c110-7f4b-4a4f" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+                <infoLink id="910a-c110-7f4b-4a4f" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="fa21-074d-e28d-7b2c" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22ac-c031-8778-0030" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1847-17b9-42ea-9850" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22ac-c031-8778-0030" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1847-17b9-42ea-9850" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="33d8-d635-3faa-77cb" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d02-4f97-4850-6a7e" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb2d-1026-7d79-ffd1" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d02-4f97-4850-6a7e" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb2d-1026-7d79-ffd1" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="4eaf-499d-d7ac-d444" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21ca-6f5a-8728-a7e0" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4d1-a7c0-062b-f993" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21ca-6f5a-8728-a7e0" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4d1-a7c0-062b-f993" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="8966-8361-a331-1c36" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a73-bebe-2e82-1389" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b229-dcdd-3b5d-3bbf" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a73-bebe-2e82-1389" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b229-dcdd-3b5d-3bbf" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="0029-c6f7-576e-9d9c" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e95f-a31f-ad42-81b6" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0458-0847-8e55-0ffa" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e95f-a31f-ad42-81b6" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0458-0847-8e55-0ffa" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="1a83-050b-78f3-3a79" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="945f-d52a-0560-bf97" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39e7-c99c-cdb0-8d31" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="945f-d52a-0560-bf97" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39e7-c99c-cdb0-8d31" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="e96e-1a28-d2c3-d269" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="472c-52b1-81d9-2cd1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="472c-52b1-81d9-2cd1" type="max" />
           </constraints>
           <profiles>
             <profile id="7932-5594-7120-436a" name="Crown Breaker" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Geigor Fell-Hand and all models in any friendly unit he has joined gain the Preferred Enemy (Independent Characters) special rule. They also gain the Feel No Pain (4+) special rule when locked in combat with one or more enemy models with the Independent Character special rule. In addition, an army with Geigor Fell-Hand as its Warlord may make an additional Reaction during the opposing player’s Movement phase as long as Geigor Fell-Hand has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Geigor Fell-Hand and all models in any friendly unit he has joined gain the Preferred Enemy (Independent Characters) special rule. They also gain the Feel No Pain (4+) special rule when locked in combat with one or more enemy models with the Independent Character special rule. In addition, an army with Geigor Fell-Hand as its Warlord may make an additional Reaction during the opposing player&#8217;s Movement phase as long as Geigor Fell-Hand has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
-        <entryLink id="5d0f-20a9-4f1b-d39c" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup"/>
+        <entryLink id="5d0f-20a9-4f1b-d39c" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup" />
         <entryLink id="9080-2dcb-f67e-ebb0" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c00c-7608-21ab-bcd0" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aaac-fdb8-424b-596b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c00c-7608-21ab-bcd0" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aaac-fdb8-424b-596b" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="31b6-168b-3c08-14b0" name="Hvarl Red-Blade" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c89d-e03f-7b36-7045" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c89d-e03f-7b36-7045" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="0638-55ed-3f00-f7e8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="1e3f-2a84-0c72-44c8" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="11eb-fb8c-8da9-a2dd" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="b2ea-ff2e-17d8-7c33" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="0638-55ed-3f00-f7e8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="1e3f-2a84-0c72-44c8" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="11eb-fb8c-8da9-a2dd" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="b2ea-ff2e-17d8-7c33" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="02e6-38a7-3cae-faa9" name="Hvarl Red-Blade" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f26-65f8-1cb1-1ace" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7ab-3696-7c48-87b2" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f26-65f8-1cb1-1ace" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7ab-3696-7c48-87b2" type="max" />
           </constraints>
           <profiles>
             <profile id="3fea-0bdf-9594-ccbc" name="Hvarl Red-Blade" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -3745,31 +3744,31 @@
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="3f38-228a-c7a9-fe63" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
-            <infoLink id="2d32-58f1-a5b7-dbe0" name="Legiones Astartes (Space Wolves) " hidden="false" targetId="f806-8d12-07ab-fdaf" type="rule"/>
-            <infoLink id="0e1d-0518-2005-b00c" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-            <infoLink id="31da-2b52-59ad-bdbb" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule"/>
+            <infoLink id="3f38-228a-c7a9-fe63" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule" />
+            <infoLink id="2d32-58f1-a5b7-dbe0" name="Legiones Astartes (Space Wolves) " hidden="false" targetId="f806-8d12-07ab-fdaf" type="rule" />
+            <infoLink id="0e1d-0518-2005-b00c" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+            <infoLink id="31da-2b52-59ad-bdbb" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule" />
             <infoLink id="6305-29eb-16f0-6c03" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Counter-Attack (1)"/>
+                <modifier type="set" field="name" value="Counter-Attack (1)" />
               </modifiers>
             </infoLink>
             <infoLink id="3e46-8e30-a012-b981" name="Fear (X)" hidden="false" targetId="21f6-7842-df5c-d2e7" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Fear (1)"/>
+                <modifier type="set" field="name" value="Fear (1)" />
               </modifiers>
             </infoLink>
             <infoLink id="197e-f213-01c5-d7b1" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Bulky (2)"/>
+                <modifier type="set" field="name" value="Bulky (2)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="59ef-784c-e7af-ed51" name="Hearth-splitter" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2387-21a2-a86e-fc16" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4971-612a-d876-77d9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2387-21a2-a86e-fc16" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4971-612a-d876-77d9" type="max" />
               </constraints>
               <profiles>
                 <profile id="4181-00ff-1c5a-b8df" name="Hearth-splitter" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -3782,81 +3781,81 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="8030-7ce5-cad7-5aa0" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="07fd-c24a-9235-4206" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf90-aaca-1830-f1fe" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e1c-cc03-aa9a-788a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf90-aaca-1830-f1fe" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e1c-cc03-aa9a-788a" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="d1b8-8e97-12a3-afe9" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a1d-2cb2-cc5c-b83e" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8dfd-0a22-b18b-31d7" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a1d-2cb2-cc5c-b83e" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8dfd-0a22-b18b-31d7" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="dc4f-750d-dbea-5007" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b91-4886-39f2-d18c" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f6c-94a7-6d71-083c" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b91-4886-39f2-d18c" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f6c-94a7-6d71-083c" type="min" />
               </constraints>
             </entryLink>
-            <entryLink id="306b-4aff-50c3-3833" name="Tartaros Terminator Armour" hidden="false" collective="false" import="true" targetId="f850-d0af-8663-ccac" type="selectionEntry"/>
+            <entryLink id="306b-4aff-50c3-3833" name="Tartaros Terminator Armour" hidden="false" collective="false" import="true" targetId="f850-d0af-8663-ccac" type="selectionEntry" />
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="f0d2-2948-a929-58ff" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d71-7403-7255-e621" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d71-7403-7255-e621" type="max" />
           </constraints>
           <profiles>
             <profile id="447d-1e9e-b0d4-f911" name="Head-taker" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Hvarl Red-Blade and all models in any friendly unit he joins gain the Preferred Enemy (Infantry) special rule. In addition, an army with Hvarl Red-Blade as its Warlord may make an additional Reaction during their opponent’s Assault phase as long as Hvarl has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Hvarl Red-Blade and all models in any friendly unit he joins gain the Preferred Enemy (Infantry) special rule. In addition, an army with Hvarl Red-Blade as its Warlord may make an additional Reaction during their opponent&#8217;s Assault phase as long as Hvarl has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
         <entryLink id="ccb9-ad21-fe24-ad15" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="167e-2e42-1769-ee97" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0657-8dee-42d9-200f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="167e-2e42-1769-ee97" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0657-8dee-42d9-200f" type="min" />
           </constraints>
         </entryLink>
-        <entryLink id="2aed-2a39-602f-9b7a" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup"/>
+        <entryLink id="2aed-2a39-602f-9b7a" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="210.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="210.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="fcc8-bc3c-e443-eb3f" name="Jorlund Hunter Pack" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="2daf-4203-d5a5-9e8a" name="Scouring Tempest" hidden="false">
-          <description>Once per battle, during the Shooting phase of one of their turns as the Active player, the controlling player of a unit made up entirely of models with this special rule may choose to activate Scouring Tempest before the unit is selected to make a Shooting Attack. Until the end of the Phase, all Flame weapons in the unit gain the Pinning and Torrent (3&quot;) special rules.</description>
+          <description>Once per battle, during the Shooting phase of one of their turns as the Active player, the controlling player of a unit made up entirely of models with this special rule may choose to activate Scouring Tempest before the unit is selected to make a Shooting Attack. Until the end of the Phase, all Flame weapons in the unit gain the Pinning and Torrent (3") special rules.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="afa9-1075-837c-87d1" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule"/>
-        <infoLink id="693a-d7ee-ebb9-7fb5" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
-        <infoLink id="f47d-7db5-4357-2fd8" name="Support Squad" hidden="false" targetId="768e-56d6-ca52-24ae" type="rule"/>
+        <infoLink id="afa9-1075-837c-87d1" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule" />
+        <infoLink id="693a-d7ee-ebb9-7fb5" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule" />
+        <infoLink id="f47d-7db5-4357-2fd8" name="Support Squad" hidden="false" targetId="768e-56d6-ca52-24ae" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="74d4-672b-5d83-787e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="6ea9-87ae-dad3-a06a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="74d4-672b-5d83-787e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="6ea9-87ae-dad3-a06a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="57d5-858f-5248-0053" name="Hunters" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73bc-0e2a-67bb-12cb" type="min"/>
-            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa54-7511-a5da-4073" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73bc-0e2a-67bb-12cb" type="min" />
+            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa54-7511-a5da-4073" type="max" />
           </constraints>
           <profiles>
             <profile id="08d2-a1d4-0fd8-f9e5" name="Hunter" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -3876,20 +3875,20 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="0a7d-31ab-699e-1377" name="Hunt-master" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7c9-44a1-e038-afb8" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8363-a9f3-aa89-2386" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7c9-44a1-e038-afb8" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8363-a9f3-aa89-2386" type="min" />
           </constraints>
           <profiles>
             <profile id="a1c3-242b-f58f-02d7" name="Hunt-master" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="fcc8-bc3c-e443-eb3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                    <condition field="selections" scope="fcc8-bc3c-e443-eb3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -3909,25 +3908,25 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="4660-da5d-c2a4-9da0" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="4660-da5d-c2a4-9da0" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="7f67-db6e-5008-8432" name="4) May take:" hidden="false" collective="false" import="true">
               <entryLinks>
                 <entryLink id="d225-144d-9bfe-c9e0" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2ee-fdb4-5324-f0bf" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2ee-fdb4-5324-f0bf" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="5804-bae5-0a56-c0c1" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08da-ed50-d662-9660" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08da-ed50-d662-9660" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -3936,48 +3935,48 @@
               <modifiers>
                 <modifier type="set" field="452e-3a37-d095-ed31" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="0a7d-31ab-699e-1377" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f24f-fadd-cc14-0b73" type="equalTo"/>
+                    <condition field="selections" scope="0a7d-31ab-699e-1377" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f24f-fadd-cc14-0b73" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="25ca-c5ee-22e6-3237" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="0a7d-31ab-699e-1377" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f24f-fadd-cc14-0b73" type="equalTo"/>
+                    <condition field="selections" scope="0a7d-31ab-699e-1377" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f24f-fadd-cc14-0b73" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="25ca-c5ee-22e6-3237" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="452e-3a37-d095-ed31" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="25ca-c5ee-22e6-3237" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="452e-3a37-d095-ed31" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="a367-0726-608c-ce60" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="a642-ff84-caca-d495" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry"/>
+                <entryLink id="a642-ff84-caca-d495" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="956a-d9a5-f5e1-079e" name="1) Melee Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="efaf-47cc-3716-0dfa">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f093-e121-949a-ea38" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b265-8ed5-cd21-36a7" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f093-e121-949a-ea38" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b265-8ed5-cd21-36a7" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="8714-4950-cea4-23c7" name="Frost Axe" hidden="false" collective="false" import="true" targetId="dba2-6933-b915-6196" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="efaf-47cc-3716-0dfa" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+                <entryLink id="efaf-47cc-3716-0dfa" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
                 <entryLink id="96a2-d2d2-2f47-8545" name="Frost Claw" hidden="false" collective="false" import="true" targetId="e919-d961-d007-ad34" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="48ea-51a2-16fb-6034" name="Frost Sword" hidden="false" collective="false" import="true" targetId="ee1c-6b24-699a-ef1e" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -3986,48 +3985,48 @@
               <modifiers>
                 <modifier type="increment" field="3405-7eec-17da-1b10" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="fcc8-bc3c-e443-eb3f" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="fcc8-bc3c-e443-eb3f" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6911-46b0-58aa-50a2" type="max"/>
-                <constraint field="selections" scope="fcc8-bc3c-e443-eb3f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3405-7eec-17da-1b10" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6911-46b0-58aa-50a2" type="max" />
+                <constraint field="selections" scope="fcc8-bc3c-e443-eb3f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3405-7eec-17da-1b10" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="45c1-d262-7e5f-86f0" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07e5-b925-8981-b972" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07e5-b925-8981-b972" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="71d6-41da-af88-c506" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d63-0f82-0497-05e9" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d63-0f82-0497-05e9" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="ce07-7d35-25f1-9f33" name="3) One Hunter may take a:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a38-9f6a-ac48-0b2a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a38-9f6a-ac48-0b2a" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="063a-346e-04b7-40cf" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -4036,25 +4035,25 @@
           <modifiers>
             <modifier type="increment" field="2284-ab10-69b9-2d2b" value="1.0">
               <repeats>
-                <repeat field="selections" scope="fcc8-bc3c-e443-eb3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="57d5-858f-5248-0053" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="fcc8-bc3c-e443-eb3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="57d5-858f-5248-0053" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
             <modifier type="increment" field="a077-fefb-c993-f41c" value="1.0">
               <repeats>
-                <repeat field="selections" scope="fcc8-bc3c-e443-eb3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="57d5-858f-5248-0053" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="fcc8-bc3c-e443-eb3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="57d5-858f-5248-0053" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
-            <modifier type="decrement" field="2284-ab10-69b9-2d2b" value="4.0"/>
+            <modifier type="decrement" field="2284-ab10-69b9-2d2b" value="4.0" />
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a077-fefb-c993-f41c" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2284-ab10-69b9-2d2b" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a077-fefb-c993-f41c" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2284-ab10-69b9-2d2b" type="min" />
           </constraints>
           <entryLinks>
-            <entryLink id="1462-e3ac-ae70-bb66" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+            <entryLink id="1462-e3ac-ae70-bb66" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
             <entryLink id="4a91-ac99-cd10-f4e1" name="Fenrisian Axe" hidden="false" collective="false" import="true" targetId="72ba-d2df-d98b-8b5d" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -4063,19 +4062,19 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="fcc8-bc3c-e443-eb3f" value="11.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
+                <condition field="selections" scope="fcc8-bc3c-e443-eb3f" value="11.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89c1-bc31-b525-56ef" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89c1-bc31-b525-56ef" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="8d37-7cd8-307d-ad2a" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -4084,7 +4083,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -4093,7 +4092,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -4102,7 +4101,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -4111,105 +4110,105 @@
         </selectionEntryGroup>
         <selectionEntryGroup id="59de-6a7b-c4f2-266c" name="2) Hunter Ranged Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="2698-090d-9ef3-6878">
           <modifiers>
-            <modifier type="decrement" field="11d7-74d9-cc57-07da" value="4.0"/>
+            <modifier type="decrement" field="11d7-74d9-cc57-07da" value="4.0" />
             <modifier type="increment" field="b092-cd63-00ce-0c9f" value="1.0">
               <repeats>
-                <repeat field="selections" scope="fcc8-bc3c-e443-eb3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="57d5-858f-5248-0053" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="fcc8-bc3c-e443-eb3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="57d5-858f-5248-0053" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
             <modifier type="increment" field="11d7-74d9-cc57-07da" value="1.0">
               <repeats>
-                <repeat field="selections" scope="fcc8-bc3c-e443-eb3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="57d5-858f-5248-0053" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="fcc8-bc3c-e443-eb3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="57d5-858f-5248-0053" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11d7-74d9-cc57-07da" type="min"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b092-cd63-00ce-0c9f" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11d7-74d9-cc57-07da" type="min" />
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b092-cd63-00ce-0c9f" type="max" />
           </constraints>
           <selectionEntryGroups>
             <selectionEntryGroup id="e411-ee1d-02fa-cb42" name="1 in every 5 models may exchange their hand flamer for:" hidden="false" collective="false" import="true">
               <modifiers>
                 <modifier type="increment" field="092f-9277-0298-749d" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="fcc8-bc3c-e443-eb3f" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="fcc8-bc3c-e443-eb3f" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
                 <modifier type="decrement" field="092f-9277-0298-749d" value="1.0">
                   <conditions>
-                    <condition field="selections" scope="fcc8-bc3c-e443-eb3f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f24f-fadd-cc14-0b73" type="equalTo"/>
+                    <condition field="selections" scope="fcc8-bc3c-e443-eb3f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f24f-fadd-cc14-0b73" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="fcc8-bc3c-e443-eb3f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="092f-9277-0298-749d" type="max"/>
+                <constraint field="selections" scope="fcc8-bc3c-e443-eb3f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="092f-9277-0298-749d" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="88dc-5402-0196-7fc4" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3774-54e5-b545-54fd" type="max"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3774-54e5-b545-54fd" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="cd38-9334-a761-91e8" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97f6-0193-1a3d-91cf" type="max"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97f6-0193-1a3d-91cf" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="2698-090d-9ef3-6878" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry"/>
+            <entryLink id="2698-090d-9ef3-6878" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="d017-4642-6a1d-a660" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97ab-f219-9a8b-8264" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e5f-8003-3c0d-89ae" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97ab-f219-9a8b-8264" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e5f-8003-3c0d-89ae" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="c45c-cd35-ed19-0f15" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fc2-d4d9-fba6-0d95" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bef0-e682-2014-5db5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fc2-d4d9-fba6-0d95" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bef0-e682-2014-5db5" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="45d5-25b0-4ef0-b517" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5fb-c242-b979-ce62" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a6b-9813-e971-fc30" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5fb-c242-b979-ce62" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a6b-9813-e971-fc30" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="f47e-c270-b62a-4205" name="Fenrisian Wolf Pack" publicationId="d0df-7166-5cd3-89fd" hidden="false" collective="false" import="true" type="upgrade">
       <rules>
         <rule id="f58a-d1de-185f-b203" name="Pack Retinue" hidden="false">
-          <description>A Fenrisian Wolf Pack may only be chosen as a Retinue for a model with both the Legiones Astartes (Space Wolves) and Master of the Legion special rules. This Model is referred to as the Fenrisian Wolf Pack’s Leader for the purposes of this special rule. The Fenrisian Wolf Pack does not use up a Force Organisation slot and is considered part of the same unit as the model taken as its Leader. The Fenrisian Wolf Pack must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Fenrisian Wolf Pack during play. A Fenrisian Wolf Pack may not be selected as part of an army without a Leader.</description>
+          <description>A Fenrisian Wolf Pack may only be chosen as a Retinue for a model with both the Legiones Astartes (Space Wolves) and Master of the Legion special rules. This Model is referred to as the Fenrisian Wolf Pack&#8217;s Leader for the purposes of this special rule. The Fenrisian Wolf Pack does not use up a Force Organisation slot and is considered part of the same unit as the model taken as its Leader. The Fenrisian Wolf Pack must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Fenrisian Wolf Pack during play. A Fenrisian Wolf Pack may not be selected as part of an army without a Leader.</description>
         </rule>
       </rules>
       <categoryLinks>
-        <categoryLink id="cd15-57a2-eb52-ba6e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="3fa3-2b6b-9450-df23" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
-        <categoryLink id="902c-d0fe-d4c8-5002" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-        <categoryLink id="a83a-860c-9cb5-1471" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="cd15-57a2-eb52-ba6e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="3fa3-2b6b-9450-df23" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false" />
+        <categoryLink id="902c-d0fe-d4c8-5002" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false" />
+        <categoryLink id="a83a-860c-9cb5-1471" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5b26-1509-991d-f166" name="Fenrisian Wolf" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4121-68b5-4ccf-c9df" type="min"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8457-2b61-452c-4ed0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4121-68b5-4ccf-c9df" type="min" />
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8457-2b61-452c-4ed0" type="max" />
           </constraints>
           <profiles>
             <profile id="2f4c-43e1-93b5-65ed" name="Fenrisian Wolf" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -4229,7 +4228,7 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="aabc-e789-59be-d5a0" name="Claws" hidden="false" collective="false" import="true" type="upgrade">
@@ -4244,12 +4243,12 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -4258,116 +4257,116 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="c07e-1433-35af-1ff0" value="1.0">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e7b1-9c83-2e60-4d2a" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c07e-1433-35af-1ff0" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e7b1-9c83-2e60-4d2a" type="max" />
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c07e-1433-35af-1ff0" type="min" />
       </constraints>
       <selectionEntryGroups>
         <selectionEntryGroup id="f589-7a04-f7ea-baa8" name="  VI: Space Wolves" publicationId="817a-6288-e016-7469" page="197" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8c01-a491-3f4d-b50a" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bdac-ef36-3f47-3f68" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8c01-a491-3f4d-b50a" type="max" />
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bdac-ef36-3f47-3f68" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="cf3a-27a1-3b1b-7c05" name="Howl of Morkai" publicationId="817a-6288-e016-7469" page="197" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d5ae-0851-58f0-6c88" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dfd8-55af-c0b1-314f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d5ae-0851-58f0-6c88" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dfd8-55af-c0b1-314f" type="max" />
               </constraints>
               <profiles>
                 <profile id="e413-6525-493e-0e0e" name="Howl of Morkai" publicationId="817a-6288-e016-7469" page="197" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Once per battle, the controlling player of a Warlord with this Trait may declare the use of this Trait at the start of their player turn. For the duration of that player turn only, all friendly models with the Legiones Astartes (Space Wolves) special rule gain a bonus of +1 Strength if the unit they are part of has successfully Charged an enemy unit. In addition, an army whose Warlord has this Trait may make an additional Reaction in the opposing player’s Movement phase so long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Once per battle, the controlling player of a Warlord with this Trait may declare the use of this Trait at the start of their player turn. For the duration of that player turn only, all friendly models with the Legiones Astartes (Space Wolves) special rule gain a bonus of +1 Strength if the unit they are part of has successfully Charged an enemy unit. In addition, an army whose Warlord has this Trait may make an additional Reaction in the opposing player&#8217;s Movement phase so long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="4887-6ec0-359f-c30d" name="Hunger of the Void" publicationId="817a-6288-e016-7469" page="197" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="734a-c145-f8cb-0609" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7985-58da-5fac-a31b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="734a-c145-f8cb-0609" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7985-58da-5fac-a31b" type="max" />
               </constraints>
               <profiles>
                 <profile id="6e29-489d-0568-d6e1" name="Hunger of the Void" publicationId="817a-6288-e016-7469" page="197" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait gains an additional Wound at the end of any Assault phase in which he inflicts at least one unsaved Wound on an enemy model. This can not increase the Warlord’s Wounds Characteristic above his starting value (including any bonuses from Wargear items like Æther-rune armour), but if this effect is triggered while the Warlord has his maximum possible number of Wounds then he instead gains +1 Attacks and Strength until the end of the controlling player’s next turn. In addition, an army whose Warlord has this Trait may make an additional Reaction in the opposing player’s Assault phase so long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait gains an additional Wound at the end of any Assault phase in which he inflicts at least one unsaved Wound on an enemy model. This can not increase the Warlord&#8217;s Wounds Characteristic above his starting value (including any bonuses from Wargear items like &#198;ther-rune armour), but if this effect is triggered while the Warlord has his maximum possible number of Wounds then he instead gains +1 Attacks and Strength until the end of the controlling player&#8217;s next turn. In addition, an army whose Warlord has this Trait may make an additional Reaction in the opposing player&#8217;s Assault phase so long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="295b-eac5-df48-e3cd" name="Crown Breaker" publicationId="817a-6288-e016-7469" page="197" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9e61-60c8-aa4e-6f38" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ee51-c886-66ed-5c08" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9e61-60c8-aa4e-6f38" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ee51-c886-66ed-5c08" type="max" />
               </constraints>
               <profiles>
                 <profile id="968c-d3e7-0da4-3a35" name="Crown Breaker" publicationId="817a-6288-e016-7469" page="197" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">The Warlord and all models in any unit he has joined gain the Preferred Enemy (Independent Characters) special rule. Those models also gain the Feel No Pain (5+) special rule when locked in combat with one or more enemy models with the Independent Character special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction in the opposing player’s Movement phase so long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">The Warlord and all models in any unit he has joined gain the Preferred Enemy (Independent Characters) special rule. Those models also gain the Feel No Pain (5+) special rule when locked in combat with one or more enemy models with the Independent Character special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction in the opposing player&#8217;s Movement phase so long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="9a01-1242-b70e-4398" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+        <entryLink id="9a01-1242-b70e-4398" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="5408-6204-0336-0ce2" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="f963-1a07-319a-a695" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="f963-1a07-319a-a695" type="max" />
       </constraints>
       <entryLinks>
         <entryLink id="ec29-4fa2-f7c1-fa38" name="Command Squad, Cataphractii" hidden="false" collective="false" import="true" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="98fa-f5c5-68da-a472" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
-        <entryLink id="3df3-f24f-ade5-13a5" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="98fa-f5c5-68da-a472" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
+        <entryLink id="3df3-f24f-ade5-13a5" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="e6b4-bd3b-1d71-963c" name="Retinue (Caster/Speaker)" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acf3-5610-f8a9-7861" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acf3-5610-f8a9-7861" type="max" />
       </constraints>
       <entryLinks>
         <entryLink id="57a5-807e-a642-c6e0" name="Deathsworn Pack" hidden="false" collective="false" import="true" targetId="3fa0-d6ed-981b-e361" type="selectionEntry">
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -4379,7 +4378,7 @@
     <profile id="a9da-5857-c0e5-aa5c" name="Grey Slayer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
       <characteristics>
         <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish, Line)</characteristic>
-        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
         <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
         <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
         <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -4394,7 +4393,7 @@
     <profile id="4d62-74ee-7111-a22c" name="Grey Stalker" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
       <characteristics>
         <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmish, Line)</characteristic>
-        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
         <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
         <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
         <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -4408,6 +4407,6 @@
     </profile>
   </sharedProfiles>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Space Wolves.cat
+++ b/2022 - LA - Space Wolves.cat
@@ -1,6 +1,5 @@
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="ca15-13de-89cb-bbb2" name="LA -   VI: Space Wolves" revision="17" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="28">
-  <entryLinks>
-    <entryLink id="ff53-69d9-ec0b-9caa" name="   VI: Space Wolves" hidden="false" collective="false" import="false" targetId="4916-965e-8339-44f6" type="selectionEntry">
+  <entryLinks><entryLink id="ff53-69d9-ec0b-9caa" name="   VI: Space Wolves" hidden="false" collective="false" import="false" targetId="4916-965e-8339-44f6" type="selectionEntry">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c8c-8356-e2e2-0b04" type="min" />
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1d3-74cd-b6b9-0bf2" type="max" />
@@ -153,959 +152,1957 @@
         <categoryLink id="071a-b942-24b6-7962" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="c875-ee84-11d8-4a4a" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d381-b3e5-f4f3-bbf5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d9a7-e6d3-71e4-c8b4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <entryLink id="c875-ee84-11d8-4a4a" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="b7df-2265-4594-bf7e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6d4-581f-4746-bec3</comment></categoryLink>
+        <categoryLink id="4e9f-4cb2-420a-8770" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_2489-ee2a-45dd-b384</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
-    <entryLink id="1b97-ffd5-a00e-d1c6" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2232-0a88-c640-9737" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="589b-60ee-12ba-45be" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
-    <entryLink id="7d0a-baa4-fef8-2fb6" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink><entryLink id="1b97-ffd5-a00e-d1c6" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b02f-e65f-4a88-a175</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_b87b-bf35-4238-b7c6</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1aff-27af-435e-8102</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_fdf9-4906-4180-a39d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9579-1448-0161-c917" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="74d2-3be1-9300-e5f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="756a-f619-7e21-024b" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="cd05-063f-4295-ab9f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8378-ede4-476d-b657</comment></categoryLink>
+        <categoryLink id="8faa-17e4-46d2-a14d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_d64f-ad19-426c-adf7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
-    <entryLink id="eb51-6d1f-6a43-2a87" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8413-d84d-5496-f2d4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="a66d-6a51-283b-59ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
-    <entryLink id="4368-a60c-a96f-de3a" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9548-32a6-cd08-0fe4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="e7ff-e224-3b47-5afb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
-    <entryLink id="46ca-3578-3252-5279" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink><entryLink id="7d0a-baa4-fef8-2fb6" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_7fd1-8ce8-4d10-82e7</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_eaae-8c43-4d30-898c</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_f67d-8cf3-424f-b491</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_b949-6414-4f3d-b268</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6eb0-486f-577e-5627" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="739a-bfcc-85bb-c8aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7094-3caa-ee44-76e4" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="e5ae-cf8f-4019-bf88" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_ac26-e639-4d53-9b8b</comment></categoryLink>
+        <categoryLink id="c3d2-3220-48d5-b9e3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_49af-0d08-4c7e-8ce6</comment></categoryLink>
+        <categoryLink id="3ba6-d136-406a-a9f1" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_b606-de16-4659-95cd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
-    <entryLink id="2ff8-6ccd-f1f4-1cc7" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink><entryLink id="eb51-6d1f-6a43-2a87" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="cfdc-b894-8560-7a5d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="6823-a6fe-bab9-a971" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
-    <entryLink id="b81f-cbff-a999-972a" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7583-6fa0-4089-a19e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_0e5c-99ab-41d3-a42e</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c296-e8e8-4a7a-989a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_8868-5bcb-4604-ba8e</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2c4b-a1e5-77f2-5345" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="007d-e4b1-66ef-f29a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ea0e-a372-4c0c-b52a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a009-a597-4b51-b228</comment></categoryLink>
+        <categoryLink id="12ea-2a73-4007-bd60" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_24f4-9145-4016-80d4</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
-    <entryLink id="b056-11c6-65e2-4864" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e2d2-2e5d-196a-8ba0" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="1f0d-3ea4-7135-c01a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="bbb1-2e28-a895-2773" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="a048-525e-9d11-0913" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup" />
-        <entryLink id="e59d-0e97-9d74-e9e4" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink><entryLink id="4368-a60c-a96f-de3a" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_e732-7499-47bf-9748</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_81a5-a959-46b7-baa4</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7ec3-447a-4644-b012</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_71e2-c430-4c99-a559</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_df7b-3fb9-4f65-9165</comment>
+                </condition>
               </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-        <entryLink id="b856-09d3-d6e5-88cb" name="Retinue (Caster/Speaker)" hidden="true" collective="false" import="true" targetId="e6b4-bd3b-1d71-963c" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="false">
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-                  </conditions>
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b625-1cef-3057-156c" type="equalTo" />
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e9ab-2cc5-4507-eded" type="equalTo" />
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
-    <entryLink id="0080-caee-e018-2221" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
-      <modifiers>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="34ea-54ce-4192-ab44" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c165-3906-463a-9c73</comment></categoryLink>
+        <categoryLink id="16bd-26c6-45db-aada" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6d1-d14c-473f-be09</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink><entryLink id="46ca-3578-3252-5279" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_27a3-1e4c-4b76-a594</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_d59a-dcd0-44fd-b866</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_0c8b-2b92-49ed-98c7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_bafe-f799-41d9-ac85</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_6369-288c-4fec-a640</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_fe53-8858-41dc-8ec4</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7e17-cec5-beeb-64fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5bbb-6981-bbb6-b22e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="3211-e977-b4b3-e574" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="159a-0184-4f9c-a433" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_3a22-caae-4eea-9bc5</comment></categoryLink>
+        <categoryLink id="3b6e-663c-4102-9b81" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f759-f33e-4698-9f8a</comment></categoryLink>
+        <categoryLink id="b450-8e3f-4676-8559" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_c624-3ae0-46c0-9b06</comment></categoryLink>
       </categoryLinks>
-      <entryLinks>
-        <entryLink id="e994-869a-97db-bfa3" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup" />
-        <entryLink id="1030-323d-58c6-593b" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink><entryLink id="2ff8-6ccd-f1f4-1cc7" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_13b3-ce1e-4f9d-8319</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d681-9d81-4abd-b11b</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a57-e48b-4534-bca5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_1859-5641-4674-9097</comment>
+                </condition>
               </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
-    <entryLink id="ec0e-c9eb-67cb-f9d8" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="c9b7-d77f-9416-29a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ba91-3515-281a-aff7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="d43b-bebe-d264-5cfc" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="053d-d261-450a-a264" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_251a-df5b-4bfd-ad63</comment></categoryLink>
+        <categoryLink id="df89-d370-444c-93ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4644-98ab-4e3f-b1fd</comment></categoryLink>
       </categoryLinks>
-      <entryLinks>
-        <entryLink id="5dda-f970-b0ed-d799" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup" />
-        <entryLink id="e808-f640-509e-7e80" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink><entryLink id="b81f-cbff-a999-972a" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_591d-d028-4663-918d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_0482-c5f9-4c95-9597</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_75a7-971d-4978-a83f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_a7d5-2bfe-4621-ac0c</comment>
+                </condition>
               </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
-    <entryLink id="2c9a-afc1-adf7-ca0a" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1afd-1b9e-18de-c80f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="2055-fb8d-2a40-b95b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
-    <entryLink id="00cf-817e-bd67-0e6d" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="00b6-7a51-ca72-92cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8fe1-aa3a-5a0a-abf2" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
-    <entryLink id="d269-cb1c-f9a7-05a9" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <modifiers>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9f13-b460-4f27-b0cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_31fc-e265-45a7-bb5b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7f01-b48c-4827-5fad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1b83-f323-38b4-92b7" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="e368-f46b-4680-964c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_67c2-df43-44fc-92d1</comment></categoryLink>
+        <categoryLink id="953d-f285-4d0b-a04e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4136-bb4e-4dd4-99f9</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
-    <entryLink id="1b2e-e05b-a2b3-5362" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink><entryLink id="b056-11c6-65e2-4864" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry"><categoryLinks>
+        <categoryLink id="6a2e-dd6c-4e31-9a31" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_2599-24e3-44e5-9568</comment></categoryLink>
+        <categoryLink id="5bae-b906-447d-9316" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_285f-6e56-473b-b2fe</comment></categoryLink>
+        <categoryLink id="7f9b-39b0-4dd3-a85f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_685e-022f-4e2f-a568</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="98d6-f266-4592-baf0" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup"><comment>    template_id_2a38-6544-4267-b584    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="fbaa-e470-4fb1-946c" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_8287-16ff-46ba-9838</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_81c1-fca9-44dc-ba4c</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_6e59-4592-47ef-b76d    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink><entryLink id="0080-caee-e018-2221" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ad5d-3c79-4239-9116</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_60b1-049b-4a5f-85c2</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="301c-085a-e2bf-6a9d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ee9e-2f37-d8ee-d7ff" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="66f4-f6fc-4f8b-b4cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bd6a-0cda-4e0f-80ae</comment></categoryLink>
+        <categoryLink id="92fd-11b5-46cb-8206" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_ae75-7cca-4701-9d56</comment></categoryLink>
+        <categoryLink id="b49e-56fc-4044-aebc" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_e517-62d4-48f7-8174</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
-    <entryLink id="de04-9e9f-bdef-b73f" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <entryLinks>
+        <entryLink id="0250-9d9d-4162-a768" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup"><comment>    template_id_fafb-6414-474a-8a09    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="2b16-3f48-4c29-a2e6" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_1e43-c980-4508-8ec2</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_4140-36a7-4203-b5e9</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_a6a6-9bc7-4d4e-86a7    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink><entryLink id="ec0e-c9eb-67cb-f9d8" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry"><categoryLinks>
+        <categoryLink id="f366-dce4-42b6-92df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fc9d-03d1-4bbd-a1c4</comment></categoryLink>
+        <categoryLink id="917b-c233-4dd3-abdf" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_f51c-73d7-4f29-be1c</comment></categoryLink>
+        <categoryLink id="eb29-8484-4752-9822" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_257d-78c0-4bab-ba65</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="b332-c2a9-4961-8234" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup"><comment>    template_id_ac26-33db-40a7-bdba    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="ab2a-b6ed-4018-9d9e" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_189b-db75-4db6-9fe9</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_cbdb-2500-4e13-876a</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_dc8e-2801-46d6-84f8    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink><entryLink id="2c9a-afc1-adf7-ca0a" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b43b-547f-472e-9076</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8ff9-0498-4540-8552</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fbfe-931a-489b-a589</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f4c3-5aa6-4caa-abf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_17f8-f055-4c9c-b757</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="32b7-0e98-c965-80a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="aa46-ab99-ca1d-d982" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="8ab4-c75b-434f-abe6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f1c8-27fd-4f98-8527</comment></categoryLink>
+        <categoryLink id="ce34-de82-4a0d-b5a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2b20-1a8b-4753-b657</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
-    <entryLink id="96a4-98a1-d338-3f29" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink><entryLink id="00cf-817e-bd67-0e6d" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d876-4430-43a4-aa60" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4207-8d8f-4b1a-836b</comment></categoryLink>
+        <categoryLink id="e0b7-6cd4-437c-86ea" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_2b34-077f-4279-86fb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink><entryLink id="d269-cb1c-f9a7-05a9" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="d338-30bf-599c-51da" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="1226-be2f-2291-9f64" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e112-f7bb-40a2-a18b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6577-e0fb-4fda-834e</comment></categoryLink>
+        <categoryLink id="8788-9654-4d90-aaac" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_5d59-09bf-4566-b7e1</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
-    <entryLink id="3b55-ae51-3e2e-1cfb" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink><entryLink id="1b2e-e05b-a2b3-5362" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"><categoryLinks>
+        <categoryLink id="516b-14e8-4960-99fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_aa93-057d-42f6-82d7</comment></categoryLink>
+        <categoryLink id="d382-ba8f-4059-a25e" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_403c-4e9c-4af5-84ec</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink><entryLink id="de04-9e9f-bdef-b73f" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_23fa-06dd-49f9-a7db</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5b26-059e-40b3-9d93</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f7bf-3a1c-4103-aed8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e355-5827-4bf3-bff8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dd44-e0a8-42a8-bdcc</comment></categoryLink>
+        <categoryLink id="6f5a-cea3-429d-9281" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_c5b0-f9ae-468d-924a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink><entryLink id="96a4-98a1-d338-3f29" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8396-e51c-4e2b-bada</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_13bb-9fb5-4580-92cf</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_bfb8-8125-4548-92f5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25e3-b8f5-4448-a7c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3d0d-8266-4608-ab97" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_f926-27fd-4a92-97a1</comment></categoryLink>
+        <categoryLink id="12a8-2aee-410a-ae00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_82e3-36e1-4e85-8fcb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink><entryLink id="3b55-ae51-3e2e-1cfb" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a7fe-cc33-a15d-5e87" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
         <categoryLink id="7814-2b4d-9ca5-67f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="987c-fcb5-d720-5551" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
-      <modifiers>
+    <entryLink id="987c-fcb5-d720-5551" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_658f-b1ad-4347-a998</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_12bc-3db2-4d28-abce</comment>
+            </condition>
           </conditions>
         </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e4d0-8af0-393c-561a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="17b0-90f5-294f-e909" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
-    <entryLink id="908b-c742-7cba-5421" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_9d83-7691-41d6-8dad</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_add7-ba48-46d4-8a02</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_1fb0-2421-40a4-9e49</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="15f3-c336-e9e6-adbb" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="bf2f-6245-0fd7-e32a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8691-3f54-d9b8-5da5" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="75f2-3cbc-4978-b9f9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7004-b00d-481f-b740</comment></categoryLink>
+        <categoryLink id="02b3-847c-45ea-bab3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4f88-2fc3-491c-bfb7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
-    <entryLink id="e4fd-db7f-0da8-27f1" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="75ca-a855-c8d6-8bdc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7d2c-675b-fd5f-df4a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
-    <entryLink id="42f1-f479-531e-d27c" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4bad-9e6e-11a9-c5e8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="03a9-09d2-055e-e1c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
-    <entryLink id="e640-d1e0-f223-6ae0" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a620-4554-c1bf-9675" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="efe0-5bc8-d758-1037" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
-    <entryLink id="f552-5192-a1ad-3567" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5e37-217a-fc08-955c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="daa5-581f-6bde-0d64" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
-    <entryLink id="7951-37ba-ea97-1fbf" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8e1f-3d06-c16f-92bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6dc9-b166-08bf-9f29" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
-    <entryLink id="4ce1-afcb-a998-139b" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e916-03bd-32d8-4be5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="7890-7142-1f66-e71d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
-    <entryLink id="147f-e6f3-1e59-d1bd" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="42dd-26b2-8549-70f4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="95b9-72ea-e6e8-a5d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
-    <entryLink id="4b91-3302-2321-8f73" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="a587-db17-1128-1fea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="eaba-5d84-966d-b027" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
-    <entryLink id="7d27-f014-42c7-959a" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ca7a-1c7e-26f3-1b35" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="d730-98de-27b8-1dc9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
-    <entryLink id="ccbd-0180-6d11-2b2f" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2fb0-88d0-8fa7-1d55" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="91e0-882d-c9ea-cb04" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
-    <entryLink id="da43-7b82-1390-31c7" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="c0e3-fd94-b038-e378" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="4d53-6abe-4314-1078" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
-    <entryLink id="f17c-af0f-f367-1a2d" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="f5ff-b22c-073c-a1ab" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="1091-c2c4-a4e5-c977" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
-    <entryLink id="2448-3b6a-1eb5-3893" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d7fb-7744-61be-0566" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="2383-9cb4-55c4-4a39" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
-    <entryLink id="7a9b-0add-54e5-d7d2" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5f45-8b44-6274-6ec6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f60e-36a0-9cd8-9a5a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
-    <entryLink id="892d-221b-1bc4-c9a9" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="939e-fc28-3576-7a8f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1049-44d6-18cb-2e84" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
-    <entryLink id="023a-80b2-012b-c1cb" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="df0b-d5b9-a329-79f8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="8eeb-eed3-1ba3-2abb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
-    <entryLink id="40eb-8d27-4e31-9ea7" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d672-c540-c41b-1144" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="524d-6b64-9e34-ba14" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
-    <entryLink id="2187-7689-25c3-8c0f" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7128-ca59-44b3-4ddd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="606d-c437-12c0-b161" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
-    <entryLink id="55ab-e092-3970-348a" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0f02-9cfc-e7b7-17cd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="adb9-c576-f4a8-1f66" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
-    <entryLink id="9dca-1c0b-ac10-a5ab" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="78f4-bc8d-0973-cbde" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="f31d-6560-9b3d-a4dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
-    <entryLink id="26f0-1c70-6b8f-2527" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1cef-7792-976c-030a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="c974-917f-8f19-a199" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
-    <entryLink id="a748-8ade-d505-9718" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7112-795a-da10-6412" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="a416-8088-db2f-998c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
-    <entryLink id="8b7c-7ea0-397c-bd00" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="a632-972c-b2e7-c4a4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="9d6d-c576-79d7-f3ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
-    <entryLink id="9cba-fa2b-41e3-1816" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="84e7-3b48-82f5-a34e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="77b8-a56e-9978-a3a8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
-    <entryLink id="69c5-c19e-f63a-8b1a" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8cc2-2db5-c63f-0a66" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="bc9f-2f0c-cb50-2cc8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
-    <entryLink id="866b-22df-9377-8855" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b129-db81-daf0-788a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="c906-2a18-cfc2-fdd8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
-    <entryLink id="5077-05bd-eafc-1dfd" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8522-1958-3938-5d6a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="d61b-2776-448a-61b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
-    <entryLink id="9438-c576-3b7f-9b59" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6538-afdf-33fd-cbf7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a713-1243-387c-339a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
-    <entryLink id="1240-b7cf-81bd-dfd4" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7690-7c01-df17-0d1b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="8939-91f4-c635-aaed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
-    <entryLink id="5a00-8d61-a643-6566" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d313-44e3-e5a3-f365" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="e673-1a76-b248-687d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
-    <entryLink id="f8f1-c14a-7b0a-3590" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4dec-8968-767d-ff54" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8c70-da6c-df95-38a8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
-    <entryLink id="4e43-5156-847b-8c66" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2818-d9aa-4665-38d3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="e7e2-bb0c-3c4a-0320" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4f47-8982-3457-e4c4" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="c1d2-7ba9-e47e-7428" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup" />
-        <entryLink id="ac31-1fdf-49e6-08d0" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
-    <entryLink id="4492-fa79-5b0b-e40d" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="08f4-136a-4976-1eaf" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="2efe-eb0d-b81b-2d13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ccfd-336b-882c-094a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="350f-07c0-7445-5d21" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup" />
-        <entryLink id="ab8a-99b0-c8fd-1597" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
-    <entryLink id="3bb3-146d-dabd-3a2d" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e002-1378-0466-6b09" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="4cb7-2028-74ba-e85d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="05ec-97d6-2b39-daea" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="544c-b6ec-b730-826e" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup" />
-        <entryLink id="44e8-69eb-9e8b-ef37" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
-    <entryLink id="6902-9449-3896-09d7" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="879c-0510-a1b8-7b67" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f971-7a09-f435-5f91" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
-    <entryLink id="e473-af51-1016-4171" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="5cfc-92f3-531c-d9cc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="2ca2-d227-0c40-e67f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
-    <entryLink id="6e50-e22e-2dac-d62b" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ed7c-c6ef-bd7a-ae22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0511-9ade-d4f4-6f77" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
-    <entryLink id="cd2c-8f8d-c0c7-1898" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="b555-f7b7-5d06-b82e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="6f96-121e-4c10-7560" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
-    <entryLink id="1041-1b38-81e8-e66d" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="023e-71c2-8c55-09be" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="70b5-db33-6588-0cd7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
-    <entryLink id="d982-a7bc-c170-28af" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ef7d-458c-0f51-f990" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="dd7d-df7c-a816-2acb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
-    <entryLink id="727e-bf5c-484d-3964" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2155-1f53-593a-ae03" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="eac3-dadd-28e3-0abb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
-    <entryLink id="e3ec-76e5-e3eb-e644" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="bd76-63cb-6fa9-40eb" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="650f-4395-8d57-116a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
-    <entryLink id="040c-ad2c-82dc-b606" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6eae-1a8a-d099-520a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c84c-de97-d069-ee48" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
-    <entryLink id="2dbf-8f01-ee5e-4e05" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a0f0-da7b-1a9f-fda1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="fac4-5b03-1aa5-eee0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
-    <entryLink id="1bfc-59f7-21fc-9522" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="fe28-67c6-1d19-8b59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="30dc-d245-86c7-92bf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
-    <entryLink id="a685-aac6-ae7f-56ff" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="15ee-4fd1-7633-8bee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5f73-1651-76e6-4403" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
-    <entryLink id="ae13-45b3-410d-db09" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5adc-e50d-7ba6-196b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4826-382e-c68a-ec41" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
-    <entryLink id="d6cf-a3dd-6f9a-c387" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f724-5371-cd99-9a3a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5502-960d-729a-013a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
-    <entryLink id="154c-33e7-c019-5776" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3c8a-32f6-3a0f-3f3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0a2b-76a3-44a3-4ed9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
-    <entryLink id="5b98-7257-55a6-1c70" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d273-5150-7505-021e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="08a6-064b-bb57-b5a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
-    <entryLink id="5faf-84f9-b693-f012" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="912b-f1b7-16cd-fbb2" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="6e0a-37aa-a8e4-ce75" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
-    <entryLink id="2edd-54be-4991-b1fb" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d672-0687-6d82-5a52" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="15c1-78a0-7544-4ba5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
-    <entryLink id="4fcb-24e5-0465-48f5" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink><entryLink id="908b-c742-7cba-5421" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_8ed4-376d-4030-9439</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_8a11-c2a0-4335-99ef</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_fa8e-1af7-4d41-ac8c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_94bd-c771-4a85-8581</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d289-5834-1624-39ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="21b4-3d77-64bd-30f9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="fc73-94b2-f659-179c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="55a3-ba5d-4a5b-adb8" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_361e-fb90-4b0e-ac3d</comment></categoryLink>
+        <categoryLink id="328c-255a-4d32-af10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d4ef-1074-45a9-959e</comment></categoryLink>
+        <categoryLink id="75b1-65b3-4908-8efc" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_febb-f536-4d25-a8ab</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
-    <entryLink id="dafc-d557-9714-d453" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="41fd-85fb-7f01-3ebc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b8e0-0c1d-e3a3-97da" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink><entryLink id="e4fd-db7f-0da8-27f1" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="672f-321b-495d-8c0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_473b-e812-4158-9416</comment></categoryLink>
+        <categoryLink id="cc29-ba3b-4639-a13a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_00a2-63ff-4698-a35b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
-    <entryLink id="96c6-9762-bd80-4224" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink><entryLink id="42f1-f479-531e-d27c" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7cf3-8a72-4f82-8cdc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_228c-5681-4ce8-b726</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_01bb-8abd-4253-9a4d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="89d2-f9bd-e35d-4876" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="15d8-8e3e-60ab-789a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4a90-60c2-4307-8244" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2a08-4432-42ad-bfdb</comment></categoryLink>
+        <categoryLink id="14b1-2992-4760-8ad8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_422e-0808-4897-8630</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
-    <entryLink id="8682-cae9-19c7-632a" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink><entryLink id="e640-d1e0-f223-6ae0" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1af8-4459-4717-8e3b</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_06b4-92b9-438c-b1a5</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6c8d-8b28-417b-9a7c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_715d-8186-4aa6-b40c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_390e-358c-4f8e-ade8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="5ca7-507e-b21e-81cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2b0b-4d09-84dd-afc0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="fabc-1717-4342-84e2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f4c0-4396-4f39-a34f</comment></categoryLink>
+        <categoryLink id="31f3-824b-4fde-aca6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1301-8415-490e-8f06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
-    <entryLink id="c9e1-64bd-499d-4779" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink><entryLink id="f552-5192-a1ad-3567" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d0c9-9a26-4324-b030</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4e9e-a61d-42f2-bacb</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ed9e-b634-4bec-9eb0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4614-ad0f-4fba-adaf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_8d08-24f6-41be-8931</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f68b-6723-43b3-b1ea" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_caf6-5548-4b89-8102</comment></categoryLink>
+        <categoryLink id="6b8a-5631-4fa9-a668" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_63a3-be61-428d-ab29</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink><entryLink id="7951-37ba-ea97-1fbf" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f318-4b03-4767-8c7f</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b8ef-7245-4df8-a8c4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_6bce-ec44-48cb-873a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="595d-99d0-46d0-b799" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0678-4fdd-48e6-8f61</comment></categoryLink>
+        <categoryLink id="f2a4-7f33-4203-875e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0d82-10a9-4de2-8ad7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink><entryLink id="4ce1-afcb-a998-139b" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ada1-1e18-4cbc-9598</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b1d1-ac44-47dd-9159</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5d64-f00c-4464-891b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25f0-f825-4a83-8f0d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_64b1-9e36-44da-b36a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1c2e-5803-4e2b-872e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_d53e-113f-4a40-a3d5</comment></categoryLink>
+        <categoryLink id="4512-cc4d-475d-93c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1939-76b5-4279-9f8c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink><entryLink id="147f-e6f3-1e59-d1bd" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d765-3bb2-4b48-bd12</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_0ca1-cfb4-4a56-ab3b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d691-db2f-243f-21c1" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="353f-9781-1a42-355a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4e06-0cdc-4890-a99c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e6f7-a6ca-4825-bfc5</comment></categoryLink>
+        <categoryLink id="15f9-ab49-4c8d-bbe5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dbec-e027-4ec1-8514</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
-    <entryLink id="0128-944f-c876-31b0" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink><entryLink id="4b91-3302-2321-8f73" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d8ee-81ed-45f9-8b79</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_8f4e-e8cb-4ac9-a415</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a0d4-e561-4398-9be7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_cefb-cfd7-4dc8-99c4</comment></categoryLink>
+        <categoryLink id="f115-8903-4fe8-bbcc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a9fd-9d16-4a5e-855c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink><entryLink id="7d27-f014-42c7-959a" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e76b-46ca-4ab8-a93d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8035-75b8-43bb-97c9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_71a4-31e7-4927-a0ab</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fa6e-dfe5-4b3a-a4cd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_a56d-347b-4b09-a918</comment></categoryLink>
+        <categoryLink id="648a-d112-4751-9c74" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_96e5-4531-4213-903e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink><entryLink id="ccbd-0180-6d11-2b2f" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1fb5-2375-4c22-b41e</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7d7c-255d-49b6-96b9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5321-254b-4890-9bf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ddf8-b8b7-4afb-b6dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4a64-2336-4559-848d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9441-d79b-4720-9667</comment></categoryLink>
+        <categoryLink id="355e-f349-4341-bc6f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7d7e-32d3-4692-b401</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink><entryLink id="da43-7b82-1390-31c7" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_99fc-5fe7-4b37-a62f</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_25f4-f6b8-4b44-8350</comment>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_81f7-2311-4cce-95bc</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_09aa-af2a-4012-91d1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_00ae-fad3-4df6-9cb9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5f0b-2ef2-49a1-805f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f65b-8958-49b3-92a5</comment></categoryLink>
+        <categoryLink id="dcc7-ec1f-4065-8e55" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0451-1929-4942-8c3f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink><entryLink id="f17c-af0f-f367-1a2d" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_edc4-4915-40ba-bbf0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_105f-ba26-4146-bc54</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7a2c-a76c-421c-a8a2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_05c9-0543-47ee-ba81</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e6ad-f0d7-4627-921b</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b36-5ac8-437f-9e3b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c6a8-22a8-4d41-b969</comment></categoryLink>
+        <categoryLink id="0173-ddca-4e50-ac86" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03ca-12cc-4e0a-b628</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink><entryLink id="2448-3b6a-1eb5-3893" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ae67-ef52-4cac-958c</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fc61-7306-4d99-acde</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1be0-67e7-45a1-bdbb</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_42a8-7fda-4e05-af0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8208-b8fc-452e-975a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_565a-1592-491f-8b9b</comment></categoryLink>
+        <categoryLink id="3071-510b-4d95-a70a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_81d5-c14a-42ab-bdde</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink><entryLink id="7a9b-0add-54e5-d7d2" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1ae7-c41b-4818-be71</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_08a5-b1bb-4ba1-ba42</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d677-b5ad-4838-8746</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_537f-bc1f-4aaa-b0dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="698a-41c5-4f93-8040" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bc67-ce1f-4004-aeb7</comment></categoryLink>
+        <categoryLink id="6d5a-495f-4aa3-b03c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_9a45-9699-4475-aeef</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink><entryLink id="892d-221b-1bc4-c9a9" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_c28f-4109-44c4-ab64</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fdc1-a894-48bc-9e7c</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_4936-a68c-4524-9088</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb37-ac0c-49ae-9d6f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="69ab-089f-4f68-a926" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3afe-cfc0-4da6-a985</comment></categoryLink>
+        <categoryLink id="abda-898e-4b99-917c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_04a8-6aae-45ae-bd4c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink><entryLink id="023a-80b2-012b-c1cb" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ae19-30c0-43c5-920e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_6ebe-1bf3-4d78-9dd0</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1887-152d-48b7-b13f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_a7c4-ee6a-4f0b-8ab0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bd85-fa90-47ff-9f84</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_7bd6-9043-4d7e-ba37</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b9c9-e2aa-4051-bc51" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3610-c975-4d55-bdfe</comment></categoryLink>
+        <categoryLink id="6126-acbb-4c05-9fb7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2fc2-f636-4c80-9608</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink><entryLink id="40eb-8d27-4e31-9ea7" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_85c5-d4d9-4b23-9e4d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_80e8-d50b-4906-8153</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_b93b-d4f1-45eb-8a69</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e183-f183-4db7-83b5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0f39-204a-4217-b896</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_eee9-7bfd-4fea-a1bd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="353d-29ad-4cbb-8116" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f81d-9435-4f11-99c1</comment></categoryLink>
+        <categoryLink id="06a0-48a8-4343-80a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9568-6142-4fdd-be3a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink><entryLink id="2187-7689-25c3-8c0f" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_005e-6607-4e2c-8dd2</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_7745-260c-4c36-b719</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_ba25-a4b2-4ba9-b023</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ddeb-f4c8-4091-9153</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4904-fd2f-429f-9cf7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_faea-b21b-43c5-b918</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b9d3-b88b-4b59-b9f2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_b24f-3ae0-4cbb-b016</comment></categoryLink>
+        <categoryLink id="3734-4b61-4a4c-a180" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fd26-8e6b-4521-92b9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink><entryLink id="55ab-e092-3970-348a" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6ecb-28e2-43ed-a6a0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_c067-1118-4d96-b28b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_250e-23c0-4e43-bf74</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1553-a6e6-4291-853f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_aab6-797b-427a-9fd8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dabb-37ef-4a32-b3cb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c77f-0819-473b-a8a2</comment></categoryLink>
+        <categoryLink id="d866-326a-4f70-b83d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_89fb-c924-4daf-923d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink><entryLink id="9dca-1c0b-ac10-a5ab" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d72c-519a-451f-81b6</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_3d16-444c-42c9-aad1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_f4b2-6371-494b-863a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_797f-a84b-42f6-8e66</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0d78-fe38-4829-9b12</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8b97-e65f-4ca6-8882" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0397-c837-4fea-a527</comment></categoryLink>
+        <categoryLink id="5836-6d13-4766-9c3f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_060b-bccb-4776-bd83</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink><entryLink id="26f0-1c70-6b8f-2527" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3c84-6d74-4c42-b38d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_5b15-7aa4-4897-aaf1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_3326-31ed-4151-9b37</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6a0e-1b65-4057-ba5d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f8c7-abc9-45ec-955f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_2538-8dc5-446c-8344</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d1c0-61a7-48fa-b90d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_c1cf-cea4-4278-8f27</comment></categoryLink>
+        <categoryLink id="6d8f-5ff8-4c9e-a80d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5f51-2734-4a46-9f72</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink><entryLink id="a748-8ade-d505-9718" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af71-f3ff-49b1-83e9</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_1c9e-b3bf-4e88-a43f</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_6d0d-1b1d-4065-89cf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d0b7-8686-491e-9d33</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_7db8-0874-487a-be6f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1034-29a0-44b1-a85f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="99bf-5233-4e1c-be12" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_0c16-6841-42b2-b02d</comment></categoryLink>
+        <categoryLink id="096e-97e6-4528-b95a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_602d-2d2d-4ff4-a82a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink><entryLink id="8b7c-7ea0-397c-bd00" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_22bd-baae-45f9-b366</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_52bd-55de-4d53-ba55</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_df1b-7476-4ab8-8d2f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_49fa-0dcf-4a61-a5b1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0ea-1443-4993-86e7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2a8-3fbe-448c-9902</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5644-99f4-46e3-acca" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3632-0b5d-4622-ae33</comment></categoryLink>
+        <categoryLink id="1611-bcd5-4331-8219" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_da44-7815-4fdd-981c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink><entryLink id="9cba-fa2b-41e3-1816" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2bfa-b203-47e2-a828</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a39b-8a3c-49cf-bf62</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2a05-07b3-49c5-8145</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f730-87fb-44bd-b68e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_2d0e-6c49-4493-a022</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2e2-50c1-40c3-b4dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="eedf-ebfd-4132-9cc5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_5ad5-8701-42cd-b2b6</comment></categoryLink>
+        <categoryLink id="9c2a-a315-47c3-9f77" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_20a4-4346-4a3b-a7d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink><entryLink id="69c5-c19e-f63a-8b1a" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_773a-1ea4-41a0-b766</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_9d4d-6fb8-4131-a5a3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e3bc-02f8-4ece-a5ea</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c371-76d9-4a4d-bc00</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b4c6-d4ba-4b2e-9b99</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="957c-8e93-47ab-a45c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6ea9-a7e5-437d-9e35</comment></categoryLink>
+        <categoryLink id="8f82-25d0-4a97-ab19" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_3cec-f053-42ab-a6eb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink><entryLink id="866b-22df-9377-8855" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1e60-42ba-4c8b-9077</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9860-f593-425e-b89b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_c842-10e8-4509-8eda</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ea52-ff41-40f6-8cf3</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_51e6-c5e1-4003-96bc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ae7a-7c11-48fb-94da" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4d7c-201f-4c99-b89a</comment></categoryLink>
+        <categoryLink id="bba6-fb07-4849-9a86" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_10f9-4718-4e07-bb32</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink><entryLink id="5077-05bd-eafc-1dfd" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="548a-d6f2-4079-897d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4e52-ad1b-48d4-8eed</comment></categoryLink>
+        <categoryLink id="78df-065f-46c8-8e10" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_6979-1ed3-4f1f-a025</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink><entryLink id="9438-c576-3b7f-9b59" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry"><categoryLinks>
+        <categoryLink id="dc08-0ef8-41ec-b9a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6140-2404-46f9-bd42</comment></categoryLink>
+        <categoryLink id="1380-be68-4f75-b778" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_1c86-fad8-46ec-a0b0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink><entryLink id="1240-b7cf-81bd-dfd4" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4729-bc86-456b-b73d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_cf0f-e3f4-4fb4-989d</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1cc8-5611-4d9a-9218</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_2e32-ca02-48f0-a8dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7a2c-dbc6-4099-b5f8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_0af1-d052-4bd7-aab6</comment></categoryLink>
+        <categoryLink id="e8ee-1a23-45ce-9d80" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_45ce-e338-43c9-b63e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink><entryLink id="5a00-8d61-a643-6566" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4dce-8632-4f7c-813e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_8a71-3995-4155-ac33</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d206-f2ce-41b8-945a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan">
+                  <comment>    node_id_2e02-cf1c-4a71-861c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ec81-bd33-45a8-8550</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_3344-743c-45d3-b930</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e48c-8501-977d-d4f4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="285b-28b3-e711-7201" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7ade-a8dc-48ca-aef2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4272-9b9d-4c59-95f0</comment></categoryLink>
+        <categoryLink id="597c-95b8-41b2-863b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_d85b-1ae7-40d5-9341</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
-    <entryLink id="1b00-d14d-b1b4-38aa" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="35b2-e100-5f07-093b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="376d-3b99-7653-20f9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink><entryLink id="f8f1-c14a-7b0a-3590" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry"><categoryLinks>
+        <categoryLink id="0060-e508-4793-a9c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ff9f-01cb-41b9-800e</comment></categoryLink>
+        <categoryLink id="2c86-7332-488d-9d32" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_1315-6051-4a46-b070</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
-    <entryLink id="bf65-1ff7-f962-26b5" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink><entryLink id="4e43-5156-847b-8c66" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry"><categoryLinks>
+        <categoryLink id="a397-9a8a-40ca-b71d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_b084-df23-4f99-812f</comment></categoryLink>
+        <categoryLink id="b6a5-8aad-482d-bc2b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_84fc-9304-4e9e-ab78</comment></categoryLink>
+        <categoryLink id="d892-b6d8-41dc-8948" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d06a-7939-4691-9aed</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="e7d4-e503-4fe1-bafb" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup"><comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+        <entryLink id="993a-5fb8-4e03-98ca" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup"><comment>    template_id_741d-8c09-4211-ada6    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink><entryLink id="4492-fa79-5b0b-e40d" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_54a4-6ec8-4c61-9c3e</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_f7fd-2d16-4603-a065</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3366-7d0f-cee2-a67a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="bd50-4ba4-2cc3-80b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="193b-2ba5-4be1-aec7" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_c0ac-4b8c-421c-a21b</comment></categoryLink>
+        <categoryLink id="5c54-036f-4f5d-b7c7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8db9-079e-4482-b200</comment></categoryLink>
+        <categoryLink id="ab30-2254-41f3-b2a4" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_413c-9273-4308-b546</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
-    <entryLink id="8a3b-87e9-09e0-3e53" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1680-22c8-6098-2e71" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="0093-5702-39e7-da16" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      <entryLinks>
+        <entryLink id="2ef4-fbcb-4f95-8fec" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup"><comment>    template_id_bbc4-33fc-4664-a18e    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="da6a-8601-4374-a0b2" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup"><comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink><entryLink id="3bb3-146d-dabd-3a2d" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry"><categoryLinks>
+        <categoryLink id="fab0-baec-4704-bff0" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_4c8d-96f6-48f9-9590</comment></categoryLink>
+        <categoryLink id="025e-155b-4081-9147" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_049c-0fa5-4575-8fa8</comment></categoryLink>
+        <categoryLink id="520a-202b-49ef-9d82" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_7358-52d7-4aae-8e07</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
-    <entryLink id="8cf1-c85b-4c68-6ef4" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+      <entryLinks>
+        <entryLink id="4c4f-ecf1-4eac-9d8e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="4d59-1610-09c5-1991" type="selectionEntryGroup"><comment>    template_id_4784-b370-444b-93ae    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="501e-9a9e-4701-82ac" name="Retinue" hidden="false" collective="false" import="true" targetId="5408-6204-0336-0ce2" type="selectionEntryGroup"><comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink><entryLink id="6902-9449-3896-09d7" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_3c03-a823-4466-9bd6</comment>
           <conditionGroups>
-            <conditionGroup type="and">
+            <conditionGroup type="or">
+              <comment>    node_id_8bbb-f95b-413f-b6f4</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_41b0-6b0a-482a-919e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e1f7-3cc6-4794-8b6d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4eb2-022b-cd69-6152" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="9523-a7ba-a4b6-326b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="381d-83e5-4540-9092" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_05ce-cc31-40ad-9320</comment></categoryLink>
+        <categoryLink id="d0e2-4440-44af-8c13" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f13c-f8e1-4a50-bfe3</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
-    <entryLink id="30fc-7395-212a-8799" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b3d4-4d1a-a01a-4bf5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="3604-8de1-1c45-a66c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
-    <entryLink id="0ad2-daf8-8b18-c43b" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3774-a720-3191-578c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="65ed-1dc6-9c7f-0c1b" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
-        <categoryLink id="e3cb-0d6f-62b7-5297" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
-    <entryLink id="3623-c92a-36d6-f65a" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="cff0-5f02-eb91-8d00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4082-670a-a9ca-8ac1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
-    <entryLink id="72d1-2201-1bf6-c35a" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink><entryLink id="e473-af51-1016-4171" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_db78-4d49-42ab-954a</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_f14d-9943-47b6-866c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a95-938f-4a07-9727</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_7775-78e1-44cc-87c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0627-08cc-4c9c-b515" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_b822-3417-4613-be37</comment></categoryLink>
+        <categoryLink id="3193-ae77-4023-a5ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_25db-b03f-4881-b310</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink><entryLink id="6e50-e22e-2dac-d62b" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry"><categoryLinks>
+        <categoryLink id="516a-fa8b-42f1-8bfe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_75a7-dc06-445b-b2dc</comment></categoryLink>
+        <categoryLink id="172f-5b69-467b-885a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_e21a-c03b-4885-ac46</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink><entryLink id="cd2c-8f8d-c0c7-1898" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9a08-5fe6-4010-bbc3</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_72cf-cfce-4e02-b379</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1947-04fa-1624-fe75" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="6a2d-9e0c-4dc1-4b00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="00be-75ea-422e-9236" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_f55b-7555-444b-beee</comment></categoryLink>
+        <categoryLink id="ee9e-e13d-4ae0-adde" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3386-c9ad-4d74-9474</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
-    <entryLink id="7232-6f4c-c3e1-6191" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="bd3c-2782-2231-8c9a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="bb47-9aee-ad52-615e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
-    <entryLink id="4001-533a-8998-a443" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink><entryLink id="1041-1b38-81e8-e66d" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_a0f6-9606-4b75-a2f8</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_94b3-1331-474b-885b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c198-3c27-918d-30c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6da4-ab27-5487-d257" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="4b83-4c6e-431b-b169" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_79fa-3370-4ae0-9e12</comment></categoryLink>
+        <categoryLink id="6ddb-ab24-4a31-bf51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bb53-4e65-4fb6-9dd7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
-  </entryLinks>
-  <sharedSelectionEntries>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink><entryLink id="d982-a7bc-c170-28af" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f8cc-833a-4ac1-bf89</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+              <comment>    node_id_5988-c012-4dad-9a66</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0f9b-d7b1-4790-a7a4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_8d82-3279-4481-84bb</comment></categoryLink>
+        <categoryLink id="288b-db66-48b6-afb0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e25c-925e-4b96-8bb3</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink><entryLink id="727e-bf5c-484d-3964" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6b73-b21c-4e2b-9d14</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_a7fe-cc62-4a6f-a781</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5be1-1937-4964-a455</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_da1d-b2bc-4117-82a4</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="14a8-dd49-4761-bfce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7010-be56-4709-b058</comment></categoryLink>
+        <categoryLink id="f10a-e01a-44e8-b59c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7379-a740-47ba-a054</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink><entryLink id="e3ec-76e5-e3eb-e644" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_dd34-83cf-47d7-b557</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_be88-afef-49b3-bd1e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1332-9f96-4fb7-bdd0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_944f-7420-4982-8ea9</comment></categoryLink>
+        <categoryLink id="3925-39e2-4820-8089" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ea80-0efe-457d-a450</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink><entryLink id="040c-ad2c-82dc-b606" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><categoryLinks>
+        <categoryLink id="f66a-a167-488b-a414" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9a36-f261-43cc-9bd1</comment></categoryLink>
+        <categoryLink id="4c23-966d-433e-ac89" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a648-8396-442a-af59</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink><entryLink id="2dbf-8f01-ee5e-4e05" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_cb81-0303-4b88-ae53</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9648-31e3-43aa-8cf3</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_0507-da81-4023-bfcf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0e84-54ff-488d-b066</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ba18-cb32-46bf-8816" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6ff-0977-4c92-bb28</comment></categoryLink>
+        <categoryLink id="a7f0-48e7-4413-918c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f555-7d39-458f-84c9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink><entryLink id="1bfc-59f7-21fc-9522" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8203-5b00-497b-b939</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_40ee-3e71-4978-b1e4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f6a8-f660-46dc-b3c5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_d988-3af6-48bf-b0a8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0eaf-0846-4971-a239" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_39e5-eda5-45d1-a643</comment></categoryLink>
+        <categoryLink id="3c26-8357-42d4-9947" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_6416-21bb-4df4-9de8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink><entryLink id="a685-aac6-ae7f-56ff" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b03e-5d91-4be3-8adc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_0443-29c0-46e9-ad1d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f2c9-7356-4c27-a22f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0e9-4a9e-4b2b-a9d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b84a-4f32-42a8-9e80" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5528-2dac-4be5-900c</comment></categoryLink>
+        <categoryLink id="0867-f1ab-4d70-b34d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_dc8f-d888-4585-991d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink><entryLink id="ae13-45b3-410d-db09" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1d3c-8e17-489f-9002</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5725-8bee-4bcc-878d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_be47-0d6f-49f2-9f4b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_863c-f3a4-4802-b80c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="558b-ccac-4b81-8509" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_899e-b052-4d5b-8c18</comment></categoryLink>
+        <categoryLink id="4bfc-b5e8-438c-bed6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f5e9-cff6-41d2-a016</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink><entryLink id="d6cf-a3dd-6f9a-c387" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_72da-1513-4e02-b595</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7a48-a3b0-4a26-849b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e232-25f3-4cb7-8ab2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_9aa4-5660-4697-8ab2</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="55ae-2e77-4d5d-aaeb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_09cd-2176-40af-bba6</comment></categoryLink>
+        <categoryLink id="b536-2ae9-4179-83c9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_05e6-7c63-4a35-9ba0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink><entryLink id="154c-33e7-c019-5776" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry"><categoryLinks>
+        <categoryLink id="b2d2-e500-498e-9493" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0dfa-4004-4751-8022</comment></categoryLink>
+        <categoryLink id="1fd8-192e-4fad-bbaf" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a669-0f5d-4fd3-811b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink><entryLink id="5b98-7257-55a6-1c70" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_09b5-4e3b-4c84-a574</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_32e5-ebba-41fb-9ff2</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_838e-0ccf-4d3a-aabd</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_dfef-0ec2-49fb-a534</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e2ca-b758-4b3c-b0e1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4f60-472b-45a9-ab9e</comment></categoryLink>
+        <categoryLink id="37ee-5b04-4acc-8fad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e2e3-af36-45a6-a955</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink><entryLink id="5faf-84f9-b693-f012" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_936f-1ef7-472e-840e</comment>
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+              <comment>    node_id_d73d-d52e-4c75-8ac0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a581-064c-4a66-9484" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_7a55-ecb4-4e5d-b955</comment></categoryLink>
+        <categoryLink id="42ec-d6a6-49a2-a473" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f28c-710e-4ff8-9810</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink><entryLink id="2edd-54be-4991-b1fb" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_a743-0cc2-45ae-a7eb</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2721-e88d-41f7-bedc</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_e10f-1390-4b33-8fcc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dcd8-bb5d-472e-84d9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2008-f1c4-4285-a14f</comment></categoryLink>
+        <categoryLink id="599c-768d-43f3-80db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e88b-a95a-4647-af3b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink><entryLink id="4fcb-24e5-0465-48f5" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_25d8-330b-4574-b515</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7836-6878-47a8-8827</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_5ea9-46dd-4a11-9410</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_ab5d-961b-4924-a705</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e681-f6f2-499e-acc5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9189-836c-475d-a52e</comment></categoryLink>
+        <categoryLink id="9110-c884-45d6-9b58" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_e1fa-b7d8-47b0-a88a</comment></categoryLink>
+        <categoryLink id="662c-0221-45f9-8ce3" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_a137-e3c0-4d63-a48c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink><entryLink id="dafc-d557-9714-d453" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry"><categoryLinks>
+        <categoryLink id="440f-8c96-432b-a1ec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b1d5-fd75-4f17-bbf4</comment></categoryLink>
+        <categoryLink id="d4d8-ed30-45a9-a93a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_f221-bf81-4045-849b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink><entryLink id="96c6-9762-bd80-4224" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_b743-7a00-43e4-beb8</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d12f-2c98-4e62-a716</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d4d7-ba67-47aa-962f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+                  <comment>    node_id_1637-edee-457a-bb0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6fba-8f8b-43cc-b380" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_f203-bc26-421f-b79e</comment></categoryLink>
+        <categoryLink id="3fe9-1db9-4585-8cbb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_a53e-59d9-4ac2-a21f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink><entryLink id="8682-cae9-19c7-632a" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry"><categoryLinks>
+        <categoryLink id="1a2f-d881-43d9-9279" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_51af-a137-4a1c-97a4</comment></categoryLink>
+        <categoryLink id="af2e-7971-47c2-bbcb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ec1f-c326-40a8-9d1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink><entryLink id="c9e1-64bd-499d-4779" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_c111-feb0-4012-98cd</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_63d7-8427-431d-9ae6</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b6f0-c7c4-4566-9816" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_e707-fde1-457f-91c4</comment></categoryLink>
+        <categoryLink id="c77e-164b-43fb-bac0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ec67-8573-4460-89db</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink><entryLink id="0128-944f-c876-31b0" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3348-16e4-4a9a-a549</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_bea4-c4a8-4843-b9fe</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2970-17ff-4be1-91e5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_503a-46e7-40e7-bd07</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_4555-15e1-43ff-80a0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6084-4116-42de-b78a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_fce3-801c-49c8-85d4</comment></categoryLink>
+        <categoryLink id="476a-4c2a-451f-8dc1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0c2d-2349-44b6-9831</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink><entryLink id="1b00-d14d-b1b4-38aa" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry"><categoryLinks>
+        <categoryLink id="727a-4271-48b7-9d9c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ac1c-b3bf-4011-918a</comment></categoryLink>
+        <categoryLink id="b012-8dbe-4444-8aa8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_589c-1d0e-4b7d-be6b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink><entryLink id="bf65-1ff7-f962-26b5" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2f46-a0b6-48a5-a0ee</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_636f-0f8a-43f1-910b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c883-39c8-4a74-aeaa</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_0796-e467-4438-89b3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4e84-11c8-40bf-b985" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_5a04-9847-4c91-a49a</comment></categoryLink>
+        <categoryLink id="06be-a46a-4dd4-91d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b4b4-daeb-483c-a306</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink><entryLink id="8a3b-87e9-09e0-3e53" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6087-a5e5-4d3c-9ebd</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c7e1-5f42-4528-bf07</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1950-08dc-4544-ab01</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_daf3-31ed-42c0-85dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c88e-56d6-45a4-9bd4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_7d4f-547c-43ed-a520</comment></categoryLink>
+        <categoryLink id="bec1-ef5c-428b-97e4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f04e-04e8-4891-9b1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink><entryLink id="8cf1-c85b-4c68-6ef4" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_dfdc-f6f6-49d2-a7b3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_354c-c71f-472f-b268</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1127-c974-4663-874d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_0843-bef2-4767-8307</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e855-bea3-4f32-b772" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_28e0-91e7-4ada-9fac</comment></categoryLink>
+        <categoryLink id="8b9c-918d-45c2-936b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4448-a712-4dd7-bf6d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink><entryLink id="30fc-7395-212a-8799" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d512-fd07-4a29-863a</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_55c6-a35f-485a-9f0d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d89e-cf1f-4ceb-b3de</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e2c9-0d01-403c-900e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_a7b8-c835-4cb2-b3d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6cea-3fc0-4af4-b83d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_e22a-c5f8-4825-a45f</comment></categoryLink>
+        <categoryLink id="b80d-1d83-4ba9-9c85" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03fc-6a7f-45a5-bcb8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink><entryLink id="0ad2-daf8-8b18-c43b" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry"><categoryLinks>
+        <categoryLink id="301e-a32f-4e0b-af58" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0aff-4f6e-4b03-a23c</comment></categoryLink>
+        <categoryLink id="4286-b203-47c4-a447" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"><comment>    template_id_7d5a-62e7-43ee-b79b</comment></categoryLink>
+        <categoryLink id="7195-be81-4c80-b973" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_4986-9157-49f2-b670</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink><entryLink id="3623-c92a-36d6-f65a" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_319e-90d4-44a3-8e83</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_28db-d943-4099-9abd</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1a45-a592-49df-9465</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb31-d0b2-4677-928e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a3f8-4d31-4268-b8cc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1b86-0977-4a8b-adac</comment></categoryLink>
+        <categoryLink id="73e2-735e-41db-a4f0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_b449-403a-4e42-9239</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink><entryLink id="72d1-2201-1bf6-c35a" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafa-470f-4c2c-8be3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_e2ba-a855-4de2-9f46</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_0171-b30d-44ee-9389</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fdfb-119b-4774-934a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_3891-9a00-4f8f-b95f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e5bd-cd82-40a5-8b2c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e5df-17d4-4521-9d5b</comment></categoryLink>
+        <categoryLink id="18e6-8ee2-43de-bd38" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"><comment>    template_id_0ecd-4873-4d3a-b28b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink><entryLink id="7232-6f4c-c3e1-6191" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_fbfa-8d78-4d6d-8a05</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_21f2-0916-46bf-b75a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_4fbd-633b-4dd6-9fdd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ceec-7125-4ce1-8b95" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4f71-446f-4cff-afda</comment></categoryLink>
+        <categoryLink id="9404-a80d-436d-af7e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_3f44-8647-43a4-ac22</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink><entryLink id="4001-533a-8998-a443" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af15-2c71-4f8b-833e</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_d95a-80b9-4463-af55</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="856f-7564-43a0-974e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6b1-886e-4194-8bcd</comment></categoryLink>
+        <categoryLink id="caef-c243-4e2d-aee1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_51b5-f9c1-4587-8fc7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink><entryLink id="cdf3-365c-4513-ae3f" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
+    <entryLink id="7e03-4aae-4edf-8047" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
+    <entryLink id="1b38-b373-49e9-b2c1" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
+    <entryLink id="07f3-9429-4144-adcf" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <entryLink id="4950-acd5-4aec-9cf2" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3531-57d1-4081-882d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_f233-2361-4177-8ba7</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b932-667a-4b43-8331</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <entryLink id="5d0e-bdaa-495e-a920" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <entryLink id="ea2e-1826-45f2-aa2b" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3129-6f59-4365-906b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2bcb-0af1-4aea-9191" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <entryLink id="c808-3197-4935-b42f" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ede2-d453-4e34-8cda</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2907-3215-4b01-96ff</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_c90c-959f-40fb-a4cb</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ba2d-50ad-45f1-91c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0e88-485e-43c2-8bef" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <entryLink id="8542-7a35-4d05-a2af" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_409c-0a5d-4ef8-a871</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7078-c1c7-4af2-b43d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_9a69-0fdc-4957-8982</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1a4c-69b5-4219-8502" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fba0-3ea7-4eaf-b33a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <entryLink id="8a8f-d59d-429d-9aed" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
+    <entryLink id="eaad-2f13-46e4-95e9" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
+    <entryLink id="e4bf-0555-4162-aed2" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
+    <entryLink id="d670-06e5-48df-b9b4" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+  </entryLinks><sharedSelectionEntries>
     <selectionEntry id="c028-dc90-e4b6-8b43" name="Leman Russ" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="00ed-3f49-ad36-075e" name="Howl of the Death Wolf" hidden="false">

--- a/2022 - LA - Space Wolves.cat
+++ b/2022 - LA - Space Wolves.cat
@@ -4338,7 +4338,7 @@
       <entryLinks>
         <entryLink id="9a01-1242-b70e-4398" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_7dee-602c-4b47-be09</comment></selectionEntryGroup>
     <selectionEntryGroup id="5408-6204-0336-0ce2" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="f963-1a07-319a-a695" type="max" />
@@ -4356,7 +4356,7 @@
         <entryLink id="98fa-f5c5-68da-a472" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
         <entryLink id="3df3-f24f-ade5-13a5" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_be38-a066-4f8e-ae54</comment></selectionEntryGroup>
     <selectionEntryGroup id="e6b4-bd3b-1d71-963c" name="Retinue (Caster/Speaker)" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acf3-5610-f8a9-7861" type="max" />

--- a/2022 - LA - Thousand Sons.cat
+++ b/2022 - LA - Thousand Sons.cat
@@ -1,1060 +1,1059 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="abac-8dd1-df65-e253" name="LA -  XV: Thousand Sons" revision="14" battleScribeVersion="2.03" authorName="Arkangelmark5" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="abac-8dd1-df65-e253" name="LA -  XV: Thousand Sons" revision="14" battleScribeVersion="2.03" authorName="Arkangelmark5" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26">
   <publications>
-    <publication id="f743-7ff9-a2f3-01c7" name="Exemplary Battles of the Age of Darkness: The Axandria IV Incident" shortName="Axandria IV" publisher="Exemplary Battles of the Age of Darkness: The Axandria IV Incident" publicationDate="9/16/2022" publisherUrl="https://www.warhammer-community.com/wp-content/uploads/2022/09/3mVvZrTG9XOWeVxv.pdf"/>
+    <publication id="f743-7ff9-a2f3-01c7" name="Exemplary Battles of the Age of Darkness: The Axandria IV Incident" shortName="Axandria IV" publisher="Exemplary Battles of the Age of Darkness: The Axandria IV Incident" publicationDate="9/16/2022" publisherUrl="https://www.warhammer-community.com/wp-content/uploads/2022/09/3mVvZrTG9XOWeVxv.pdf" />
   </publications>
   <entryLinks>
     <entryLink id="5900-484e-9f23-c753" name="  XV: Thousand Sons" hidden="false" collective="false" import="false" targetId="21c3-2f28-7820-e51a" type="selectionEntry">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d49c-72c4-b170-6dc6" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9206-fcb8-ba7e-4fbf" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d49c-72c4-b170-6dc6" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9206-fcb8-ba7e-4fbf" type="max" />
       </constraints>
       <profiles>
         <profile id="d241-183c-06ad-80b2" name="Fortress of the Mind" hidden="false" typeId="90b9-7fab-87db-aed3" typeName="Reactions">
           <characteristics>
-            <characteristic name="Description" typeId="c627-4637-8de5-65fb">This Advanced Reaction may be made once per battle during the opposing player’s Shooting phase when any enemy unit declares a Shooting Attack targeting a unit under the Reactive player’s control, made up entirely of models with the Legiones Astartes (Thousand Sons) special rule and the Psyker Subtype. Once the Active player has resolved all To Hit and To Wound rolls, but before any Armour Saves are made, the Reactive player must make a Psychic check. If the Check is passed, the Reacting unit gains a 3+ Invulnerable Save against all Wounds inflicted as part of the Shooting Attack that triggered the Reaction. If the Check is failed then the Reacting unit gains only a 5+ Invulnerable Save and both the attacking unit and the reacting unit suffer Perils of the Warp, removing any casualties immediately before resolving any unsaved Wounds inflicted by the Shooting Attack that triggered this Reaction.</characteristic>
+            <characteristic name="Description" typeId="c627-4637-8de5-65fb">This Advanced Reaction may be made once per battle during the opposing player&#8217;s Shooting phase when any enemy unit declares a Shooting Attack targeting a unit under the Reactive player&#8217;s control, made up entirely of models with the Legiones Astartes (Thousand Sons) special rule and the Psyker Subtype. Once the Active player has resolved all To Hit and To Wound rolls, but before any Armour Saves are made, the Reactive player must make a Psychic check. If the Check is passed, the Reacting unit gains a 3+ Invulnerable Save against all Wounds inflicted as part of the Shooting Attack that triggered the Reaction. If the Check is failed then the Reacting unit gains only a 5+ Invulnerable Save and both the attacking unit and the reacting unit suffer Perils of the Warp, removing any casualties immediately before resolving any unsaved Wounds inflicted by the Shooting Attack that triggered this Reaction.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="5f54-eecd-70e9-68ae" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="5f54-eecd-70e9-68ae" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="4ca2-991b-8a05-495b" name="Ahzek Ahriman" hidden="false" collective="false" import="false" targetId="f1d9-5c86-f496-61f0" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a860-2386-adfb-9190" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="0195-28e3-c5c1-05d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="920c-4841-9359-1c16" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="a860-2386-adfb-9190" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="0195-28e3-c5c1-05d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="920c-4841-9359-1c16" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="ef34-0fc0-70a1-9511" name="Ammitara Occult Intercession Cabal" hidden="false" collective="false" import="false" targetId="d3ad-275c-e22b-a28f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="355f-01ed-32c7-4131" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="a731-aa94-4f2c-24d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="355f-01ed-32c7-4131" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="a731-aa94-4f2c-24d5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="eccd-7e17-7359-665c" name="Castellax-Achea Automata" hidden="false" collective="false" import="false" targetId="95cb-9366-295e-f10d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="96c0-503c-eb35-b5c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dc90-d478-5300-3dd9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="96c0-503c-eb35-b5c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="dc90-d478-5300-3dd9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="803c-bb4e-a743-cfe2" name="Magistus Amon" hidden="false" collective="false" import="false" targetId="161b-2f2a-8616-9d4f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4f1c-f718-fd3a-7b34" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f9a9-61a7-3163-99e5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="dca3-8510-af4c-2eba" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="4f1c-f718-fd3a-7b34" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f9a9-61a7-3163-99e5" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="dca3-8510-af4c-2eba" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="2f6f-dd0e-e3b7-262e" name="Magnus the Red" hidden="false" collective="false" import="false" targetId="07f4-98a2-a371-5191" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9eae-bf6a-4193-af6b" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
-        <categoryLink id="922a-8088-b111-6bad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9eae-bf6a-4193-af6b" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true" />
+        <categoryLink id="922a-8088-b111-6bad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="cefc-c45c-128a-fbce" name="Sekhmet Terminator Cabal" hidden="false" collective="false" import="false" targetId="dda2-bdd0-3ced-b427" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ac58-0cd7-c143-5583" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="993d-e85b-bfeb-8a0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ac58-0cd7-c143-5583" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="993d-e85b-bfeb-8a0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="b132-3f20-976c-ff1c" name="Khenetai Occult Cabal" hidden="false" collective="false" import="false" targetId="faa7-27d5-2ee2-5d58" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a55f-2ae6-b17c-e872" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7bfb-d732-cefe-f207" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="a55f-2ae6-b17c-e872" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7bfb-d732-cefe-f207" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="396f-5ab5-e4c1-89c4" name="Contemptor-Osiron Dreadnought Talon" hidden="false" collective="false" import="false" targetId="eef1-0f91-a59f-b3e2" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8ada-aa38-fcb3-d993" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="497d-849e-d9b4-be08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8ada-aa38-fcb3-d993" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="497d-849e-d9b4-be08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="db25-4002-f4d3-2544" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="84e7-eddc-4289-b5c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dabd-dfc4-cef1-0d1f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="84e7-eddc-4289-b5c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="dabd-dfc4-cef1-0d1f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
     <entryLink id="535a-6435-abd5-c52f" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="129f-baa2-7a79-db0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0bb1-bc2b-0986-c26f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="129f-baa2-7a79-db0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0bb1-bc2b-0986-c26f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
     <entryLink id="2a9c-7cc1-c26b-384a" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="80c9-6006-0cad-636d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="9be3-ada3-a64a-6d9b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8954-a74a-0528-4f89" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="80c9-6006-0cad-636d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="9be3-ada3-a64a-6d9b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8954-a74a-0528-4f89" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="760c-2ea5-4492-6e3c" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="42b7-8e15-add0-1653" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="f43c-4bde-395e-22d2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="42b7-8e15-add0-1653" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="f43c-4bde-395e-22d2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
     <entryLink id="4fb3-9f32-425d-ce89" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3974-a905-64e8-6a85" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="3b03-f1ce-3de3-235c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3974-a905-64e8-6a85" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="3b03-f1ce-3de3-235c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
     <entryLink id="99c8-f0b7-7334-7c9f" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7d5e-09d7-e265-0df6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="fda0-da57-0e09-3b36" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a72a-c505-b685-45e4" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="7d5e-09d7-e265-0df6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fda0-da57-0e09-3b36" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a72a-c505-b685-45e4" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
     <entryLink id="7f24-67c9-bf67-1163" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="912c-dcaf-319c-7f80" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="eeec-83c3-de4c-ee87" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="912c-dcaf-319c-7f80" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="eeec-83c3-de4c-ee87" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
     <entryLink id="3bd0-a47a-2916-4ec4" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0433-c92b-094a-d42e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="bb15-f483-394b-e079" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0433-c92b-094a-d42e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="bb15-f483-394b-e079" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
     <entryLink id="741b-5a90-d34b-d709" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b5a4-b534-297d-a893" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="0040-68a2-8816-e4f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="99f6-b84b-2ec3-780b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="b5a4-b534-297d-a893" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="0040-68a2-8816-e4f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="99f6-b84b-2ec3-780b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="7c11-9b6f-e3df-9170" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup"/>
+        <entryLink id="7c11-9b6f-e3df-9170" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup" />
         <entryLink id="cf74-e9fe-4bd7-ec6b" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
     <entryLink id="854d-39d3-408a-2745" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4956-69cf-a1f6-cb1b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d240-e08f-d8a4-c5ca" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="7c9d-b30e-7ad0-a1e9" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="4956-69cf-a1f6-cb1b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d240-e08f-d8a4-c5ca" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="7c9d-b30e-7ad0-a1e9" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="8392-599d-5e9d-718e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup"/>
+        <entryLink id="8392-599d-5e9d-718e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup" />
         <entryLink id="e259-a292-d1c2-83b2" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
     <entryLink id="998c-50ac-bbb9-245e" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f2e8-e0e6-28c5-9f04" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1d60-3007-e583-71dc" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="8eb0-7dda-305b-784b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="f2e8-e0e6-28c5-9f04" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1d60-3007-e583-71dc" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="8eb0-7dda-305b-784b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="7e40-1a85-bbea-36c2" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup"/>
+        <entryLink id="7e40-1a85-bbea-36c2" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup" />
         <entryLink id="9876-987e-6f65-d685" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
     <entryLink id="509d-9171-e8e2-84ca" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e1fd-d7ce-4a03-0016" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="065c-c457-4777-8f24" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e1fd-d7ce-4a03-0016" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="065c-c457-4777-8f24" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
     <entryLink id="4e9d-586d-9da8-2dba" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7210-86d1-e777-2819" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cba2-ee78-1c90-95cd" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="7210-86d1-e777-2819" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cba2-ee78-1c90-95cd" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
     <entryLink id="aa8e-3301-ff58-8790" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9582-859d-e933-b3b0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a9e-f3ea-6143-94d5" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="9582-859d-e933-b3b0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a9e-f3ea-6143-94d5" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
     <entryLink id="8aa3-f18d-3323-3f4a" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c9d1-a92c-aa5a-96cc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ba2a-c066-eb39-8b0d" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="c9d1-a92c-aa5a-96cc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ba2a-c066-eb39-8b0d" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
     <entryLink id="30c5-e44f-7c47-e971" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b75f-1fb9-3a88-8f8d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dc18-5584-91b0-19a0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="b75f-1fb9-3a88-8f8d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="dc18-5584-91b0-19a0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
     <entryLink id="97fb-5eb3-b4e4-db61" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="79a4-1109-306c-2d53" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="0bd4-5197-36a1-abe1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="79a4-1109-306c-2d53" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="0bd4-5197-36a1-abe1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
     <entryLink id="82f9-f6dd-7616-2e07" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e724-bf87-c22c-2ee9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="4b03-986e-8a8f-7787" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e724-bf87-c22c-2ee9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="4b03-986e-8a8f-7787" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="ce1c-cf99-3bf5-e1ef" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="71c2-9cda-b2db-6a18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f860-7f81-630e-5bda" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="71c2-9cda-b2db-6a18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f860-7f81-630e-5bda" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
     <entryLink id="6a44-ab07-cb0d-7f6d" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1197-91a9-cdc8-aad4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="e692-0c21-f983-ee2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="454f-6cd5-3910-4047" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="1197-91a9-cdc8-aad4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="e692-0c21-f983-ee2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="454f-6cd5-3910-4047" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="6c37-b1e1-747f-c93e" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3d25-ef84-e8c8-a7ea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="604a-5342-8a56-e4fe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="3d25-ef84-e8c8-a7ea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="604a-5342-8a56-e4fe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="8eb9-da53-4df0-9a20" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0fad-0b78-4d3c-9c84" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="382b-504e-87e1-fbc0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0fad-0b78-4d3c-9c84" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="382b-504e-87e1-fbc0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
     <entryLink id="5c7e-d632-a1f7-31c2" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="eb65-8a7c-275f-2d90" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="beaf-07f8-a942-4a16" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="eb65-8a7c-275f-2d90" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="beaf-07f8-a942-4a16" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
     <entryLink id="25dd-db68-56f0-0d09" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="efb1-38f6-cede-acc2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="836e-d21e-6395-89b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="efb1-38f6-cede-acc2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="836e-d21e-6395-89b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
     <entryLink id="3382-bc4e-5766-917f" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="eb9a-db3c-090e-c778" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2283-e1b8-b295-b9f8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="eb9a-db3c-090e-c778" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2283-e1b8-b295-b9f8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
     <entryLink id="577e-1f0c-3ea2-ce15" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="cbd3-898e-21ad-1b03" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="d40d-7c84-fd8c-0c2a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="cbd3-898e-21ad-1b03" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="d40d-7c84-fd8c-0c2a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
     <entryLink id="9d7f-87f1-a6f7-a9b6" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="50cb-612d-8ae6-bcaa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="bf88-8e65-40f6-202a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="50cb-612d-8ae6-bcaa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="bf88-8e65-40f6-202a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
     <entryLink id="0fc5-f21e-23bf-674a" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bffd-57ef-9bd8-0026" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a4a6-287f-244f-161a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="bffd-57ef-9bd8-0026" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a4a6-287f-244f-161a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
     <entryLink id="87bb-bff2-5be7-1ce7" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1ea3-f3d7-0b5a-1210" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="a9c5-a889-18e9-8b1c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1ea3-f3d7-0b5a-1210" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="a9c5-a889-18e9-8b1c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
     <entryLink id="bb9a-a828-d268-650b" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0f5a-7dba-37c5-cc88" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b9a5-d96a-11d1-a48e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="0f5a-7dba-37c5-cc88" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b9a5-d96a-11d1-a48e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="5410-ddf3-9b5f-6346" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8fa1-c6d9-6ed7-0072" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="1df5-29b9-c6e4-c6c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8fa1-c6d9-6ed7-0072" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="1df5-29b9-c6e4-c6c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
     <entryLink id="65d5-eec6-1030-d756" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="89e7-33ea-521c-1db9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="f7f5-0ec8-3fa9-cfc5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="89e7-33ea-521c-1db9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="f7f5-0ec8-3fa9-cfc5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
     <entryLink id="d88b-6b14-5e71-71f6" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2220-a788-d1b2-9a46" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="e4a8-9ba6-11b6-4b78" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2220-a788-d1b2-9a46" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="e4a8-9ba6-11b6-4b78" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
     <entryLink id="3aa6-167c-6612-0ddb" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8fbb-da0d-f9f3-c24b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="02ab-7b58-1707-4598" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="8fbb-da0d-f9f3-c24b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="02ab-7b58-1707-4598" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
     <entryLink id="3e19-3b02-a3ab-1f4a" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="67f1-ea02-b68b-c362" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="aff1-bf9a-9a70-1580" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="67f1-ea02-b68b-c362" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="aff1-bf9a-9a70-1580" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
     <entryLink id="8a69-dd44-4b8d-60f9" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="00f6-41d4-81b3-76e4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="dd96-2953-2507-4fc0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="00f6-41d4-81b3-76e4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="dd96-2953-2507-4fc0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
     <entryLink id="5c98-3dc1-f22b-08aa" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dbfd-f303-2d66-adbe" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="b3a0-908c-6a19-279f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="dbfd-f303-2d66-adbe" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="b3a0-908c-6a19-279f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
     <entryLink id="6676-5302-e270-4855" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7f58-759c-ce19-64ba" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="1ad3-f137-e96f-612a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7f58-759c-ce19-64ba" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="1ad3-f137-e96f-612a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
     <entryLink id="c3b6-baad-9af2-9539" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bdc3-29b8-97cf-4a6b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="5448-8016-ede3-7eda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bdc3-29b8-97cf-4a6b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="5448-8016-ede3-7eda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
     <entryLink id="958c-419d-6c26-bbc7" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6238-d954-ceaa-b31f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="56d3-f45b-4d1e-7334" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6238-d954-ceaa-b31f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="56d3-f45b-4d1e-7334" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
     <entryLink id="bc36-4e5d-3ba3-a99d" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="92a1-d830-e866-6ad4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="6e22-8ed0-3b19-1cc6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="92a1-d830-e866-6ad4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="6e22-8ed0-3b19-1cc6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
     <entryLink id="3a98-a2ff-6fd2-a487" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dde6-c705-9432-9404" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="b1ee-7886-7084-e358" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="dde6-c705-9432-9404" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="b1ee-7886-7084-e358" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
     <entryLink id="8195-844d-b3f3-5288" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e54a-b42b-8e9e-d3ec" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="fe45-78be-1409-fc40" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e54a-b42b-8e9e-d3ec" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="fe45-78be-1409-fc40" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
     <entryLink id="48d8-0a9f-e2a6-11e6" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="63e4-9753-3816-b496" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c934-587e-9917-632d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="63e4-9753-3816-b496" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="c934-587e-9917-632d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
     <entryLink id="c024-5c8b-0572-14dd" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2bd6-755b-a993-41e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ebc7-d68f-7dd3-ef67" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="2bd6-755b-a993-41e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ebc7-d68f-7dd3-ef67" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
     <entryLink id="f8a9-bb4b-161f-0a03" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9da7-cdad-1da2-343e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="501c-eb08-ec84-e481" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9da7-cdad-1da2-343e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="501c-eb08-ec84-e481" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
     <entryLink id="fe14-86fe-12a7-cfb7" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6540-0169-9f36-5092" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="f752-a39e-8108-97a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6540-0169-9f36-5092" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="f752-a39e-8108-97a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
     <entryLink id="e07c-6d50-ba3c-2c4d" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="97b4-df26-0495-35bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d4d5-5975-0bd8-fdcd" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="97b4-df26-0495-35bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d4d5-5975-0bd8-fdcd" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="61b3-339e-aef9-1483" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ff58-513d-cf4e-6987" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="fae5-8363-b65a-3470" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ff58-513d-cf4e-6987" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="fae5-8363-b65a-3470" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
     <entryLink id="1dc5-8c4b-e3be-f0b7" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bf51-c20f-ea94-c734" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="8ad8-00a7-2f83-0e2c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bf51-c20f-ea94-c734" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="8ad8-00a7-2f83-0e2c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="84ee-d391-e9d5-7f71" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ee62-4670-cbeb-3ea8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="868e-e1a9-98f8-3a2d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="ee62-4670-cbeb-3ea8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="868e-e1a9-98f8-3a2d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="19dd-ef2a-c108-1bf6" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3924-23cf-d749-3f20" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="ea39-4e31-73e4-9f4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5f47-43ab-500d-b9f3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="3924-23cf-d749-3f20" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="ea39-4e31-73e4-9f4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5f47-43ab-500d-b9f3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="aab8-384e-e368-a65e" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup"/>
-        <entryLink id="3181-0ca0-ee8a-fe72" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup"/>
+        <entryLink id="aab8-384e-e368-a65e" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup" />
+        <entryLink id="3181-0ca0-ee8a-fe72" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
     <entryLink id="9002-32d6-4b59-f4b2" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7b25-ff49-9242-77d3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="ef23-c037-7a45-0634" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d366-c9a8-6556-45e8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="7b25-ff49-9242-77d3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="ef23-c037-7a45-0634" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d366-c9a8-6556-45e8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="1045-709b-f0d8-a92d" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup"/>
-        <entryLink id="4170-2192-817e-9ac3" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup"/>
+        <entryLink id="1045-709b-f0d8-a92d" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup" />
+        <entryLink id="4170-2192-817e-9ac3" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
     <entryLink id="dfec-61dc-4fee-0b7b" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9b9e-f16b-a7e5-8697" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="fb14-d791-e9c1-f6e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="754c-44ad-e3b0-b498" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="9b9e-f16b-a7e5-8697" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="fb14-d791-e9c1-f6e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="754c-44ad-e3b0-b498" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="d49e-d0a9-a629-0dd7" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup"/>
-        <entryLink id="5d11-57d8-7a10-a5f7" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup"/>
+        <entryLink id="d49e-d0a9-a629-0dd7" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup" />
+        <entryLink id="5d11-57d8-7a10-a5f7" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
     <entryLink id="42e2-762f-a3c9-8f00" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6a9a-404a-285d-944c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6bb8-0629-2f81-6090" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6a9a-404a-285d-944c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6bb8-0629-2f81-6090" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="b840-9827-acb5-c4dc" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bea6-1c1b-cae8-79e3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="3855-4d3b-2c71-3c0c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bea6-1c1b-cae8-79e3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="3855-4d3b-2c71-3c0c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
     <entryLink id="90c7-62b9-abec-0e72" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="03e3-9573-f6c5-f8cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="128b-10cd-56a0-b62b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="03e3-9573-f6c5-f8cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="128b-10cd-56a0-b62b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="ed8f-90a3-283d-e1ec" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ca28-b12c-3ecd-f990" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="cba8-2529-98a8-5789" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ca28-b12c-3ecd-f990" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="cba8-2529-98a8-5789" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
     <entryLink id="64de-75cf-c7d1-40c9" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2468-65f7-9c0a-770e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="aacf-8a74-6fdf-0937" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2468-65f7-9c0a-770e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="aacf-8a74-6fdf-0937" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
     <entryLink id="b34e-9318-d3e5-72dd" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4984-3e7b-b60c-7a32" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="6abc-1cf7-f453-a808" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4984-3e7b-b60c-7a32" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="6abc-1cf7-f453-a808" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
     <entryLink id="d96a-68da-14c5-0efc" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0961-11f6-8eb0-4da4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fae7-1c63-3c94-110f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="0961-11f6-8eb0-4da4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="fae7-1c63-3c94-110f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
     <entryLink id="1704-0515-a9e4-b29e" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a7c7-9db8-9556-0b55" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="20be-cbc2-2e7d-001b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a7c7-9db8-9556-0b55" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="20be-cbc2-2e7d-001b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
     <entryLink id="de20-8fa3-ee41-33f9" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="58be-6811-f327-5fd3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9a00-75af-2f5c-07c5" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="58be-6811-f327-5fd3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9a00-75af-2f5c-07c5" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
     <entryLink id="5219-13e2-8441-36ee" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ab68-0036-d151-f758" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6d53-a8d2-978e-df48" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="ab68-0036-d151-f758" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6d53-a8d2-978e-df48" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
     <entryLink id="5677-104c-dab0-139b" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ae8b-8fe9-7b4a-ea2e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="228a-fb65-b620-80f7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="ae8b-8fe9-7b4a-ea2e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="228a-fb65-b620-80f7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
     <entryLink id="b782-b02a-aeba-3044" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ac1d-6c1b-7bc5-e90c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="fd2c-3eff-eb7f-a585" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="ac1d-6c1b-7bc5-e90c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="fd2c-3eff-eb7f-a585" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
     <entryLink id="0f72-6b3e-9034-8a3c" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f7ec-8877-ea57-3a38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ad6a-6983-8ca5-e7aa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="f7ec-8877-ea57-3a38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ad6a-6983-8ca5-e7aa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="2ce0-24a1-a941-a332" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3332-4d00-ff20-1b6f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c507-0c6d-aa99-7a67" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3332-4d00-ff20-1b6f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c507-0c6d-aa99-7a67" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
     <entryLink id="7df6-8b3c-f20f-012a" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b661-3646-cce1-996a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b285-09a4-411b-d478" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="b661-3646-cce1-996a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b285-09a4-411b-d478" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="f676-aae1-f729-7051" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7090-6650-fdfe-e79e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="a910-2956-2438-a7ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7090-6650-fdfe-e79e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="a910-2956-2438-a7ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
     <entryLink id="7cbd-4031-cbed-74ed" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bf90-0641-1bc8-2916" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="3471-e913-c817-b201" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bf90-0641-1bc8-2916" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="3471-e913-c817-b201" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
     <entryLink id="3e50-9098-4a8b-770f" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="12f5-c4ba-01c1-1c9a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="5c5e-02e6-bb22-9ed7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="12f5-c4ba-01c1-1c9a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="5c5e-02e6-bb22-9ed7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
     <entryLink id="aeb6-7fd7-b0eb-f99c" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b9f0-d793-78b2-3059" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7eca-10cd-f2a8-06d6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="4ce9-2184-eac8-b11c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="b9f0-d793-78b2-3059" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7eca-10cd-f2a8-06d6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="4ce9-2184-eac8-b11c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="ffa9-f77a-058e-6c50" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9e61-d557-8f39-93a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="55c9-f05c-9463-b38a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9e61-d557-8f39-93a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="55c9-f05c-9463-b38a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
     <entryLink id="50a9-d17a-a89a-03fb" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="629c-db73-2a83-43de" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="6fd3-a404-11dc-ec7d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="629c-db73-2a83-43de" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="6fd3-a404-11dc-ec7d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
     <entryLink id="46ed-d30e-31f7-53b2" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="de62-5a11-2f4f-7519" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ebbc-98c2-7e40-6075" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="de62-5a11-2f4f-7519" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ebbc-98c2-7e40-6075" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
     <entryLink id="9833-cce9-1afa-0901" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3536-06ba-c677-3cef" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="fd40-a03c-b134-cfda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3536-06ba-c677-3cef" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="fd40-a03c-b134-cfda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="365c-1f32-6a04-c1ef" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e634-43c2-1198-b1eb" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="033c-7e01-a4c8-ee91" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e634-43c2-1198-b1eb" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="033c-7e01-a4c8-ee91" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
     <entryLink id="5034-2e8a-21c5-06bb" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a635-101f-a4a1-e2ef" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="320e-4280-817a-bb5a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a635-101f-a4a1-e2ef" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="320e-4280-817a-bb5a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="3b01-e912-2b38-9d0a" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fc4e-f4dc-aa52-263e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="e0fb-5180-8b33-b731" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fc4e-f4dc-aa52-263e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="e0fb-5180-8b33-b731" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
     <entryLink id="a96c-46cc-4a9c-4786" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="193e-d0f2-1d40-6cfc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="6ea6-9cc0-746b-1102" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="193e-d0f2-1d40-6cfc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="6ea6-9cc0-746b-1102" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
     <entryLink id="6b5e-9cea-ae25-6d2b" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="08b7-5f3e-6d36-5461" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="9bf9-0299-caac-fb40" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="08b7-5f3e-6d36-5461" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="9bf9-0299-caac-fb40" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
     <entryLink id="9967-c2e0-8192-fa08" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4f0c-f9cd-7748-0c86" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="8c3f-676b-b372-344b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4f0c-f9cd-7748-0c86" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="8c3f-676b-b372-344b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
     <entryLink id="22eb-15a1-aab6-d452" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3505-56d5-8a98-3752" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9995-bc5a-631a-1c0d" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="b17f-a5c6-8606-5d97" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="3505-56d5-8a98-3752" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9995-bc5a-631a-1c0d" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
+        <categoryLink id="b17f-a5c6-8606-5d97" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="b353-8bbc-20ca-b2d6" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6af4-1740-0631-3a05" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4164-64cb-d189-febf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6af4-1740-0631-3a05" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4164-64cb-d189-febf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
     <entryLink id="34f6-5e05-e439-57df" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="056c-8130-a7a2-6864" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="929c-1e02-015e-d72d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="056c-8130-a7a2-6864" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="929c-1e02-015e-d72d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
     <entryLink id="538e-9e82-793f-c984" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c4aa-9d4d-0819-92f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d85a-619c-8d1c-0c83" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="c4aa-9d4d-0819-92f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d85a-619c-8d1c-0c83" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
     <entryLink id="24ba-d2c2-3e6a-cdc8" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <infoLinks>
-        <infoLink id="8b46-7db6-f3c3-ad65" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
+        <infoLink id="8b46-7db6-f3c3-ad65" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="3785-dd74-e83e-7694" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5dc3-0e05-020e-d5fd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="3785-dd74-e83e-7694" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5dc3-0e05-020e-d5fd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
     <entryLink id="c30e-4af9-f2ed-e8d6" name="Numerologist Cabal" hidden="true" collective="false" import="false" targetId="ca26-b6e2-0bef-85a5" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d4c0-d8df-f1a9-dc78" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="917a-7a8b-060f-5d86" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d4c0-d8df-f1a9-dc78" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="917a-7a8b-060f-5d86" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -1068,33 +1067,33 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="01bc-e9e5-ad1e-3dd6" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
-        <infoLink id="0aa5-4f98-7457-fa00" name="Infiltrate" hidden="false" targetId="0e32-5b92-a95a-8464" type="rule"/>
-        <infoLink id="ed2d-1c94-1154-99aa" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule"/>
-        <infoLink id="432d-548e-f694-8c15" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="01bc-e9e5-ad1e-3dd6" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule" />
+        <infoLink id="0aa5-4f98-7457-fa00" name="Infiltrate" hidden="false" targetId="0e32-5b92-a95a-8464" type="rule" />
+        <infoLink id="ed2d-1c94-1154-99aa" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule" />
+        <infoLink id="432d-548e-f694-8c15" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="d9d7-3f8d-2221-4a72" name="Shrouded (X)" hidden="false" targetId="10c3-fdb0-089f-ca65" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Shrouded (6+)"/>
+            <modifier type="set" field="name" value="Shrouded (6+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4f4b-14a1-2bc3-0dae" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="280a-d3f2-d095-83c1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="adbf-ca76-7b97-3526" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
-        <categoryLink id="5e1a-c5d0-2524-ec10" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="4f4b-14a1-2bc3-0dae" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="280a-d3f2-d095-83c1" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="adbf-ca76-7b97-3526" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false" />
+        <categoryLink id="5e1a-c5d0-2524-ec10" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="f786-ea3b-93e3-b24c" name="Ammitara Fate" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd9d-6555-139c-ac1c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1a3-e470-7fbd-1515" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd9d-6555-139c-ac1c" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1a3-e470-7fbd-1515" type="min" />
           </constraints>
           <profiles>
             <profile id="97b5-08b9-57fe-3f5d" name="Ammitara Fate" publicationId="d0df-7166-5cd3-89fd" page="90" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Light, Psyker, Skirmish)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1108,46 +1107,46 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="70dd-9240-a310-b1da" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink id="44c0-6cc5-6fea-0efa" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-            <categoryLink id="075a-42ce-300a-8b4f" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+            <categoryLink id="70dd-9240-a310-b1da" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
+            <categoryLink id="44c0-6cc5-6fea-0efa" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false" />
+            <categoryLink id="075a-42ce-300a-8b4f" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a00a-9922-6df6-38d1" name="May take any:" hidden="false" collective="false" import="true">
               <entryLinks>
                 <entryLink id="936a-3742-e9ba-2cad" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa5a-76d6-6d07-e532" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa5a-76d6-6d07-e532" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="3a63-ff4f-d663-08eb" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8e4-4fe5-2ed2-51e9" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8e4-4fe5-2ed2-51e9" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="2f2d-3799-8787-45b7" name="Ammitara Intercessors" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="292c-49ad-2d1d-ac1e" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13b3-8c6e-ba6d-2f9b" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="292c-49ad-2d1d-ac1e" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13b3-8c6e-ba6d-2f9b" type="min" />
           </constraints>
           <profiles>
             <profile id="d39d-9aaf-d806-6985" name="Ammitara Intercessors" publicationId="d0df-7166-5cd3-89fd" page="90" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Light, Psyker, Skirmish)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1161,11 +1160,11 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="e865-2752-163b-293f" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-            <categoryLink id="ef7e-6a43-4e20-d68e" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+            <categoryLink id="e865-2752-163b-293f" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false" />
+            <categoryLink id="ef7e-6a43-4e20-d68e" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false" />
           </categoryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1174,85 +1173,85 @@
           <modifiers>
             <modifier type="increment" field="82c2-2414-5fa7-2bce" value="1.0">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f2d-3799-8787-45b7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f2d-3799-8787-45b7" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
             <modifier type="increment" field="0b0e-eb41-af38-e15d" value="1.0">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f2d-3799-8787-45b7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f2d-3799-8787-45b7" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
-            <modifier type="decrement" field="82c2-2414-5fa7-2bce" value="4.0"/>
+            <modifier type="decrement" field="82c2-2414-5fa7-2bce" value="4.0" />
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b0e-eb41-af38-e15d" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82c2-2414-5fa7-2bce" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b0e-eb41-af38-e15d" type="max" />
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82c2-2414-5fa7-2bce" type="min" />
           </constraints>
           <entryLinks>
             <entryLink id="185b-8767-fe08-21cb" name="Asphyx Bolt Pistol" hidden="false" collective="false" import="true" targetId="07f7-c486-f597-a1b9" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0" />
               </costs>
             </entryLink>
-            <entryLink id="8aed-5856-132d-4b17" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+            <entryLink id="8aed-5856-132d-4b17" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="c1b1-3760-be20-d597" name="1) Main Weapons:" hidden="false" collective="false" import="true" defaultSelectionEntryId="96ea-4b62-6aae-0cb3">
           <modifiers>
             <modifier type="increment" field="a0a9-118b-40d4-bde5" value="1.0">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f2d-3799-8787-45b7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f2d-3799-8787-45b7" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
             <modifier type="increment" field="4ef6-a5f1-1e32-487d" value="1.0">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f2d-3799-8787-45b7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f2d-3799-8787-45b7" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
-            <modifier type="decrement" field="4ef6-a5f1-1e32-487d" value="4.0"/>
+            <modifier type="decrement" field="4ef6-a5f1-1e32-487d" value="4.0" />
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0a9-118b-40d4-bde5" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ef6-a5f1-1e32-487d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0a9-118b-40d4-bde5" type="max" />
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ef6-a5f1-1e32-487d" type="min" />
           </constraints>
           <selectionEntryGroups>
             <selectionEntryGroup id="dda1-1067-30d0-4ba6" name="One in five may exchange their Nemesis bolter for:" hidden="false" collective="false" import="true">
               <modifiers>
                 <modifier type="increment" field="782d-b6fe-cf4a-b23e" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="782d-b6fe-cf4a-b23e" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="782d-b6fe-cf4a-b23e" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="c9e4-5663-a412-faa1" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="bc23-4350-1c52-e06d" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="96ea-4b62-6aae-0cb3" name="Nemesis Bolter" hidden="false" collective="false" import="true" targetId="c10a-61f8-9c33-fe8a" type="selectionEntry"/>
+            <entryLink id="96ea-4b62-6aae-0cb3" name="Nemesis Bolter" hidden="false" collective="false" import="true" targetId="c10a-61f8-9c33-fe8a" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="3917-2a71-78b2-20da" name="Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c9c-24b5-fcfb-435f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c9c-24b5-fcfb-435f" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="b5e7-449d-b458-870e" name="Storm Eagle Gunship" hidden="false" collective="false" import="true" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="85c2-ae14-65c4-d607" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="85c2-ae14-65c4-d607" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
@@ -1261,64 +1260,64 @@
       <entryLinks>
         <entryLink id="f200-1d8b-7cad-4352" name="Scout Armour" hidden="false" collective="false" import="true" targetId="b282-55aa-d1e2-ebe7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59a4-6296-4df8-b25e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5bb-83c2-49b1-a03d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59a4-6296-4df8-b25e" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5bb-83c2-49b1-a03d" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="3dd8-9ff6-7eb1-bbb3" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f15-19c4-a68a-2fa0" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b800-5fe6-320d-3dc7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f15-19c4-a68a-2fa0" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b800-5fe6-320d-3dc7" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="6f1b-fc05-f05e-7876" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4dc-67e2-fd85-d46b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1b1-695b-a098-4bac" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4dc-67e2-fd85-d46b" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1b1-695b-a098-4bac" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="1493-7a22-be9c-8a60" name="Shroud Bombs" hidden="false" collective="false" import="true" targetId="5d4d-36b7-6bf5-fc92" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f38c-97e8-04f2-61e7" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d5e-0838-0e3a-9935" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f38c-97e8-04f2-61e7" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d5e-0838-0e3a-9935" type="min" />
           </constraints>
         </entryLink>
-        <entryLink id="c6b5-57dd-8db1-4d93" name="Prosperine Arcana:" hidden="false" collective="false" import="true" targetId="e6a0-3ea2-f7ca-411f" type="selectionEntryGroup"/>
+        <entryLink id="c6b5-57dd-8db1-4d93" name="Prosperine Arcana:" hidden="false" collective="false" import="true" targetId="e6a0-3ea2-f7ca-411f" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="95cb-9366-295e-f10d" name="Castellax-Achea Automata" hidden="false" collective="false" import="true" type="upgrade">
       <rules>
         <rule id="01cd-939f-c8a5-3e4a" name="Psy -automata" publicationId="09c5-eeae-f398-b653" page="267" hidden="false">
-          <description>Models with the Psy-automata Sub - type that are not within 6&quot; of a friendly model with the Psyker Sub-type and both the Legiones Astartes (Thousand Sons) and Independent Character special rules are subject to the Programmed Behaviour provision:
+          <description>Models with the Psy-automata Sub - type that are not within 6" of a friendly model with the Psyker Sub-type and both the Legiones Astartes (Thousand Sons) and Independent Character special rules are subject to the Programmed Behaviour provision:
 - During both the controlling player s Shooting phase and the Charge sub- phase, a Psy -automata unit must attempt a Shooting Attack and /or Charge if there is an enemy unit within range, and must target the closest enemy unit possible that is within its line of sight and is a valid target for a Shooting Attack or Charge. If two or more targets are equally close then the controlling player chooses which will be the target of a Shooting Attack or Charge.
-• A model with the Psy -automata Sub- type may fire all weapons they are equipped with in each Shooting Attack they make, including as part of a Reaction where eligible ( this rule on its own does not allow&apos; Automata units to make Reactions).
-• Models with the Psy-automata Sub- type may fire Heavy and Ordnance weapons and count as Stationary even if they moved in the preceding Movement phase, and may declare Charges as normal regardless of any Shooting Attacks made in the same turn.
-• Models with the Psy -automata Sub-type may fire Heavy and Ordnance weapons and count as Stationary even if they moved in the preceding Movement phase, and may declare charges as normal regardless of any Shooting Attacks made in the same turn.
-• Models with the Psy -automata Sub -type ignore any penalties to their Initiative Characteristic when Charging into or through Difficult Terrain or Dangerous Terrain.
-• When using a Psychic Weapon to make a Shooting Attack from within 12&quot; of a Castellax-Achea model, a model with the Psyker Sub- type and with the Legiones Astartes (Thousand Sons) special rule may use the Castellax- Achea model as the origin point of the attack, drawing line of sight and range from it rather than themselves.</description>
+&#8226; A model with the Psy -automata Sub- type may fire all weapons they are equipped with in each Shooting Attack they make, including as part of a Reaction where eligible ( this rule on its own does not allow' Automata units to make Reactions).
+&#8226; Models with the Psy-automata Sub- type may fire Heavy and Ordnance weapons and count as Stationary even if they moved in the preceding Movement phase, and may declare Charges as normal regardless of any Shooting Attacks made in the same turn.
+&#8226; Models with the Psy -automata Sub-type may fire Heavy and Ordnance weapons and count as Stationary even if they moved in the preceding Movement phase, and may declare charges as normal regardless of any Shooting Attacks made in the same turn.
+&#8226; Models with the Psy -automata Sub -type ignore any penalties to their Initiative Characteristic when Charging into or through Difficult Terrain or Dangerous Terrain.
+&#8226; When using a Psychic Weapon to make a Shooting Attack from within 12" of a Castellax-Achea model, a model with the Psyker Sub- type and with the Legiones Astartes (Thousand Sons) special rule may use the Castellax- Achea model as the origin point of the attack, drawing line of sight and range from it rather than themselves.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="e9dd-447e-a8de-1ddb" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
+        <infoLink id="e9dd-447e-a8de-1ddb" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="c1ad-3434-2f99-5b24" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
-        <categoryLink id="02a9-7e5a-890d-2cf8" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="c1ad-3434-2f99-5b24" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false" />
+        <categoryLink id="02a9-7e5a-890d-2cf8" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="403b-b9ba-b004-d4a5" name="Castellax-Achea" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c355-0b58-7786-486c" type="min"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d171-ea6f-1563-62ef" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c355-0b58-7786-486c" type="min" />
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d171-ea6f-1563-62ef" type="max" />
           </constraints>
           <profiles>
             <profile id="0492-c094-882d-9108" name="Castellax - Achea" publicationId="09c5-eeae-f398-b653" page="266" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Psy -automata, Psyker)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
@@ -1334,51 +1333,51 @@
           <infoLinks>
             <infoLink id="56ae-b7de-6255-f20e" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+                <modifier type="set" field="name" value="Hammer of Wrath (1)" />
               </modifiers>
             </infoLink>
             <infoLink id="9cfa-b588-f36d-fbc1" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Adamantium Will (4+)"/>
+                <modifier type="set" field="name" value="Adamantium Will (4+)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <categoryLinks>
-            <categoryLink id="b81a-622a-27d1-2522" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+            <categoryLink id="b81a-622a-27d1-2522" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false" />
           </categoryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="140.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="140.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="63bd-b91e-cade-bf5a" name="Any model may replace its Æther-Fire Cannon with:" hidden="false" collective="false" import="true" defaultSelectionEntryId="113d-a1c0-2555-4291">
+        <selectionEntryGroup id="63bd-b91e-cade-bf5a" name="Any model may replace its &#198;ther-Fire Cannon with:" hidden="false" collective="false" import="true" defaultSelectionEntryId="113d-a1c0-2555-4291">
           <modifiers>
             <modifier type="increment" field="6b41-8040-8cec-7482" value="1.0">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
             <modifier type="increment" field="add3-5d43-600f-02ed" value="1.0">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
-            <modifier type="decrement" field="6b41-8040-8cec-7482" value="1.0"/>
+            <modifier type="decrement" field="6b41-8040-8cec-7482" value="1.0" />
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6b41-8040-8cec-7482" type="min"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="add3-5d43-600f-02ed" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6b41-8040-8cec-7482" type="min" />
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="add3-5d43-600f-02ed" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="113d-a1c0-2555-4291" name="Æther-Fire Cannon" hidden="false" collective="false" import="true" targetId="0139-b673-7b21-0470" type="selectionEntry">
+            <entryLink id="113d-a1c0-2555-4291" name="&#198;ther-Fire Cannon" hidden="false" collective="false" import="true" targetId="0139-b673-7b21-0470" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aa91-418d-e233-95a8" type="max"/>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aa91-418d-e233-95a8" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="f165-991b-2f99-75ff" name="Asphyx Bolt Cannon" hidden="false" collective="false" import="true" targetId="ebce-ebc9-8ff7-d42d" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="51d5-e5bc-1fae-c7b6" type="max"/>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="51d5-e5bc-1fae-c7b6" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
@@ -1387,47 +1386,47 @@
       <entryLinks>
         <entryLink id="2b7a-993c-d297-9c3f" name="Achea Force Claw" hidden="false" collective="false" import="true" targetId="ecf4-e882-7893-5a67" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c10c-6001-b021-0f64" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6642-7ac8-1f55-767a" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c10c-6001-b021-0f64" type="min" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6642-7ac8-1f55-767a" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="58a8-96b6-6424-ca65" name="Asphyx Bolter" hidden="false" collective="false" import="true" targetId="88c0-4623-9da3-f2b5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae8d-d591-1c32-72cb" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b14-b391-4c37-942e" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae8d-d591-1c32-72cb" type="min" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b14-b391-4c37-942e" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="79e1-fb19-9ccf-e317" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1359-acba-3971-4c46" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9496-724a-3cdf-15f7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1359-acba-3971-4c46" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9496-724a-3cdf-15f7" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="eef1-0f91-a59f-b3e2" name="Contemptor-Osiron Dreadnought Talon" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="1082-9f2c-235b-5cfd" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
+        <infoLink id="1082-9f2c-235b-5cfd" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b5d7-81e8-c908-4d38" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
-        <categoryLink id="051f-84da-a459-4760" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="b5d7-81e8-c908-4d38" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false" />
+        <categoryLink id="051f-84da-a459-4760" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1626-a09f-d9ed-dca1" name="Contemptor-Osiron Dreadnought" hidden="false" collective="false" import="true" type="model">
           <modifiers>
             <modifier type="set" field="name" value="Contemptor-Osiron Magus Dreadnought">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a85-fbcb-f946-530f" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a85-fbcb-f946-530f" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e29-f267-8293-82e0" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4be3-e253-5948-e58c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e29-f267-8293-82e0" type="min" />
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4be3-e253-5948-e58c" type="max" />
           </constraints>
           <profiles>
             <profile id="216b-57b5-50b5-c63e" name="Contemptor-Osiron Dreadnought" publicationId="09c5-eeae-f398-b653" page="264" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -1447,29 +1446,29 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="fb8e-818b-26f7-7e4d" name="Dreadnought Talon" hidden="false" targetId="a924-2634-73fd-aa96" type="rule"/>
+            <infoLink id="fb8e-818b-26f7-7e4d" name="Dreadnought Talon" hidden="false" targetId="a924-2634-73fd-aa96" type="rule" />
             <infoLink id="f97c-5ffa-4d98-2e6b" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Adamantium Will (4+)"/>
+                <modifier type="set" field="name" value="Adamantium Will (4+)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <categoryLinks>
-            <categoryLink id="7e1b-a2cc-89f8-3824" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+            <categoryLink id="7e1b-a2cc-89f8-3824" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false" />
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="51f2-4b7a-a6c0-08e7" name="Minor Arcana" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd0c-8e04-d251-c0f8" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd0c-8e04-d251-c0f8" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="37c5-59fc-8437-d725" name="Gravis Force Blade" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7746-4c2e-bedd-a78a" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c449-801e-95fa-0898" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7746-4c2e-bedd-a78a" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c449-801e-95fa-0898" type="max" />
               </constraints>
               <profiles>
                 <profile id="f713-b149-183a-f379" name="Gravis Force Blade" publicationId="09c5-eeae-f398-b653" page="265" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1482,76 +1481,76 @@
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="a99b-5a77-2229-8085" name="Achean Force" hidden="false" targetId="c56f-80ff-5d8e-1af4" type="rule"/>
+                <infoLink id="a99b-5a77-2229-8085" name="Achean Force" hidden="false" targetId="c56f-80ff-5d8e-1af4" type="rule" />
                 <infoLink id="24f3-bfd8-7291-9218" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Brutal (2)"/>
+                    <modifier type="set" field="name" value="Brutal (2)" />
                   </modifiers>
                 </infoLink>
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
             <selectionEntryGroup id="0d4e-fb30-c8db-6ebc" name="1) May replace its Gravis bolt cannon with one of the following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="e55e-1905-46b8-71ba">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0507-8004-69dd-c821" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c019-a938-8ace-c4bf" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0507-8004-69dd-c821" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c019-a938-8ace-c4bf" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="e55e-1905-46b8-71ba" name="Gravis Bolt Cannon" hidden="false" collective="false" import="true" targetId="3b5f-52ab-6534-94a3" type="selectionEntry"/>
+                <entryLink id="e55e-1905-46b8-71ba" name="Gravis Bolt Cannon" hidden="false" collective="false" import="true" targetId="3b5f-52ab-6534-94a3" type="selectionEntry" />
                 <entryLink id="a933-01ae-318a-db08" name="Gravis Melta Cannon" hidden="false" collective="false" import="true" targetId="ef6c-f656-171a-03e1" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="ec39-c1ca-0bc3-09ba" name="Æther-Fire Magna-Cannon" hidden="false" collective="false" import="true" targetId="ab6a-176c-e2e4-e902" type="selectionEntry">
+                <entryLink id="ec39-c1ca-0bc3-09ba" name="&#198;ther-Fire Magna-Cannon" hidden="false" collective="false" import="true" targetId="ab6a-176c-e2e4-e902" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="7cd1-0b22-b462-fece" name="Kheres Assault Cannon" hidden="false" collective="false" import="true" targetId="fe77-2e74-160d-c7af" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="0f43-5237-a49e-b443" name="Conversion Beam Cannon" hidden="false" collective="false" import="true" targetId="5775-0d94-8e13-8c1f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="4801-a1f6-ca0c-5617" name="Gravis Lascannon" hidden="false" collective="false" import="true" targetId="1fe0-7c96-5200-0e39" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="2881-e11d-8a07-78a3" name="Gravis Force Blade" hidden="false" collective="false" import="true" targetId="96aa-954e-b2e9-92df" type="selectionEntry">
                   <modifiers>
-                    <modifier type="append" field="name" value="with in-built combi-bolter"/>
+                    <modifier type="append" field="name" value="with in-built combi-bolter" />
                   </modifiers>
                 </entryLink>
                 <entryLink id="ea68-705f-0f67-b5fc" name="Volkite Dual-Culverin" hidden="false" collective="false" import="true" targetId="fead-f3b9-f7c7-1081" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="b21b-1107-8f46-8ada" name="Gravis Autocannon" hidden="false" collective="false" import="true" targetId="8a23-e57d-b4a8-14a9" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="e1be-b698-edc3-9111" name="May take one of the following:" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c6c-321b-760f-f46a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c6c-321b-760f-f46a" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="df13-2ee6-341b-aa9c" name="Havoc Launcher" hidden="false" collective="false" import="true" targetId="bde9-5abf-ec3d-2273" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1560,39 +1559,39 @@
               <modifiers>
                 <modifier type="set" field="8d22-ecdd-65cd-534a" value="2.0">
                   <conditions>
-                    <condition field="selections" scope="1626-a09f-d9ed-dca1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2881-e11d-8a07-78a3" type="equalTo"/>
+                    <condition field="selections" scope="1626-a09f-d9ed-dca1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2881-e11d-8a07-78a3" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="ce2c-6462-a0ce-5894" value="2.0">
                   <conditions>
-                    <condition field="selections" scope="1626-a09f-d9ed-dca1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2881-e11d-8a07-78a3" type="equalTo"/>
+                    <condition field="selections" scope="1626-a09f-d9ed-dca1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2881-e11d-8a07-78a3" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce2c-6462-a0ce-5894" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d22-ecdd-65cd-534a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce2c-6462-a0ce-5894" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d22-ecdd-65cd-534a" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="ef9d-06a1-ebd4-a3af" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                <entryLink id="ef9d-06a1-ebd4-a3af" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry" />
                 <entryLink id="be4e-bbac-8934-4c94" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="6651-1fc0-3b7a-81ea" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="0807-a778-877b-9910" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="21b7-9560-500c-bd4c" name="Æther-Fire Blaster" hidden="false" collective="false" import="true" targetId="d078-5f42-c02b-c73d" type="selectionEntry">
+                <entryLink id="21b7-9560-500c-bd4c" name="&#198;ther-Fire Blaster" hidden="false" collective="false" import="true" targetId="d078-5f42-c02b-c73d" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1601,45 +1600,45 @@
           <entryLinks>
             <entryLink id="cfb7-7546-a17c-0c4c" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dc6-0891-1d20-d5dc" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3862-99b9-ceeb-f0d4" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dc6-0891-1d20-d5dc" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3862-99b9-ceeb-f0d4" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="fee6-d44c-3f1d-23e2" name="Prosperine Arcana:" hidden="false" collective="false" import="true" targetId="e6a0-3ea2-f7ca-411f" type="selectionEntryGroup">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="51f2-4b7a-a6c0-08e7" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="51f2-4b7a-a6c0-08e7" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="0a85-fbcb-f946-530f" name="Contemptor-Osiron Magus Upgrade" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1626-a09f-d9ed-dca1" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1626-a09f-d9ed-dca1" type="greaterThan" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17bc-0cbc-df7b-53ee" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cce-2169-075f-860c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17bc-0cbc-df7b-53ee" type="max" />
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cce-2169-075f-860c" type="min" />
           </constraints>
           <entryLinks>
             <entryLink id="760c-7f8f-6d8f-c686" name="Psychic Disciplines" hidden="false" collective="false" import="true" targetId="d632-a8aa-19f1-8e72" type="selectionEntryGroup">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1648,47 +1647,47 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1626-a09f-d9ed-dca1" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1626-a09f-d9ed-dca1" type="greaterThan" />
               </conditions>
             </modifier>
           </modifiers>
           <entryLinks>
             <entryLink id="c206-6b8d-7be8-fb89" name="Dreadnought Drop Pod" hidden="false" collective="false" import="true" targetId="1ffe-82e4-12db-538d" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2425-2752-02bf-f9ea" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2425-2752-02bf-f9ea" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="161b-2f2a-8616-9d4f" name="Magistus Amon" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d75d-fcad-c8ca-0a77" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d75d-fcad-c8ca-0a77" type="max" />
       </constraints>
       <infoLinks>
-        <infoLink id="003c-d933-e89e-dc9c" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
+        <infoLink id="003c-d933-e89e-dc9c" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="68e3-d5fc-41b5-8cf7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="83a3-0ef9-edb4-003d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="de93-44e6-fcd3-f27a" name="Independant Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="68e3-d5fc-41b5-8cf7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="83a3-0ef9-edb4-003d" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="de93-44e6-fcd3-f27a" name="Independant Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7214-1716-4e2a-3b57" name="Magistus Amon" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9244-64fb-4c33-193b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d6f-d688-5a67-a6e2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9244-64fb-4c33-193b" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d6f-d688-5a67-a6e2" type="min" />
           </constraints>
           <profiles>
             <profile id="6d47-d0f4-6196-7450" name="Magistus Amon" publicationId="09c5-eeae-f398-b653" page="272" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Psyker, Unique)
 </characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1707,40 +1706,40 @@
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="77e5-69bc-2466-f310" name="Infiltrate" hidden="false" targetId="0e32-5b92-a95a-8464" type="rule"/>
-            <infoLink id="df88-a557-b6da-db45" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+            <infoLink id="77e5-69bc-2466-f310" name="Infiltrate" hidden="false" targetId="0e32-5b92-a95a-8464" type="rule" />
+            <infoLink id="df88-a557-b6da-db45" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="c609-1504-8ba4-2a09" name="Psychic powers" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3090-a6f3-a7cc-b756" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf7d-363e-e28d-82cf" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3090-a6f3-a7cc-b756" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf7d-363e-e28d-82cf" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="da86-bfff-4310-2636" name="Aetheric Lightning" hidden="false" targetId="3d0c-e779-247f-0332" type="profile"/>
+                <infoLink id="da86-bfff-4310-2636" name="Aetheric Lightning" hidden="false" targetId="3d0c-e779-247f-0332" type="profile" />
               </infoLinks>
               <entryLinks>
                 <entryLink id="4284-9471-581d-005c" name="Psychic Discipline: Divination" hidden="false" collective="false" import="true" targetId="0c22-a776-e7e3-2981" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7f4-7336-96b8-98a9" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="49f4-c26e-968d-29b7" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7f4-7336-96b8-98a9" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="49f4-c26e-968d-29b7" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="49b4-3424-b3ee-ac34" name="Psychic Discipline: Telepathy" hidden="false" collective="false" import="true" targetId="b751-a605-75e8-dd6f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec41-115d-b782-adbd" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ebb1-efcd-d2b0-afda" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec41-115d-b782-adbd" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ebb1-efcd-d2b0-afda" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="31b0-afe6-8133-33bf" name="The Armour of Shades" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4dbf-e7ef-22fb-d663" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5278-ff39-8901-782a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4dbf-e7ef-22fb-d663" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5278-ff39-8901-782a" type="max" />
               </constraints>
               <profiles>
                 <profile id="a3f3-1dd4-52f2-c1ab" name="The Armour of Shades" publicationId="09c5-eeae-f398-b653" page="272" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
@@ -1752,18 +1751,18 @@
               <infoLinks>
                 <infoLink id="4f23-2a5d-2675-f6d9" name="Shrouded (X)" hidden="false" targetId="10c3-fdb0-089f-ca65" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Shrouded (4+)"/>
+                    <modifier type="set" field="name" value="Shrouded (4+)" />
                   </modifiers>
                 </infoLink>
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="0c61-8c16-3993-e0ca" name="The Reliquary of Dust (Melee)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06dc-8449-d4c5-36ed" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad85-2b23-bcc8-d115" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06dc-8449-d4c5-36ed" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad85-2b23-bcc8-d115" type="max" />
               </constraints>
               <profiles>
                 <profile id="086d-719b-7c48-a666" name="The Reliquary of Dust (Melee)" publicationId="09c5-eeae-f398-b653" page="273" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1776,36 +1775,36 @@
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="7dc6-c059-58d3-3035" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="7dc6-c059-58d3-3035" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
                 <infoLink id="5c1c-ab0b-2092-d5b9" name="Reach (X)" hidden="false" targetId="19bf-62a2-5737-890b" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Reach (1)"/>
+                    <modifier type="set" field="name" value="Reach (1)" />
                   </modifiers>
                 </infoLink>
                 <infoLink id="79db-c3f5-a665-13d5" name="Poisoned (X)" hidden="false" targetId="e70e-23ea-3251-0edb" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Poisoned (4+)"/>
+                    <modifier type="set" field="name" value="Poisoned (4+)" />
                   </modifiers>
                 </infoLink>
                 <infoLink id="6dad-75df-9b0e-ce2d" name="Reaping Blow (X)" hidden="false" targetId="bd8c-4f52-d682-1b40" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Reaping Blow (1)"/>
+                    <modifier type="set" field="name" value="Reaping Blow (1)" />
                   </modifiers>
                 </infoLink>
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="4cf9-3e50-dbf3-a9b5" name="The Reliquary of Dust (Ranged)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f3a-07ee-5d4f-2fbc" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1320-590c-8df9-5913" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f3a-07ee-5d4f-2fbc" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1320-590c-8df9-5913" type="max" />
               </constraints>
               <profiles>
                 <profile id="46a3-ad1c-b17f-bdba" name="The Reliquary of Dust (Ranged)" publicationId="09c5-eeae-f398-b653" page="273" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">6&quot;</characteristic>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">6"</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">1</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
                     <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 2D6, Poisoned (4+ ), Concussive ( 3), Rending (6+ )</characteristic>
@@ -1820,102 +1819,102 @@
               <infoLinks>
                 <infoLink id="38bf-6c40-928b-038b" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Rending (6+)"/>
+                    <modifier type="set" field="name" value="Rending (6+)" />
                   </modifiers>
                 </infoLink>
                 <infoLink id="8167-8363-f9f5-b333" name="Poisoned (X)" hidden="false" targetId="e70e-23ea-3251-0edb" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Poisoned (4+)"/>
+                    <modifier type="set" field="name" value="Poisoned (4+)" />
                   </modifiers>
                 </infoLink>
                 <infoLink id="0ea7-d9e7-0107-c51b" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Concussive (1)"/>
+                    <modifier type="set" field="name" value="Concussive (1)" />
                   </modifiers>
                 </infoLink>
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="a0d2-4fa5-af4b-b0d6" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22b1-7f6a-aced-00f3" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0de4-ee5f-7788-75ca" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22b1-7f6a-aced-00f3" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0de4-ee5f-7788-75ca" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="1bf5-bd39-e794-640a" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afc0-5c95-0977-8825" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e074-576c-14a3-31b7" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afc0-5c95-0977-8825" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e074-576c-14a3-31b7" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="113e-7181-6c4c-d8b9" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f49-ebe6-3bd6-cc70" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8ee-5406-0c0a-0754" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f49-ebe6-3bd6-cc70" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8ee-5406-0c0a-0754" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="c568-699e-f0be-3e23" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39f7-42a5-f028-d163" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8d6-40e6-80fb-595b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39f7-42a5-f028-d163" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8d6-40e6-80fb-595b" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="fa49-9200-41b0-f286" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4285-2c61-4385-b808" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4285-2c61-4385-b808" type="max" />
           </constraints>
           <profiles>
             <profile id="90f4-0e8c-9d18-b8a6" name="Lord of Hidden Paths" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If an army’s Warlord has this Trait, then all units with the Infiltrate and Scout special rules gain the Shrouded (5+) special rules from the start of the controlling player’s First turn until the beginning of the controlling player’s second turn. In addition, an army whose Warlord has this Trait may make an additional Reaction in the Movement phase</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If an army&#8217;s Warlord has this Trait, then all units with the Infiltrate and Scout special rules gain the Shrouded (5+) special rules from the start of the controlling player&#8217;s First turn until the beginning of the controlling player&#8217;s second turn. In addition, an army whose Warlord has this Trait may make an additional Reaction in the Movement phase</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
-        <entryLink id="75c4-4e21-669b-f6d1" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup"/>
+        <entryLink id="75c4-4e21-669b-f6d1" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup" />
         <entryLink id="62f9-33a7-feca-7150" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e16-0076-5395-1b65" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10fe-8ebf-6afa-9cc6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e16-0076-5395-1b65" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10fe-8ebf-6afa-9cc6" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="f1d9-5c86-f496-61f0" name="Ahzek Ahriman" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3eb-f7d1-c04f-1aff" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3eb-f7d1-c04f-1aff" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="d7b8-d408-02a0-260a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="6fb7-0274-47e5-c469" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="f713-16d5-2a05-9a2b" name="Independant Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="d7b8-d408-02a0-260a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="6fb7-0274-47e5-c469" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="f713-16d5-2a05-9a2b" name="Independant Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="653f-9f43-92d9-3176" name="Ahzek Ahriman" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="941c-0f16-37cb-b560" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1d3-c9de-0da7-dba6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="941c-0f16-37cb-b560" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1d3-c9de-0da7-dba6" type="min" />
           </constraints>
           <profiles>
             <profile id="c6fa-4a4c-d8aa-8a05" name="Ahzek Ahriman" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Psyker, Unique)
 </characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1936,65 +1935,65 @@
           <infoLinks>
             <infoLink id="5bae-c778-51c1-ad5e" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Adamantium Will (3+)"/>
+                <modifier type="set" field="name" value="Adamantium Will (3+)" />
               </modifiers>
             </infoLink>
-            <infoLink id="6a57-4e47-6a1a-9e42" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
-            <infoLink id="e75a-ed68-07d1-4f34" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
+            <infoLink id="6a57-4e47-6a1a-9e42" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule" />
+            <infoLink id="e75a-ed68-07d1-4f34" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule" />
           </infoLinks>
           <categoryLinks>
-            <categoryLink id="2725-e4f0-1cf8-6f29" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink id="7672-7fc0-3907-9518" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+            <categoryLink id="2725-e4f0-1cf8-6f29" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
+            <categoryLink id="7672-7fc0-3907-9518" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="ba7a-2388-5475-2ff6" name="Master-crafted Asphyx Bolt Pistol" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18de-71ef-badc-9489" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8404-fa77-9757-067f" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18de-71ef-badc-9489" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8404-fa77-9757-067f" type="min" />
               </constraints>
               <infoLinks>
-                <infoLink id="23aa-2c87-a4d1-b03a" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+                <infoLink id="23aa-2c87-a4d1-b03a" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
                 <infoLink id="4659-fd71-9d8f-7990" name="Asphyx Bolt Pistol" hidden="false" targetId="7a88-ce87-0cb7-6a99" type="profile">
                   <modifiers>
-                    <modifier type="append" field="2f86-c8b4-b3b4-3ff9" value="Master-crafted"/>
+                    <modifier type="append" field="2f86-c8b4-b3b4-3ff9" value="Master-crafted" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="f22b-8d8e-de3a-25f7" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="f22b-8d8e-de3a-25f7" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="6ac1-bc5a-c38b-1225" name="Psychic Powers" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e102-1c31-164a-6c8e" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aed-e2ab-6c72-adaa" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e102-1c31-164a-6c8e" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aed-e2ab-6c72-adaa" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="d4c8-f004-749c-c716" name="Aetheric Lightning" hidden="false" targetId="3d0c-e779-247f-0332" type="profile"/>
+                <infoLink id="d4c8-f004-749c-c716" name="Aetheric Lightning" hidden="false" targetId="3d0c-e779-247f-0332" type="profile" />
               </infoLinks>
               <entryLinks>
                 <entryLink id="fa82-9e65-6ddc-9d49" name="Psychic Discipline: Divination" hidden="false" collective="false" import="true" targetId="0c22-a776-e7e3-2981" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b583-c550-514f-6d2b" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="719e-cec1-56d7-67a7" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b583-c550-514f-6d2b" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="719e-cec1-56d7-67a7" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="a8b2-3668-e31b-1f4b" name="Psychic Discipline: Thaumaturgy" hidden="false" collective="false" import="true" targetId="f7ab-1fb2-91b0-028d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28d6-a835-a562-1201" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8a27-cebf-bf23-3853" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28d6-a835-a562-1201" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8a27-cebf-bf23-3853" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="70a8-dba8-78b7-cfb7" name="The Corvidaean Sceptre" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3127-d097-f592-ab57" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f60-76dd-f229-f9b9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3127-d097-f592-ab57" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f60-76dd-f229-f9b9" type="max" />
               </constraints>
               <profiles>
                 <profile id="8491-f29b-2d47-4364" name="The Corvidaean Sceptre" publicationId="09c5-eeae-f398-b653" page="270" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2007,108 +2006,108 @@
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="39d5-a46e-4169-3964" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="39d5-a46e-4169-3964" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
                 <infoLink id="3dfa-0ec3-6021-e8de" name="Reach (X)" hidden="false" targetId="19bf-62a2-5737-890b" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Reach (1)"/>
+                    <modifier type="set" field="name" value="Reach (1)" />
                   </modifiers>
                 </infoLink>
-                <infoLink id="ec9b-29e3-4c64-e4c8" name="Force" hidden="false" targetId="f39e-4c3b-38e0-0050" type="rule"/>
+                <infoLink id="ec9b-29e3-4c64-e4c8" name="Force" hidden="false" targetId="f39e-4c3b-38e0-0050" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="8108-b831-c0b2-a68d" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c480-02bc-fe2f-a46a" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1977-f20b-e160-a68b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c480-02bc-fe2f-a46a" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1977-f20b-e160-a68b" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="766c-bf7b-8b94-9ce4" name="Corvidae" hidden="false" collective="false" import="true" targetId="f040-f723-e145-9e1f" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="478b-cd72-6c44-65a3" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2ffe-600c-673e-810b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="478b-cd72-6c44-65a3" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2ffe-600c-673e-810b" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="7fe4-890f-9a49-e9da" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb8b-3907-32a6-237f" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68f5-e8ef-1f62-df23" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb8b-3907-32a6-237f" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68f5-e8ef-1f62-df23" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="3b47-13b5-b42e-58b7" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad8d-e18e-70d0-1b89" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c1-20dd-be08-3d06" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad8d-e18e-70d0-1b89" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c1-20dd-be08-3d06" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="f139-5d58-21d1-324a" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f05-86ab-fcec-3c1d" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="506b-d802-9239-6ba4" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f05-86ab-fcec-3c1d" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="506b-d802-9239-6ba4" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="c4b1-aed7-2c54-af62" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea4b-e7ae-827c-051d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea4b-e7ae-827c-051d" type="max" />
           </constraints>
           <profiles>
             <profile id="4a6c-ddc4-f185-2a38" name="The Pattern of Fates" publicationId="09c5-eeae-f398-b653" page="270" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If an army’s Warlord has this Trait, then once all models have been deployed onto the battlefield (including any Infiltrating units and after any units have been redeployed using the Scout special rule), but before the first turn is begun, the controlling player may select up to three friendly units and either redeploy them to any other position within the controlling player’s Deployment Zone or remove them from the battlefield and place them in Reserves. In addition, an army that includes Ahriman may make an additional Reaction in any one phase once per turn, as long as Ahriman has not been removed as a casualty (the Phase in which the additional Reaction is made does not need to be declared in advance).</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If an army&#8217;s Warlord has this Trait, then once all models have been deployed onto the battlefield (including any Infiltrating units and after any units have been redeployed using the Scout special rule), but before the first turn is begun, the controlling player may select up to three friendly units and either redeploy them to any other position within the controlling player&#8217;s Deployment Zone or remove them from the battlefield and place them in Reserves. In addition, an army that includes Ahriman may make an additional Reaction in any one phase once per turn, as long as Ahriman has not been removed as a casualty (the Phase in which the additional Reaction is made does not need to be declared in advance).</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
-        <entryLink id="4fb4-2d5f-5c07-1ee2" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup"/>
+        <entryLink id="4fb4-2d5f-5c07-1ee2" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup" />
         <entryLink id="abfb-21dc-23f9-a75a" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aba2-8d75-5836-418a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58c2-4d3c-7783-934d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aba2-8d75-5836-418a" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58c2-4d3c-7783-934d" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="dda2-bdd0-3ced-b427" name="Sekhmet Terminator Cabal" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="f574-03d6-2b3b-01bc" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="f574-03d6-2b3b-01bc" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
         <infoLink id="ef2c-8b12-6630-5961" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="5b03-c67e-670f-f0bf" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
+        <infoLink id="5b03-c67e-670f-f0bf" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ee57-776c-ef90-1f77" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="3066-9075-b4df-8684" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="ea5b-1965-f2b0-cd0d" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="4863-5593-dedb-fb54" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
+        <categoryLink id="ee57-776c-ef90-1f77" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="3066-9075-b4df-8684" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="ea5b-1965-f2b0-cd0d" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="4863-5593-dedb-fb54" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0ee5-6264-b5e4-5a9b" name="Sekhmet Inceptor" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a9e-5b72-e9e9-3837" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f136-05ff-d71e-18ee" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a9e-5b72-e9e9-3837" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f136-05ff-d71e-18ee" type="min" />
           </constraints>
           <profiles>
             <profile id="8a8b-808e-1a69-046c" name="Sekhmet Inceptor" publicationId="09c5-eeae-f398-b653" page="262" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character, Psyker)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2122,85 +2121,85 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="9a2f-0507-13a4-8ac8" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink id="7c63-0f76-63cb-2c82" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink id="9a2f-0507-13a4-8ac8" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
+            <categoryLink id="7c63-0f76-63cb-2c82" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="a14c-93c1-d16e-d057" name="Psychic Discipline" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27a2-93b1-2db1-7245" type="max"/>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6405-ea7f-01e6-6425" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27a2-93b1-2db1-7245" type="max" />
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6405-ea7f-01e6-6425" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="30d7-34d3-ceed-a8d5" name="Psychic Disciplines" hidden="false" collective="false" import="true" targetId="d632-a8aa-19f1-8e72" type="selectionEntryGroup">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
             <selectionEntryGroup id="a7cf-6683-01aa-599e" name="Melee Weapon Option:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ecc9-df96-3212-fc59">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f01-1ab6-7694-0975" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c437-c6ee-4918-f0bf" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f01-1ab6-7694-0975" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c437-c6ee-4918-f0bf" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="64c0-fea8-ee9b-49cb" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="3008-bd1c-7cb5-ac23" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="0a8d-e6f3-42e8-808a" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="013d-fe4a-f779-e276" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="974a-2f34-69c5-d850" name="Achea Force Maul" hidden="false" collective="false" import="true" targetId="126d-534d-dcb0-e931" type="selectionEntry"/>
-                <entryLink id="9ada-07dd-f750-4fa3" name="Achea Force Sword" hidden="false" collective="false" import="true" targetId="3cf4-3b3b-2188-6bd4" type="selectionEntry"/>
-                <entryLink id="ecc9-df96-3212-fc59" name="Achea Force Axe" hidden="false" collective="false" import="true" targetId="d27f-9247-2c27-4450" type="selectionEntry"/>
+                <entryLink id="974a-2f34-69c5-d850" name="Achea Force Maul" hidden="false" collective="false" import="true" targetId="126d-534d-dcb0-e931" type="selectionEntry" />
+                <entryLink id="9ada-07dd-f750-4fa3" name="Achea Force Sword" hidden="false" collective="false" import="true" targetId="3cf4-3b3b-2188-6bd4" type="selectionEntry" />
+                <entryLink id="ecc9-df96-3212-fc59" name="Achea Force Axe" hidden="false" collective="false" import="true" targetId="d27f-9247-2c27-4450" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
             <entryLink id="fe32-af03-5421-2502" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6dd1-ff0b-b1dc-35a8" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6dd1-ff0b-b1dc-35a8" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
-            <entryLink id="588a-1182-16b8-0358" name="Terminator Ranged Weapon" hidden="false" collective="false" import="true" targetId="bb49-6a88-7ffa-6aa7" type="selectionEntryGroup"/>
+            <entryLink id="588a-1182-16b8-0358" name="Terminator Ranged Weapon" hidden="false" collective="false" import="true" targetId="bb49-6a88-7ffa-6aa7" type="selectionEntryGroup" />
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="8833-5c95-8d08-9c7c" name="Sekhmet" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3bf-05ae-0cda-3b91" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f77-39c1-40e4-2de2" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3bf-05ae-0cda-3b91" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f77-39c1-40e4-2de2" type="min" />
           </constraints>
           <profiles>
             <profile id="8065-f488-4f4d-b019" name="Sekhmet" publicationId="09c5-eeae-f398-b653" page="262" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Psyker)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2214,89 +2213,89 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="9e82-d5b4-dc5f-8930" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink id="9e82-d5b4-dc5f-8930" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f89b-c4b5-a9c7-f49a" name="Melee Weapon Option:" hidden="false" collective="false" import="true" defaultSelectionEntryId="68ba-9107-dc08-5e20">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="509f-ae66-b8d8-4703" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69ab-425c-dbfe-06ca" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="509f-ae66-b8d8-4703" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69ab-425c-dbfe-06ca" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="aff3-d3f8-6630-67a8" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="42b3-7111-565e-bf8f" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="d141-4059-5084-dd1b" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="ed0d-8cbf-7361-b750" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="68ba-9107-dc08-5e20" name="Achea Force Axe" hidden="false" collective="false" import="true" targetId="d27f-9247-2c27-4450" type="selectionEntry"/>
-                <entryLink id="c40b-9722-f10a-8833" name="Achea Force Sword" hidden="false" collective="false" import="true" targetId="3cf4-3b3b-2188-6bd4" type="selectionEntry"/>
-                <entryLink id="f7ba-8e30-e034-a400" name="Achea Force Maul" hidden="false" collective="false" import="true" targetId="126d-534d-dcb0-e931" type="selectionEntry"/>
+                <entryLink id="68ba-9107-dc08-5e20" name="Achea Force Axe" hidden="false" collective="false" import="true" targetId="d27f-9247-2c27-4450" type="selectionEntry" />
+                <entryLink id="c40b-9722-f10a-8833" name="Achea Force Sword" hidden="false" collective="false" import="true" targetId="3cf4-3b3b-2188-6bd4" type="selectionEntry" />
+                <entryLink id="f7ba-8e30-e034-a400" name="Achea Force Maul" hidden="false" collective="false" import="true" targetId="126d-534d-dcb0-e931" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
             <entryLink id="9090-0e25-2870-9b02" name="Terminator Ranged Weapon" hidden="false" collective="false" import="true" targetId="bb49-6a88-7ffa-6aa7" type="selectionEntryGroup">
               <modifiers>
-                <modifier type="set" field="name" value="May exchange Combi-bolter weapon for:"/>
+                <modifier type="set" field="name" value="May exchange Combi-bolter weapon for:" />
               </modifiers>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="107d-8bfb-e857-2fd6" name="Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f431-7df5-5d4c-3138" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f431-7df5-5d4c-3138" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="96a9-3f40-0ad9-0592" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9420-43f0-a3e8-1d1b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9420-43f0-a3e8-1d1b" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="ebe7-f8bb-bd8c-55a3" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8833-5c95-8d08-9c7c" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8833-5c95-8d08-9c7c" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c383-9137-1f26-1899" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c383-9137-1f26-1899" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0" />
               </costs>
             </entryLink>
             <entryLink id="79d8-a009-76cb-d7ff" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="true" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8833-5c95-8d08-9c7c" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8833-5c95-8d08-9c7c" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8448-645d-f545-7074" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8448-645d-f545-7074" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
@@ -2305,21 +2304,21 @@
       <entryLinks>
         <entryLink id="80d7-8f9f-d0fe-c907" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbc2-2d12-c0fd-8607" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd09-c598-2354-d7ea" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbc2-2d12-c0fd-8607" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd09-c598-2354-d7ea" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="f9bf-df0f-bd00-6773" name="Prosperine Arcana:" hidden="false" collective="false" import="true" targetId="e6a0-3ea2-f7ca-411f" type="selectionEntryGroup"/>
+        <entryLink id="f9bf-df0f-bd00-6773" name="Prosperine Arcana:" hidden="false" collective="false" import="true" targetId="e6a0-3ea2-f7ca-411f" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="faa7-27d5-2ee2-5d58" name="Khenetai Occult Cabal" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="ddfb-45bb-3827-fb21" name="Mindsong of Blades" publicationId="09c5-eeae-f398-b653" page="269" hidden="false" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power">
           <characteristics>
-            <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">At the start of the controlling player’s turn, a Psychic check may be made for a unit composed entirely of models With this Psychic Power, using the highest Leadership Characteristic among those models. If the Check is successful then the unit gains +1 to the following Characteristics until the start of the Controlling player s next turn: Movement , Weapon Skill , and Attacks. If the test is failed then the unit suffers Perils of the Warp.</characteristic>
+            <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">At the start of the controlling player&#8217;s turn, a Psychic check may be made for a unit composed entirely of models With this Psychic Power, using the highest Leadership Characteristic among those models. If the Check is successful then the unit gains +1 to the following Characteristics until the start of the Controlling player s next turn: Movement , Weapon Skill , and Attacks. If the test is failed then the unit suffers Perils of the Warp.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -2329,24 +2328,24 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="c95d-d4b5-33c9-b2a7" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
-        <infoLink id="bb41-1a39-e46f-158a" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
+        <infoLink id="c95d-d4b5-33c9-b2a7" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
+        <infoLink id="bb41-1a39-e46f-158a" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="55f4-4cab-9cec-c75d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="ae48-095c-6184-34bf" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="55f4-4cab-9cec-c75d" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="ae48-095c-6184-34bf" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="aa09-819a-fa02-c669" name="Khenetai Blades" publicationId="09c5-eeae-f398-b653" page="268" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec3a-89f1-2e6c-be3c" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6e1-4f8c-d463-eb9c" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec3a-89f1-2e6c-be3c" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6e1-4f8c-d463-eb9c" type="min" />
           </constraints>
           <profiles>
             <profile id="f6e9-20cc-e461-8a14" name="Khenetai Blades" publicationId="09c5-eeae-f398-b653" page="268" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Psyker)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2360,29 +2359,29 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="ecbe-a6e3-dabb-49b6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink id="ecbe-a6e3-dabb-49b6" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
           </categoryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="24.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="24.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="60a2-d509-07de-5374" name="Khenetai Blademaster" publicationId="09c5-eeae-f398-b653" page="268" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b461-e846-a08a-9955" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4077-0f99-add9-d9a5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b461-e846-a08a-9955" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4077-0f99-add9-d9a5" type="min" />
           </constraints>
           <profiles>
             <profile id="1c4b-4726-5b68-cae0" name="Khenetai Blademaster" publicationId="09c5-eeae-f398-b653" page="268" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="faa7-27d5-2ee2-5d58" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6c81-51e5-160a-4294" type="equalTo"/>
+                    <condition field="selections" scope="faa7-27d5-2ee2-5d58" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6c81-51e5-160a-4294" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Psyker)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2396,41 +2395,41 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="8145-7dfb-29b1-e3c5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink id="8145-7dfb-29b1-e3c5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="21dd-b84f-2e92-d62a" name="May take:" hidden="false" collective="false" import="true">
               <categoryLinks>
-                <categoryLink id="5f91-1703-613a-9aea" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink id="5f91-1703-613a-9aea" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
               </categoryLinks>
               <entryLinks>
                 <entryLink id="6c81-51e5-160a-4294" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3793-fd87-0632-1044" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3793-fd87-0632-1044" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="f95b-bc49-fb42-c9c4" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1911-707e-f910-71f4" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1911-707e-f910-71f4" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="49.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="49.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="034f-641c-4c27-3b63" name="Pair of Achea Force Swords" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f9f-d02d-35c7-954c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac83-781a-6e14-aedd" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f9f-d02d-35c7-954c" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac83-781a-6e14-aedd" type="min" />
           </constraints>
           <profiles>
             <profile id="b25b-0654-8c53-6057" name="Achean Force Sword" publicationId="09c5-eeae-f398-b653" page="259" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2444,56 +2443,56 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="ae68-8180-857e-ea86" name="Achean Force" hidden="false" targetId="c56f-80ff-5d8e-1af4" type="rule"/>
+            <infoLink id="ae68-8180-857e-ea86" name="Achean Force" hidden="false" targetId="c56f-80ff-5d8e-1af4" type="rule" />
             <infoLink id="b7bb-12ea-6c07-f842" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Rending (6+)"/>
+                <modifier type="set" field="name" value="Rending (6+)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="31d8-ca46-050a-2468" name="Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0b39-b494-d378-da80" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0b39-b494-d378-da80" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="74b6-6613-5d4f-051c" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a1d6-10d2-3572-ea59" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a1d6-10d2-3572-ea59" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0" />
               </costs>
             </entryLink>
             <entryLink id="212a-ea96-2805-71dc" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b74a-6481-6491-bb70" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b74a-6481-6491-bb70" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="e37e-3fab-553c-9e2c" name="Storm Eagle Gunship" hidden="true" collective="false" import="true" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -2504,41 +2503,41 @@
           <modifiers>
             <modifier type="increment" field="6033-1413-065f-67fe" value="1.0">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aa09-819a-fa02-c669" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aa09-819a-fa02-c669" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
             <modifier type="increment" field="a21c-5c94-0375-841e" value="1.0">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aa09-819a-fa02-c669" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aa09-819a-fa02-c669" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
-            <modifier type="decrement" field="a21c-5c94-0375-841e" value="4.0"/>
+            <modifier type="decrement" field="a21c-5c94-0375-841e" value="4.0" />
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6033-1413-065f-67fe" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a21c-5c94-0375-841e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6033-1413-065f-67fe" type="max" />
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a21c-5c94-0375-841e" type="min" />
           </constraints>
           <selectionEntryGroups>
             <selectionEntryGroup id="dbf3-29de-4add-89ed" name="One in five may exchange their Bolt Pistol for:" hidden="false" collective="false" import="true">
               <modifiers>
                 <modifier type="increment" field="374b-ed49-2e43-d889" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="374b-ed49-2e43-d889" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="374b-ed49-2e43-d889" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="1dbd-9230-9949-4d14" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="7f31-bfab-74e0-fe5b" name="Æther-Fire Pistol" hidden="false" collective="false" import="true" targetId="ae13-0ae8-a3ba-f6ff" type="selectionEntry">
+                <entryLink id="7f31-bfab-74e0-fe5b" name="&#198;ther-Fire Pistol" hidden="false" collective="false" import="true" targetId="ae13-0ae8-a3ba-f6ff" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -2547,40 +2546,40 @@
           <entryLinks>
             <entryLink id="3071-a2f5-467c-b1d0" name="Asphyx Bolt Pistol" hidden="false" collective="false" import="true" targetId="07f7-c486-f597-a1b9" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0" />
               </costs>
             </entryLink>
-            <entryLink id="e624-f792-fc7e-1fa4" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+            <entryLink id="e624-f792-fc7e-1fa4" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="5692-6031-7cc0-25ba" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2b6-e91b-ae59-9d63" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="524e-9feb-de75-96d1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2b6-e91b-ae59-9d63" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="524e-9feb-de75-96d1" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="64f1-f939-a191-b399" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6819-c725-cdc6-cddc" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19f8-6346-cb4b-d3a1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6819-c725-cdc6-cddc" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19f8-6346-cb4b-d3a1" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="355a-4891-12de-c8b2" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11bb-7ea5-81d6-e599" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c569-ce77-6169-9a6b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11bb-7ea5-81d6-e599" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c569-ce77-6169-9a6b" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="07f4-98a2-a371-5191" name="Magnus the Red" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6898-f9fe-d35a-e601" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6898-f9fe-d35a-e601" type="max" />
       </constraints>
       <profiles>
         <profile id="dc50-95ed-64cd-f3f7" name="Magnus the Red" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2607,27 +2606,27 @@
       <infoLinks>
         <infoLink id="5d23-c220-5963-1ec1" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Adamantium Will (3+)"/>
+            <modifier type="set" field="name" value="Adamantium Will (3+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="6c56-b4c9-663d-c904" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
+        <infoLink id="6c56-b4c9-663d-c904" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule" />
         <infoLink id="477c-0038-cd80-6956" name="Shrouded (X)" hidden="false" targetId="10c3-fdb0-089f-ca65" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Shrouded (5+)"/>
+            <modifier type="set" field="name" value="Shrouded (5+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="414e-3741-48f2-7114" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
+        <infoLink id="414e-3741-48f2-7114" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="45af-d7ac-39f4-2234" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="false"/>
-        <categoryLink id="2f4f-2382-f656-0475" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="9f33-3de6-2245-536e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="45af-d7ac-39f4-2234" name="Primarch:" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="false" />
+        <categoryLink id="2f4f-2382-f656-0475" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="9f33-3de6-2245-536e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b643-0093-699a-1d81" name="Arch-Sorcerer" page="" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6bd1-b762-ac7f-7de9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7c6d-283d-e3e1-809c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6bd1-b762-ac7f-7de9" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7c6d-283d-e3e1-809c" type="max" />
           </constraints>
           <rules>
             <rule id="26cc-e50d-a31d-729d" name="Arch-Sorcerer" publicationId="09c5-eeae-f398-b653" page="261" hidden="false">
@@ -2637,109 +2636,109 @@
           <selectionEntries>
             <selectionEntry id="2736-73ed-4732-8191" name="Cult Arcana" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f63f-41df-7bf1-1043" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3d47-bc63-9230-151b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f63f-41df-7bf1-1043" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3d47-bc63-9230-151b" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="a4c5-5349-21be-aa3c" name="Athanaen" hidden="false" collective="false" import="true" targetId="a06f-f3f7-ba92-365d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04ed-0ef9-d3a6-820e" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b6a2-4dde-db3e-289d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04ed-0ef9-d3a6-820e" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b6a2-4dde-db3e-289d" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="10f4-e093-3942-6f79" name="Corvidae" hidden="false" collective="false" import="true" targetId="f040-f723-e145-9e1f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1304-d7a5-e9cf-c057" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="634f-d1cf-3ec7-576b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1304-d7a5-e9cf-c057" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="634f-d1cf-3ec7-576b" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="8049-d65a-f245-22f1" name="Pavoni" hidden="false" collective="false" import="true" targetId="5532-04aa-8302-2038" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9307-d7b0-a297-9e72" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="67fc-e574-00cc-efa3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9307-d7b0-a297-9e72" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="67fc-e574-00cc-efa3" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="c364-171c-beae-9d73" name="Pyrae" hidden="false" collective="false" import="true" targetId="78eb-adbb-1cc2-b002" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b82-feeb-573c-d0e8" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6244-64e8-e77e-607f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b82-feeb-573c-d0e8" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6244-64e8-e77e-607f" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="3e98-791e-1b43-3af6" name="Raptora" hidden="false" collective="false" import="true" targetId="1aa4-4557-f274-2ba1" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9407-2748-7c41-ba9f" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="312b-bb47-6836-3096" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9407-2748-7c41-ba9f" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="312b-bb47-6836-3096" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="eb98-48e8-66a9-93dc" name="Psychic powers" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e29-f15e-3e8c-cd56" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8d63-08fb-e215-03f8" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e29-f15e-3e8c-cd56" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8d63-08fb-e215-03f8" type="max" />
               </constraints>
               <infoLinks>
-                <infoLink id="d944-9770-4941-9514" name="Aetheric Lightning" hidden="false" targetId="3d0c-e779-247f-0332" type="profile"/>
+                <infoLink id="d944-9770-4941-9514" name="Aetheric Lightning" hidden="false" targetId="3d0c-e779-247f-0332" type="profile" />
               </infoLinks>
               <entryLinks>
                 <entryLink id="2457-b703-84a0-e18e" name="Psychic Discipline: Biomancy" hidden="false" collective="false" import="true" targetId="861c-3744-c4ff-ef6c" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01df-eba8-779f-b254" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2031-d427-aeba-ea99" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01df-eba8-779f-b254" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2031-d427-aeba-ea99" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="b588-35a4-f838-5de6" name="Psychic Discipline: Divination" hidden="false" collective="false" import="true" targetId="0c22-a776-e7e3-2981" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cbb-a752-b821-9095" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="18c1-58d4-380e-a3c3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cbb-a752-b821-9095" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="18c1-58d4-380e-a3c3" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="71b9-0c7c-6b67-bfbd" name="Psychic Discipline: Pyromancy" hidden="false" collective="false" import="true" targetId="c73a-8c52-4780-71e1" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8105-56f6-272b-9a39" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="13aa-2ac5-a35c-ae1a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8105-56f6-272b-9a39" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="13aa-2ac5-a35c-ae1a" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="772d-3ef0-2a29-e9ba" name="Psychic Discipline: Telekinesis" hidden="false" collective="false" import="true" targetId="2599-31ff-74a5-70ec" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d9c-c855-2809-dc60" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3dc1-839d-ce75-34f1" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d9c-c855-2809-dc60" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3dc1-839d-ce75-34f1" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="b4bc-2625-3b16-f7c8" name="Psychic Discipline: Telepathy" hidden="false" collective="false" import="true" targetId="b751-a605-75e8-dd6f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92d3-dd4b-8d40-89f1" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="365a-a916-9dbc-397a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92d3-dd4b-8d40-89f1" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="365a-a916-9dbc-397a" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="e95a-a7fb-a771-8694" name="Psychic Discipline: Thaumaturgy" hidden="false" collective="false" import="true" targetId="f7ab-1fb2-91b0-028d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e98b-1911-3cb2-3524" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2243-27b1-6b0b-4371" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e98b-1911-3cb2-3524" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2243-27b1-6b0b-4371" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="3da5-ea02-18a1-c5cb" name="Psyfire serpenta" publicationId="09c5-eeae-f398-b653" page="261" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1ad-3b52-00d3-69fb" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4740-d5ec-741a-ed0a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1ad-3b52-00d3-69fb" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4740-d5ec-741a-ed0a" type="max" />
           </constraints>
           <profiles>
             <profile id="f8f2-cde4-3735-1398" name="Psyfire serpenta" publicationId="09c5-eeae-f398-b653" page="261" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">15&quot;</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">15"</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">3</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 3, Deflagrate, Force</characteristic>
@@ -2748,21 +2747,21 @@
           </profiles>
           <rules>
             <rule id="0d71-0a7d-ca1a-0638" name="Psyfire serpenta" publicationId="09c5-eeae-f398-b653" page="261" hidden="false">
-              <description>The weapon listed here is counted as &quot;Plasma&quot; and &quot;Force&quot; weapon for those rules that affect such weapons.</description>
+              <description>The weapon listed here is counted as "Plasma" and "Force" weapon for those rules that affect such weapons.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="0284-c535-9da8-30e5" name="Force" hidden="false" targetId="f39e-4c3b-38e0-0050" type="rule"/>
-            <infoLink id="e16b-4fbb-928f-a432" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
+            <infoLink id="0284-c535-9da8-30e5" name="Force" hidden="false" targetId="f39e-4c3b-38e0-0050" type="rule" />
+            <infoLink id="e16b-4fbb-928f-a432" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="38c5-443a-aa10-4169" name="The Blade of Ahn-nunurta" publicationId="09c5-eeae-f398-b653" page="261" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eacb-d8cd-6471-cdc1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c545-d6a3-8ff4-1556" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eacb-d8cd-6471-cdc1" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c545-d6a3-8ff4-1556" type="max" />
           </constraints>
           <profiles>
             <profile id="4b1a-e2fa-975e-11d3" name="The Blade of Ahn-nunurta" publicationId="09c5-eeae-f398-b653" page="261" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2776,21 +2775,21 @@
           </profiles>
           <rules>
             <rule id="422a-827d-e765-2c3f" name="The Blade of Ahn-nunurta" publicationId="09c5-eeae-f398-b653" page="261" hidden="false">
-              <description>The weapon listed here is counted as a &quot;Power&quot; and &quot;Force&quot; weapon for those rules that affect such weapons.</description>
+              <description>The weapon listed here is counted as a "Power" and "Force" weapon for those rules that affect such weapons.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="3b73-e247-20d5-1a09" name="Force" hidden="false" targetId="f39e-4c3b-38e0-0050" type="rule"/>
-            <infoLink id="eba3-cbe0-3fff-04ca" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+            <infoLink id="3b73-e247-20d5-1a09" name="Force" hidden="false" targetId="f39e-4c3b-38e0-0050" type="rule" />
+            <infoLink id="eba3-cbe0-3fff-04ca" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="4f35-be6a-0b72-f74e" name="The Horned Raiment" publicationId="09c5-eeae-f398-b653" page="261" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ba6-6df8-426c-5ac7" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="973d-8df1-90ca-6170" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ba6-6df8-426c-5ac7" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="973d-8df1-90ca-6170" type="max" />
           </constraints>
           <profiles>
             <profile id="7e5a-ebf9-1138-e23e" name="The Horned Raiment" publicationId="09c5-eeae-f398-b653" page="261" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
@@ -2800,27 +2799,27 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="b91d-50cb-90d4-87fa" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9f4-23b7-2fec-8754" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2e30-669c-dbf2-dfc5" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9f4-23b7-2fec-8754" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2e30-669c-dbf2-dfc5" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="28e6-bb04-55c7-9c12" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c696-e08b-8708-8dfa" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="119f-9802-3778-a686" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c696-e08b-8708-8dfa" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="119f-9802-3778-a686" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="3c70-596c-4b3f-ae87" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b45-940f-81be-b2b2" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77a9-8685-aff9-fa5d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b45-940f-81be-b2b2" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77a9-8685-aff9-fa5d" type="min" />
           </constraints>
           <profiles>
             <profile id="1beb-b273-c551-b92e" name="Sire of the Thousand Sons" publicationId="09c5-eeae-f398-b653" page="260" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
@@ -2832,35 +2831,35 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="520.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="520.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="ca26-b6e2-0bef-85a5" name="Numerologist Cabal" publicationId="f743-7ff9-a2f3-01c7" page="6" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eeb3-8dfb-9ebb-5eb0" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eeb3-8dfb-9ebb-5eb0" type="max" />
       </constraints>
       <profiles>
         <profile id="93f9-cf71-b933-04ff" name="Psy-synchronicity" page="" hidden="false" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power">
           <characteristics>
-            <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">At the start of the controlling player&apos;s turn, a Psychic check may be made for a unit that contains one or more models with this Psychic Power, using the highest Leadership Characteristic among those models. If the Check is successful, a model with this power gains a geo-locator beacon until the end of the turn. In addition, up to two friendly units composed entirely of models with the Legiones Astartes (Thousand Sons) special rule with one or more models within 6&quot; of any models using Psy-synchronicity gain a bonus of +1 to their BS during the Active player&apos;s Shooting phase, so long as models with this Psychic Power do not make a Shooting Attack in the Shooting phase. If the Check is failed then the unit suffers Perils of the Warp.</characteristic>
+            <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">At the start of the controlling player's turn, a Psychic check may be made for a unit that contains one or more models with this Psychic Power, using the highest Leadership Characteristic among those models. If the Check is successful, a model with this power gains a geo-locator beacon until the end of the turn. In addition, up to two friendly units composed entirely of models with the Legiones Astartes (Thousand Sons) special rule with one or more models within 6" of any models using Psy-synchronicity gain a bonus of +1 to their BS during the Active player's Shooting phase, so long as models with this Psychic Power do not make a Shooting Attack in the Shooting phase. If the Check is failed then the unit suffers Perils of the Warp.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="af81-7294-801f-6ca9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="da52-1de8-5089-fd73" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="af81-7294-801f-6ca9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="da52-1de8-5089-fd73" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d78c-0412-116d-2bdb" name="Numerologist" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8601-c2f6-036d-3e14" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15cc-b333-8a6b-33b1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8601-c2f6-036d-3e14" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15cc-b333-8a6b-33b1" type="min" />
           </constraints>
           <profiles>
             <profile id="6e93-2a37-caa7-e68f" name="Numerologist" page="" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Psyker)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2875,7 +2874,7 @@
           </profiles>
           <rules>
             <rule id="3d26-05d0-677d-032b" name="Life Warded" page="" hidden="false">
-              <description>No Wounds may be allocated to a Numerologist, regardless of the attacking model’s rules or effects, as long as there is another model without the Life Warded special rule in the unit. If the Numerologist is Engaged in a Challenge — then this rule does not apply. However, if the Numerologist’s controlling player chooses to refuse a Challenge for a unit that includes a model with the Life Warded special rule then the opposing player loses the option to stop one model from participating in the combat.
+              <description>No Wounds may be allocated to a Numerologist, regardless of the attacking model&#8217;s rules or effects, as long as there is another model without the Life Warded special rule in the unit. If the Numerologist is Engaged in a Challenge &#8212; then this rule does not apply. However, if the Numerologist&#8217;s controlling player chooses to refuse a Challenge for a unit that includes a model with the Life Warded special rule then the opposing player loses the option to stop one model from participating in the combat.
 
 Additionally, a unit that includes any models with this special rule may not be joined by any model that does not also have this special rule (this includes Legion Techmarines and Legion Apothecaries, which may not be assigned to a unit with this special rule unless they also have this special rule)</description>
             </rule>
@@ -2884,93 +2883,93 @@ Additionally, a unit that includes any models with this special rule may not be 
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="d97e-626e-22d9-c252" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+            <infoLink id="d97e-626e-22d9-c252" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
             <infoLink id="5c52-c6d4-3b40-d7ed" name="Battlesmith (X)" hidden="false" targetId="5d57-4d02-1e36-4a82" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Battlesmith (4+)"/>
+                <modifier type="set" field="name" value="Battlesmith (4+)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <categoryLinks>
-            <categoryLink id="800e-13a8-47de-1127" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink id="3f06-e271-542a-0eda" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink id="800e-13a8-47de-1127" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
+            <categoryLink id="3f06-e271-542a-0eda" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f524-7b20-49ef-df28" name="1) May take one of the following weapons" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c1e-29c8-4a32-247c" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c1e-29c8-4a32-247c" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="c982-8a52-79bf-ed69" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="4be4-fb04-7db1-9408" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="Master-crafted Bolter"/>
+                    <modifier type="set" field="name" value="Master-crafted Bolter" />
                   </modifiers>
                   <infoLinks>
-                    <infoLink id="288d-982f-9ace-f94a" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                    <infoLink id="288d-982f-9ace-f94a" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
                   </infoLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="8fd0-e464-9c17-346c" name="Minor Combi-Weapon" hidden="false" collective="false" import="true" targetId="605e-1b86-ca08-9226" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="3292-a518-8bcf-2309" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="8337-89b7-62f3-3a2b" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="1fb9-196c-2d65-ca98" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="7d9b-75df-6b48-2aff" name="Magna Combi-Weapon" hidden="false" collective="false" import="true" targetId="e5b1-83e5-7272-a59e" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="bbd1-bc74-9a7f-935d" name="Æther-Fire Blaster" hidden="false" collective="false" import="true" targetId="d078-5f42-c02b-c73d" type="selectionEntry">
+                <entryLink id="bbd1-bc74-9a7f-935d" name="&#198;ther-Fire Blaster" hidden="false" collective="false" import="true" targetId="d078-5f42-c02b-c73d" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="b82e-f539-b9b7-c73d" name="Æther-Fire Pistol" hidden="false" collective="false" import="true" targetId="ae13-0ae8-a3ba-f6ff" type="selectionEntry">
+                <entryLink id="b82e-f539-b9b7-c73d" name="&#198;ther-Fire Pistol" hidden="false" collective="false" import="true" targetId="ae13-0ae8-a3ba-f6ff" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="74ef-42e4-3dc5-020e" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="88fb-8a5c-a5d1-759f" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="3920-3cc1-ca7c-fd5f" name="Asphyx Bolter" hidden="false" collective="false" import="true" targetId="88c0-4623-9da3-f2b5" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="Master-crafted Asphyx Bolter"/>
+                    <modifier type="set" field="name" value="Master-crafted Asphyx Bolter" />
                   </modifiers>
                   <infoLinks>
-                    <infoLink id="ba71-e37f-9c32-d3e5" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                    <infoLink id="ba71-e37f-9c32-d3e5" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
                   </infoLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="6.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="6.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -2979,57 +2978,57 @@ Additionally, a unit that includes any models with this special rule may not be 
               <entryLinks>
                 <entryLink id="6713-cb5d-300d-8ed6" name="Cyber-Familiar" hidden="false" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abf6-7cda-dfca-d145" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abf6-7cda-dfca-d145" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="f3bf-b033-c2b6-77cb" name="2) May exchange his Achea Force axe for a:" hidden="false" collective="false" import="true" defaultSelectionEntryId="90b0-a696-aff1-3b67">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97d5-b35b-cc26-8baf" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33a1-4050-575a-e7a2" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97d5-b35b-cc26-8baf" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33a1-4050-575a-e7a2" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="7c69-b2a9-bbc4-a67c" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="90b0-a696-aff1-3b67" name="Achea Force Axe" hidden="false" collective="false" import="true" targetId="d27f-9247-2c27-4450" type="selectionEntry"/>
+                <entryLink id="90b0-a696-aff1-3b67" name="Achea Force Axe" hidden="false" collective="false" import="true" targetId="d27f-9247-2c27-4450" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
             <entryLink id="a364-f338-4d6f-f4cf" name="Servo-Arm" hidden="false" collective="false" import="true" targetId="4168-fc85-8912-7188" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93cb-bd37-8969-e45e" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f69d-c9d2-9aac-dbe9" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93cb-bd37-8969-e45e" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f69d-c9d2-9aac-dbe9" type="min" />
               </constraints>
             </entryLink>
             <entryLink id="386d-fc71-56e0-e203" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1818-ba1f-0638-7747" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31fa-1db4-77be-71dd" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1818-ba1f-0638-7747" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31fa-1db4-77be-71dd" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="90.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="90.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="bd2b-85e6-c442-dc0b" name="Life Wards" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e034-9ad0-1ff8-38cd" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29e2-9dc7-f776-eda4" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e034-9ad0-1ff8-38cd" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29e2-9dc7-f776-eda4" type="min" />
           </constraints>
           <profiles>
             <profile id="fea7-d084-7159-84df" name="Life Ward" page="" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Psyker)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -3043,10 +3042,10 @@ Additionally, a unit that includes any models with this special rule may not be 
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="71de-96dc-adfa-47e5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+            <categoryLink id="71de-96dc-adfa-47e5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
           </categoryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -3055,61 +3054,61 @@ Additionally, a unit that includes any models with this special rule may not be 
           <modifiers>
             <modifier type="decrement" field="5175-dd0d-5943-2727" value="1.0">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="54bc-ead5-f140-863c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="54bc-ead5-f140-863c" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
             <modifier type="decrement" field="ed9b-d2fe-54eb-d5e9" value="1.0">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="54bc-ead5-f140-863c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="54bc-ead5-f140-863c" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
-            <modifier type="decrement" field="5175-dd0d-5943-2727" value="4.0"/>
+            <modifier type="decrement" field="5175-dd0d-5943-2727" value="4.0" />
             <modifier type="increment" field="ed9b-d2fe-54eb-d5e9" value="1.0">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd2b-85e6-c442-dc0b" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd2b-85e6-c442-dc0b" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
             <modifier type="increment" field="5175-dd0d-5943-2727" value="1.0">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd2b-85e6-c442-dc0b" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd2b-85e6-c442-dc0b" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed9b-d2fe-54eb-d5e9" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5175-dd0d-5943-2727" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed9b-d2fe-54eb-d5e9" type="max" />
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5175-dd0d-5943-2727" type="min" />
           </constraints>
           <entryLinks>
             <entryLink id="71bd-ac82-f2ed-9250" name="Asphyx Bolt Pistol" hidden="false" collective="false" import="true" targetId="07f7-c486-f597-a1b9" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0" />
               </costs>
             </entryLink>
-            <entryLink id="074c-04ca-ea9f-0145" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+            <entryLink id="074c-04ca-ea9f-0145" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="2223-a09a-0942-f0cb" name="Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0d98-f45f-fdeb-aaf5" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0d98-f45f-fdeb-aaf5" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="2b62-0cd9-0016-f611" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6ed9-0c3b-4a17-e516" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6ed9-0c3b-4a17-e516" type="max" />
               </constraints>
             </entryLink>
             <entryLink id="b907-2b15-4d9f-0097" name="Storm Eagle Gunship" hidden="true" collective="false" import="true" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -3120,35 +3119,35 @@ Additionally, a unit that includes any models with this special rule may not be 
           <entryLinks>
             <entryLink id="b327-003e-3dfa-95a9" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6278-8ca1-7340-876a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6278-8ca1-7340-876a" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="dc4f-6504-a7df-c5e3" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3cb-3066-7c3c-a1c4" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3cb-3066-7c3c-a1c4" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="3215-2428-7601-f527" name="1) One Life Ward may exchange his chainsword for a:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8abf-b4bf-f146-c34c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8abf-b4bf-f146-c34c" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="2725-e26e-7870-1b83" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </entryLink>
             <entryLink id="ccb0-b9da-ceda-f139" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -3157,22 +3156,22 @@ Additionally, a unit that includes any models with this special rule may not be 
           <modifiers>
             <modifier type="increment" field="0eb7-6438-0f93-754d" value="1.0">
               <repeats>
-                <repeat field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0eb7-6438-0f93-754d" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0eb7-6438-0f93-754d" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="3985-437c-694e-7d4d" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
             <entryLink id="f5db-3d8b-1c55-4133" name="Volkite Caliver" hidden="false" collective="false" import="true" targetId="9250-490f-abeb-b901" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -3181,37 +3180,37 @@ Additionally, a unit that includes any models with this special rule may not be 
       <entryLinks>
         <entryLink id="985a-5d3f-2eb2-a84f" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5f5-b480-5683-36e7" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9227-3a59-8b07-87b9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5f5-b480-5683-36e7" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9227-3a59-8b07-87b9" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="9075-f8de-7ba5-9b9a" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb41-c250-4800-c500" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4736-4a42-84b2-0ff9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb41-c250-4800-c500" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4736-4a42-84b2-0ff9" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="8676-2234-1b84-fc41" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef95-393a-0b33-6b10" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f49-a01c-b09c-014e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef95-393a-0b33-6b10" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f49-a01c-b09c-014e" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="84a1-a262-3c71-6210" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d12b-d545-d5b2-4ea8" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef50-fc52-7813-a356" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d12b-d545-d5b2-4ea8" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef50-fc52-7813-a356" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="7967-dc72-e92e-4a53" name="Geo-locator Beacon" hidden="false" collective="false" import="true" targetId="9333-3d3a-1c13-c602" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43d7-8510-284e-830f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0efa-8d31-79a6-2ddc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43d7-8510-284e-830f" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0efa-8d31-79a6-2ddc" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -3220,98 +3219,98 @@ Additionally, a unit that includes any models with this special rule may not be 
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="ec0a-b050-0b4d-4d62" value="1.0">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fc31-1573-6755-d75e" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec0a-b050-0b4d-4d62" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fc31-1573-6755-d75e" type="max" />
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec0a-b050-0b4d-4d62" type="min" />
       </constraints>
       <selectionEntryGroups>
         <selectionEntryGroup id="cd1f-6c56-62f0-d277" name=" XV: Thousand Sons" publicationId="09c5-eeae-f398-b653" page="256" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b3a1-ecbc-c19f-3be7" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d55f-955b-3eed-58eb" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b3a1-ecbc-c19f-3be7" type="max" />
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d55f-955b-3eed-58eb" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="4ae4-8be5-2cbd-a671" name="Evoker of Pain (Traitor only)" publicationId="09c5-eeae-f398-b653" page="256" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="416d-e0ee-efbc-9fdc" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ce65-886a-dca0-64ab" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="416d-e0ee-efbc-9fdc" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ce65-886a-dca0-64ab" type="max" />
               </constraints>
               <profiles>
                 <profile id="bf82-e47a-b04c-dae8" name="Evoker of Pain" publicationId="09c5-eeae-f398-b653" page="256" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When a Warlord with this Trait fails a Psychic check and suffers Perils of the Warp , neither the Warlord nor any models in a unit it has joined suffer any Wounds. Instead, select one enemy unit that either has at least one model w ithin 6&quot; of the Warlord with this Trait, or is locked in combat with the Warlord with this Trait. The selected enemy unit suffers D3 Wounds against which only Invulnerable Saves may be made and no Damage Mitigation rolls may be made, if there is no valid enemy unit within 6&quot; then resolve Perils of the Warp against the Warlord’s unit as normal. Wounds inflicted in this manner during the Assault phase do not count for resolving the winner of a combat and never cause Morale checks or Pinning tests. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When a Warlord with this Trait fails a Psychic check and suffers Perils of the Warp , neither the Warlord nor any models in a unit it has joined suffer any Wounds. Instead, select one enemy unit that either has at least one model w ithin 6" of the Warlord with this Trait, or is locked in combat with the Warlord with this Trait. The selected enemy unit suffers D3 Wounds against which only Invulnerable Saves may be made and no Damage Mitigation rolls may be made, if there is no valid enemy unit within 6" then resolve Perils of the Warp against the Warlord&#8217;s unit as normal. Wounds inflicted in this manner during the Assault phase do not count for resolving the winner of a combat and never cause Morale checks or Pinning tests. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="7fb4-3cbc-c178-62b3" name="Magister of Prospero" publicationId="09c5-eeae-f398-b653" page="256" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b2bb-4153-72a1-17e8" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e262-ec8d-128b-5d25" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b2bb-4153-72a1-17e8" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e262-ec8d-128b-5d25" type="max" />
               </constraints>
               <profiles>
                 <profile id="39b3-ab29-52a0-4488" name="Magister of Prospero" publicationId="09c5-eeae-f398-b653" page="256" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait , and any model with the Legiones Astartes (Thousand Sons) special rule in a unit it joins that makes a Psychic check (such as when using the Force or Psychic Focus special rules) may roll an additional dice and discard the highest rolled dice before determining the result of the Check. In addition, whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait , and any model with the Legiones Astartes (Thousand Sons) special rule in a unit it joins that makes a Psychic check (such as when using the Force or Psychic Focus special rules) may roll an additional dice and discard the highest rolled dice before determining the result of the Check. In addition, whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Movement phase long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="d00a-91a0-bbb4-b7a1" name="Eidolon of Suffering" publicationId="09c5-eeae-f398-b653" page="256" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="efdf-a713-2ca5-aea2" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5825-8491-f20c-97cb" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="efdf-a713-2ca5-aea2" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5825-8491-f20c-97cb" type="max" />
               </constraints>
               <profiles>
                 <profile id="fabf-f3c9-8c4b-5919" name="Eidolon of Suffering" publicationId="09c5-eeae-f398-b653" page="256" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait may not use Psychic Powers or Psychic Weapons and gains the Adamantium Will (3+) special rule. When another model, friendly or enemy, makes a psychic check within 12” of the Warlord , the controlling player must roll a D6. On the score of a &apos;1&apos;, there is no effect, and on the score of a ‘2’ or higher the Warlord gains the Rage (2) special rule for the remainder of the battle. If this Trait would grant the Warlord the Rage (2) special rule a further time then it instead increases the value of the Rage special rule by +1 (from Rage (2) to Rage (3) and so on) up to a maximum of Rage (4 ). In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait may not use Psychic Powers or Psychic Weapons and gains the Adamantium Will (3+) special rule. When another model, friendly or enemy, makes a psychic check within 12&#8221; of the Warlord , the controlling player must roll a D6. On the score of a '1', there is no effect, and on the score of a &#8216;2&#8217; or higher the Warlord gains the Rage (2) special rule for the remainder of the battle. If this Trait would grant the Warlord the Rage (2) special rule a further time then it instead increases the value of the Rage special rule by +1 (from Rage (2) to Rage (3) and so on) up to a maximum of Rage (4 ). In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="0290-0d6b-21d5-7953" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+        <entryLink id="0290-0d6b-21d5-7953" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="39e7-5296-42e0-fe94" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="c754-54a9-5065-364d" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="c754-54a9-5065-364d" type="max" />
       </constraints>
       <entryLinks>
         <entryLink id="5bcf-3e18-a2da-bb84" name="Command Squad, Cataphractii" hidden="false" collective="false" import="true" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
@@ -3320,19 +3319,19 @@ Additionally, a unit that includes any models with this special rule may not be 
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="c505-e39e-a306-c969" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
-        <entryLink id="d46c-418f-b9b2-b2c8" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="c505-e39e-a306-c969" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
+        <entryLink id="d46c-418f-b9b2-b2c8" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Thousand Sons.cat
+++ b/2022 - LA - Thousand Sons.cat
@@ -2,8 +2,7 @@
   <publications>
     <publication id="f743-7ff9-a2f3-01c7" name="Exemplary Battles of the Age of Darkness: The Axandria IV Incident" shortName="Axandria IV" publisher="Exemplary Battles of the Age of Darkness: The Axandria IV Incident" publicationDate="9/16/2022" publisherUrl="https://www.warhammer-community.com/wp-content/uploads/2022/09/3mVvZrTG9XOWeVxv.pdf" />
   </publications>
-  <entryLinks>
-    <entryLink id="5900-484e-9f23-c753" name="  XV: Thousand Sons" hidden="false" collective="false" import="false" targetId="21c3-2f28-7820-e51a" type="selectionEntry">
+  <entryLinks><entryLink id="5900-484e-9f23-c753" name="  XV: Thousand Sons" hidden="false" collective="false" import="false" targetId="21c3-2f28-7820-e51a" type="selectionEntry">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d49c-72c4-b170-6dc6" type="min" />
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9206-fcb8-ba7e-4fbf" type="max" />
@@ -104,946 +103,1695 @@
         <categoryLink id="497d-849e-d9b4-be08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="db25-4002-f4d3-2544" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="84e7-eddc-4289-b5c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="dabd-dfc4-cef1-0d1f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <entryLink id="db25-4002-f4d3-2544" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="c10f-85c7-4e8d-8292" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6d4-581f-4746-bec3</comment></categoryLink>
+        <categoryLink id="4ff6-a50a-4f99-843f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_2489-ee2a-45dd-b384</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
-    <entryLink id="535a-6435-abd5-c52f" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="129f-baa2-7a79-db0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0bb1-bc2b-0986-c26f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
-    <entryLink id="2a9c-7cc1-c26b-384a" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink><entryLink id="535a-6435-abd5-c52f" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b02f-e65f-4a88-a175</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_b87b-bf35-4238-b7c6</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1aff-27af-435e-8102</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_fdf9-4906-4180-a39d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="80c9-6006-0cad-636d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="9be3-ada3-a64a-6d9b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8954-a74a-0528-4f89" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="304d-9cad-4281-99c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8378-ede4-476d-b657</comment></categoryLink>
+        <categoryLink id="ef77-8316-4602-9268" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_d64f-ad19-426c-adf7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
-    <entryLink id="760c-2ea5-4492-6e3c" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="42b7-8e15-add0-1653" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="f43c-4bde-395e-22d2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
-    <entryLink id="4fb3-9f32-425d-ce89" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3974-a905-64e8-6a85" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="3b03-f1ce-3de3-235c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
-    <entryLink id="99c8-f0b7-7334-7c9f" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink><entryLink id="2a9c-7cc1-c26b-384a" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_7fd1-8ce8-4d10-82e7</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_eaae-8c43-4d30-898c</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_f67d-8cf3-424f-b491</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_b949-6414-4f3d-b268</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7d5e-09d7-e265-0df6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="fda0-da57-0e09-3b36" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a72a-c505-b685-45e4" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="41ed-ac9f-4667-ae92" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_ac26-e639-4d53-9b8b</comment></categoryLink>
+        <categoryLink id="bc15-407c-466c-afd0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_49af-0d08-4c7e-8ce6</comment></categoryLink>
+        <categoryLink id="782e-0283-4f69-9624" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_b606-de16-4659-95cd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
-    <entryLink id="7f24-67c9-bf67-1163" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink><entryLink id="760c-2ea5-4492-6e3c" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="912c-dcaf-319c-7f80" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="eeec-83c3-de4c-ee87" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
-    <entryLink id="3bd0-a47a-2916-4ec4" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7583-6fa0-4089-a19e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_0e5c-99ab-41d3-a42e</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c296-e8e8-4a7a-989a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_8868-5bcb-4604-ba8e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c740-6d2a-4e2f-8837" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a009-a597-4b51-b228</comment></categoryLink>
+        <categoryLink id="3f3c-abdb-4001-a527" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_24f4-9145-4016-80d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink><entryLink id="4fb3-9f32-425d-ce89" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_e732-7499-47bf-9748</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_81a5-a959-46b7-baa4</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7ec3-447a-4644-b012</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_71e2-c430-4c99-a559</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_df7b-3fb9-4f65-9165</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="048b-297e-4a31-a975" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c165-3906-463a-9c73</comment></categoryLink>
+        <categoryLink id="ec07-c419-4ccb-8fd9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6d1-d14c-473f-be09</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink><entryLink id="99c8-f0b7-7334-7c9f" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_27a3-1e4c-4b76-a594</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_d59a-dcd0-44fd-b866</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_0c8b-2b92-49ed-98c7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_bafe-f799-41d9-ac85</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_6369-288c-4fec-a640</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_fe53-8858-41dc-8ec4</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0433-c92b-094a-d42e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="bb15-f483-394b-e079" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3ab1-272e-44d6-b20e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_3a22-caae-4eea-9bc5</comment></categoryLink>
+        <categoryLink id="399d-b8d1-4ea7-bfa8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f759-f33e-4698-9f8a</comment></categoryLink>
+        <categoryLink id="d867-86af-4ee8-a41f" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_c624-3ae0-46c0-9b06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
-    <entryLink id="741b-5a90-d34b-d709" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b5a4-b534-297d-a893" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="0040-68a2-8816-e4f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="99f6-b84b-2ec3-780b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="7c11-9b6f-e3df-9170" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup" />
-        <entryLink id="cf74-e9fe-4bd7-ec6b" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink><entryLink id="7f24-67c9-bf67-1163" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_13b3-ce1e-4f9d-8319</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d681-9d81-4abd-b11b</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a57-e48b-4534-bca5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_1859-5641-4674-9097</comment>
+                </condition>
               </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
-    <entryLink id="854d-39d3-408a-2745" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
-      <modifiers>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9cca-ba09-43a3-b09e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_251a-df5b-4bfd-ad63</comment></categoryLink>
+        <categoryLink id="188d-829a-4030-9f81" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4644-98ab-4e3f-b1fd</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink><entryLink id="3bd0-a47a-2916-4ec4" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_591d-d028-4663-918d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_0482-c5f9-4c95-9597</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_75a7-971d-4978-a83f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_a7d5-2bfe-4621-ac0c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9f13-b460-4f27-b0cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_31fc-e265-45a7-bb5b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4956-69cf-a1f6-cb1b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d240-e08f-d8a4-c5ca" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="7c9d-b30e-7ad0-a1e9" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="515c-31c8-4ecc-9df6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_67c2-df43-44fc-92d1</comment></categoryLink>
+        <categoryLink id="167f-4975-484b-9eee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4136-bb4e-4dd4-99f9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink><entryLink id="741b-5a90-d34b-d709" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry"><categoryLinks>
+        <categoryLink id="84bd-c305-4d96-88f6" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_2599-24e3-44e5-9568</comment></categoryLink>
+        <categoryLink id="7a96-eab2-471e-8ff2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_285f-6e56-473b-b2fe</comment></categoryLink>
+        <categoryLink id="3080-605c-4d94-b686" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_685e-022f-4e2f-a568</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="8392-599d-5e9d-718e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup" />
-        <entryLink id="e259-a292-d1c2-83b2" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup">
+        <entryLink id="5628-e552-406c-bf6f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup"><comment>    template_id_2a38-6544-4267-b584    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="f663-b752-4b5d-b81b" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_8287-16ff-46ba-9838</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_81c1-fca9-44dc-ba4c</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_6e59-4592-47ef-b76d    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
-    <entryLink id="998c-50ac-bbb9-245e" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f2e8-e0e6-28c5-9f04" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1d60-3007-e583-71dc" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="8eb0-7dda-305b-784b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="7e40-1a85-bbea-36c2" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup" />
-        <entryLink id="9876-987e-6f65-d685" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
-    <entryLink id="509d-9171-e8e2-84ca" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e1fd-d7ce-4a03-0016" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="065c-c457-4777-8f24" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
-    <entryLink id="4e9d-586d-9da8-2dba" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7210-86d1-e777-2819" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="cba2-ee78-1c90-95cd" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
-    <entryLink id="aa8e-3301-ff58-8790" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink><entryLink id="854d-39d3-408a-2745" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ad5d-3c79-4239-9116</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_60b1-049b-4a5f-85c2</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9582-859d-e933-b3b0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1a9e-f3ea-6143-94d5" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="69e8-ff52-4bb0-8670" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bd6a-0cda-4e0f-80ae</comment></categoryLink>
+        <categoryLink id="2fa4-9036-42e9-bc3d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_ae75-7cca-4701-9d56</comment></categoryLink>
+        <categoryLink id="43d0-a7e7-4d98-8429" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_e517-62d4-48f7-8174</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
-    <entryLink id="8aa3-f18d-3323-3f4a" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
+      <entryLinks>
+        <entryLink id="f809-3586-4445-85d0" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup"><comment>    template_id_fafb-6414-474a-8a09    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="43ce-8a16-4805-8631" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_1e43-c980-4508-8ec2</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_4140-36a7-4203-b5e9</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_a6a6-9bc7-4d4e-86a7    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink><entryLink id="998c-50ac-bbb9-245e" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry"><categoryLinks>
+        <categoryLink id="9083-93ea-4585-b714" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fc9d-03d1-4bbd-a1c4</comment></categoryLink>
+        <categoryLink id="55ad-5002-4511-8bc3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_f51c-73d7-4f29-be1c</comment></categoryLink>
+        <categoryLink id="3809-fa0a-49e1-88da" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_257d-78c0-4bab-ba65</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="6dd2-2f5d-49dc-8858" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup"><comment>    template_id_ac26-33db-40a7-bdba    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="2ddc-8f62-49cc-a868" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_189b-db75-4db6-9fe9</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_cbdb-2500-4e13-876a</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_dc8e-2801-46d6-84f8    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink><entryLink id="509d-9171-e8e2-84ca" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b43b-547f-472e-9076</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8ff9-0498-4540-8552</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fbfe-931a-489b-a589</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f4c3-5aa6-4caa-abf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_17f8-f055-4c9c-b757</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="c9d1-a92c-aa5a-96cc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ba2a-c066-eb39-8b0d" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="ce9d-ba16-41a2-a47f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f1c8-27fd-4f98-8527</comment></categoryLink>
+        <categoryLink id="4fd2-aca5-4de8-8946" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2b20-1a8b-4753-b657</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
-    <entryLink id="30c5-e44f-7c47-e971" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink><entryLink id="4e9d-586d-9da8-2dba" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry"><categoryLinks>
+        <categoryLink id="a76d-22e2-47bf-b4fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4207-8d8f-4b1a-836b</comment></categoryLink>
+        <categoryLink id="c3b1-ab38-4a5a-a952" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_2b34-077f-4279-86fb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink><entryLink id="aa8e-3301-ff58-8790" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="b75f-1fb9-3a88-8f8d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="dc18-5584-91b0-19a0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="0c6d-3fc1-4ce7-8f74" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6577-e0fb-4fda-834e</comment></categoryLink>
+        <categoryLink id="c292-5e0f-4fba-a530" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_5d59-09bf-4566-b7e1</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
-    <entryLink id="97fb-5eb3-b4e4-db61" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink><entryLink id="8aa3-f18d-3323-3f4a" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"><categoryLinks>
+        <categoryLink id="5ba5-a120-4608-8b86" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_aa93-057d-42f6-82d7</comment></categoryLink>
+        <categoryLink id="d277-f37c-4d81-a221" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_403c-4e9c-4af5-84ec</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink><entryLink id="30c5-e44f-7c47-e971" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_23fa-06dd-49f9-a7db</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5b26-059e-40b3-9d93</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f7bf-3a1c-4103-aed8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="79a4-1109-306c-2d53" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="0bd4-5197-36a1-abe1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="eb73-432c-40b3-9b96" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dd44-e0a8-42a8-bdcc</comment></categoryLink>
+        <categoryLink id="1210-f963-470e-bd56" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_c5b0-f9ae-468d-924a</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
-    <entryLink id="82f9-f6dd-7616-2e07" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink><entryLink id="97fb-5eb3-b4e4-db61" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8396-e51c-4e2b-bada</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_13bb-9fb5-4580-92cf</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_bfb8-8125-4548-92f5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25e3-b8f5-4448-a7c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8db3-4f3a-432e-8e7b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_f926-27fd-4a92-97a1</comment></categoryLink>
+        <categoryLink id="7a3f-3db1-4b57-8bec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_82e3-36e1-4e85-8fcb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink><entryLink id="82f9-f6dd-7616-2e07" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e724-bf87-c22c-2ee9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
         <categoryLink id="4b03-986e-8a8f-7787" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="ce1c-cf99-3bf5-e1ef" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
-      <modifiers>
+    <entryLink id="ce1c-cf99-3bf5-e1ef" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_658f-b1ad-4347-a998</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_12bc-3db2-4d28-abce</comment>
+            </condition>
           </conditions>
         </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="71c2-9cda-b2db-6a18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f860-7f81-630e-5bda" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
-    <entryLink id="6a44-ab07-cb0d-7f6d" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_9d83-7691-41d6-8dad</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_add7-ba48-46d4-8a02</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_1fb0-2421-40a4-9e49</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1197-91a9-cdc8-aad4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="e692-0c21-f983-ee2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="454f-6cd5-3910-4047" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="10f7-0350-4748-8eee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7004-b00d-481f-b740</comment></categoryLink>
+        <categoryLink id="92c1-accd-4e9a-bc9f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4f88-2fc3-491c-bfb7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
-    <entryLink id="6c37-b1e1-747f-c93e" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3d25-ef84-e8c8-a7ea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="604a-5342-8a56-e4fe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
-    <entryLink id="8eb9-da53-4df0-9a20" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0fad-0b78-4d3c-9c84" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="382b-504e-87e1-fbc0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
-    <entryLink id="5c7e-d632-a1f7-31c2" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="eb65-8a7c-275f-2d90" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="beaf-07f8-a942-4a16" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
-    <entryLink id="25dd-db68-56f0-0d09" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="efb1-38f6-cede-acc2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="836e-d21e-6395-89b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
-    <entryLink id="3382-bc4e-5766-917f" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="eb9a-db3c-090e-c778" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2283-e1b8-b295-b9f8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
-    <entryLink id="577e-1f0c-3ea2-ce15" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="cbd3-898e-21ad-1b03" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="d40d-7c84-fd8c-0c2a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
-    <entryLink id="9d7f-87f1-a6f7-a9b6" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="50cb-612d-8ae6-bcaa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="bf88-8e65-40f6-202a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
-    <entryLink id="0fc5-f21e-23bf-674a" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="bffd-57ef-9bd8-0026" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a4a6-287f-244f-161a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
-    <entryLink id="87bb-bff2-5be7-1ce7" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1ea3-f3d7-0b5a-1210" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="a9c5-a889-18e9-8b1c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
-    <entryLink id="bb9a-a828-d268-650b" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0f5a-7dba-37c5-cc88" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b9a5-d96a-11d1-a48e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
-    <entryLink id="5410-ddf3-9b5f-6346" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8fa1-c6d9-6ed7-0072" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="1df5-29b9-c6e4-c6c1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
-    <entryLink id="65d5-eec6-1030-d756" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="89e7-33ea-521c-1db9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="f7f5-0ec8-3fa9-cfc5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
-    <entryLink id="d88b-6b14-5e71-71f6" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2220-a788-d1b2-9a46" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="e4a8-9ba6-11b6-4b78" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
-    <entryLink id="3aa6-167c-6612-0ddb" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8fbb-da0d-f9f3-c24b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="02ab-7b58-1707-4598" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
-    <entryLink id="3e19-3b02-a3ab-1f4a" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="67f1-ea02-b68b-c362" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="aff1-bf9a-9a70-1580" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
-    <entryLink id="8a69-dd44-4b8d-60f9" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="00f6-41d4-81b3-76e4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="dd96-2953-2507-4fc0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
-    <entryLink id="5c98-3dc1-f22b-08aa" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="dbfd-f303-2d66-adbe" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="b3a0-908c-6a19-279f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
-    <entryLink id="6676-5302-e270-4855" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7f58-759c-ce19-64ba" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="1ad3-f137-e96f-612a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
-    <entryLink id="c3b6-baad-9af2-9539" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="bdc3-29b8-97cf-4a6b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="5448-8016-ede3-7eda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
-    <entryLink id="958c-419d-6c26-bbc7" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6238-d954-ceaa-b31f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="56d3-f45b-4d1e-7334" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
-    <entryLink id="bc36-4e5d-3ba3-a99d" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="92a1-d830-e866-6ad4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="6e22-8ed0-3b19-1cc6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
-    <entryLink id="3a98-a2ff-6fd2-a487" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="dde6-c705-9432-9404" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="b1ee-7886-7084-e358" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
-    <entryLink id="8195-844d-b3f3-5288" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e54a-b42b-8e9e-d3ec" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="fe45-78be-1409-fc40" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
-    <entryLink id="48d8-0a9f-e2a6-11e6" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="63e4-9753-3816-b496" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="c934-587e-9917-632d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
-    <entryLink id="c024-5c8b-0572-14dd" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="2bd6-755b-a993-41e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ebc7-d68f-7dd3-ef67" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
-    <entryLink id="f8a9-bb4b-161f-0a03" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9da7-cdad-1da2-343e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="501c-eb08-ec84-e481" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
-    <entryLink id="fe14-86fe-12a7-cfb7" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6540-0169-9f36-5092" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="f752-a39e-8108-97a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
-    <entryLink id="e07c-6d50-ba3c-2c4d" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="97b4-df26-0495-35bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d4d5-5975-0bd8-fdcd" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
-    <entryLink id="61b3-339e-aef9-1483" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="ff58-513d-cf4e-6987" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="fae5-8363-b65a-3470" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
-    <entryLink id="1dc5-8c4b-e3be-f0b7" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="bf51-c20f-ea94-c734" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="8ad8-00a7-2f83-0e2c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
-    <entryLink id="84ee-d391-e9d5-7f71" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ee62-4670-cbeb-3ea8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="868e-e1a9-98f8-3a2d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
-    <entryLink id="19dd-ef2a-c108-1bf6" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3924-23cf-d749-3f20" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="ea39-4e31-73e4-9f4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5f47-43ab-500d-b9f3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="aab8-384e-e368-a65e" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup" />
-        <entryLink id="3181-0ca0-ee8a-fe72" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
-    <entryLink id="9002-32d6-4b59-f4b2" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7b25-ff49-9242-77d3" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="ef23-c037-7a45-0634" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d366-c9a8-6556-45e8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="1045-709b-f0d8-a92d" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup" />
-        <entryLink id="4170-2192-817e-9ac3" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
-    <entryLink id="dfec-61dc-4fee-0b7b" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9b9e-f16b-a7e5-8697" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="fb14-d791-e9c1-f6e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="754c-44ad-e3b0-b498" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="d49e-d0a9-a629-0dd7" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup" />
-        <entryLink id="5d11-57d8-7a10-a5f7" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
-    <entryLink id="42e2-762f-a3c9-8f00" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6a9a-404a-285d-944c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6bb8-0629-2f81-6090" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
-    <entryLink id="b840-9827-acb5-c4dc" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="bea6-1c1b-cae8-79e3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="3855-4d3b-2c71-3c0c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
-    <entryLink id="90c7-62b9-abec-0e72" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="03e3-9573-f6c5-f8cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="128b-10cd-56a0-b62b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
-    <entryLink id="ed8f-90a3-283d-e1ec" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="ca28-b12c-3ecd-f990" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="cba8-2529-98a8-5789" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
-    <entryLink id="64de-75cf-c7d1-40c9" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="2468-65f7-9c0a-770e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="aacf-8a74-6fdf-0937" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
-    <entryLink id="b34e-9318-d3e5-72dd" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4984-3e7b-b60c-7a32" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="6abc-1cf7-f453-a808" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
-    <entryLink id="d96a-68da-14c5-0efc" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0961-11f6-8eb0-4da4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="fae7-1c63-3c94-110f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
-    <entryLink id="1704-0515-a9e4-b29e" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="a7c7-9db8-9556-0b55" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="20be-cbc2-2e7d-001b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
-    <entryLink id="de20-8fa3-ee41-33f9" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="58be-6811-f327-5fd3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9a00-75af-2f5c-07c5" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
-    <entryLink id="5219-13e2-8441-36ee" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ab68-0036-d151-f758" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6d53-a8d2-978e-df48" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
-    <entryLink id="5677-104c-dab0-139b" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ae8b-8fe9-7b4a-ea2e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="228a-fb65-b620-80f7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
-    <entryLink id="b782-b02a-aeba-3044" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ac1d-6c1b-7bc5-e90c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="fd2c-3eff-eb7f-a585" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
-    <entryLink id="0f72-6b3e-9034-8a3c" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f7ec-8877-ea57-3a38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ad6a-6983-8ca5-e7aa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
-    <entryLink id="2ce0-24a1-a941-a332" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3332-4d00-ff20-1b6f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c507-0c6d-aa99-7a67" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
-    <entryLink id="7df6-8b3c-f20f-012a" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b661-3646-cce1-996a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b285-09a4-411b-d478" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
-    <entryLink id="f676-aae1-f729-7051" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7090-6650-fdfe-e79e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="a910-2956-2438-a7ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
-    <entryLink id="7cbd-4031-cbed-74ed" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="bf90-0641-1bc8-2916" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="3471-e913-c817-b201" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
-    <entryLink id="3e50-9098-4a8b-770f" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="12f5-c4ba-01c1-1c9a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="5c5e-02e6-bb22-9ed7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
-    <entryLink id="aeb6-7fd7-b0eb-f99c" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink><entryLink id="6a44-ab07-cb0d-7f6d" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_8ed4-376d-4030-9439</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_8a11-c2a0-4335-99ef</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_fa8e-1af7-4d41-ac8c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_94bd-c771-4a85-8581</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b9f0-d793-78b2-3059" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7eca-10cd-f2a8-06d6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="4ce9-2184-eac8-b11c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="f7bb-fcb8-4b80-8b55" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_361e-fb90-4b0e-ac3d</comment></categoryLink>
+        <categoryLink id="48ad-3019-4681-8ed9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d4ef-1074-45a9-959e</comment></categoryLink>
+        <categoryLink id="b9bc-56d4-4568-bb43" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_febb-f536-4d25-a8ab</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
-    <entryLink id="ffa9-f77a-058e-6c50" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9e61-d557-8f39-93a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="55c9-f05c-9463-b38a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink><entryLink id="6c37-b1e1-747f-c93e" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="adc8-237c-462c-ad5d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_473b-e812-4158-9416</comment></categoryLink>
+        <categoryLink id="2c87-2acc-4084-932f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_00a2-63ff-4698-a35b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
-    <entryLink id="50a9-d17a-a89a-03fb" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink><entryLink id="8eb9-da53-4df0-9a20" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7cf3-8a72-4f82-8cdc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_228c-5681-4ce8-b726</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_01bb-8abd-4253-9a4d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="629c-db73-2a83-43de" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="6fd3-a404-11dc-ec7d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1720-f31e-4e65-8842" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2a08-4432-42ad-bfdb</comment></categoryLink>
+        <categoryLink id="d76b-e45f-49e3-8fea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_422e-0808-4897-8630</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
-    <entryLink id="46ed-d30e-31f7-53b2" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink><entryLink id="5c7e-d632-a1f7-31c2" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1af8-4459-4717-8e3b</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_06b4-92b9-438c-b1a5</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6c8d-8b28-417b-9a7c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_715d-8186-4aa6-b40c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_390e-358c-4f8e-ade8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="de62-5a11-2f4f-7519" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ebbc-98c2-7e40-6075" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="a435-6de8-491b-b430" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f4c0-4396-4f39-a34f</comment></categoryLink>
+        <categoryLink id="7a25-cd6e-419e-9324" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1301-8415-490e-8f06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
-    <entryLink id="9833-cce9-1afa-0901" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink><entryLink id="25dd-db68-56f0-0d09" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d0c9-9a26-4324-b030</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4e9e-a61d-42f2-bacb</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ed9e-b634-4bec-9eb0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4614-ad0f-4fba-adaf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_8d08-24f6-41be-8931</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2640-23b1-4684-a0e4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_caf6-5548-4b89-8102</comment></categoryLink>
+        <categoryLink id="f52e-ec5b-45cc-a862" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_63a3-be61-428d-ab29</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink><entryLink id="3382-bc4e-5766-917f" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f318-4b03-4767-8c7f</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b8ef-7245-4df8-a8c4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_6bce-ec44-48cb-873a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5fd7-f0dd-497d-a4b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0678-4fdd-48e6-8f61</comment></categoryLink>
+        <categoryLink id="e7a2-da7a-4af3-9bc1" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0d82-10a9-4de2-8ad7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink><entryLink id="577e-1f0c-3ea2-ce15" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ada1-1e18-4cbc-9598</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b1d1-ac44-47dd-9159</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5d64-f00c-4464-891b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25f0-f825-4a83-8f0d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_64b1-9e36-44da-b36a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="523a-4823-4d02-87dc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_d53e-113f-4a40-a3d5</comment></categoryLink>
+        <categoryLink id="5650-1132-4bf7-ab3a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1939-76b5-4279-9f8c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink><entryLink id="9d7f-87f1-a6f7-a9b6" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d765-3bb2-4b48-bd12</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_0ca1-cfb4-4a56-ab3b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3536-06ba-c677-3cef" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="fd40-a03c-b134-cfda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4ae6-97a7-4dbc-948e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e6f7-a6ca-4825-bfc5</comment></categoryLink>
+        <categoryLink id="b62e-b779-4523-9055" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dbec-e027-4ec1-8514</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
-    <entryLink id="365c-1f32-6a04-c1ef" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink><entryLink id="0fc5-f21e-23bf-674a" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d8ee-81ed-45f9-8b79</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_8f4e-e8cb-4ac9-a415</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="81cf-63ff-451c-98fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_cefb-cfd7-4dc8-99c4</comment></categoryLink>
+        <categoryLink id="f485-d407-43b0-ba95" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a9fd-9d16-4a5e-855c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink><entryLink id="87bb-bff2-5be7-1ce7" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e76b-46ca-4ab8-a93d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8035-75b8-43bb-97c9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_71a4-31e7-4927-a0ab</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7ee4-1602-4b35-ae9c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_a56d-347b-4b09-a918</comment></categoryLink>
+        <categoryLink id="ce83-860a-41cc-bf52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_96e5-4531-4213-903e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink><entryLink id="bb9a-a828-d268-650b" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1fb5-2375-4c22-b41e</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7d7c-255d-49b6-96b9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5321-254b-4890-9bf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ddf8-b8b7-4afb-b6dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="becf-a5d8-4a1b-9dee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9441-d79b-4720-9667</comment></categoryLink>
+        <categoryLink id="baa6-df49-4429-9e68" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7d7e-32d3-4692-b401</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink><entryLink id="5410-ddf3-9b5f-6346" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_99fc-5fe7-4b37-a62f</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_25f4-f6b8-4b44-8350</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_81f7-2311-4cce-95bc</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_09aa-af2a-4012-91d1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_00ae-fad3-4df6-9cb9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c686-9249-4d26-8736" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f65b-8958-49b3-92a5</comment></categoryLink>
+        <categoryLink id="3981-9482-422c-96bc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0451-1929-4942-8c3f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink><entryLink id="65d5-eec6-1030-d756" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_edc4-4915-40ba-bbf0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_105f-ba26-4146-bc54</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7a2c-a76c-421c-a8a2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_05c9-0543-47ee-ba81</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e6ad-f0d7-4627-921b</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4d52-eb41-4b81-9c18" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c6a8-22a8-4d41-b969</comment></categoryLink>
+        <categoryLink id="df3f-1170-4260-bb67" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03ca-12cc-4e0a-b628</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink><entryLink id="d88b-6b14-5e71-71f6" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ae67-ef52-4cac-958c</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fc61-7306-4d99-acde</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1be0-67e7-45a1-bdbb</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_42a8-7fda-4e05-af0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="87eb-5ce7-4fcf-b3bc" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_565a-1592-491f-8b9b</comment></categoryLink>
+        <categoryLink id="504b-5fbb-49f7-98b0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_81d5-c14a-42ab-bdde</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink><entryLink id="3aa6-167c-6612-0ddb" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1ae7-c41b-4818-be71</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_08a5-b1bb-4ba1-ba42</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d677-b5ad-4838-8746</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_537f-bc1f-4aaa-b0dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7aa1-831c-4f6e-8555" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bc67-ce1f-4004-aeb7</comment></categoryLink>
+        <categoryLink id="825a-f3a6-4c3a-a264" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_9a45-9699-4475-aeef</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink><entryLink id="3e19-3b02-a3ab-1f4a" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_c28f-4109-44c4-ab64</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fdc1-a894-48bc-9e7c</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_4936-a68c-4524-9088</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb37-ac0c-49ae-9d6f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e7d8-133e-4967-89e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3afe-cfc0-4da6-a985</comment></categoryLink>
+        <categoryLink id="4f6d-4999-4e4c-a25d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_04a8-6aae-45ae-bd4c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink><entryLink id="8a69-dd44-4b8d-60f9" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ae19-30c0-43c5-920e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_6ebe-1bf3-4d78-9dd0</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1887-152d-48b7-b13f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_a7c4-ee6a-4f0b-8ab0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bd85-fa90-47ff-9f84</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_7bd6-9043-4d7e-ba37</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8981-35f8-495e-a1aa" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3610-c975-4d55-bdfe</comment></categoryLink>
+        <categoryLink id="4276-5794-4e99-afac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2fc2-f636-4c80-9608</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink><entryLink id="5c98-3dc1-f22b-08aa" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_85c5-d4d9-4b23-9e4d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_80e8-d50b-4906-8153</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_b93b-d4f1-45eb-8a69</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e183-f183-4db7-83b5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0f39-204a-4217-b896</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_eee9-7bfd-4fea-a1bd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="649e-4277-4d31-807e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f81d-9435-4f11-99c1</comment></categoryLink>
+        <categoryLink id="ce7c-86cc-4b63-8137" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9568-6142-4fdd-be3a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink><entryLink id="6676-5302-e270-4855" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_005e-6607-4e2c-8dd2</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_7745-260c-4c36-b719</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_ba25-a4b2-4ba9-b023</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ddeb-f4c8-4091-9153</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4904-fd2f-429f-9cf7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_faea-b21b-43c5-b918</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d9b7-69c1-4350-8bdc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_b24f-3ae0-4cbb-b016</comment></categoryLink>
+        <categoryLink id="f205-5930-46d8-bfe7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fd26-8e6b-4521-92b9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink><entryLink id="c3b6-baad-9af2-9539" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6ecb-28e2-43ed-a6a0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_c067-1118-4d96-b28b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_250e-23c0-4e43-bf74</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1553-a6e6-4291-853f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_aab6-797b-427a-9fd8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="13c2-30bb-4b43-9993" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c77f-0819-473b-a8a2</comment></categoryLink>
+        <categoryLink id="d09a-ddb1-4699-b8f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_89fb-c924-4daf-923d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink><entryLink id="958c-419d-6c26-bbc7" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d72c-519a-451f-81b6</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_3d16-444c-42c9-aad1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_f4b2-6371-494b-863a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_797f-a84b-42f6-8e66</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0d78-fe38-4829-9b12</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d56-0632-4a19-8c97" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0397-c837-4fea-a527</comment></categoryLink>
+        <categoryLink id="9582-6d96-44b3-af54" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_060b-bccb-4776-bd83</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink><entryLink id="bc36-4e5d-3ba3-a99d" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3c84-6d74-4c42-b38d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_5b15-7aa4-4897-aaf1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_3326-31ed-4151-9b37</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6a0e-1b65-4057-ba5d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f8c7-abc9-45ec-955f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_2538-8dc5-446c-8344</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="668c-e26b-4c0a-b9fc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_c1cf-cea4-4278-8f27</comment></categoryLink>
+        <categoryLink id="b475-3f5f-40f1-b346" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5f51-2734-4a46-9f72</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink><entryLink id="3a98-a2ff-6fd2-a487" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af71-f3ff-49b1-83e9</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_1c9e-b3bf-4e88-a43f</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_6d0d-1b1d-4065-89cf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d0b7-8686-491e-9d33</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_7db8-0874-487a-be6f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1034-29a0-44b1-a85f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="efea-baab-4717-82ed" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_0c16-6841-42b2-b02d</comment></categoryLink>
+        <categoryLink id="ba23-54a7-4140-99ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_602d-2d2d-4ff4-a82a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink><entryLink id="8195-844d-b3f3-5288" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_22bd-baae-45f9-b366</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_52bd-55de-4d53-ba55</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_df1b-7476-4ab8-8d2f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_49fa-0dcf-4a61-a5b1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0ea-1443-4993-86e7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2a8-3fbe-448c-9902</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="bf6a-ebd6-4360-88a5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3632-0b5d-4622-ae33</comment></categoryLink>
+        <categoryLink id="f360-57e8-4df5-8dcb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_da44-7815-4fdd-981c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink><entryLink id="48d8-0a9f-e2a6-11e6" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2bfa-b203-47e2-a828</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a39b-8a3c-49cf-bf62</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2a05-07b3-49c5-8145</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f730-87fb-44bd-b68e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_2d0e-6c49-4493-a022</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2e2-50c1-40c3-b4dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a682-09c9-4625-a2f3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_5ad5-8701-42cd-b2b6</comment></categoryLink>
+        <categoryLink id="74c8-b5d3-412a-ab20" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_20a4-4346-4a3b-a7d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink><entryLink id="c024-5c8b-0572-14dd" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_773a-1ea4-41a0-b766</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_9d4d-6fb8-4131-a5a3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e3bc-02f8-4ece-a5ea</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c371-76d9-4a4d-bc00</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b4c6-d4ba-4b2e-9b99</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="25e1-fa6b-4636-b39e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6ea9-a7e5-437d-9e35</comment></categoryLink>
+        <categoryLink id="8014-7340-4696-8eee" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_3cec-f053-42ab-a6eb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink><entryLink id="f8a9-bb4b-161f-0a03" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1e60-42ba-4c8b-9077</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9860-f593-425e-b89b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_c842-10e8-4509-8eda</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ea52-ff41-40f6-8cf3</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_51e6-c5e1-4003-96bc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="30da-c976-4e26-bd6d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4d7c-201f-4c99-b89a</comment></categoryLink>
+        <categoryLink id="556c-ddc6-40e4-bc7a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_10f9-4718-4e07-bb32</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink><entryLink id="fe14-86fe-12a7-cfb7" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c589-7535-4852-bdf6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4e52-ad1b-48d4-8eed</comment></categoryLink>
+        <categoryLink id="6750-d52a-4317-8704" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_6979-1ed3-4f1f-a025</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink><entryLink id="e07c-6d50-ba3c-2c4d" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d3cb-4905-4959-9607" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6140-2404-46f9-bd42</comment></categoryLink>
+        <categoryLink id="2c19-68fc-492f-8abe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_1c86-fad8-46ec-a0b0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink><entryLink id="61b3-339e-aef9-1483" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4729-bc86-456b-b73d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_cf0f-e3f4-4fb4-989d</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1cc8-5611-4d9a-9218</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_2e32-ca02-48f0-a8dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dcdd-c72e-4553-ae6a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_0af1-d052-4bd7-aab6</comment></categoryLink>
+        <categoryLink id="3096-9e25-4808-b4fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_45ce-e338-43c9-b63e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink><entryLink id="1dc5-8c4b-e3be-f0b7" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4dce-8632-4f7c-813e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_8a71-3995-4155-ac33</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d206-f2ce-41b8-945a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan">
+                  <comment>    node_id_2e02-cf1c-4a71-861c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ec81-bd33-45a8-8550</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_3344-743c-45d3-b930</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e634-43c2-1198-b1eb" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="033c-7e01-a4c8-ee91" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1802-2ed8-45fc-af94" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4272-9b9d-4c59-95f0</comment></categoryLink>
+        <categoryLink id="1d07-6860-4db3-a74c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_d85b-1ae7-40d5-9341</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
-    <entryLink id="5034-2e8a-21c5-06bb" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a635-101f-a4a1-e2ef" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="320e-4280-817a-bb5a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink><entryLink id="84ee-d391-e9d5-7f71" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d766-8463-4c2b-bb2d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ff9f-01cb-41b9-800e</comment></categoryLink>
+        <categoryLink id="3e35-267f-4f08-9034" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_1315-6051-4a46-b070</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
-    <entryLink id="3b01-e912-2b38-9d0a" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink><entryLink id="19dd-ef2a-c108-1bf6" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry"><categoryLinks>
+        <categoryLink id="f53a-d6d7-4f8f-aa72" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_b084-df23-4f99-812f</comment></categoryLink>
+        <categoryLink id="554d-13a7-43ad-8088" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_84fc-9304-4e9e-ab78</comment></categoryLink>
+        <categoryLink id="f320-2f44-497f-8a1e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d06a-7939-4691-9aed</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="4a84-14d3-4be1-8667" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup"><comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+        <entryLink id="f4f9-f2cd-4304-b25c" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup"><comment>    template_id_741d-8c09-4211-ada6    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink><entryLink id="9002-32d6-4b59-f4b2" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_54a4-6ec8-4c61-9c3e</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_f7fd-2d16-4603-a065</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fc4e-f4dc-aa52-263e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="e0fb-5180-8b33-b731" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a97b-7f3f-4dda-b5dd" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_c0ac-4b8c-421c-a21b</comment></categoryLink>
+        <categoryLink id="c027-abf5-4346-a360" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8db9-079e-4482-b200</comment></categoryLink>
+        <categoryLink id="41e2-e773-4a3a-8e15" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_413c-9273-4308-b546</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
-    <entryLink id="a96c-46cc-4a9c-4786" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="193e-d0f2-1d40-6cfc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="6ea6-9cc0-746b-1102" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      <entryLinks>
+        <entryLink id="eb90-309c-4acc-8c8a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup"><comment>    template_id_bbc4-33fc-4664-a18e    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="5e06-505d-44f7-9f16" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup"><comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink><entryLink id="dfec-61dc-4fee-0b7b" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d725-79c3-47ed-8c34" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_4c8d-96f6-48f9-9590</comment></categoryLink>
+        <categoryLink id="74cd-8a73-46f5-ad55" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_049c-0fa5-4575-8fa8</comment></categoryLink>
+        <categoryLink id="d73e-837b-4922-a041" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_7358-52d7-4aae-8e07</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
-    <entryLink id="6b5e-9cea-ae25-6d2b" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+      <entryLinks>
+        <entryLink id="de5f-a8ef-41a5-a512" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="631b-b029-0909-b8f6" type="selectionEntryGroup"><comment>    template_id_4784-b370-444b-93ae    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="5b28-2886-4761-8a69" name="Retinue" hidden="false" collective="false" import="true" targetId="39e7-5296-42e0-fe94" type="selectionEntryGroup"><comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink><entryLink id="42e2-762f-a3c9-8f00" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_3c03-a823-4466-9bd6</comment>
           <conditionGroups>
-            <conditionGroup type="and">
+            <conditionGroup type="or">
+              <comment>    node_id_8bbb-f95b-413f-b6f4</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_41b0-6b0a-482a-919e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e1f7-3cc6-4794-8b6d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="08b7-5f3e-6d36-5461" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="9bf9-0299-caac-fb40" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="54d7-0b89-4192-995a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_05ce-cc31-40ad-9320</comment></categoryLink>
+        <categoryLink id="6642-9c49-4d57-a3e2" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f13c-f8e1-4a50-bfe3</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
-    <entryLink id="9967-c2e0-8192-fa08" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4f0c-f9cd-7748-0c86" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="8c3f-676b-b372-344b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
-    <entryLink id="22eb-15a1-aab6-d452" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3505-56d5-8a98-3752" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9995-bc5a-631a-1c0d" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
-        <categoryLink id="b17f-a5c6-8606-5d97" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
-    <entryLink id="b353-8bbc-20ca-b2d6" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6af4-1740-0631-3a05" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4164-64cb-d189-febf" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
-    <entryLink id="34f6-5e05-e439-57df" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink><entryLink id="b840-9827-acb5-c4dc" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_db78-4d49-42ab-954a</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_f14d-9943-47b6-866c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a95-938f-4a07-9727</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_7775-78e1-44cc-87c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a991-b0a3-4228-a66c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_b822-3417-4613-be37</comment></categoryLink>
+        <categoryLink id="e41f-fb38-4424-9fda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_25db-b03f-4881-b310</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink><entryLink id="90c7-62b9-abec-0e72" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry"><categoryLinks>
+        <categoryLink id="6239-ee6f-4f16-819f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_75a7-dc06-445b-b2dc</comment></categoryLink>
+        <categoryLink id="a8ff-f2fd-42e9-a601" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_e21a-c03b-4885-ac46</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink><entryLink id="ed8f-90a3-283d-e1ec" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9a08-5fe6-4010-bbc3</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_72cf-cfce-4e02-b379</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="056c-8130-a7a2-6864" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="929c-1e02-015e-d72d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5e55-87e1-4eef-8322" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_f55b-7555-444b-beee</comment></categoryLink>
+        <categoryLink id="6a2a-d28c-41b4-84aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3386-c9ad-4d74-9474</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
-    <entryLink id="538e-9e82-793f-c984" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c4aa-9d4d-0819-92f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d85a-619c-8d1c-0c83" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
-    <entryLink id="24ba-d2c2-3e6a-cdc8" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink><entryLink id="64de-75cf-c7d1-40c9" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_a0f6-9606-4b75-a2f8</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_94b3-1331-474b-885b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
-      <infoLinks>
-        <infoLink id="8b46-7db6-f3c3-ad65" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule" />
-      </infoLinks>
       <categoryLinks>
-        <categoryLink id="3785-dd74-e83e-7694" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5dc3-0e05-020e-d5fd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="b93f-878c-43f0-90ea" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_79fa-3370-4ae0-9e12</comment></categoryLink>
+        <categoryLink id="c95b-5096-4c73-817f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bb53-4e65-4fb6-9dd7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
-    <entryLink id="c30e-4af9-f2ed-e8d6" name="Numerologist Cabal" hidden="true" collective="false" import="false" targetId="ca26-b6e2-0bef-85a5" type="selectionEntry">
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink><entryLink id="b34e-9318-d3e5-72dd" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f8cc-833a-4ac1-bf89</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+              <comment>    node_id_5988-c012-4dad-9a66</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fc9-0135-421c-837c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_8d82-3279-4481-84bb</comment></categoryLink>
+        <categoryLink id="440c-a7cb-4d10-99cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e25c-925e-4b96-8bb3</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink><entryLink id="d96a-68da-14c5-0efc" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6b73-b21c-4e2b-9d14</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_a7fe-cc62-4a6f-a781</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5be1-1937-4964-a455</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_da1d-b2bc-4117-82a4</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f2aa-efef-499c-862e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7010-be56-4709-b058</comment></categoryLink>
+        <categoryLink id="16f6-3deb-4aa3-9881" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7379-a740-47ba-a054</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink><entryLink id="1704-0515-a9e4-b29e" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_dd34-83cf-47d7-b557</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_be88-afef-49b3-bd1e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f919-038f-48ff-91da" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_944f-7420-4982-8ea9</comment></categoryLink>
+        <categoryLink id="e232-f5c4-4919-a04c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ea80-0efe-457d-a450</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink><entryLink id="de20-8fa3-ee41-33f9" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><categoryLinks>
+        <categoryLink id="7b43-7613-4256-b87c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9a36-f261-43cc-9bd1</comment></categoryLink>
+        <categoryLink id="4f98-5e8e-49e3-9a55" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a648-8396-442a-af59</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink><entryLink id="5219-13e2-8441-36ee" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_cb81-0303-4b88-ae53</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9648-31e3-43aa-8cf3</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_0507-da81-4023-bfcf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0e84-54ff-488d-b066</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0ea8-f34e-4928-ae95" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6ff-0977-4c92-bb28</comment></categoryLink>
+        <categoryLink id="5ca2-1061-4d96-b037" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f555-7d39-458f-84c9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink><entryLink id="5677-104c-dab0-139b" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8203-5b00-497b-b939</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_40ee-3e71-4978-b1e4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f6a8-f660-46dc-b3c5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_d988-3af6-48bf-b0a8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="941c-7e71-4424-8ef4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_39e5-eda5-45d1-a643</comment></categoryLink>
+        <categoryLink id="9299-1c88-4814-97ac" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_6416-21bb-4df4-9de8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink><entryLink id="b782-b02a-aeba-3044" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b03e-5d91-4be3-8adc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_0443-29c0-46e9-ad1d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f2c9-7356-4c27-a22f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0e9-4a9e-4b2b-a9d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7656-328d-426c-85e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5528-2dac-4be5-900c</comment></categoryLink>
+        <categoryLink id="1d84-3099-419a-8a08" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_dc8f-d888-4585-991d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink><entryLink id="0f72-6b3e-9034-8a3c" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1d3c-8e17-489f-9002</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5725-8bee-4bcc-878d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_be47-0d6f-49f2-9f4b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_863c-f3a4-4802-b80c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="797e-72f4-4dd7-a740" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_899e-b052-4d5b-8c18</comment></categoryLink>
+        <categoryLink id="86fb-2f08-45c8-bd7e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f5e9-cff6-41d2-a016</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink><entryLink id="2ce0-24a1-a941-a332" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_72da-1513-4e02-b595</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7a48-a3b0-4a26-849b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e232-25f3-4cb7-8ab2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_9aa4-5660-4697-8ab2</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4373-1e9f-48f4-9b68" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_09cd-2176-40af-bba6</comment></categoryLink>
+        <categoryLink id="4c07-e2c5-4395-b6ba" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_05e6-7c63-4a35-9ba0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink><entryLink id="7df6-8b3c-f20f-012a" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry"><categoryLinks>
+        <categoryLink id="cd9a-5e26-4846-aad8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0dfa-4004-4751-8022</comment></categoryLink>
+        <categoryLink id="c07d-c334-419c-a718" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a669-0f5d-4fd3-811b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink><entryLink id="f676-aae1-f729-7051" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_09b5-4e3b-4c84-a574</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_32e5-ebba-41fb-9ff2</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_838e-0ccf-4d3a-aabd</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_dfef-0ec2-49fb-a534</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="54a5-0b0c-4491-93c7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4f60-472b-45a9-ab9e</comment></categoryLink>
+        <categoryLink id="a059-8961-405f-9160" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e2e3-af36-45a6-a955</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink><entryLink id="7cbd-4031-cbed-74ed" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_936f-1ef7-472e-840e</comment>
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+              <comment>    node_id_d73d-d52e-4c75-8ac0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6f72-f2db-4421-8fb2" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_7a55-ecb4-4e5d-b955</comment></categoryLink>
+        <categoryLink id="bb93-1689-41b4-94f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f28c-710e-4ff8-9810</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink><entryLink id="3e50-9098-4a8b-770f" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_a743-0cc2-45ae-a7eb</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2721-e88d-41f7-bedc</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_e10f-1390-4b33-8fcc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8387-307f-46e0-8f80" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2008-f1c4-4285-a14f</comment></categoryLink>
+        <categoryLink id="44e5-b0f2-433f-b275" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e88b-a95a-4647-af3b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink><entryLink id="aeb6-7fd7-b0eb-f99c" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_25d8-330b-4574-b515</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7836-6878-47a8-8827</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_5ea9-46dd-4a11-9410</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_ab5d-961b-4924-a705</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="166f-9368-4883-b9ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9189-836c-475d-a52e</comment></categoryLink>
+        <categoryLink id="32a1-447c-4246-96ee" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_e1fa-b7d8-47b0-a88a</comment></categoryLink>
+        <categoryLink id="6528-46fe-4454-a5e9" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_a137-e3c0-4d63-a48c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink><entryLink id="ffa9-f77a-058e-6c50" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d204-cfab-493d-808c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b1d5-fd75-4f17-bbf4</comment></categoryLink>
+        <categoryLink id="b3b4-c04d-47d5-b82d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_f221-bf81-4045-849b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink><entryLink id="50a9-d17a-a89a-03fb" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_b743-7a00-43e4-beb8</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d12f-2c98-4e62-a716</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d4d7-ba67-47aa-962f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+                  <comment>    node_id_1637-edee-457a-bb0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0c83-37db-456c-a292" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_f203-bc26-421f-b79e</comment></categoryLink>
+        <categoryLink id="4a9c-8aae-4b56-aead" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_a53e-59d9-4ac2-a21f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink><entryLink id="46ed-d30e-31f7-53b2" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry"><categoryLinks>
+        <categoryLink id="2bdc-5018-41da-aac6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_51af-a137-4a1c-97a4</comment></categoryLink>
+        <categoryLink id="93c0-8933-41de-bd88" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ec1f-c326-40a8-9d1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink><entryLink id="9833-cce9-1afa-0901" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_c111-feb0-4012-98cd</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_63d7-8427-431d-9ae6</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a6e6-8ad5-4d11-b674" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_e707-fde1-457f-91c4</comment></categoryLink>
+        <categoryLink id="2d76-805d-4969-a039" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ec67-8573-4460-89db</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink><entryLink id="365c-1f32-6a04-c1ef" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3348-16e4-4a9a-a549</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_bea4-c4a8-4843-b9fe</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2970-17ff-4be1-91e5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_503a-46e7-40e7-bd07</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_4555-15e1-43ff-80a0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e124-9bed-4310-97e4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_fce3-801c-49c8-85d4</comment></categoryLink>
+        <categoryLink id="eeb3-f16d-4d37-beda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0c2d-2349-44b6-9831</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink><entryLink id="5034-2e8a-21c5-06bb" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry"><categoryLinks>
+        <categoryLink id="2acd-a123-4de7-849d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ac1c-b3bf-4011-918a</comment></categoryLink>
+        <categoryLink id="8179-cb1c-4529-9688" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_589c-1d0e-4b7d-be6b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink><entryLink id="3b01-e912-2b38-9d0a" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2f46-a0b6-48a5-a0ee</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_636f-0f8a-43f1-910b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c883-39c8-4a74-aeaa</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_0796-e467-4438-89b3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="09b1-f990-4c12-ade9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_5a04-9847-4c91-a49a</comment></categoryLink>
+        <categoryLink id="add5-9f92-4919-bc70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b4b4-daeb-483c-a306</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink><entryLink id="a96c-46cc-4a9c-4786" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6087-a5e5-4d3c-9ebd</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c7e1-5f42-4528-bf07</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1950-08dc-4544-ab01</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_daf3-31ed-42c0-85dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8691-a29b-45e6-a9f8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_7d4f-547c-43ed-a520</comment></categoryLink>
+        <categoryLink id="8a5c-5fca-4294-8c70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f04e-04e8-4891-9b1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink><entryLink id="6b5e-9cea-ae25-6d2b" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_dfdc-f6f6-49d2-a7b3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_354c-c71f-472f-b268</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1127-c974-4663-874d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_0843-bef2-4767-8307</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="60ed-4a72-443d-9e8f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_28e0-91e7-4ada-9fac</comment></categoryLink>
+        <categoryLink id="f91a-89ca-4253-894c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4448-a712-4dd7-bf6d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink><entryLink id="9967-c2e0-8192-fa08" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d512-fd07-4a29-863a</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_55c6-a35f-485a-9f0d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d89e-cf1f-4ceb-b3de</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e2c9-0d01-403c-900e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_a7b8-c835-4cb2-b3d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e7e7-5f34-4114-a5af" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_e22a-c5f8-4825-a45f</comment></categoryLink>
+        <categoryLink id="02ff-7ff3-4f18-a10d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03fc-6a7f-45a5-bcb8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink><entryLink id="22eb-15a1-aab6-d452" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry"><categoryLinks>
+        <categoryLink id="0e29-e10a-4f98-87bc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0aff-4f6e-4b03-a23c</comment></categoryLink>
+        <categoryLink id="11f9-36ff-43ae-9f79" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"><comment>    template_id_7d5a-62e7-43ee-b79b</comment></categoryLink>
+        <categoryLink id="5f14-1a64-4e56-809f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_4986-9157-49f2-b670</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink><entryLink id="b353-8bbc-20ca-b2d6" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_319e-90d4-44a3-8e83</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_28db-d943-4099-9abd</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1a45-a592-49df-9465</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb31-d0b2-4677-928e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ae0c-7705-40e5-be4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1b86-0977-4a8b-adac</comment></categoryLink>
+        <categoryLink id="de81-ff1e-49b8-8218" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_b449-403a-4e42-9239</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink><entryLink id="34f6-5e05-e439-57df" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafa-470f-4c2c-8be3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_e2ba-a855-4de2-9f46</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_0171-b30d-44ee-9389</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fdfb-119b-4774-934a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_3891-9a00-4f8f-b95f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4ed5-6bcb-47de-91c6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e5df-17d4-4521-9d5b</comment></categoryLink>
+        <categoryLink id="45e5-2b1f-424e-b4d3" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"><comment>    template_id_0ecd-4873-4d3a-b28b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink><entryLink id="538e-9e82-793f-c984" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_fbfa-8d78-4d6d-8a05</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_21f2-0916-46bf-b75a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_4fbd-633b-4dd6-9fdd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2b92-ccfe-4994-8909" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4f71-446f-4cff-afda</comment></categoryLink>
+        <categoryLink id="1400-9c6f-49c7-84bc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_3f44-8647-43a4-ac22</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink><entryLink id="24ba-d2c2-3e6a-cdc8" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af15-2c71-4f8b-833e</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_d95a-80b9-4463-af55</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ee64-9503-4fb9-860d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6b1-886e-4194-8bcd</comment></categoryLink>
+        <categoryLink id="fd48-5425-4c33-a7a9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_51b5-f9c1-4587-8fc7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink><entryLink id="c30e-4af9-f2ed-e8d6" name="Numerologist Cabal" hidden="true" collective="false" import="false" targetId="ca26-b6e2-0bef-85a5" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -1056,8 +1804,269 @@
         <categoryLink id="917a-7a8b-060f-5d86" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-  </entryLinks>
-  <sharedSelectionEntries>
+  <entryLink id="94d8-aa8a-4a74-a9c1" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
+    <entryLink id="c3fa-e472-4334-bd0f" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
+    <entryLink id="2e31-e63c-415a-ada3" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
+    <entryLink id="0ba1-11a6-46b1-9da4" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <entryLink id="343e-5caf-4fb0-b0ac" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3531-57d1-4081-882d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_f233-2361-4177-8ba7</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b932-667a-4b43-8331</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <entryLink id="dc87-f519-4086-a1e6" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <entryLink id="2cf5-c486-47c2-8838" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3129-6f59-4365-906b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2bcb-0af1-4aea-9191" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <entryLink id="faa0-d3df-427c-9b67" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ede2-d453-4e34-8cda</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2907-3215-4b01-96ff</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_c90c-959f-40fb-a4cb</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ba2d-50ad-45f1-91c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0e88-485e-43c2-8bef" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <entryLink id="d1a5-f1db-497f-ab65" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_409c-0a5d-4ef8-a871</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7078-c1c7-4af2-b43d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_9a69-0fdc-4957-8982</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1a4c-69b5-4219-8502" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fba0-3ea7-4eaf-b33a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <entryLink id="14cd-820d-4c53-b362" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
+    <entryLink id="8c3a-9851-41a9-b7e9" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
+    <entryLink id="4cf6-31fa-4a0e-b26d" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
+    <entryLink id="3f63-2151-4de3-814e" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+  </entryLinks><sharedSelectionEntries>
     <selectionEntry id="d3ad-275c-e22b-a28f" name="Ammitara Occult Intercession Cabal" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="d00c-1621-c7cd-c912" name="Mind Killer" hidden="false" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power">

--- a/2022 - LA - Thousand Sons.cat
+++ b/2022 - LA - Thousand Sons.cat
@@ -3307,7 +3307,7 @@ Additionally, a unit that includes any models with this special rule may not be 
       <entryLinks>
         <entryLink id="0290-0d6b-21d5-7953" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_7dee-602c-4b47-be09</comment></selectionEntryGroup>
     <selectionEntryGroup id="39e7-5296-42e0-fe94" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="c754-54a9-5065-364d" type="max" />
@@ -3329,7 +3329,7 @@ Additionally, a unit that includes any models with this special rule may not be 
         <entryLink id="c505-e39e-a306-c969" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
         <entryLink id="d46c-418f-b9b2-b2c8" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_be38-a066-4f8e-ae54</comment></selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
     <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />

--- a/2022 - LA - Thousand Sons.cat
+++ b/2022 - LA - Thousand Sons.cat
@@ -320,7 +320,7 @@
         <categoryLink id="b75f-1fb9-3a88-8f8d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="dc18-5584-91b0-19a0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
     <entryLink id="97fb-5eb3-b4e4-db61" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="79a4-1109-306c-2d53" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
@@ -748,7 +748,7 @@
         <categoryLink id="03e3-9573-f6c5-f8cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="128b-10cd-56a0-b62b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
     <entryLink id="ed8f-90a3-283d-e1ec" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
@@ -829,7 +829,7 @@
         <categoryLink id="f7ec-8877-ea57-3a38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="ad6a-6983-8ca5-e7aa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
     <entryLink id="2ce0-24a1-a941-a332" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3332-4d00-ff20-1b6f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -841,7 +841,7 @@
         <categoryLink id="b661-3646-cce1-996a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="b285-09a4-411b-d478" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
     <entryLink id="f676-aae1-f729-7051" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7090-6650-fdfe-e79e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -923,7 +923,7 @@
         <categoryLink id="3536-06ba-c677-3cef" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="fd40-a03c-b134-cfda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
     <entryLink id="365c-1f32-6a04-c1ef" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -951,7 +951,7 @@
         <categoryLink id="a635-101f-a4a1-e2ef" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="320e-4280-817a-bb5a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
     <entryLink id="3b01-e912-2b38-9d0a" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -1001,7 +1001,7 @@
         <categoryLink id="9995-bc5a-631a-1c0d" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
         <categoryLink id="b17f-a5c6-8606-5d97" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
     <entryLink id="b353-8bbc-20ca-b2d6" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6af4-1740-0631-3a05" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />

--- a/2022 - LA - Ultramarines.cat
+++ b/2022 - LA - Ultramarines.cat
@@ -3242,7 +3242,7 @@
           </modifiers>
         </entryLink>
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_be38-a066-4f8e-ae54</comment></selectionEntryGroup>
     <selectionEntryGroup id="5e14-ad5c-00c3-8c3e" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -3344,7 +3344,7 @@ Once per battle, a Warlord with this Warlord Trait may, at the start of any one 
       <entryLinks>
         <entryLink id="18a7-66b3-8db8-72cd" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_7dee-602c-4b47-be09</comment></selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
     <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />

--- a/2022 - LA - Ultramarines.cat
+++ b/2022 - LA - Ultramarines.cat
@@ -1,13 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="68ae-9855-b56a-95e6" name="LA -  XIII: Ultramarines" revision="13" battleScribeVersion="2.03" authorName="Mr_Dark, Alphalas, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="68ae-9855-b56a-95e6" name="LA -  XIII: Ultramarines" revision="13" battleScribeVersion="2.03" authorName="Mr_Dark, Alphalas, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26">
   <entryLinks>
     <entryLink id="76b3-52d9-a195-2b31" name="  XIII: Ultramarines" hidden="false" collective="false" import="false" targetId="8e0f-3552-8842-f281" type="selectionEntry">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d88f-ca52-7232-c2b1" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f435-f8a1-01a1-f153" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d88f-ca52-7232-c2b1" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f435-f8a1-01a1-f153" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="9c1f-9d40-238f-fcd4" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="9c1f-9d40-238f-fcd4" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="ec0b-803f-6220-45e0" name="Fulmentarus Terminator Squad" hidden="false" collective="false" import="false" targetId="7fb0-6302-d46f-029d" type="selectionEntry">
@@ -16,20 +15,20 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4aee-83b8-37b5-66a7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="7321-3a91-dcef-123d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4aee-83b8-37b5-66a7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="7321-3a91-dcef-123d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="b4d9-c808-7d7a-bf39" name="Locutarus Storm Squad" hidden="false" collective="false" import="false" targetId="314d-f363-fb52-743a" type="selectionEntry">
@@ -38,15 +37,15 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ca0e-9ea0-9afa-adb3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="c1ef-40b1-7263-83a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ca0e-9ea0-9afa-adb3" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="c1ef-40b1-7263-83a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="055f-9c17-0de4-f903" name="Honoured Telemechrus" hidden="false" collective="false" import="false" targetId="c688-58bc-b6c5-c02b" type="selectionEntry">
@@ -55,1032 +54,1032 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0853-84b5-6391-70b4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="d957-5e7f-47b5-4f68" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0853-84b5-6391-70b4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="d957-5e7f-47b5-4f68" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="0601-875a-65a7-9702" name="Invictarus Suzerain Squad" hidden="false" collective="false" import="false" targetId="ed63-e872-9410-a4b5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a64a-afb1-07f6-2e1c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="6a17-2ae0-dd91-fce4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a64a-afb1-07f6-2e1c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="6a17-2ae0-dd91-fce4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="a0ee-1e5c-eefb-cbe8" name="Praetorian Breacher Squad" hidden="false" collective="false" import="false" targetId="7587-35cc-01f6-b5d2" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c367-a4e7-916c-f376" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="85bf-5fad-fade-3696" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c367-a4e7-916c-f376" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="85bf-5fad-fade-3696" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="7b2b-7eec-41c8-ac72" name="Remus Ventanus" hidden="false" collective="false" import="false" targetId="e055-f9d2-33d9-739f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0da5-c661-19f7-a22b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="72db-c9b1-2570-cf99" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="19b5-180b-0b78-cc2f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="0da5-c661-19f7-a22b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="72db-c9b1-2570-cf99" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="19b5-180b-0b78-cc2f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="f0af-547d-1b9d-2530" name="Roboute Guilliman" hidden="false" collective="false" import="false" targetId="a35d-8563-eb47-e985" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4e41-472d-ebca-f3ce" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
-        <categoryLink id="9f58-9b7f-011e-d79c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4e41-472d-ebca-f3ce" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true" />
+        <categoryLink id="9f58-9b7f-011e-d79c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="ea1b-3176-6e4b-8a4d" name="Nemesis Destroyer Squad" hidden="false" collective="false" import="false" targetId="32d1-29a6-9023-142c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5c12-7aef-b106-7159" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="3c4b-fd38-d4d8-9480" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5c12-7aef-b106-7159" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="3c4b-fd38-d4d8-9480" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="15f2-0f56-6650-9a06" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="103d-bd19-1fd2-8e10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9611-92f8-c4d9-2955" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="103d-bd19-1fd2-8e10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9611-92f8-c4d9-2955" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
     <entryLink id="a970-0cf4-8052-ba14" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="abf4-7dad-5f2e-52a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d548-a94e-4d87-f631" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="abf4-7dad-5f2e-52a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d548-a94e-4d87-f631" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
     <entryLink id="5a4e-4ae4-d306-0f94" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bbeb-55f5-e2e0-e267" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="0587-1681-790c-b01a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b84e-0f7a-912f-5a15" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="bbeb-55f5-e2e0-e267" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0587-1681-790c-b01a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b84e-0f7a-912f-5a15" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="7584-4ae5-fa83-7a27" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7016-91d1-80e8-a7ab" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="4833-0524-1498-eb9d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7016-91d1-80e8-a7ab" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="4833-0524-1498-eb9d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
     <entryLink id="3b2d-d558-e9fd-157f" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4a72-9436-7e09-58c9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="f897-825c-85c1-7c52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4a72-9436-7e09-58c9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="f897-825c-85c1-7c52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
     <entryLink id="d512-7d42-1395-38fc" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fb71-201c-bb53-360f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="3456-74cc-dbaa-22fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="54c8-ca75-861e-0fbe" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="fb71-201c-bb53-360f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="3456-74cc-dbaa-22fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="54c8-ca75-861e-0fbe" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
     <entryLink id="3dfc-2705-ad0d-0cd8" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0ae9-c130-96f0-9934" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="5d76-3ae0-3ac5-2c2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0ae9-c130-96f0-9934" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="5d76-3ae0-3ac5-2c2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
     <entryLink id="ffa9-bcdf-9c4b-c7c8" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e486-a7a3-5dd0-8632" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="afd6-4974-845a-712e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e486-a7a3-5dd0-8632" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="afd6-4974-845a-712e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
     <entryLink id="cc30-0a84-f423-4e07" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ff55-5369-f4d6-a82a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="a6ef-5d0e-3963-5b18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="deaf-51af-7c13-54a0" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="ff55-5369-f4d6-a82a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="a6ef-5d0e-3963-5b18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="deaf-51af-7c13-54a0" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="90ad-f2f7-b28d-ed44" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup"/>
+        <entryLink id="90ad-f2f7-b28d-ed44" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup" />
         <entryLink id="79aa-e90d-e85e-3f59" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
     <entryLink id="d598-1823-e7ee-be5b" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5e86-acfb-d21c-4382" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2871-a2d7-e315-a2c1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="21a6-cc23-d6bf-2485" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="5e86-acfb-d21c-4382" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2871-a2d7-e315-a2c1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="21a6-cc23-d6bf-2485" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="e900-3630-914c-9e1c" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup"/>
+        <entryLink id="e900-3630-914c-9e1c" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup" />
         <entryLink id="6954-ab73-5668-b30a" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
     <entryLink id="f64e-e785-a5b7-325b" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c298-9cb6-d7e2-0cb5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5bd1-0cca-328a-2ed3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="adf8-85f5-1197-1e42" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="c298-9cb6-d7e2-0cb5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5bd1-0cca-328a-2ed3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="adf8-85f5-1197-1e42" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="27da-d185-f71e-4cfa" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup"/>
+        <entryLink id="27da-d185-f71e-4cfa" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup" />
         <entryLink id="9c4e-eb5e-d398-f02b" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
     <entryLink id="c50e-9b4e-cdcd-4949" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="26f7-73d6-47b5-e712" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="1c38-cc8a-5a2d-0ac4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="26f7-73d6-47b5-e712" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="1c38-cc8a-5a2d-0ac4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
     <entryLink id="a7bd-0ec8-cefa-e114" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f813-59ed-cd0c-4bb7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="939a-4445-59f2-4042" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="f813-59ed-cd0c-4bb7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="939a-4445-59f2-4042" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
     <entryLink id="ed53-e716-d08b-ce4b" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3d40-fb89-6429-e3d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b62e-0cfd-53fc-8c6e" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="3d40-fb89-6429-e3d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b62e-0cfd-53fc-8c6e" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
     <entryLink id="9771-30e2-246e-d113" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3baf-1f47-7d8d-afe5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="82d4-b975-851e-17f3" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="3baf-1f47-7d8d-afe5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="82d4-b975-851e-17f3" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
     <entryLink id="acad-001e-2a68-f7d3" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8fe7-a07e-bfc5-6216" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b661-ba42-ec94-8470" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="8fe7-a07e-bfc5-6216" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b661-ba42-ec94-8470" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
     <entryLink id="3838-664d-df8f-b709" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a301-243e-4046-9ef1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="9aeb-82de-847f-18d6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a301-243e-4046-9ef1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="9aeb-82de-847f-18d6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
     <entryLink id="e071-62be-b613-776a" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8528-fc5e-1d14-4b11" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="acbc-4493-37ab-d439" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8528-fc5e-1d14-4b11" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="acbc-4493-37ab-d439" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="0c6d-b0fa-0692-92d4" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d536-9404-cc68-a546" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1dda-78bf-0e8b-66e4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="d536-9404-cc68-a546" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1dda-78bf-0e8b-66e4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
     <entryLink id="c1dd-2f22-a40d-b85f" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cf13-99d0-d540-c5ca" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="3ed7-89ba-35df-dd0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f97f-458b-b7bf-ca41" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="cf13-99d0-d540-c5ca" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="3ed7-89ba-35df-dd0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f97f-458b-b7bf-ca41" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="e738-71c4-9208-96c9" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="00c9-4e2f-c3db-a8aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="19aa-fce0-d6ee-641a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="00c9-4e2f-c3db-a8aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="19aa-fce0-d6ee-641a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="2ae3-51f3-e1a0-357d" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b05d-806e-ce1c-8000" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="661b-0757-fa8b-1b68" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b05d-806e-ce1c-8000" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="661b-0757-fa8b-1b68" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
     <entryLink id="b1fd-5d15-aae2-5ccf" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="eab0-94bc-adde-8950" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="1c6c-2429-319e-563d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="eab0-94bc-adde-8950" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="1c6c-2429-319e-563d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
     <entryLink id="7592-f5b3-62d6-585b" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="32f2-a601-66cb-5ebc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="1a61-5343-473b-d7ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="32f2-a601-66cb-5ebc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="1a61-5343-473b-d7ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
     <entryLink id="3f8d-6108-1eba-52e8" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4ab0-5343-8d33-0852" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3c13-4cb7-93bc-09ef" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="4ab0-5343-8d33-0852" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3c13-4cb7-93bc-09ef" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
     <entryLink id="897c-cf17-121f-dd2d" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="75ca-6ff3-9a11-2f0b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="dfe2-ff73-1dbf-b436" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="75ca-6ff3-9a11-2f0b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="dfe2-ff73-1dbf-b436" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
     <entryLink id="7948-f5a4-0c23-bb50" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="33e6-53ab-bf6a-3869" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="bbd4-f326-4f86-5181" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="33e6-53ab-bf6a-3869" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="bbd4-f326-4f86-5181" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
     <entryLink id="35d1-8532-38ae-ef94" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c536-8249-3470-d08d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c1fb-e1dc-19ed-cf5a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="c536-8249-3470-d08d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c1fb-e1dc-19ed-cf5a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
     <entryLink id="d783-76ac-8c75-c835" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b804-d1c0-1d80-5dd3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="b251-26ce-319c-502f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b804-d1c0-1d80-5dd3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="b251-26ce-319c-502f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
     <entryLink id="fa75-ac6c-1509-a99c" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="65e4-8fee-42eb-ebbc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c966-3b8a-1b13-1945" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="65e4-8fee-42eb-ebbc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c966-3b8a-1b13-1945" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="e68a-3c96-ad2a-0c61" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bf96-2290-0e1c-e130" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="58c7-bd73-f4e9-51aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="bf96-2290-0e1c-e130" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="58c7-bd73-f4e9-51aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
     <entryLink id="03cb-edf0-5843-015b" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b350-f3a1-1504-c504" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="e894-af6f-88e8-a1c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b350-f3a1-1504-c504" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="e894-af6f-88e8-a1c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
     <entryLink id="4000-82a8-ab28-5a0f" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a4b0-5884-cfe4-0175" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="b93c-7fb0-9a1f-ed0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a4b0-5884-cfe4-0175" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="b93c-7fb0-9a1f-ed0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
     <entryLink id="06b6-76fb-fc4c-f155" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3d78-dac0-bfe5-d21e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="06d6-9335-3ac1-0160" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3d78-dac0-bfe5-d21e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="06d6-9335-3ac1-0160" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
     <entryLink id="16c7-0e13-5bbf-c9b4" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e1ad-32b8-71d5-1bd7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="60c0-56bd-46e1-d72c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="e1ad-32b8-71d5-1bd7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="60c0-56bd-46e1-d72c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
     <entryLink id="f7a0-6cf6-c506-477c" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="eb00-193a-3062-088e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="ac22-14fe-c617-bb30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="eb00-193a-3062-088e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="ac22-14fe-c617-bb30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
     <entryLink id="532f-1bb1-a378-b707" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6137-a9d0-3010-d963" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="9d50-cd48-689c-2b0f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6137-a9d0-3010-d963" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="9d50-cd48-689c-2b0f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
     <entryLink id="f1f1-cd0c-30d3-3340" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7d7c-363c-1de3-ca97" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="026d-3576-419c-a832" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7d7c-363c-1de3-ca97" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="026d-3576-419c-a832" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
     <entryLink id="5b10-7e2a-cdc4-58b4" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dfad-30f0-63a1-0e62" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="0fe4-f82e-889c-87de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="dfad-30f0-63a1-0e62" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="0fe4-f82e-889c-87de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
     <entryLink id="2d6e-4f3b-a15b-9562" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dca3-c1fb-1ad5-98a1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="06ad-fcdd-feb4-3de0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="dca3-c1fb-1ad5-98a1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="06ad-fcdd-feb4-3de0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
     <entryLink id="95c8-556a-46e4-4843" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c626-f48c-85ee-9d2d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="01e4-5d96-f4dc-53e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c626-f48c-85ee-9d2d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="01e4-5d96-f4dc-53e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
     <entryLink id="ec6f-c256-5e18-d4cd" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fdde-74f7-4573-8037" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="a6ad-d099-c367-5081" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fdde-74f7-4573-8037" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="a6ad-d099-c367-5081" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
     <entryLink id="8820-3f8a-7f9c-b91f" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3799-0c30-32c5-6b0a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="4bc4-e4a7-6252-242b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3799-0c30-32c5-6b0a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="4bc4-e4a7-6252-242b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
     <entryLink id="663f-29d7-844c-20f6" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="99dd-6077-7202-7af0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="472b-9de1-4069-451a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="99dd-6077-7202-7af0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="472b-9de1-4069-451a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
     <entryLink id="08a5-52b0-a090-3edb" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b0ef-b784-963a-6b28" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="99ab-f281-8a8d-d1aa" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="b0ef-b784-963a-6b28" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="99ab-f281-8a8d-d1aa" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
     <entryLink id="212b-318d-8265-6776" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1609-371b-95d8-e0ec" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="aec1-d564-f18b-ad00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1609-371b-95d8-e0ec" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="aec1-d564-f18b-ad00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
     <entryLink id="bb2a-2637-b2ee-1844" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9d04-5a21-4dd9-f0f4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="e595-4ee1-396b-c3c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9d04-5a21-4dd9-f0f4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="e595-4ee1-396b-c3c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
     <entryLink id="f7fe-4e6f-5ef4-d7ef" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1408-6bc2-c0be-bbb9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cfea-6de4-b9b2-8640" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1408-6bc2-c0be-bbb9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cfea-6de4-b9b2-8640" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="c533-12ff-a59b-a45e" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="95e4-fcfa-76d3-e03c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="8b9a-0fcb-0dc0-0a8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="95e4-fcfa-76d3-e03c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="8b9a-0fcb-0dc0-0a8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
     <entryLink id="26f7-1f20-c5c3-9e68" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fdad-9422-1087-27ca" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="7792-9e96-23bc-8b27" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fdad-9422-1087-27ca" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="7792-9e96-23bc-8b27" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="5605-e26d-48ea-85b9" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="bcbe-a779-6d21-eee3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3c35-9366-2580-9533" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="bcbe-a779-6d21-eee3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3c35-9366-2580-9533" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="3487-5202-a7aa-81a2" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a005-23d4-c0f3-0bca" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="c718-ab16-d647-5e4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a7c7-01e5-7ff5-cd9a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="a005-23d4-c0f3-0bca" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c718-ab16-d647-5e4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a7c7-01e5-7ff5-cd9a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="aa05-e924-c52a-1e7c" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup"/>
-        <entryLink id="4729-9a12-064a-17c1" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup"/>
+        <entryLink id="aa05-e924-c52a-1e7c" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup" />
+        <entryLink id="4729-9a12-064a-17c1" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
     <entryLink id="9a5d-e588-a1d9-012e" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="56ab-c130-8ffa-4a69" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="5a42-81cc-2428-502f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7c5e-33a9-c82d-3e87" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="56ab-c130-8ffa-4a69" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="5a42-81cc-2428-502f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7c5e-33a9-c82d-3e87" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="5f4f-394d-b0bd-a1b9" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup"/>
-        <entryLink id="b146-3a66-a907-8f9a" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup"/>
+        <entryLink id="5f4f-394d-b0bd-a1b9" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup" />
+        <entryLink id="b146-3a66-a907-8f9a" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
     <entryLink id="67e1-84f4-acad-0918" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b34b-e514-5c6d-b900" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="5a2c-4b2a-e924-b6d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="af42-ddbf-4854-21f3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="b34b-e514-5c6d-b900" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="5a2c-4b2a-e924-b6d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="af42-ddbf-4854-21f3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="e8aa-a451-7f0e-c58e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup"/>
-        <entryLink id="a807-e841-ce49-761c" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup"/>
+        <entryLink id="e8aa-a451-7f0e-c58e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup" />
+        <entryLink id="a807-e841-ce49-761c" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
     <entryLink id="3aea-1d09-75f3-7c3b" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e272-a08b-5685-bd32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b31a-7288-7cdb-9843" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="e272-a08b-5685-bd32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b31a-7288-7cdb-9843" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="8adf-0f8e-2ebd-ce86" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e9ff-b95e-b289-845a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="8edb-41e0-e37b-1620" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e9ff-b95e-b289-845a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="8edb-41e0-e37b-1620" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
     <entryLink id="3285-8801-b5ec-f34b" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2b1c-5c52-0e33-d52c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c2b0-61ba-8e71-c418" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="2b1c-5c52-0e33-d52c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c2b0-61ba-8e71-c418" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="5970-2e1d-a74f-eb86" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="993f-9367-c890-318d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="033c-a9d7-6d84-e8fc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="993f-9367-c890-318d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="033c-a9d7-6d84-e8fc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
     <entryLink id="65c5-3be0-7a3b-2473" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8740-5235-de3c-1dae" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="bfd9-4627-4b22-93b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8740-5235-de3c-1dae" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="bfd9-4627-4b22-93b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
     <entryLink id="d63e-595f-771a-ce6f" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3a22-f6c9-76e0-4ae1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="6e8e-80ee-36cf-b334" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3a22-f6c9-76e0-4ae1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="6e8e-80ee-36cf-b334" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
     <entryLink id="e655-b121-a181-44bc" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="cac1-bfc6-19ce-cef5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="af7c-c45c-40f5-04fa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="cac1-bfc6-19ce-cef5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="af7c-c45c-40f5-04fa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
     <entryLink id="6bce-5278-9da0-819c" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8811-6377-505e-0135" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="8371-21cf-2bcc-6dd0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8811-6377-505e-0135" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="8371-21cf-2bcc-6dd0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
     <entryLink id="c9c5-6693-fc50-36b8" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="67b9-5ab8-abaf-6dc4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4cfe-1750-f96d-7fc0" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="67b9-5ab8-abaf-6dc4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4cfe-1750-f96d-7fc0" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
     <entryLink id="64f1-a9ad-60a6-5b54" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ae67-1519-4100-184a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3756-cb49-a86a-e120" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="ae67-1519-4100-184a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3756-cb49-a86a-e120" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
     <entryLink id="f119-518a-0171-0785" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="724f-0abc-2389-e369" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5f13-d632-504e-50d3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="724f-0abc-2389-e369" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5f13-d632-504e-50d3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
     <entryLink id="3b27-9963-213a-e1c2" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="68f9-c872-a692-546f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7752-76f3-4b9a-b8c0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="68f9-c872-a692-546f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7752-76f3-4b9a-b8c0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
     <entryLink id="01d9-6649-d136-f394" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5bb6-2d1a-6280-9377" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9163-f2d4-a35c-d79b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="5bb6-2d1a-6280-9377" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9163-f2d4-a35c-d79b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="0527-0258-ad43-036d" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4d5f-587d-499b-0c1c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9824-801d-3059-92a9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="4d5f-587d-499b-0c1c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9824-801d-3059-92a9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
     <entryLink id="1826-9280-fbdf-5ef0" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b336-efe4-7576-284a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0f54-d272-2d2e-366e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="b336-efe4-7576-284a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0f54-d272-2d2e-366e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="5838-e0ae-041e-bf5b" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7255-4402-4c25-3aa1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="3b31-470b-b119-35d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7255-4402-4c25-3aa1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="3b31-470b-b119-35d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
     <entryLink id="6418-eab9-8cdf-e862" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d326-c66a-fcaa-9856" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="1548-3f62-54c4-7c08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d326-c66a-fcaa-9856" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="1548-3f62-54c4-7c08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
     <entryLink id="947b-263d-02a6-fce2" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f6e1-061b-657a-3b6a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="030d-d536-d3c6-23d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f6e1-061b-657a-3b6a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="030d-d536-d3c6-23d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
     <entryLink id="3910-263b-0738-cbeb" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d688-e5b0-580e-b518" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="23d5-8cbb-e7ac-9da6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="e440-657f-1092-f31e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="d688-e5b0-580e-b518" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="23d5-8cbb-e7ac-9da6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="e440-657f-1092-f31e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="3d40-1429-b75f-54d5" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9329-19b7-0b61-7e4c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f093-f450-f569-3fc9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="9329-19b7-0b61-7e4c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f093-f450-f569-3fc9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
     <entryLink id="2e81-0ee8-0f22-b5a0" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="89dd-a734-a87f-d233" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="cf4d-39ec-39f4-30a8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="89dd-a734-a87f-d233" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="cf4d-39ec-39f4-30a8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
     <entryLink id="8708-c58c-932c-3c46" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a055-4d19-0c3e-e531" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3cdb-6db6-ba08-edcb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="a055-4d19-0c3e-e531" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3cdb-6db6-ba08-edcb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
     <entryLink id="31fb-3c0b-b74e-9dc6" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="629a-aa20-9942-50b8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="ca17-dfe8-1835-4a4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="629a-aa20-9942-50b8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="ca17-dfe8-1835-4a4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="c3ad-c410-87b0-d488" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9a9c-e747-c23f-87ad" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="67c0-3dc2-2ea3-abb6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9a9c-e747-c23f-87ad" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="67c0-3dc2-2ea3-abb6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
     <entryLink id="cb9f-8965-41ef-bf1d" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7170-4acc-5e10-8723" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="ff6b-2b23-5bfd-ea84" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7170-4acc-5e10-8723" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="ff6b-2b23-5bfd-ea84" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="bee2-cfa3-bc11-02cc" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2a41-e97e-28d7-8029" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="a0e4-e39d-8717-fb6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2a41-e97e-28d7-8029" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="a0e4-e39d-8717-fb6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
     <entryLink id="19e8-8e05-0538-14ff" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4b7d-647d-15b3-be5b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="b40b-2c4d-5a56-fdde" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4b7d-647d-15b3-be5b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="b40b-2c4d-5a56-fdde" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
     <entryLink id="81a5-dccd-497b-5fdc" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="31fc-f53d-cc58-ee5c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="b41a-1ca2-0f5f-f20f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="31fc-f53d-cc58-ee5c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="b41a-1ca2-0f5f-f20f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
     <entryLink id="c302-bdce-f4a0-d98b" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="db4f-9e47-1049-421a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="ebcc-bc75-ed11-793e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="db4f-9e47-1049-421a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="ebcc-bc75-ed11-793e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
     <entryLink id="147e-3ece-113b-567d" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e53a-dae5-c3e9-5061" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0c01-0e72-3014-2434" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="0a5a-8cd2-3b3e-9c07" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="e53a-dae5-c3e9-5061" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0c01-0e72-3014-2434" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
+        <categoryLink id="0a5a-8cd2-3b3e-9c07" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="b9ea-66c3-d09e-aa03" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3c0d-c381-8a0a-9eda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1e47-889d-0e59-a1e5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3c0d-c381-8a0a-9eda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1e47-889d-0e59-a1e5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
     <entryLink id="0c9f-82a5-0ee7-4861" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d673-3a28-e1fb-4cf8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="6af2-0361-ba7c-6762" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d673-3a28-e1fb-4cf8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="6af2-0361-ba7c-6762" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
     <entryLink id="820c-10ee-b4f0-92a8" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8c3a-d87c-bc84-3421" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b1da-3607-ed7d-a268" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="8c3a-d87c-bc84-3421" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b1da-3607-ed7d-a268" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
     <entryLink id="6537-127c-7018-6ed6" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="10d6-a2aa-a83e-eb5d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8406-3e04-d5b7-771b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="10d6-a2aa-a83e-eb5d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8406-3e04-d5b7-771b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="a35d-8563-eb47-e985" name="Roboute Guilliman" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="7543-c1ba-1564-20a8" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="ceea-9434-a82b-934b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="7543-c1ba-1564-20a8" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="ceea-9434-a82b-934b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c91f-d9e6-97eb-9233" name="Roboute Guilliman" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26d3-605d-c832-2a1f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce30-ba57-5303-3207" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26d3-605d-c832-2a1f" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce30-ba57-5303-3207" type="min" />
           </constraints>
           <profiles>
             <profile id="40dd-adeb-3cf8-f598" name="Robute Gulliman" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -1101,28 +1100,28 @@
           </profiles>
           <rules>
             <rule id="0054-1928-75a9-36c0" name="Preternatural Strategy" hidden="false">
-              <description>At the start of each of the controlling player’s turns as the Active player in which Roboute Guilliman is on the battlefield (including when Embarked on a model with the Transport Unit Sub-type or Building), the controlling player may select one of the following options, but may not select the same option twice in a row (however, each option may be selected more than once in a single battle as long as it is not in successive turns). The effects of this option are applied to all models in the army with the Legiones Astartes (Ultramarines) special rule (including Roboute Guilliman, but not any models with the Vehicle Unit Type) and last until the start of the controlling player’s next turn as the Active player: 
+              <description>At the start of each of the controlling player&#8217;s turns as the Active player in which Roboute Guilliman is on the battlefield (including when Embarked on a model with the Transport Unit Sub-type or Building), the controlling player may select one of the following options, but may not select the same option twice in a row (however, each option may be selected more than once in a single battle as long as it is not in successive turns). The effects of this option are applied to all models in the army with the Legiones Astartes (Ultramarines) special rule (including Roboute Guilliman, but not any models with the Vehicle Unit Type) and last until the start of the controlling player&#8217;s next turn as the Active player: 
 
-• The Fleet (2) special rule
-• The Counter-attack (1) special rule
-• The Furious Charge (1) special rule
-• The Stubborn special rule</description>
+&#8226; The Fleet (2) special rule
+&#8226; The Counter-attack (1) special rule
+&#8226; The Furious Charge (1) special rule
+&#8226; The Stubborn special rule</description>
             </rule>
             <rule id="4aa8-fbc4-30c9-9f24" name="Calculating Swordsman" hidden="false">
-              <description>When fighting in a Challenge, Roboute Guilliman may re-roll all failed To Hit rolls of ‘1’ on the second and all subsequent rounds of the Challenge.</description>
+              <description>When fighting in a Challenge, Roboute Guilliman may re-roll all failed To Hit rolls of &#8216;1&#8217; on the second and all subsequent rounds of the Challenge.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="88cb-7aab-4d24-18a2" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule"/>
+            <infoLink id="88cb-7aab-4d24-18a2" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="ee3b-2513-7839-c14b" name="The Armour of Reason" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9919-6acf-be7d-61df" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="372b-72b3-95e1-fdd6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9919-6acf-be7d-61df" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="372b-72b3-95e1-fdd6" type="min" />
           </constraints>
           <profiles>
             <profile id="1091-812c-b124-2609" name="The Armour of Reason" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
@@ -1132,13 +1131,13 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="425e-0e15-3c92-3dea" name="The Gladius Incandor and the Hand of Dominion" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ba2-d237-d596-63ce" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0b9-3dac-eeb5-64ec" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ba2-d237-d596-63ce" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0b9-3dac-eeb5-64ec" type="min" />
           </constraints>
           <profiles>
             <profile id="5132-e36b-0e82-d587" name="The Gladius Incandor" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1159,34 +1158,34 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="d163-f0f0-34fc-beb6" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
-            <infoLink id="9dd9-8d93-9067-2da4" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+            <infoLink id="d163-f0f0-34fc-beb6" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
+            <infoLink id="9dd9-8d93-9067-2da4" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
             <infoLink id="4838-2710-5e2c-7909" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Murderous Strike (5+)"/>
+                <modifier type="set" field="name" value="Murderous Strike (5+)" />
               </modifiers>
             </infoLink>
-            <infoLink id="b377-b7e6-6724-c7ba" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
-            <infoLink id="2ba9-71f4-3e82-31d3" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+            <infoLink id="b377-b7e6-6724-c7ba" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule" />
+            <infoLink id="2ba9-71f4-3e82-31d3" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
             <infoLink id="5d29-6390-b732-6565" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Brutal (2)"/>
+                <modifier type="set" field="name" value="Brutal (2)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="3883-0b18-3bd8-2f19" name="The Arbitrator" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db23-39d7-0fcf-0d69" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4aeb-0d28-5440-b2fa" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db23-39d7-0fcf-0d69" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4aeb-0d28-5440-b2fa" type="min" />
           </constraints>
           <profiles>
             <profile id="fc53-063f-cb6f-6c5f" name="The Arbitrator" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">18"</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 2, Rending (5+), Master-crafted</characteristic>
@@ -1196,88 +1195,88 @@
           <infoLinks>
             <infoLink id="102e-bce6-2106-4e24" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Rending (5+)"/>
+                <modifier type="set" field="name" value="Rending (5+)" />
               </modifiers>
             </infoLink>
-            <infoLink id="54d1-9623-4ce8-3e5c" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="54d1-9623-4ce8-3e5c" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="d098-0b3b-3aba-6f03" name="Cognis-Signum" hidden="false" collective="false" import="true" targetId="93b3-2d66-f7a3-be42" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f15-2efb-7e44-8be6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2820-8e6e-c02b-4737" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f15-2efb-7e44-8be6" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2820-8e6e-c02b-4737" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="83fb-54a3-ff73-7258" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a00d-cf91-8a24-b179" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="630b-1851-18ef-9e6c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a00d-cf91-8a24-b179" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="630b-1851-18ef-9e6c" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="29d6-0b23-dae1-de87" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd42-d237-2f5a-4dd6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d44-0feb-ec43-4e16" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd42-d237-2f5a-4dd6" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d44-0feb-ec43-4e16" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="2e5c-aa4d-c433-ca32" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f87b-e6f4-8942-22a6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3020-0164-47ce-8c9b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f87b-e6f4-8942-22a6" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3020-0164-47ce-8c9b" type="min" />
           </constraints>
           <profiles>
             <profile id="1bb4-7b2e-fa50-e47a" name="Sire of the Ultramarines" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All models with the Legiones Astartes (Ultramarines) special rule in the same army as Roboute Guilliman gain +1 to their Leadership Characteristic (to a maximum of 10) while he is on the battlefield and is not in Reserve or removed as a casualty. In addition, at the start of the battle, before any models are deployed onto the battlefield, an army with Roboute Guilliman as its Warlord must select one of the following Phases: Movement, Shooting or  Assault. For the duration of the battle, an army with Roboute Guilliman as its Warlord gains an additional Reaction in the chosen Phase of the opposing player’s turn as long as Roboute Guilliman has not been removed as a casualty. </characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All models with the Legiones Astartes (Ultramarines) special rule in the same army as Roboute Guilliman gain +1 to their Leadership Characteristic (to a maximum of 10) while he is on the battlefield and is not in Reserve or removed as a casualty. In addition, at the start of the battle, before any models are deployed onto the battlefield, an army with Roboute Guilliman as its Warlord must select one of the following Phases: Movement, Shooting or  Assault. For the duration of the battle, an army with Roboute Guilliman as its Warlord gains an additional Reaction in the chosen Phase of the opposing player&#8217;s turn as long as Roboute Guilliman has not been removed as a casualty. </characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="465.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="465.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="ed63-e872-9410-a4b5" name="Invictarus Suzerain Squad" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="bcf1-931d-e8bf-f5cb" name="Lords of Ultramar" hidden="false" typeId="b46c-270c-d29e-f0ff" typeName="Ability">
           <characteristics>
-            <characteristic name="Description" typeId="0982-427b-1d4a-d07c">Any friendly unit made up entirely of models with the Infantry or Cavalry Unit Type which is not Pinned or Falling Back and does not include any models with this special rule gains a +1 modifier to their Leadership Characteristic (to a maximum of 9) while it has at least one model within 6&quot; of a friendly unit that includes one or more models with this special rule.</characteristic>
+            <characteristic name="Description" typeId="0982-427b-1d4a-d07c">Any friendly unit made up entirely of models with the Infantry or Cavalry Unit Type which is not Pinned or Falling Back and does not include any models with this special rule gains a +1 modifier to their Leadership Characteristic (to a maximum of 9) while it has at least one model within 6" of a friendly unit that includes one or more models with this special rule.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <rules>
         <rule id="0977-55b4-322d-ec13" name="Honour Bearers" hidden="true">
-          <description>An Invictarus Suzerain Squad may be selected as a Retinue Squad in a Detachment that includes at least one model with both the Master of the Legion and Legiones Astartes (Ultramarines) special rules, instead of as an Elites choice. A unit selected as a ‘Retinue Squad’ must have one model with both the Master of the Legion and Legiones Astartes (Ultramarines) special rules from the same Detachment selected by the controlling player as the Invictarus Suzerain Squad’s Leader for the purposes of this special rule. An Invictarus Suzerain Squad selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. An Invictarus Suzerain Squad selected as a Retinue Squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Retinue Squad during play. One Suzerain in an Invictarus Suzerain Squad selected as a Retinue may exchange their bolt pistol for a Legion standard for +15 points.</description>
+          <description>An Invictarus Suzerain Squad may be selected as a Retinue Squad in a Detachment that includes at least one model with both the Master of the Legion and Legiones Astartes (Ultramarines) special rules, instead of as an Elites choice. A unit selected as a &#8216;Retinue Squad&#8217; must have one model with both the Master of the Legion and Legiones Astartes (Ultramarines) special rules from the same Detachment selected by the controlling player as the Invictarus Suzerain Squad&#8217;s Leader for the purposes of this special rule. An Invictarus Suzerain Squad selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. An Invictarus Suzerain Squad selected as a Retinue Squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Retinue Squad during play. One Suzerain in an Invictarus Suzerain Squad selected as a Retinue may exchange their bolt pistol for a Legion standard for +15 points.</description>
         </rule>
       </rules>
       <categoryLinks>
-        <categoryLink id="c1fb-3d4b-27f5-b426" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="2515-1c11-b0e3-ede9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="f8fc-6ad9-18f9-52bb" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="2939-9165-c065-999f" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="c1fb-3d4b-27f5-b426" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="2515-1c11-b0e3-ede9" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="f8fc-6ad9-18f9-52bb" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="2939-9165-c065-999f" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="3062-8ad4-10a2-9744" name="2) Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abe5-fb76-bf85-f708" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abe5-fb76-bf85-f708" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="f50a-6d8d-756a-b73a" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry"/>
+            <entryLink id="f50a-6d8d-756a-b73a" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="c8ea-e46e-51f2-459e" name="1) Suzerains" hidden="false" collective="false" import="true" defaultSelectionEntryId="1ca9-991d-ff13-4c7d">
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b5d-a171-63f8-93ab" type="min"/>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa9e-e533-5bea-307b" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b5d-a171-63f8-93ab" type="min" />
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa9e-e533-5bea-307b" type="max" />
           </constraints>
           <categoryLinks>
-            <categoryLink id="995c-625b-eb78-487c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="995c-625b-eb78-487c" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="1ca9-991d-ff13-4c7d" name="Suzerain w/Bolt Pistol &amp; Legatine Axe" hidden="false" collective="false" import="true" type="model">
@@ -1301,19 +1300,19 @@
               <entryLinks>
                 <entryLink id="6754-7d98-fe7c-108b" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26a2-e0bc-83e8-b32e" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d982-8222-ddfd-0b07" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26a2-e0bc-83e8-b32e" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d982-8222-ddfd-0b07" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="81c4-cc7c-a182-afea" name="Legatine Axe" hidden="false" collective="false" import="true" targetId="4f12-8517-f1a2-f111" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f35e-b0a1-e91a-4128" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2528-9193-1e97-1a9a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f35e-b0a1-e91a-4128" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2528-9193-1e97-1a9a" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="5790-aef9-aa7d-9ec4" name="Suzerain w/Bolt Pistol &amp; Thunder Hammer" hidden="false" collective="false" import="true" type="model">
@@ -1337,19 +1336,19 @@
               <entryLinks>
                 <entryLink id="97d7-cde5-5853-e038" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f94c-f1f3-02bc-ac41" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd17-3104-68bf-cd91" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f94c-f1f3-02bc-ac41" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd17-3104-68bf-cd91" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="0cdc-725f-eca7-a346" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="d8b7-fe8b-0ef7-8731" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c90-ea2a-9b87-86d7" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b7b-5ba9-7a2f-6bf5" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c90-ea2a-9b87-86d7" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b7b-5ba9-7a2f-6bf5" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="2859-846d-8545-752c" name="Suzerain w/Plasma Pistol &amp; Legatine Axe" hidden="false" collective="false" import="true" type="model">
@@ -1373,22 +1372,22 @@
               <entryLinks>
                 <entryLink id="1214-518c-493a-fbdf" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="9b65-20fa-dde1-c183" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="989c-2136-9575-de70" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c44e-e1e2-5f1a-1bf9" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="989c-2136-9575-de70" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c44e-e1e2-5f1a-1bf9" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="bd3a-9482-ec66-cab3" name="Legatine Axe" hidden="false" collective="false" import="true" targetId="4f12-8517-f1a2-f111" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="hidden" value="false"/>
+                    <modifier type="set" field="hidden" value="false" />
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aac1-cc85-8ac2-a60a" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f18b-1e8c-cb88-2f64" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aac1-cc85-8ac2-a60a" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f18b-1e8c-cb88-2f64" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="276d-8bc1-5949-baa7" name="Suzerain w/Plasma Pistol &amp; Thunder Hammer" hidden="false" collective="false" import="true" type="model">
@@ -1412,19 +1411,19 @@
               <entryLinks>
                 <entryLink id="8f28-0e2b-3cb9-f47c" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="9b65-20fa-dde1-c183" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0c6-781d-e2e7-356b" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52e5-cc04-a1f8-f66d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0c6-781d-e2e7-356b" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52e5-cc04-a1f8-f66d" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="fc44-421d-33bd-354f" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="d8b7-fe8b-0ef7-8731" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d09d-331d-d108-ef41" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fb5-5f76-982d-6dd8" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d09d-331d-d108-ef41" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fb5-5f76-982d-6dd8" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1433,12 +1432,12 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="f822-e866-658f-a875" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="f822-e866-658f-a875" type="notInstanceOf" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13a7-d523-c720-e83f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13a7-d523-c720-e83f" type="max" />
               </constraints>
               <selectionEntries>
                 <selectionEntry id="9d68-7a33-6a0f-6eca" name="Suzerain w/Legion Standard &amp; Legatine Axe" hidden="false" collective="false" import="true" type="model">
@@ -1462,22 +1461,22 @@
                   <entryLinks>
                     <entryLink id="77ab-a60e-48a1-72ab" name="Legion Standard" hidden="false" collective="false" import="true" targetId="7e13-cc1f-6bd7-7ac6" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee57-72e3-242c-51e9" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a08-c83c-7e7f-7fb1" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee57-72e3-242c-51e9" type="max" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a08-c83c-7e7f-7fb1" type="min" />
                       </constraints>
                     </entryLink>
                     <entryLink id="c539-6bab-a4c6-a613" name="Legatine Axe" hidden="false" collective="false" import="true" targetId="4e21-746a-8d09-ee37" type="selectionEntry">
                       <modifiers>
-                        <modifier type="set" field="hidden" value="false"/>
+                        <modifier type="set" field="hidden" value="false" />
                       </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bd0-71e5-1a0a-d970" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce38-6c1d-dfd7-05f5" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bd0-71e5-1a0a-d970" type="min" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce38-6c1d-dfd7-05f5" type="max" />
                       </constraints>
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0" />
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1b60-c439-0b96-10cf" name="Suzerain w/Legion Standard &amp; Thunder Hammer" hidden="false" collective="false" import="true" type="model">
@@ -1501,19 +1500,19 @@
                   <entryLinks>
                     <entryLink id="e3ce-0e2d-f688-473f" name="Legion Standard" hidden="false" collective="false" import="true" targetId="7e13-cc1f-6bd7-7ac6" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e737-1d05-b52b-19d9" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="825a-63c8-6644-3fda" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e737-1d05-b52b-19d9" type="max" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="825a-63c8-6644-3fda" type="min" />
                       </constraints>
                     </entryLink>
                     <entryLink id="4308-af8e-2872-876f" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5c2-ded2-561b-360f" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5805-3dbb-3d9a-bf17" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5c2-ded2-561b-360f" type="min" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5805-3dbb-3d9a-bf17" type="max" />
                       </constraints>
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -1524,60 +1523,60 @@
       <entryLinks>
         <entryLink id="bdfa-2f07-e145-2697" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a304-bd99-408c-62f6" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e35b-a7c8-d001-05c3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a304-bd99-408c-62f6" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e35b-a7c8-d001-05c3" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="b27a-72f0-6ad7-91e2" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a2d-314e-00af-3c16" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30df-a1dd-84fc-5c09" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a2d-314e-00af-3c16" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30df-a1dd-84fc-5c09" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="55ab-4a15-6b56-0d27" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e0e-c0f6-ed33-691f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c71e-05e4-10a1-d11c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e0e-c0f6-ed33-691f" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c71e-05e4-10a1-d11c" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="89b5-bcd5-e3ea-210b" name="Argyrum pattern boarding shield" hidden="false" collective="false" import="true" targetId="bd9c-928f-16d6-6ecd" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="180f-eea2-034c-653b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0181-1f8a-ee4e-0930" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="180f-eea2-034c-653b" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0181-1f8a-ee4e-0930" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="7587-35cc-01f6-b5d2" name="Praetorian Breacher Squad" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="660e-9fb7-c5e6-2d91" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
+        <infoLink id="660e-9fb7-c5e6-2d91" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
         <infoLink id="b51f-ec0b-2f77-b3f3" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+            <modifier type="set" field="name" value="Hammer of Wrath (1)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="18bd-fce6-63db-d58d" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="f8aa-a104-90eb-b32f" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="a5b1-bdaf-421c-1167" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
-        <categoryLink id="9d2c-fdc3-3b78-373f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="18bd-fce6-63db-d58d" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="f8aa-a104-90eb-b32f" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="a5b1-bdaf-421c-1167" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+        <categoryLink id="9d2c-fdc3-3b78-373f" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3808-d884-54f1-c8c7" name="Praetorian Primus" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27dd-704a-95f3-6392" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9674-357f-bdd1-ff4a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27dd-704a-95f3-6392" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9674-357f-bdd1-ff4a" type="min" />
           </constraints>
           <profiles>
             <profile id="3d35-24a2-917c-987e" name="Praetorian Primus" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="7587-35cc-01f6-b5d2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                    <condition field="selections" scope="7587-35cc-01f6-b5d2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1599,171 +1598,171 @@
           <selectionEntryGroups>
             <selectionEntryGroup id="d5c2-e2b5-b294-e90c" name="2) Bolt Pistol Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="2456-72c4-1845-c815">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c9a-f091-8706-be8d" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="712d-5127-0787-ef4b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c9a-f091-8706-be8d" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="712d-5127-0787-ef4b" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="2456-72c4-1845-c815" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+                <entryLink id="2456-72c4-1845-c815" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry" />
                 <entryLink id="1163-fcec-7836-d58e" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="5b3e-c22f-07bc-434b" name="3) Armor Choice" hidden="false" collective="false" import="true" defaultSelectionEntryId="54ad-1458-ddce-9daa">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e59-f5dc-869c-8e46" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dbd-4aeb-49a2-1bb7" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e59-f5dc-869c-8e46" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dbd-4aeb-49a2-1bb7" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="1fb1-18b2-1bdc-6cb2" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry"/>
-                <entryLink id="54ad-1458-ddce-9daa" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry"/>
+                <entryLink id="1fb1-18b2-1bdc-6cb2" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry" />
+                <entryLink id="54ad-1458-ddce-9daa" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="4ca8-e52b-9c16-9b63" name="1) Power Sword Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="3654-8f22-0799-85c3">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a8f-84d2-7765-ed8e" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="673f-4cb2-5701-65ec" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a8f-84d2-7765-ed8e" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="673f-4cb2-5701-65ec" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="23dc-fe28-9678-2a49" name="Legatine Axe" hidden="false" collective="false" import="true" targetId="4e21-746a-8d09-ee37" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="hidden" value="false"/>
+                    <modifier type="set" field="hidden" value="false" />
                   </modifiers>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="b1ff-5597-9be9-f39e" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="3654-8f22-0799-85c3" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
+                <entryLink id="3654-8f22-0799-85c3" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="f5ec-8c2f-dd23-88d1" name="3) Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33d1-6a6c-e733-b77d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33d1-6a6c-e733-b77d" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="de52-02be-cf09-921f" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry"/>
+            <entryLink id="de52-02be-cf09-921f" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="74e5-68c2-768d-a916" name="2) One Praetorian may take:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="5938-9b1c-c199-05cb" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a356-0d07-561b-0685" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a356-0d07-561b-0685" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="e5a4-2f34-47c3-999c" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6358-a73d-af0f-9384" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6358-a73d-af0f-9384" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="1318-115c-4ca4-1d8b" name="1) Praetorians" hidden="false" collective="false" import="true" defaultSelectionEntryId="c2b6-7c8c-66e0-2ee0">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cefa-24ed-9a09-d5cc" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05ea-efa2-35bd-f1b1" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cefa-24ed-9a09-d5cc" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05ea-efa2-35bd-f1b1" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="c2b6-7c8c-66e0-2ee0" name=" Praetorian w/Power Sword" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="757a-2162-6e07-75da" name="Praetorian" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e"/>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5"/>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84"/>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244"/>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8"/>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f"/>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672"/>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc"/>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0"/>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727"/>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0"/>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e" />
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5" />
+                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84" />
+                    <characteristic name="BS" typeId="74ae-c840-0036-d244" />
+                    <characteristic name="S" typeId="e478-41d4-a092-48a8" />
+                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f" />
+                    <characteristic name="W" typeId="57ee-1126-32a9-5672" />
+                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc" />
+                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0" />
+                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727" />
+                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0" />
                   </characteristics>
                 </profile>
               </profiles>
               <entryLinks>
                 <entryLink id="baa8-515c-e028-3d5c" name="Power Sword" hidden="false" collective="false" import="true" targetId="fa06-cac0-3d98-125e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f574-5990-f8a4-8cb3" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d9a-26f4-8259-c818" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f574-5990-f8a4-8cb3" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d9a-26f4-8259-c818" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="c44d-d61e-13b3-0002" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0b9-c20f-ea72-e02a" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17d1-c732-cb6a-04ce" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0b9-c20f-ea72-e02a" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17d1-c732-cb6a-04ce" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="6a92-6844-79a1-6513" name="Praetorian w/Legatine Axe (1 in 5)" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="8236-76ce-9122-9d33" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="7587-35cc-01f6-b5d2" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="7587-35cc-01f6-b5d2" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8236-76ce-9122-9d33" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8236-76ce-9122-9d33" type="max" />
               </constraints>
               <profiles>
                 <profile id="6c9b-8bcf-f920-3627" name="Praetorian" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e"/>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5"/>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84"/>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244"/>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8"/>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f"/>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672"/>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc"/>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0"/>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727"/>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0"/>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e" />
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5" />
+                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84" />
+                    <characteristic name="BS" typeId="74ae-c840-0036-d244" />
+                    <characteristic name="S" typeId="e478-41d4-a092-48a8" />
+                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f" />
+                    <characteristic name="W" typeId="57ee-1126-32a9-5672" />
+                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc" />
+                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0" />
+                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727" />
+                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0" />
                   </characteristics>
                 </profile>
               </profiles>
               <entryLinks>
                 <entryLink id="0631-2b58-1716-93f3" name="Legatine Axe" hidden="false" collective="false" import="true" targetId="4f12-8517-f1a2-f111" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="554c-1a60-5c83-588b" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35e6-fa26-9316-432e" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="554c-1a60-5c83-588b" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35e6-fa26-9316-432e" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="d98e-513c-f267-3c32" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2534-572a-1515-9c2d" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e31-e906-1e37-436c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2534-572a-1515-9c2d" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e31-e906-1e37-436c" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="32.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="32.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1772,59 +1771,59 @@
       <entryLinks>
         <entryLink id="2221-b21d-ada3-4d96" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6743-7744-2174-601f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3c6-ad7f-df88-ec18" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6743-7744-2174-601f" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3c6-ad7f-df88-ec18" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="355e-7c96-36b0-14b7" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aeec-8f42-ed02-6492" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8351-467f-4061-36bd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aeec-8f42-ed02-6492" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8351-467f-4061-36bd" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="bf0e-cab4-8b07-a445" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b2b-5f61-607e-035d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7c95-dfc9-d637-ca40" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b2b-5f61-607e-035d" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7c95-dfc9-d637-ca40" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="2f3b-40c8-38a7-45dd" name="Boarding Shield" hidden="false" collective="false" import="true" targetId="0c0f-f751-cc4e-4951" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6954-beed-69c4-bcd5" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3bc-10c1-bd92-573e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6954-beed-69c4-bcd5" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3bc-10c1-bd92-573e" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="47.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="47.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="7fb0-6302-d46f-029d" name="Fulmentarus Terminator Squad" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="e9ea-75c3-9fa6-a27b" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="0762-b14e-185a-3f29" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule"/>
+        <infoLink id="e9ea-75c3-9fa6-a27b" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="0762-b14e-185a-3f29" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule" />
         <infoLink id="23a6-1462-a39c-e13a" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
         <infoLink id="5edb-44f4-b9fc-3e97" name="Firing Protocols (X)" hidden="false" targetId="32a3-f599-5c92-2945" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Firing Protocols (2)"/>
+            <modifier type="set" field="name" value="Firing Protocols (2)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="d762-cd12-7679-e649" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="51d5-8c99-7bfa-92f8" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="07ca-16ef-6bbf-515a" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="e47f-ba3e-879c-88fd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="d762-cd12-7679-e649" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="51d5-8c99-7bfa-92f8" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
+        <categoryLink id="07ca-16ef-6bbf-515a" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="e47f-ba3e-879c-88fd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0ca3-4024-dbe5-6be3" name="Fulmentarus Decurion" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac5b-9ad8-4fc3-1a4d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47d5-7609-e6b9-0ef9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac5b-9ad8-4fc3-1a4d" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47d5-7609-e6b9-0ef9" type="min" />
           </constraints>
           <profiles>
             <profile id="d3cb-ec58-d466-b8c1" name="Fulmentarus Decurion" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -1844,83 +1843,83 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="cea8-d359-a93d-931f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="cea8-d359-a93d-931f" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="7df2-f403-dfa4-a651" name="Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="435c-ba08-f299-6063">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ad2-13b6-b3df-bda9" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a566-c8f7-9462-b74a" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ad2-13b6-b3df-bda9" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a566-c8f7-9462-b74a" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="ce94-7b1d-0771-31af" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
+                <entryLink id="ce94-7b1d-0771-31af" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
                 <entryLink id="ae7d-faa3-7cd2-2c8a" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="bc2d-4699-2841-e2ab" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="816f-af79-8cc6-d306" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="2518-c1a9-b56c-af23" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry"/>
-                <entryLink id="3e83-f294-47aa-485a" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
-                <entryLink id="435c-ba08-f299-6063" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
+                <entryLink id="2518-c1a9-b56c-af23" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry" />
+                <entryLink id="3e83-f294-47aa-485a" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry" />
+                <entryLink id="435c-ba08-f299-6063" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
             <entryLink id="7d3d-2768-10ed-14b0" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc1c-8edd-ba6b-9f2d" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9364-36ad-07fb-93cf" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc1c-8edd-ba6b-9f2d" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9364-36ad-07fb-93cf" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="758b-5c20-3c0e-d20e" name="2) One Fulmentarus Terminator may take:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2eb-943e-799c-ea33" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2eb-943e-799c-ea33" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="fe66-473c-00e8-4f14" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="2b95-e997-fe5b-6ece" name="3) Dedicated Transport" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="568b-e800-1cf0-15e4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="568b-e800-1cf0-15e4" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="d1c0-ed7d-4ccd-ef9e" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="true" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="7fb0-6302-d46f-029d" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="selections" scope="7fb0-6302-d46f-029d" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="4789-0438-f81a-a52e" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"/>
+            <entryLink id="4789-0438-f81a-a52e" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry" />
             <entryLink id="655a-7b92-4437-f057" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="7fb0-6302-d46f-029d" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="selections" scope="7fb0-6302-d46f-029d" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1929,8 +1928,8 @@
         </selectionEntryGroup>
         <selectionEntryGroup id="40a2-52bc-f6c5-e0cf" name="1) Fulmentarii" hidden="false" collective="false" import="true" defaultSelectionEntryId="af54-e19a-6e39-3308">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b84f-3c73-5e6f-a0ff" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="706d-59c0-aa46-d897" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b84f-3c73-5e6f-a0ff" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="706d-59c0-aa46-d897" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="af54-e19a-6e39-3308" name="Fulmentarus Terminator w/Power Sword" hidden="false" collective="false" import="true" type="model">
@@ -1954,19 +1953,19 @@
               <entryLinks>
                 <entryLink id="6578-81c9-67bc-215c" name="Power Sword" hidden="false" collective="false" import="true" targetId="fa06-cac0-3d98-125e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d26-5281-5992-8753" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2861-5bfc-29e6-3d40" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d26-5281-5992-8753" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2861-5bfc-29e6-3d40" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="2cca-9c63-bc48-0ea8" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="0f3d-c07c-7a7e-d534" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d559-3cf8-a2e3-ef09" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a76-60cb-f573-64a9" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d559-3cf8-a2e3-ef09" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a76-60cb-f573-64a9" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="6209-7e08-1c9f-f440" name="Fulmentarus Terminator w/Power Axe" hidden="false" collective="false" import="true" type="model">
@@ -1990,19 +1989,19 @@
               <entryLinks>
                 <entryLink id="d71c-d3ff-3fdd-0b3d" name="Power Axe" hidden="false" collective="false" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7380-58f7-ed9e-aa90" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4582-961c-8bf6-e458" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7380-58f7-ed9e-aa90" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4582-961c-8bf6-e458" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="eba9-8baa-0a16-9ed0" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="0f3d-c07c-7a7e-d534" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24b3-6677-1f9a-2a66" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c62-3095-3ea4-cf2f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24b3-6677-1f9a-2a66" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c62-3095-3ea4-cf2f" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="e38f-329f-6a2f-2c17" name="Fulmentarus Terminator w/Power Lance" hidden="false" collective="false" import="true" type="model">
@@ -2026,19 +2025,19 @@
               <entryLinks>
                 <entryLink id="d11b-8835-cf29-6894" name="Power Lance" hidden="false" collective="false" import="true" targetId="fca3-4ec1-c581-1ba3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dca0-92cd-d554-2334" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97d7-9908-64cf-9285" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dca0-92cd-d554-2334" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97d7-9908-64cf-9285" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="387c-af9b-c602-e89b" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="0f3d-c07c-7a7e-d534" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffc9-c677-5dc2-2259" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b94-4471-093f-1601" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffc9-c677-5dc2-2259" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b94-4471-093f-1601" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="5b75-16e1-76fc-2db1" name="Fulmentarus Terminator w/Power Maul" hidden="false" collective="false" import="true" type="model">
@@ -2062,19 +2061,19 @@
               <entryLinks>
                 <entryLink id="7c74-ab70-960e-3f37" name="Power Maul" hidden="false" collective="false" import="true" targetId="98e8-f217-dea9-0493" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66f8-74c4-3209-f0e5" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c64-2788-9dd7-574d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66f8-74c4-3209-f0e5" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c64-2788-9dd7-574d" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="79a4-e697-55f0-18c7" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="0f3d-c07c-7a7e-d534" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f46-fea0-620d-1364" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3348-e81d-c8b2-812d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f46-fea0-620d-1364" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3348-e81d-c8b2-812d" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="24b1-c85f-8c31-36d7" name="Fulmentarus Terminator w/Power Fist" hidden="false" collective="false" import="true" type="model">
@@ -2098,19 +2097,19 @@
               <entryLinks>
                 <entryLink id="3547-0e26-36e4-75a1" name="Power Fist" hidden="false" collective="false" import="true" targetId="a472-3ded-51a3-44a0" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40ac-46b3-ab03-a387" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a69-807a-fea9-6e57" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40ac-46b3-ab03-a387" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a69-807a-fea9-6e57" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="096f-e5ad-9358-ab56" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="0f3d-c07c-7a7e-d534" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3613-25f9-4989-3622" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d6a-04a8-521c-adb7" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3613-25f9-4989-3622" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d6a-04a8-521c-adb7" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="e153-e0b3-912e-b6b8" name="Fulmentarus Terminator w/Chainfist" hidden="false" collective="false" import="true" type="model">
@@ -2134,19 +2133,19 @@
               <entryLinks>
                 <entryLink id="cfd6-9a27-8d5a-638b" name="Chainfist" hidden="false" collective="false" import="true" targetId="1b03-1224-cd1a-6d3e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fed1-9841-0d28-f3a2" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c76a-813e-36e4-78aa" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fed1-9841-0d28-f3a2" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c76a-813e-36e4-78aa" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="3482-4e88-9685-c4fa" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="0f3d-c07c-7a7e-d534" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3284-08f7-bd8f-0b06" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9b3-f355-9137-e4b1" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3284-08f7-bd8f-0b06" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9b3-f355-9137-e4b1" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2155,47 +2154,47 @@
       <entryLinks>
         <entryLink id="6689-670a-9681-6768" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9ea-9e83-af17-9c89" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10ea-2285-a1d6-1c11" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9ea-9e83-af17-9c89" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10ea-2285-a1d6-1c11" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="5cb0-88eb-5376-c2d3" name="Peritarch targeter" hidden="false" collective="false" import="true" targetId="35c3-a948-99df-5477" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="399d-5db2-d248-14a5" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d6f-ec6a-2326-45a7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="399d-5db2-d248-14a5" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d6f-ec6a-2326-45a7" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="1a85-19bd-f92d-29a0" name="Fulmentarus missile array (with Splinter and Hellfire plasma missiles)" hidden="false" collective="false" import="true" targetId="5441-6fff-b5ac-615f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c2e-ee94-da0b-948f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b04a-3a4f-2402-104f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c2e-ee94-da0b-948f" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b04a-3a4f-2402-104f" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="e055-f9d2-33d9-739f" name="Remus Ventanus" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="764d-4747-9a62-0219" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="764d-4747-9a62-0219" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="c823-19f8-80ae-939b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="8ea4-d107-ba41-10c3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="e1a7-e770-96e0-6224" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="c823-19f8-80ae-939b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="8ea4-d107-ba41-10c3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="e1a7-e770-96e0-6224" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8fb6-2c1b-d30b-e993" name="Remus Ventanus" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e029-0d71-bf93-bec1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7dfe-56cc-9a26-8af2" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e029-0d71-bf93-bec1" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7dfe-56cc-9a26-8af2" type="max" />
           </constraints>
           <profiles>
             <profile id="d827-60d0-9da2-6abf" name="Remus Ventanus" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2209,29 +2208,29 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="b9e6-ae55-a847-ed79" name="Legiones Astartes (Ultramarines) " hidden="false" targetId="519d-a6ed-f57f-3642" type="rule"/>
+            <infoLink id="b9e6-ae55-a847-ed79" name="Legiones Astartes (Ultramarines) " hidden="false" targetId="519d-a6ed-f57f-3642" type="rule" />
             <infoLink id="8e2d-0ee6-1961-83e4" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Adamantium Will (3+)"/>
+                <modifier type="set" field="name" value="Adamantium Will (3+)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <entryLinks>
             <entryLink id="2c90-1380-2ca9-4c8a" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42ac-794b-a19b-21fb" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14a8-4db4-cb20-8437" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42ac-794b-a19b-21fb" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14a8-4db4-cb20-8437" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="24b6-8803-d0a2-10ff" name="Phaethon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="984a-ae4c-ec7d-f5bf" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c2e-9a3b-e0df-27f7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="984a-ae4c-ec7d-f5bf" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c2e-9a3b-e0df-27f7" type="max" />
           </constraints>
           <profiles>
             <profile id="b458-235a-2ad5-2d0b" name="Phaethon" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2246,103 +2245,103 @@
           <infoLinks>
             <infoLink id="9de3-c133-6d5b-5a3b" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Rending (5+)"/>
+                <modifier type="set" field="name" value="Rending (5+)" />
               </modifiers>
             </infoLink>
-            <infoLink id="9a44-cc66-9cf3-2aa7" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="9a44-cc66-9cf3-2aa7" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="b98c-d0e5-517b-829e" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3b5-c99c-7e51-1312" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7a7-869c-8c27-d074" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3b5-c99c-7e51-1312" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7a7-869c-8c27-d074" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="df17-9741-4303-bb4f" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a14-0979-293d-597f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80fb-1ace-7525-e278" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a14-0979-293d-597f" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80fb-1ace-7525-e278" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="20f5-8f77-9d84-9a8d" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb9e-036c-2089-5e5c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ec6-f1c1-9c80-4b00" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb9e-036c-2089-5e5c" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ec6-f1c1-9c80-4b00" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="0af0-e3c8-a0b8-7f64" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7b1-c362-32d2-8994" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58ef-7763-5c91-763f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7b1-c362-32d2-8994" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58ef-7763-5c91-763f" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="f18b-0dbd-db14-1305" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b43-d9de-5a09-9423" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cafc-2e37-5652-e582" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b43-d9de-5a09-9423" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cafc-2e37-5652-e582" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="105a-12ec-9bdc-d493" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9cd-710a-4c94-6dfe" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f79-3ddc-ea34-3dfa" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9cd-710a-4c94-6dfe" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f79-3ddc-ea34-3dfa" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="f14f-ed37-1d17-1ed6" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5484-bff4-fe96-4c9b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b5b-d601-d12e-1958" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5484-bff4-fe96-4c9b" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b5b-d601-d12e-1958" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="0d70-7503-0a9a-c993" name="Legion Standard" hidden="false" collective="false" import="true" targetId="7e13-cc1f-6bd7-7ac6" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f6a-ee6e-d7e8-661d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6499-75ee-383d-25ec" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f6a-ee6e-d7e8-661d" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6499-75ee-383d-25ec" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="dca6-0baa-0be9-1253" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d07b-2110-11cd-b015" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d07b-2110-11cd-b015" type="max" />
           </constraints>
           <profiles>
             <profile id="1a7a-03a2-2fbe-62a3" name="Warlord: Resolute Planning" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Both Remus Ventanus and any units composed entirely of models with the Legiones Astartes (Ultramarines) special rule in an army with Remus Ventanus as its Warlord automatically pass any Leadership tests or Morale checks made while they have at least one model within 3&quot; of an objective. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as Remus Ventanus has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Both Remus Ventanus and any units composed entirely of models with the Legiones Astartes (Ultramarines) special rule in an army with Remus Ventanus as its Warlord automatically pass any Leadership tests or Morale checks made while they have at least one model within 3" of an objective. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Movement phase as long as Remus Ventanus has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
-        <entryLink id="a64d-5538-961d-a1c4" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup"/>
+        <entryLink id="a64d-5538-961d-a1c4" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="c688-58bc-b6c5-c02b" name="Honoured Telemechrus" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ce78-3d90-c9db-228d" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ce78-3d90-c9db-228d" type="max" />
       </constraints>
       <infoLinks>
         <infoLink id="9dd7-5074-5c1c-359c" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hatred (Everything)"/>
+            <modifier type="set" field="name" value="Hatred (Everything)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="2e8a-b2ef-e4fc-cf8d" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
-        <categoryLink id="6c25-0ad5-bf61-85dd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="2e8a-b2ef-e4fc-cf8d" name="Dreadnought Unit-type:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false" />
+        <categoryLink id="6c25-0ad5-bf61-85dd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5204-ec1a-dfe5-1940" name="Honoured Telemechrus" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58d7-f9e3-3a72-cbbc" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="429d-0627-4ce9-e12b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58d7-f9e3-3a72-cbbc" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="429d-0627-4ce9-e12b" type="max" />
           </constraints>
           <profiles>
             <profile id="cf1b-f8e9-add2-6034" name="Honoured Telemechrus" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2362,41 +2361,41 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="ed5d-2ff7-febd-1d5b" name="Kheres Assault Cannon" hidden="false" collective="false" import="true" targetId="fe77-2e74-160d-c7af" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4955-317b-60a5-fa43" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48ff-92a0-820b-718d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4955-317b-60a5-fa43" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48ff-92a0-820b-718d" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="4842-d440-caeb-733e" name="Gravis Power Fist" hidden="false" collective="false" import="true" targetId="08be-6994-6a63-6279" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="name" value="Gravis Power Fist with in-built combi-bolter"/>
+            <modifier type="set" field="name" value="Gravis Power Fist with in-built combi-bolter" />
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0278-47c6-4ecf-c30a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8814-51cc-eef9-6b5b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0278-47c6-4ecf-c30a" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8814-51cc-eef9-6b5b" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="6e65-03f7-008e-94e5" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="025d-6b37-27bd-fe78" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bce-d22a-273d-ad03" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="025d-6b37-27bd-fe78" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bce-d22a-273d-ad03" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="3af4-f126-15a3-749f" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33fe-f49b-4cf0-e2af" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c44-dc1e-9e46-074a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33fe-f49b-4cf0-e2af" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c44-dc1e-9e46-074a" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="240.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="240.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="314d-f363-fb52-743a" name="Locutarus Storm Squad" hidden="false" collective="false" import="true" type="unit">
@@ -2406,18 +2405,18 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="d481-c887-6aaa-1612" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
+        <infoLink id="d481-c887-6aaa-1612" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="64a6-866c-d4f5-f6df" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="0fa2-0756-6373-2c2a" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
-        <categoryLink id="cbae-7580-9e8f-7512" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="64a6-866c-d4f5-f6df" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="0fa2-0756-6373-2c2a" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false" />
+        <categoryLink id="cbae-7580-9e8f-7512" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a0db-8d26-958f-5f5f" name="Locutarus Strike Leader" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0c1-241f-2be9-a223" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7975-a535-0efb-2fd3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0c1-241f-2be9-a223" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7975-a535-0efb-2fd3" type="max" />
           </constraints>
           <profiles>
             <profile id="1220-55d2-e987-cb35" name="Locutarus Strike Leader" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2437,62 +2436,62 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="2a72-86f0-130e-7ebe" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="2a72-86f0-130e-7ebe" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f41b-c392-66ce-3dfa" name="1) Melee Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="a887-9d78-c1e4-8ceb">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32be-936b-f389-9165" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65eb-c154-dcc5-1c6a" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32be-936b-f389-9165" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65eb-c154-dcc5-1c6a" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="8bc8-ae56-6523-b7ff" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
+                <entryLink id="8bc8-ae56-6523-b7ff" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
                 <entryLink id="674b-845d-1cae-6dcc" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="5d91-3965-dba5-f121" name="Legatine Axe" hidden="false" collective="false" import="true" targetId="4e21-746a-8d09-ee37" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="hidden" value="false"/>
+                    <modifier type="set" field="hidden" value="false" />
                   </modifiers>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="1987-a822-bee1-fff8" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="eca5-535f-cf22-c575" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="a887-9d78-c1e4-8ceb" name="Argean power sword" hidden="false" collective="false" import="true" targetId="013e-d478-87eb-badc" type="selectionEntry"/>
+                <entryLink id="a887-9d78-c1e4-8ceb" name="Argean power sword" hidden="false" collective="false" import="true" targetId="013e-d478-87eb-badc" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="7af0-de3f-a14b-4103" name="2) Bolt Pistol Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="825f-afc2-efcf-6eba">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8344-752c-6ad7-06ff" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f18f-86b1-76fe-3611" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8344-752c-6ad7-06ff" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f18f-86b1-76fe-3611" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="825f-afc2-efcf-6eba" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+                <entryLink id="825f-afc2-efcf-6eba" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry" />
                 <entryLink id="cbbd-746e-c785-6a81" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="b5a1-3c59-9afc-8119" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="7e44-2b9a-240a-d9a3" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -2501,38 +2500,38 @@
               <entryLinks>
                 <entryLink id="72bc-19c5-7173-2de8" name="Combat Shield" hidden="false" collective="false" import="true" targetId="472a-8297-2c71-3a9c" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64ee-47f3-f9d4-48e9" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64ee-47f3-f9d4-48e9" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="46c8-8827-4112-a573" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="548a-9c8e-68f9-1dd6" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="548a-9c8e-68f9-1dd6" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="206c-4efc-56bb-d556" name="Locutarii" hidden="false" collective="false" import="true" defaultSelectionEntryId="4039-d784-3398-72fc">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af1c-f008-588a-7990" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1492-f394-8179-9ca6" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af1c-f008-588a-7990" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1492-f394-8179-9ca6" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="4039-d784-3398-72fc" name="Locutarus" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abc8-f75a-37c0-e83a" type="max"/>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abc8-f75a-37c0-e83a" type="max" />
               </constraints>
               <profiles>
                 <profile id="a006-002c-28d1-bc61" name="Locutarus" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2554,31 +2553,31 @@
               <entryLinks>
                 <entryLink id="9265-980f-cbac-7969" name="Argean Power Sword" hidden="false" collective="false" import="true" targetId="013e-d478-87eb-badc" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2409-f03d-7cd4-c904" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f221-b11d-cc46-809f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2409-f03d-7cd4-c904" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f221-b11d-cc46-809f" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="43b0-2fe8-2de6-4d26" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce7f-8fea-9d31-1687" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2578-e04e-2246-d37b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce7f-8fea-9d31-1687" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2578-e04e-2246-d37b" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="ea36-9644-7d23-b95f" name="Locutarus w/Special Pistol" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="bf39-8076-6a75-fab1" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="314d-f363-fb52-743a" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="314d-f363-fb52-743a" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf39-8076-6a75-fab1" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf39-8076-6a75-fab1" type="max" />
               </constraints>
               <profiles>
                 <profile id="5a10-84e2-6ebf-db4f" name="Locutarus" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2600,23 +2599,23 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="f581-5733-7ba5-2bc7" name="Pistol Option" hidden="false" collective="false" import="true" defaultSelectionEntryId="98ef-5359-72d1-52d6">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8266-77d3-de35-078c" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4278-306d-6bcb-eeab" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8266-77d3-de35-078c" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4278-306d-6bcb-eeab" type="max" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="1fe1-cad4-c772-97c5" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="56e7-0e38-8c6e-8cc7" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="98ef-5359-72d1-52d6" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -2625,13 +2624,13 @@
               <entryLinks>
                 <entryLink id="7abb-682f-d585-f13e" name="Argean Power Sword" hidden="false" collective="false" import="true" targetId="013e-d478-87eb-badc" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00f1-b19f-53e7-e394" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9eaf-4926-0235-8b4c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00f1-b19f-53e7-e394" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9eaf-4926-0235-8b4c" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2640,59 +2639,59 @@
       <entryLinks>
         <entryLink id="e064-06c1-58b8-e38b" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0872-d024-a54b-5b7c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eeb4-8a4c-0e03-ee4d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0872-d024-a54b-5b7c" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eeb4-8a4c-0e03-ee4d" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="813d-f947-bc84-dcf8" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fdd-1acf-5113-33be" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc68-98cc-a087-05db" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fdd-1acf-5113-33be" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc68-98cc-a087-05db" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="97c7-e9ce-663f-1af8" name="Warhawk Jump Pack" hidden="false" collective="false" import="true" targetId="a298-8584-70ed-18ce" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25e8-2e3a-511a-2e13" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e5a-b3cc-caf3-ce87" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25e8-2e3a-511a-2e13" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e5a-b3cc-caf3-ce87" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="17f5-433e-d73f-a06a" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b04-d014-c896-e4fa" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eacf-bcde-8ffc-5943" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b04-d014-c896-e4fa" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eacf-bcde-8ffc-5943" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="32d1-29a6-9023-142c" name="Nemesis Destroyer Squad" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="3b70-e562-2c3b-f4c1" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="3b70-e562-2c3b-f4c1" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
         <infoLink id="9427-32e6-58b3-b667" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Counter-Attack (1)"/>
+            <modifier type="set" field="name" value="Counter-Attack (1)" />
           </modifiers>
         </infoLink>
-        <infoLink id="2a20-3379-5a88-7066" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
+        <infoLink id="2a20-3379-5a88-7066" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="dab5-4ae9-9a89-dbb7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="ba64-c048-fbe1-1eec" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="dab5-4ae9-9a89-dbb7" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="ba64-c048-fbe1-1eec" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9063-d5a3-8354-3cef" name="Nemesis Destroyer Sergeant" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91f8-d00c-7ffb-2cf8" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58f4-918b-e694-c03c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91f8-d00c-7ffb-2cf8" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58f4-918b-e694-c03c" type="min" />
           </constraints>
           <profiles>
             <profile id="5fbc-3ad8-71d3-e29f" name="Nemesis Destroyer Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="32d1-29a6-9023-142c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="greaterThan"/>
+                    <condition field="selections" scope="32d1-29a6-9023-142c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -2712,80 +2711,80 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="aa98-3308-c2e0-fbd2" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="aa98-3308-c2e0-fbd2" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="3d76-9955-751a-735e" name="2) May take:" hidden="false" collective="false" import="true">
               <entryLinks>
                 <entryLink id="eb99-9aef-7d56-3200" name="Phosphex Bomb" hidden="false" collective="false" import="true" targetId="4188-13ff-cb03-109e" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="A single Phosphex Bomb"/>
+                    <modifier type="set" field="name" value="A single Phosphex Bomb" />
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b44-3f3b-3f1c-716f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b44-3f3b-3f1c-716f" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="8de6-04fa-eb4b-92cc" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6417-c0d1-7bc2-0409" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6417-c0d1-7bc2-0409" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="3f91-237c-f3e9-8bad" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="051f-1178-cf46-6541" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="051f-1178-cf46-6541" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="3eb4-9ecf-3161-1d56" name="1) Chainsword Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="f7e7-5798-3921-9132">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aad7-58d5-4835-1490" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12fd-9e0d-6bc2-92d7" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aad7-58d5-4835-1490" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12fd-9e0d-6bc2-92d7" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="a1ea-a4ea-858e-4acd" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="f8a2-c2f6-a6df-d5d7" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="e7e4-6213-1e68-a6b2" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="23d6-e825-e1dc-2398" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="f7e7-5798-3921-9132" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+                <entryLink id="f7e7-5798-3921-9132" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
                 <entryLink id="393c-4334-f494-41f2" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="8ba3-9a4a-780a-7990" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="e0a4-ef61-5a19-3283" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -2794,13 +2793,13 @@
           <entryLinks>
             <entryLink id="51c5-097b-7dc2-7d12" name="Mortifier Bolter" hidden="false" collective="false" import="true" targetId="c74f-08c0-79c1-50e3" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a33-1706-48fb-90f2" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df3d-cbc9-1c8b-5fa0" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a33-1706-48fb-90f2" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df3d-cbc9-1c8b-5fa0" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2809,19 +2808,19 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="32d1-29a6-9023-142c" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                <condition field="selections" scope="32d1-29a6-9023-142c" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0956-6f9d-0c0b-478f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0956-6f9d-0c0b-478f" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="81b4-e8bd-3602-ac4a" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -2830,7 +2829,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -2839,7 +2838,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -2848,7 +2847,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -2859,31 +2858,31 @@
           <entryLinks>
             <entryLink id="a75c-bbde-d7f6-d5d2" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="561d-b412-8e66-1440" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="561d-b412-8e66-1440" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="2c7c-1737-cd41-92fd" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f050-c2f1-5b04-29de" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f050-c2f1-5b04-29de" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="93d5-65ea-2a68-63ba" name="1) Nemesis Destroyers" hidden="false" collective="false" import="true" defaultSelectionEntryId="be25-1d05-32f1-1849">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a34-03a2-1877-2f05" type="min"/>
-            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e21b-bebb-3f0f-9a11" type="max"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a34-03a2-1877-2f05" type="min" />
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e21b-bebb-3f0f-9a11" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="be25-1d05-32f1-1849" name="Nemesis Destroyer" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="825f-c084-ff52-39f6" type="max"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="825f-c084-ff52-39f6" type="max" />
               </constraints>
               <profiles>
                 <profile id="1a33-dcc3-f511-6a0d" name="Nemesis Destroyer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2905,25 +2904,25 @@
               <entryLinks>
                 <entryLink id="2393-f8ff-1f8b-261c" name="Mortifier Bolter" hidden="false" collective="false" import="true" targetId="c74f-08c0-79c1-50e3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0dc-da42-810c-92cf" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36e0-22a3-ce3a-5ba6" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0dc-da42-810c-92cf" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36e0-22a3-ce3a-5ba6" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="e674-2512-0b17-2208" name="Nemesis Destroyer w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="458a-cf5e-68a6-da65" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="32d1-29a6-9023-142c" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="32d1-29a6-9023-142c" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="458a-cf5e-68a6-da65" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="458a-cf5e-68a6-da65" type="max" />
               </constraints>
               <profiles>
                 <profile id="defc-8de3-13fc-9c46" name="Nemesis Destroyer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2945,58 +2944,58 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="a97b-75d3-ca9f-db5a" name="1) Heavy Weapon Choice" hidden="false" collective="false" import="true" defaultSelectionEntryId="73df-eee7-68e3-ccdd">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0375-d5a5-8ec5-2001" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63b5-ee21-461b-8f21" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0375-d5a5-8ec5-2001" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63b5-ee21-461b-8f21" type="min" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="3de4-5fb0-0fab-daf0" name="Missile Launcher (With suspensor web and rad missiles only)" hidden="false" collective="false" import="true" targetId="d000-9713-6bc2-e93b" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="aa63-662a-9320-340c" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="07fd-c24a-9235-4206" type="selectionEntry">
                       <modifiers>
-                        <modifier type="set" field="name" value="Heavy bolter with suspensor web"/>
+                        <modifier type="set" field="name" value="Heavy bolter with suspensor web" />
                       </modifiers>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="43d0-31af-77a2-c74a" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="73df-eee7-68e3-ccdd" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="41e2-b889-8fc1-b241" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="b05c-11d5-007b-95ee" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="e228-53fb-a6bc-5126" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="020b-4540-56f0-09eb" name="Lascutter" hidden="false" collective="false" import="true" targetId="6331-c1b9-bf0e-d0e5" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3005,37 +3004,37 @@
       <entryLinks>
         <entryLink id="4c3f-3b4f-2cc6-657e" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba70-e098-2e8b-0a52" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a19-5112-1a7d-e48a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba70-e098-2e8b-0a52" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a19-5112-1a7d-e48a" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="deb1-81e1-552a-0845" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69c3-da7d-ad3e-b04b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27cd-e581-1909-20ec" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69c3-da7d-ad3e-b04b" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27cd-e581-1909-20ec" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="5753-c98a-c27c-f23e" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d2e-40cd-f2a1-ccf9" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c92f-8e84-8614-188d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d2e-40cd-f2a1-ccf9" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c92f-8e84-8614-188d" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="4bfa-0b6f-7963-2577" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7dcf-3ad8-12dd-953d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e52-af51-449b-423c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7dcf-3ad8-12dd-953d" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e52-af51-449b-423c" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="6e52-027a-a05c-83aa" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1475-47c6-9626-1d11" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07f7-0c45-7f76-4f03" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1475-47c6-9626-1d11" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07f7-0c45-7f76-4f03" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="bd9c-928f-16d6-6ecd" name="Argyrum-pattern Boarding Shield" hidden="false" collective="false" import="true" type="upgrade">
@@ -3047,7 +3046,7 @@
         </profile>
       </profiles>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="013e-d478-87eb-badc" name="Argean Power Sword" hidden="false" collective="true" import="true" type="upgrade">
@@ -3057,47 +3056,47 @@
             <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">User</characteristic>
             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Rending (5+), Duellist&apos;s Edge (1)</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Rending (5+), Duellist's Edge (1)</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
         <infoLink id="cf92-723e-8a5c-0b93" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Rending (5+)"/>
+            <modifier type="set" field="name" value="Rending (5+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="6a6c-5ad8-54ae-d6f1" name="Duellist’s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule">
+        <infoLink id="6a6c-5ad8-54ae-d6f1" name="Duellist&#8217;s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Duellist’s Edge (1)"/>
+            <modifier type="set" field="name" value="Duellist&#8217;s Edge (1)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="35c3-a948-99df-5477" name="Peritarch Targeter" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="c367-46db-77ea-de07" name="Peritarch Targeter" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
           <characteristics>
-            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A unit that includes at least one model with a Peritarch Targeter may activate it at the start of any of their own turns before any models are moved. Once the Peritarch Targeter is activated, the unit affected may not move but gains the Guided Fire and Night Vision special rules until the start of the controlling player’s next turn. A unit that has activated a Peritarch Targeter may not make any Reactions other than the Interceptor or Overwatch Reaction, unless it can draw a line of sight to any models in the unit that triggered the Reaction. In addition, all models in a unit that has activated a Peritarch Targeter must use the same missile type for any attacks made for the duration of that player turn. </characteristic>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A unit that includes at least one model with a Peritarch Targeter may activate it at the start of any of their own turns before any models are moved. Once the Peritarch Targeter is activated, the unit affected may not move but gains the Guided Fire and Night Vision special rules until the start of the controlling player&#8217;s next turn. A unit that has activated a Peritarch Targeter may not make any Reactions other than the Interceptor or Overwatch Reaction, unless it can draw a line of sight to any models in the unit that triggered the Reaction. In addition, all models in a unit that has activated a Peritarch Targeter must use the same missile type for any attacks made for the duration of that player turn. </characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="fa13-e2d8-6a34-415a" name="Guided Fire" hidden="false" targetId="fa1e-0112-943e-b1f6" type="rule"/>
-        <infoLink id="e489-92bc-dd76-d969" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
+        <infoLink id="fa13-e2d8-6a34-415a" name="Guided Fire" hidden="false" targetId="fa1e-0112-943e-b1f6" type="rule" />
+        <infoLink id="e489-92bc-dd76-d969" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule" />
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="5441-6fff-b5ac-615f" name="Fulmentarus missile array (with Splinter and Hellfire plasma missiles)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="b99a-e882-f98f-b227" name="Fulmentarus missile array (Splinter missiles)" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
           <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">36"</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
             <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 4, Breaching (6+), Pinning</characteristic>
@@ -3105,7 +3104,7 @@
         </profile>
         <profile id="efb1-06c5-2100-7e1b" name="Fulmentarus missile array (Hellfire plasma missiles)" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
           <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24"</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
             <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Brutal (2)</characteristic>
@@ -3115,18 +3114,18 @@
       <infoLinks>
         <infoLink id="33cd-9791-9f8d-53fa" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Breaching (6+)"/>
+            <modifier type="set" field="name" value="Breaching (6+)" />
           </modifiers>
         </infoLink>
         <infoLink id="9e76-879f-e560-948c" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Brutal (2)"/>
+            <modifier type="set" field="name" value="Brutal (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="048e-a2ee-5e99-9f74" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+        <infoLink id="048e-a2ee-5e99-9f74" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule" />
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="4f12-8517-f1a2-f111" name="Legatine Axe" hidden="false" collective="true" import="true" type="upgrade">
@@ -3141,18 +3140,18 @@
         </profile>
       </profiles>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="c74f-08c0-79c1-50e3" name="Mortifier Bolter" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="80a5-4f04-0cee-9376" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9437-1428-0bbc-f2e1" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="80a5-4f04-0cee-9376" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9437-1428-0bbc-f2e1" type="max" />
       </constraints>
       <profiles>
         <profile id="fc3d-0342-e5cb-9c51" name="Mortifier bolter" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
           <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">18"</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
             <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 2, Harrower</characteristic>
@@ -3165,14 +3164,14 @@
         </profile>
       </profiles>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="9b65-20fa-dde1-c183" name="Plasma Pistol" hidden="false" collective="true" import="true" type="upgrade">
       <profiles>
         <profile id="ea33-8fd7-9767-ddc3" name="Plasma Pistol" publicationId="a716-c1c4-7b26-8424" page="134" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
           <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12"</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
             <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 1, Breaching (4+), Gets Hot</characteristic>
@@ -3182,13 +3181,13 @@
       <infoLinks>
         <infoLink id="88c9-3347-4c23-6691" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Breaching (4+)"/>
+            <modifier type="set" field="name" value="Breaching (4+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="2222-4966-2df2-685f" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
+        <infoLink id="2222-4966-2df2-685f" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule" />
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="d8b7-fe8b-0ef7-8731" name="Thunder Hammer" hidden="false" collective="true" import="true" type="upgrade">
@@ -3203,32 +3202,32 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="35a9-fd56-117a-16b8" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
-        <infoLink id="9c78-e187-4dca-8155" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
+        <infoLink id="35a9-fd56-117a-16b8" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
+        <infoLink id="9c78-e187-4dca-8155" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule" />
         <infoLink id="6200-d4e2-a873-b306" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Brutal (2)"/>
+            <modifier type="set" field="name" value="Brutal (2)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="f822-e866-658f-a875" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="111c-187c-20e5-1564" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="111c-187c-20e5-1564" type="max" />
       </constraints>
       <entryLinks>
-        <entryLink id="de58-0a0d-c78f-0e1a" name="Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
-        <entryLink id="ad52-b9f5-8c48-72b3" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="de58-0a0d-c78f-0e1a" name="Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
+        <entryLink id="ad52-b9f5-8c48-72b3" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
         <entryLink id="ba01-b8d8-1825-8220" name="Command Squad, Cataphractii" hidden="false" collective="false" import="true" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -3237,7 +3236,7 @@
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -3248,106 +3247,106 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="b095-a9b5-7531-1be6" value="1.0">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a42a-52d4-46da-c446" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b095-a9b5-7531-1be6" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a42a-52d4-46da-c446" type="max" />
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b095-a9b5-7531-1be6" type="min" />
       </constraints>
       <selectionEntryGroups>
         <selectionEntryGroup id="94cc-0bba-dbab-26f4" name=" XIII: Ultramarines" publicationId="817a-6288-e016-7469" page="292" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6fcc-5e68-ac24-d5dc" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="89fc-34d6-612c-0f58" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6fcc-5e68-ac24-d5dc" type="max" />
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="89fc-34d6-612c-0f58" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="843a-8343-49a1-5380" name="The Burden of Kings (Loyalist only)" publicationId="817a-6288-e016-7469" page="292" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d726-562e-5db3-5f82" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6136-b737-07f6-13fc" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d726-562e-5db3-5f82" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6136-b737-07f6-13fc" type="max" />
               </constraints>
               <profiles>
                 <profile id="c004-541e-a3e9-5d67" name="The Burden of Kings" publicationId="817a-6288-e016-7469" page="292" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Loyalist Allegiance.
-In any Phase in which one or more Wounds has been allocated to a Warlord with this Trait, whether saved or unsaved, the Warlord gains the It Will Not Die (4+) and Fearless special rules until the end of the Warlord’s controlling player’s next turn. In addition, an army whose Warlord has this Trait may, once in each of the opposing player’s turns, make a single Reaction without spending a point of the controlling player’s Reaction Allotment, as long as the Reaction is made by the Warlord or a unit the Warlord has joined.</characteristic>
+In any Phase in which one or more Wounds has been allocated to a Warlord with this Trait, whether saved or unsaved, the Warlord gains the It Will Not Die (4+) and Fearless special rules until the end of the Warlord&#8217;s controlling player&#8217;s next turn. In addition, an army whose Warlord has this Trait may, once in each of the opposing player&#8217;s turns, make a single Reaction without spending a point of the controlling player&#8217;s Reaction Allotment, as long as the Reaction is made by the Warlord or a unit the Warlord has joined.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="edae-1902-1b50-dfdb" name="The Aegis of Wisdom" publicationId="817a-6288-e016-7469" page="292" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2c34-7fc5-8132-ce80" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eb1c-5950-bb8f-432a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2c34-7fc5-8132-ce80" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eb1c-5950-bb8f-432a" type="max" />
               </constraints>
               <profiles>
                 <profile id="578a-f56f-a662-5963" name="The Aegis of Wisdom" publicationId="817a-6288-e016-7469" page="292" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any friendly unit made up entirely of models with the Legiones Astartes (Ultramarines) special rule that can draw a line of sight to a Warlord with this Warlord Trait, may, when called upon to Regroup, use the Warlord’s Leadership Characteristic for that test, and if successful the unit may make Shooting Attacks and declare Charges as normal, ignoring the normal restrictions for units that have Regrouped in the same turn. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any friendly unit made up entirely of models with the Legiones Astartes (Ultramarines) special rule that can draw a line of sight to a Warlord with this Warlord Trait, may, when called upon to Regroup, use the Warlord&#8217;s Leadership Characteristic for that test, and if successful the unit may make Shooting Attacks and declare Charges as normal, ignoring the normal restrictions for units that have Regrouped in the same turn. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
-            <selectionEntry id="c094-ea5c-6976-91ff" name="Pride’s Dark Power (Traitor only)" publicationId="817a-6288-e016-7469" page="292" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="c094-ea5c-6976-91ff" name="Pride&#8217;s Dark Power (Traitor only)" publicationId="817a-6288-e016-7469" page="292" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="015b-294c-70f8-bf8e" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="142e-5048-ed23-28d5" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="015b-294c-70f8-bf8e" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="142e-5048-ed23-28d5" type="max" />
               </constraints>
               <profiles>
-                <profile id="aead-3f06-6a05-3af5" name="Pride’s Dark Power" publicationId="817a-6288-e016-7469" page="292" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="aead-3f06-6a05-3af5" name="Pride&#8217;s Dark Power" publicationId="817a-6288-e016-7469" page="292" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Traitor Allegiance.
-Once per battle, a Warlord with this Warlord Trait may, at the start of any one Phase in either players’ turn, choose to use his Leadership Characteristic in place of his Toughness when resolving any To Wound rolls made against it until the end of that Phase (thus, a Warlord with Leadership 10 that chooses to activate this Trait at the start of the enemy player’s Shooting phase would treat his Toughness as if it was 10 until the end of that Phase). In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty. </characteristic>
+Once per battle, a Warlord with this Warlord Trait may, at the start of any one Phase in either players&#8217; turn, choose to use his Leadership Characteristic in place of his Toughness when resolving any To Wound rolls made against it until the end of that Phase (thus, a Warlord with Leadership 10 that chooses to activate this Trait at the start of the enemy player&#8217;s Shooting phase would treat his Toughness as if it was 10 until the end of that Phase). In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Assault phase as long as the Warlord has not been removed as a casualty. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="18a7-66b3-8db8-72cd" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+        <entryLink id="18a7-66b3-8db8-72cd" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Ultramarines.cat
+++ b/2022 - LA - Ultramarines.cat
@@ -348,7 +348,7 @@
         <categoryLink id="8fe7-a07e-bfc5-6216" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="b661-ba42-ec94-8470" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
     <entryLink id="3838-664d-df8f-b709" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a301-243e-4046-9ef1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
@@ -776,7 +776,7 @@
         <categoryLink id="2b1c-5c52-0e33-d52c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="c2b0-61ba-8e71-c418" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
     <entryLink id="5970-2e1d-a74f-eb86" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
@@ -857,7 +857,7 @@
         <categoryLink id="5bb6-2d1a-6280-9377" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="9163-f2d4-a35c-d79b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
     <entryLink id="0527-0258-ad43-036d" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4d5f-587d-499b-0c1c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -869,7 +869,7 @@
         <categoryLink id="b336-efe4-7576-284a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="0f54-d272-2d2e-366e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
     <entryLink id="5838-e0ae-041e-bf5b" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7255-4402-4c25-3aa1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -951,7 +951,7 @@
         <categoryLink id="629a-aa20-9942-50b8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="ca17-dfe8-1835-4a4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
     <entryLink id="c3ad-c410-87b0-d488" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -979,7 +979,7 @@
         <categoryLink id="7170-4acc-5e10-8723" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="ff6b-2b23-5bfd-ea84" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
     <entryLink id="bee2-cfa3-bc11-02cc" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -1029,7 +1029,7 @@
         <categoryLink id="0c01-0e72-3014-2434" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
         <categoryLink id="0a5a-8cd2-3b3e-9c07" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
     <entryLink id="b9ea-66c3-d09e-aa03" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3c0d-c381-8a0a-9eda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />

--- a/2022 - LA - Ultramarines.cat
+++ b/2022 - LA - Ultramarines.cat
@@ -1,6 +1,5 @@
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="68ae-9855-b56a-95e6" name="LA -  XIII: Ultramarines" revision="13" battleScribeVersion="2.03" authorName="Mr_Dark, Alphalas, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26">
-  <entryLinks>
-    <entryLink id="76b3-52d9-a195-2b31" name="  XIII: Ultramarines" hidden="false" collective="false" import="false" targetId="8e0f-3552-8842-f281" type="selectionEntry">
+  <entryLinks><entryLink id="76b3-52d9-a195-2b31" name="  XIII: Ultramarines" hidden="false" collective="false" import="false" targetId="8e0f-3552-8842-f281" type="selectionEntry">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d88f-ca52-7232-c2b1" type="min" />
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f435-f8a1-01a1-f153" type="max" />
@@ -132,944 +131,1957 @@
         <categoryLink id="3c4b-fd38-d4d8-9480" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="15f2-0f56-6650-9a06" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="103d-bd19-1fd2-8e10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9611-92f8-c4d9-2955" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <entryLink id="15f2-0f56-6650-9a06" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d735-8a47-4b85-8d2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6d4-581f-4746-bec3</comment></categoryLink>
+        <categoryLink id="1f2f-6c25-43ba-9afa" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_2489-ee2a-45dd-b384</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
-    <entryLink id="a970-0cf4-8052-ba14" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="abf4-7dad-5f2e-52a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d548-a94e-4d87-f631" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
-    <entryLink id="5a4e-4ae4-d306-0f94" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink><entryLink id="a970-0cf4-8052-ba14" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b02f-e65f-4a88-a175</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_b87b-bf35-4238-b7c6</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1aff-27af-435e-8102</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_fdf9-4906-4180-a39d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bbeb-55f5-e2e0-e267" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="0587-1681-790c-b01a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b84e-0f7a-912f-5a15" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="05a9-d0e7-4a5e-96b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8378-ede4-476d-b657</comment></categoryLink>
+        <categoryLink id="64c7-fee6-4242-8554" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_d64f-ad19-426c-adf7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
-    <entryLink id="7584-4ae5-fa83-7a27" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7016-91d1-80e8-a7ab" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="4833-0524-1498-eb9d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
-    <entryLink id="3b2d-d558-e9fd-157f" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="4a72-9436-7e09-58c9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="f897-825c-85c1-7c52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
-    <entryLink id="d512-7d42-1395-38fc" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink><entryLink id="5a4e-4ae4-d306-0f94" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_7fd1-8ce8-4d10-82e7</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_eaae-8c43-4d30-898c</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_f67d-8cf3-424f-b491</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_b949-6414-4f3d-b268</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fb71-201c-bb53-360f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="3456-74cc-dbaa-22fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="54c8-ca75-861e-0fbe" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="779b-35d4-421b-9b1a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_ac26-e639-4d53-9b8b</comment></categoryLink>
+        <categoryLink id="6adb-1e33-409f-900d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_49af-0d08-4c7e-8ce6</comment></categoryLink>
+        <categoryLink id="7be2-6d35-4fd4-878e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_b606-de16-4659-95cd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
-    <entryLink id="3dfc-2705-ad0d-0cd8" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink><entryLink id="7584-4ae5-fa83-7a27" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0ae9-c130-96f0-9934" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="5d76-3ae0-3ac5-2c2f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
-    <entryLink id="ffa9-bcdf-9c4b-c7c8" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7583-6fa0-4089-a19e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_0e5c-99ab-41d3-a42e</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c296-e8e8-4a7a-989a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_8868-5bcb-4604-ba8e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4fdc-1bc9-49a9-a69b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a009-a597-4b51-b228</comment></categoryLink>
+        <categoryLink id="8c32-21d8-4c1f-a8cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_24f4-9145-4016-80d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink><entryLink id="3b2d-d558-e9fd-157f" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_e732-7499-47bf-9748</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_81a5-a959-46b7-baa4</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7ec3-447a-4644-b012</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_71e2-c430-4c99-a559</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_df7b-3fb9-4f65-9165</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b1bb-3815-4200-af90" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c165-3906-463a-9c73</comment></categoryLink>
+        <categoryLink id="3669-3534-4dcc-8d30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6d1-d14c-473f-be09</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink><entryLink id="d512-7d42-1395-38fc" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_27a3-1e4c-4b76-a594</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_d59a-dcd0-44fd-b866</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_0c8b-2b92-49ed-98c7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_bafe-f799-41d9-ac85</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_6369-288c-4fec-a640</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_fe53-8858-41dc-8ec4</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e486-a7a3-5dd0-8632" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="afd6-4974-845a-712e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="dd3c-da69-45c7-ac50" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_3a22-caae-4eea-9bc5</comment></categoryLink>
+        <categoryLink id="3965-db97-4f40-86d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f759-f33e-4698-9f8a</comment></categoryLink>
+        <categoryLink id="f898-db80-4e97-bcd5" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_c624-3ae0-46c0-9b06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
-    <entryLink id="cc30-0a84-f423-4e07" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ff55-5369-f4d6-a82a" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="a6ef-5d0e-3963-5b18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="deaf-51af-7c13-54a0" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="90ad-f2f7-b28d-ed44" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup" />
-        <entryLink id="79aa-e90d-e85e-3f59" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink><entryLink id="3dfc-2705-ad0d-0cd8" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_13b3-ce1e-4f9d-8319</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d681-9d81-4abd-b11b</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a57-e48b-4534-bca5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_1859-5641-4674-9097</comment>
+                </condition>
               </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
-    <entryLink id="d598-1823-e7ee-be5b" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
-      <modifiers>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c8ed-999c-4962-a546" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_251a-df5b-4bfd-ad63</comment></categoryLink>
+        <categoryLink id="884b-5b33-40ab-a6fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4644-98ab-4e3f-b1fd</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink><entryLink id="ffa9-bcdf-9c4b-c7c8" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_591d-d028-4663-918d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_0482-c5f9-4c95-9597</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_75a7-971d-4978-a83f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_a7d5-2bfe-4621-ac0c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9f13-b460-4f27-b0cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_31fc-e265-45a7-bb5b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5e86-acfb-d21c-4382" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2871-a2d7-e315-a2c1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="21a6-cc23-d6bf-2485" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="f1e2-dd85-4389-ad26" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_67c2-df43-44fc-92d1</comment></categoryLink>
+        <categoryLink id="221a-dff8-4ed6-9557" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4136-bb4e-4dd4-99f9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink><entryLink id="cc30-0a84-f423-4e07" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry"><categoryLinks>
+        <categoryLink id="c898-39da-46f6-9ddc" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_2599-24e3-44e5-9568</comment></categoryLink>
+        <categoryLink id="825a-595c-4e0f-a368" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_285f-6e56-473b-b2fe</comment></categoryLink>
+        <categoryLink id="e762-0ecd-48cb-9b39" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_685e-022f-4e2f-a568</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="e900-3630-914c-9e1c" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup" />
-        <entryLink id="6954-ab73-5668-b30a" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup">
+        <entryLink id="d6e9-77bb-4939-8e39" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup"><comment>    template_id_2a38-6544-4267-b584    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="cdef-c74f-4003-98a7" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_8287-16ff-46ba-9838</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_81c1-fca9-44dc-ba4c</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_6e59-4592-47ef-b76d    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
-    <entryLink id="f64e-e785-a5b7-325b" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c298-9cb6-d7e2-0cb5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5bd1-0cca-328a-2ed3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="adf8-85f5-1197-1e42" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="27da-d185-f71e-4cfa" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup" />
-        <entryLink id="9c4e-eb5e-d398-f02b" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
-    <entryLink id="c50e-9b4e-cdcd-4949" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="26f7-73d6-47b5-e712" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="1c38-cc8a-5a2d-0ac4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
-    <entryLink id="a7bd-0ec8-cefa-e114" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f813-59ed-cd0c-4bb7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="939a-4445-59f2-4042" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
-    <entryLink id="ed53-e716-d08b-ce4b" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink><entryLink id="d598-1823-e7ee-be5b" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ad5d-3c79-4239-9116</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_60b1-049b-4a5f-85c2</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3d40-fb89-6429-e3d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b62e-0cfd-53fc-8c6e" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="ee5a-76c1-438c-9117" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bd6a-0cda-4e0f-80ae</comment></categoryLink>
+        <categoryLink id="09e1-4fc2-43a9-a37e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_ae75-7cca-4701-9d56</comment></categoryLink>
+        <categoryLink id="f5a5-149a-434e-a314" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_e517-62d4-48f7-8174</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
-    <entryLink id="9771-30e2-246e-d113" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
+      <entryLinks>
+        <entryLink id="665a-f588-4231-8804" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup"><comment>    template_id_fafb-6414-474a-8a09    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="9b1e-d18f-4c47-8b61" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_1e43-c980-4508-8ec2</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_4140-36a7-4203-b5e9</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_a6a6-9bc7-4d4e-86a7    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink><entryLink id="f64e-e785-a5b7-325b" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry"><categoryLinks>
+        <categoryLink id="81d4-1d01-48fb-be23" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fc9d-03d1-4bbd-a1c4</comment></categoryLink>
+        <categoryLink id="cb3e-46b8-4e75-a59d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_f51c-73d7-4f29-be1c</comment></categoryLink>
+        <categoryLink id="7ba7-a587-4e41-98bb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_257d-78c0-4bab-ba65</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="6062-cda1-4ee8-8fcd" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup"><comment>    template_id_ac26-33db-40a7-bdba    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="c824-646e-4491-9f89" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_189b-db75-4db6-9fe9</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_cbdb-2500-4e13-876a</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_dc8e-2801-46d6-84f8    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink><entryLink id="c50e-9b4e-cdcd-4949" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b43b-547f-472e-9076</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8ff9-0498-4540-8552</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fbfe-931a-489b-a589</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f4c3-5aa6-4caa-abf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_17f8-f055-4c9c-b757</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="3baf-1f47-7d8d-afe5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="82d4-b975-851e-17f3" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="d92a-5a05-40a5-8ded" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f1c8-27fd-4f98-8527</comment></categoryLink>
+        <categoryLink id="1d4f-58bf-468a-bcbb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2b20-1a8b-4753-b657</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
-    <entryLink id="acad-001e-2a68-f7d3" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink><entryLink id="a7bd-0ec8-cefa-e114" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry"><categoryLinks>
+        <categoryLink id="b011-a7f8-4eb3-bf73" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4207-8d8f-4b1a-836b</comment></categoryLink>
+        <categoryLink id="22bc-0d14-457c-8de1" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_2b34-077f-4279-86fb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink><entryLink id="ed53-e716-d08b-ce4b" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="8fe7-a07e-bfc5-6216" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b661-ba42-ec94-8470" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="cdb8-c979-4255-94f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6577-e0fb-4fda-834e</comment></categoryLink>
+        <categoryLink id="9fad-ddcf-4d45-ba0c" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_5d59-09bf-4566-b7e1</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
-    <entryLink id="3838-664d-df8f-b709" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink><entryLink id="9771-30e2-246e-d113" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"><categoryLinks>
+        <categoryLink id="a65c-f47c-443c-86a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_aa93-057d-42f6-82d7</comment></categoryLink>
+        <categoryLink id="f281-29b7-4055-8a5f" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_403c-4e9c-4af5-84ec</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink><entryLink id="acad-001e-2a68-f7d3" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_23fa-06dd-49f9-a7db</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5b26-059e-40b3-9d93</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f7bf-3a1c-4103-aed8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="a301-243e-4046-9ef1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="9aeb-82de-847f-18d6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="94eb-0240-48bd-8f0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dd44-e0a8-42a8-bdcc</comment></categoryLink>
+        <categoryLink id="f46f-1bf0-41bd-9a64" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_c5b0-f9ae-468d-924a</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
-    <entryLink id="e071-62be-b613-776a" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink><entryLink id="3838-664d-df8f-b709" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8396-e51c-4e2b-bada</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_13bb-9fb5-4580-92cf</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_bfb8-8125-4548-92f5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25e3-b8f5-4448-a7c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4f96-451e-4fe7-ae4e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_f926-27fd-4a92-97a1</comment></categoryLink>
+        <categoryLink id="9ca4-5a78-42c2-b708" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_82e3-36e1-4e85-8fcb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink><entryLink id="e071-62be-b613-776a" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8528-fc5e-1d14-4b11" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
         <categoryLink id="acbc-4493-37ab-d439" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="0c6d-b0fa-0692-92d4" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
-      <modifiers>
+    <entryLink id="0c6d-b0fa-0692-92d4" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_658f-b1ad-4347-a998</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_12bc-3db2-4d28-abce</comment>
+            </condition>
           </conditions>
         </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d536-9404-cc68-a546" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1dda-78bf-0e8b-66e4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
-    <entryLink id="c1dd-2f22-a40d-b85f" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_9d83-7691-41d6-8dad</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_add7-ba48-46d4-8a02</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_1fb0-2421-40a4-9e49</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cf13-99d0-d540-c5ca" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="3ed7-89ba-35df-dd0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f97f-458b-b7bf-ca41" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="9ff3-866e-435e-a466" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7004-b00d-481f-b740</comment></categoryLink>
+        <categoryLink id="3fe3-6c6c-4b63-8282" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4f88-2fc3-491c-bfb7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
-    <entryLink id="e738-71c4-9208-96c9" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="00c9-4e2f-c3db-a8aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="19aa-fce0-d6ee-641a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
-    <entryLink id="2ae3-51f3-e1a0-357d" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b05d-806e-ce1c-8000" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="661b-0757-fa8b-1b68" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
-    <entryLink id="b1fd-5d15-aae2-5ccf" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="eab0-94bc-adde-8950" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="1c6c-2429-319e-563d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
-    <entryLink id="7592-f5b3-62d6-585b" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="32f2-a601-66cb-5ebc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="1a61-5343-473b-d7ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
-    <entryLink id="3f8d-6108-1eba-52e8" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4ab0-5343-8d33-0852" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3c13-4cb7-93bc-09ef" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
-    <entryLink id="897c-cf17-121f-dd2d" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="75ca-6ff3-9a11-2f0b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="dfe2-ff73-1dbf-b436" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
-    <entryLink id="7948-f5a4-0c23-bb50" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="33e6-53ab-bf6a-3869" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="bbd4-f326-4f86-5181" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
-    <entryLink id="35d1-8532-38ae-ef94" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="c536-8249-3470-d08d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c1fb-e1dc-19ed-cf5a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
-    <entryLink id="d783-76ac-8c75-c835" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b804-d1c0-1d80-5dd3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="b251-26ce-319c-502f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
-    <entryLink id="fa75-ac6c-1509-a99c" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="65e4-8fee-42eb-ebbc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c966-3b8a-1b13-1945" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
-    <entryLink id="e68a-3c96-ad2a-0c61" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="bf96-2290-0e1c-e130" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="58c7-bd73-f4e9-51aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
-    <entryLink id="03cb-edf0-5843-015b" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="b350-f3a1-1504-c504" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="e894-af6f-88e8-a1c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
-    <entryLink id="4000-82a8-ab28-5a0f" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a4b0-5884-cfe4-0175" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="b93c-7fb0-9a1f-ed0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
-    <entryLink id="06b6-76fb-fc4c-f155" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3d78-dac0-bfe5-d21e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="06d6-9335-3ac1-0160" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
-    <entryLink id="16c7-0e13-5bbf-c9b4" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e1ad-32b8-71d5-1bd7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="60c0-56bd-46e1-d72c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
-    <entryLink id="f7a0-6cf6-c506-477c" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="eb00-193a-3062-088e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="ac22-14fe-c617-bb30" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
-    <entryLink id="532f-1bb1-a378-b707" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6137-a9d0-3010-d963" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="9d50-cd48-689c-2b0f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
-    <entryLink id="f1f1-cd0c-30d3-3340" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7d7c-363c-1de3-ca97" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="026d-3576-419c-a832" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
-    <entryLink id="5b10-7e2a-cdc4-58b4" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="dfad-30f0-63a1-0e62" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="0fe4-f82e-889c-87de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
-    <entryLink id="2d6e-4f3b-a15b-9562" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="dca3-c1fb-1ad5-98a1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="06ad-fcdd-feb4-3de0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
-    <entryLink id="95c8-556a-46e4-4843" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="c626-f48c-85ee-9d2d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="01e4-5d96-f4dc-53e1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
-    <entryLink id="ec6f-c256-5e18-d4cd" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="fdde-74f7-4573-8037" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="a6ad-d099-c367-5081" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
-    <entryLink id="8820-3f8a-7f9c-b91f" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3799-0c30-32c5-6b0a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="4bc4-e4a7-6252-242b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
-    <entryLink id="663f-29d7-844c-20f6" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="99dd-6077-7202-7af0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="472b-9de1-4069-451a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
-    <entryLink id="08a5-52b0-a090-3edb" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="b0ef-b784-963a-6b28" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="99ab-f281-8a8d-d1aa" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
-    <entryLink id="212b-318d-8265-6776" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1609-371b-95d8-e0ec" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="aec1-d564-f18b-ad00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
-    <entryLink id="bb2a-2637-b2ee-1844" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9d04-5a21-4dd9-f0f4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="e595-4ee1-396b-c3c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
-    <entryLink id="f7fe-4e6f-5ef4-d7ef" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1408-6bc2-c0be-bbb9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="cfea-6de4-b9b2-8640" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
-    <entryLink id="c533-12ff-a59b-a45e" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="95e4-fcfa-76d3-e03c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="8b9a-0fcb-0dc0-0a8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
-    <entryLink id="26f7-1f20-c5c3-9e68" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="fdad-9422-1087-27ca" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="7792-9e96-23bc-8b27" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
-    <entryLink id="5605-e26d-48ea-85b9" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="bcbe-a779-6d21-eee3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3c35-9366-2580-9533" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
-    <entryLink id="3487-5202-a7aa-81a2" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a005-23d4-c0f3-0bca" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="c718-ab16-d647-5e4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a7c7-01e5-7ff5-cd9a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="aa05-e924-c52a-1e7c" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup" />
-        <entryLink id="4729-9a12-064a-17c1" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
-    <entryLink id="9a5d-e588-a1d9-012e" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="56ab-c130-8ffa-4a69" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="5a42-81cc-2428-502f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7c5e-33a9-c82d-3e87" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="5f4f-394d-b0bd-a1b9" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup" />
-        <entryLink id="b146-3a66-a907-8f9a" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
-    <entryLink id="67e1-84f4-acad-0918" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b34b-e514-5c6d-b900" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="5a2c-4b2a-e924-b6d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="af42-ddbf-4854-21f3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="e8aa-a451-7f0e-c58e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup" />
-        <entryLink id="a807-e841-ce49-761c" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
-    <entryLink id="3aea-1d09-75f3-7c3b" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e272-a08b-5685-bd32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b31a-7288-7cdb-9843" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
-    <entryLink id="8adf-0f8e-2ebd-ce86" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e9ff-b95e-b289-845a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="8edb-41e0-e37b-1620" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
-    <entryLink id="3285-8801-b5ec-f34b" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2b1c-5c52-0e33-d52c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c2b0-61ba-8e71-c418" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
-    <entryLink id="5970-2e1d-a74f-eb86" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="993f-9367-c890-318d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="033c-a9d7-6d84-e8fc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
-    <entryLink id="65c5-3be0-7a3b-2473" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8740-5235-de3c-1dae" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="bfd9-4627-4b22-93b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
-    <entryLink id="d63e-595f-771a-ce6f" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3a22-f6c9-76e0-4ae1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="6e8e-80ee-36cf-b334" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
-    <entryLink id="e655-b121-a181-44bc" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="cac1-bfc6-19ce-cef5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="af7c-c45c-40f5-04fa" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
-    <entryLink id="6bce-5278-9da0-819c" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8811-6377-505e-0135" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="8371-21cf-2bcc-6dd0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
-    <entryLink id="c9c5-6693-fc50-36b8" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="67b9-5ab8-abaf-6dc4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4cfe-1750-f96d-7fc0" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
-    <entryLink id="64f1-a9ad-60a6-5b54" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ae67-1519-4100-184a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3756-cb49-a86a-e120" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
-    <entryLink id="f119-518a-0171-0785" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="724f-0abc-2389-e369" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5f13-d632-504e-50d3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
-    <entryLink id="3b27-9963-213a-e1c2" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="68f9-c872-a692-546f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7752-76f3-4b9a-b8c0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
-    <entryLink id="01d9-6649-d136-f394" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5bb6-2d1a-6280-9377" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9163-f2d4-a35c-d79b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
-    <entryLink id="0527-0258-ad43-036d" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4d5f-587d-499b-0c1c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9824-801d-3059-92a9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
-    <entryLink id="1826-9280-fbdf-5ef0" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b336-efe4-7576-284a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0f54-d272-2d2e-366e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
-    <entryLink id="5838-e0ae-041e-bf5b" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7255-4402-4c25-3aa1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="3b31-470b-b119-35d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
-    <entryLink id="6418-eab9-8cdf-e862" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d326-c66a-fcaa-9856" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="1548-3f62-54c4-7c08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
-    <entryLink id="947b-263d-02a6-fce2" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f6e1-061b-657a-3b6a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="030d-d536-d3c6-23d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
-    <entryLink id="3910-263b-0738-cbeb" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink><entryLink id="c1dd-2f22-a40d-b85f" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_8ed4-376d-4030-9439</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_8a11-c2a0-4335-99ef</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_fa8e-1af7-4d41-ac8c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_94bd-c771-4a85-8581</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d688-e5b0-580e-b518" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="23d5-8cbb-e7ac-9da6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="e440-657f-1092-f31e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="fa19-116c-47b6-9e54" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_361e-fb90-4b0e-ac3d</comment></categoryLink>
+        <categoryLink id="b1b6-fc35-44b2-8ad3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d4ef-1074-45a9-959e</comment></categoryLink>
+        <categoryLink id="f8f4-7968-4603-a885" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_febb-f536-4d25-a8ab</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
-    <entryLink id="3d40-1429-b75f-54d5" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9329-19b7-0b61-7e4c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f093-f450-f569-3fc9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink><entryLink id="e738-71c4-9208-96c9" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="835a-0c4b-4fd7-b7b8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_473b-e812-4158-9416</comment></categoryLink>
+        <categoryLink id="2d90-50d1-43cd-8ec1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_00a2-63ff-4698-a35b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
-    <entryLink id="2e81-0ee8-0f22-b5a0" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink><entryLink id="2ae3-51f3-e1a0-357d" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7cf3-8a72-4f82-8cdc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_228c-5681-4ce8-b726</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_01bb-8abd-4253-9a4d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="89dd-a734-a87f-d233" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="cf4d-39ec-39f4-30a8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1c81-f7ce-4848-a610" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2a08-4432-42ad-bfdb</comment></categoryLink>
+        <categoryLink id="1b16-e972-4426-a66e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_422e-0808-4897-8630</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
-    <entryLink id="8708-c58c-932c-3c46" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink><entryLink id="b1fd-5d15-aae2-5ccf" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1af8-4459-4717-8e3b</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_06b4-92b9-438c-b1a5</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6c8d-8b28-417b-9a7c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_715d-8186-4aa6-b40c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_390e-358c-4f8e-ade8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="a055-4d19-0c3e-e531" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3cdb-6db6-ba08-edcb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="f616-2a99-46b9-a04c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f4c0-4396-4f39-a34f</comment></categoryLink>
+        <categoryLink id="2a0c-0a7f-49fe-9ca7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1301-8415-490e-8f06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
-    <entryLink id="31fb-3c0b-b74e-9dc6" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink><entryLink id="7592-f5b3-62d6-585b" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d0c9-9a26-4324-b030</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4e9e-a61d-42f2-bacb</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ed9e-b634-4bec-9eb0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4614-ad0f-4fba-adaf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_8d08-24f6-41be-8931</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8146-9879-4fde-8a55" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_caf6-5548-4b89-8102</comment></categoryLink>
+        <categoryLink id="983d-4198-415f-949f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_63a3-be61-428d-ab29</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink><entryLink id="3f8d-6108-1eba-52e8" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f318-4b03-4767-8c7f</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b8ef-7245-4df8-a8c4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_6bce-ec44-48cb-873a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="19c0-c47d-41a0-8ca3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0678-4fdd-48e6-8f61</comment></categoryLink>
+        <categoryLink id="0039-ff37-4ee6-a3bc" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0d82-10a9-4de2-8ad7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink><entryLink id="897c-cf17-121f-dd2d" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ada1-1e18-4cbc-9598</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b1d1-ac44-47dd-9159</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5d64-f00c-4464-891b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25f0-f825-4a83-8f0d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_64b1-9e36-44da-b36a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d7d6-0836-43a0-ab5c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_d53e-113f-4a40-a3d5</comment></categoryLink>
+        <categoryLink id="eb19-ef54-43e4-8974" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1939-76b5-4279-9f8c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink><entryLink id="7948-f5a4-0c23-bb50" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d765-3bb2-4b48-bd12</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_0ca1-cfb4-4a56-ab3b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="629a-aa20-9942-50b8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="ca17-dfe8-1835-4a4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3e5b-6e04-43a4-9534" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e6f7-a6ca-4825-bfc5</comment></categoryLink>
+        <categoryLink id="2862-5772-45db-b4e6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dbec-e027-4ec1-8514</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
-    <entryLink id="c3ad-c410-87b0-d488" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink><entryLink id="35d1-8532-38ae-ef94" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d8ee-81ed-45f9-8b79</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_8f4e-e8cb-4ac9-a415</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2cd1-73ae-4ad8-b885" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_cefb-cfd7-4dc8-99c4</comment></categoryLink>
+        <categoryLink id="4251-3d0b-4422-b21a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a9fd-9d16-4a5e-855c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink><entryLink id="d783-76ac-8c75-c835" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e76b-46ca-4ab8-a93d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8035-75b8-43bb-97c9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_71a4-31e7-4927-a0ab</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="42f1-b104-44bf-9ce5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_a56d-347b-4b09-a918</comment></categoryLink>
+        <categoryLink id="60f6-31bb-4e75-9038" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_96e5-4531-4213-903e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink><entryLink id="fa75-ac6c-1509-a99c" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1fb5-2375-4c22-b41e</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7d7c-255d-49b6-96b9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5321-254b-4890-9bf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ddf8-b8b7-4afb-b6dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e10d-9052-498b-8ff1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9441-d79b-4720-9667</comment></categoryLink>
+        <categoryLink id="3c3a-82a9-42ef-83e1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7d7e-32d3-4692-b401</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink><entryLink id="e68a-3c96-ad2a-0c61" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_99fc-5fe7-4b37-a62f</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_25f4-f6b8-4b44-8350</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_81f7-2311-4cce-95bc</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_09aa-af2a-4012-91d1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_00ae-fad3-4df6-9cb9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0683-47de-4499-80d8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f65b-8958-49b3-92a5</comment></categoryLink>
+        <categoryLink id="bed4-381c-4d0f-9474" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0451-1929-4942-8c3f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink><entryLink id="03cb-edf0-5843-015b" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_edc4-4915-40ba-bbf0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_105f-ba26-4146-bc54</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7a2c-a76c-421c-a8a2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_05c9-0543-47ee-ba81</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e6ad-f0d7-4627-921b</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9dd1-e727-4346-bede" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c6a8-22a8-4d41-b969</comment></categoryLink>
+        <categoryLink id="0a6f-ed22-4e49-9fde" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03ca-12cc-4e0a-b628</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink><entryLink id="4000-82a8-ab28-5a0f" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ae67-ef52-4cac-958c</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fc61-7306-4d99-acde</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1be0-67e7-45a1-bdbb</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_42a8-7fda-4e05-af0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f7a4-82e4-42a3-91f5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_565a-1592-491f-8b9b</comment></categoryLink>
+        <categoryLink id="c029-61c6-4fe9-a115" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_81d5-c14a-42ab-bdde</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink><entryLink id="06b6-76fb-fc4c-f155" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1ae7-c41b-4818-be71</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_08a5-b1bb-4ba1-ba42</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d677-b5ad-4838-8746</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_537f-bc1f-4aaa-b0dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c00e-ee33-47dd-8866" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bc67-ce1f-4004-aeb7</comment></categoryLink>
+        <categoryLink id="ecba-bff7-41ed-857d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_9a45-9699-4475-aeef</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink><entryLink id="16c7-0e13-5bbf-c9b4" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_c28f-4109-44c4-ab64</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fdc1-a894-48bc-9e7c</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_4936-a68c-4524-9088</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb37-ac0c-49ae-9d6f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3948-bf97-49e4-9891" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3afe-cfc0-4da6-a985</comment></categoryLink>
+        <categoryLink id="28d5-a927-40b6-b412" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_04a8-6aae-45ae-bd4c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink><entryLink id="f7a0-6cf6-c506-477c" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ae19-30c0-43c5-920e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_6ebe-1bf3-4d78-9dd0</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1887-152d-48b7-b13f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_a7c4-ee6a-4f0b-8ab0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bd85-fa90-47ff-9f84</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_7bd6-9043-4d7e-ba37</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b9da-f503-4fe8-93cb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3610-c975-4d55-bdfe</comment></categoryLink>
+        <categoryLink id="b81a-4881-4c63-a874" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2fc2-f636-4c80-9608</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink><entryLink id="532f-1bb1-a378-b707" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_85c5-d4d9-4b23-9e4d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_80e8-d50b-4906-8153</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_b93b-d4f1-45eb-8a69</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e183-f183-4db7-83b5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0f39-204a-4217-b896</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_eee9-7bfd-4fea-a1bd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4744-b6cd-479e-a1c7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f81d-9435-4f11-99c1</comment></categoryLink>
+        <categoryLink id="d93c-1ecb-4e7d-a550" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9568-6142-4fdd-be3a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink><entryLink id="f1f1-cd0c-30d3-3340" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_005e-6607-4e2c-8dd2</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_7745-260c-4c36-b719</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_ba25-a4b2-4ba9-b023</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ddeb-f4c8-4091-9153</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4904-fd2f-429f-9cf7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_faea-b21b-43c5-b918</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe3e-f422-405b-a4ae" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_b24f-3ae0-4cbb-b016</comment></categoryLink>
+        <categoryLink id="c51b-549c-49ba-9fd4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fd26-8e6b-4521-92b9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink><entryLink id="5b10-7e2a-cdc4-58b4" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6ecb-28e2-43ed-a6a0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_c067-1118-4d96-b28b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_250e-23c0-4e43-bf74</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1553-a6e6-4291-853f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_aab6-797b-427a-9fd8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4208-98e5-4d04-bb77" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c77f-0819-473b-a8a2</comment></categoryLink>
+        <categoryLink id="cff3-2b0e-4ab1-9865" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_89fb-c924-4daf-923d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink><entryLink id="2d6e-4f3b-a15b-9562" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d72c-519a-451f-81b6</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_3d16-444c-42c9-aad1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_f4b2-6371-494b-863a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_797f-a84b-42f6-8e66</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0d78-fe38-4829-9b12</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="128e-d9da-48fe-bd2a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0397-c837-4fea-a527</comment></categoryLink>
+        <categoryLink id="6ca1-d3ec-4472-aced" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_060b-bccb-4776-bd83</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink><entryLink id="95c8-556a-46e4-4843" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3c84-6d74-4c42-b38d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_5b15-7aa4-4897-aaf1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_3326-31ed-4151-9b37</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6a0e-1b65-4057-ba5d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f8c7-abc9-45ec-955f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_2538-8dc5-446c-8344</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4e92-85a8-4a2d-bae3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_c1cf-cea4-4278-8f27</comment></categoryLink>
+        <categoryLink id="48c0-6bd7-440b-8d1b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5f51-2734-4a46-9f72</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink><entryLink id="ec6f-c256-5e18-d4cd" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af71-f3ff-49b1-83e9</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_1c9e-b3bf-4e88-a43f</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_6d0d-1b1d-4065-89cf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d0b7-8686-491e-9d33</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_7db8-0874-487a-be6f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1034-29a0-44b1-a85f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="792d-2775-4021-a534" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_0c16-6841-42b2-b02d</comment></categoryLink>
+        <categoryLink id="cff4-3965-4fa8-a816" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_602d-2d2d-4ff4-a82a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink><entryLink id="8820-3f8a-7f9c-b91f" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_22bd-baae-45f9-b366</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_52bd-55de-4d53-ba55</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_df1b-7476-4ab8-8d2f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_49fa-0dcf-4a61-a5b1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0ea-1443-4993-86e7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2a8-3fbe-448c-9902</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cb4c-aa80-4aea-9987" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3632-0b5d-4622-ae33</comment></categoryLink>
+        <categoryLink id="9dd3-2099-49f3-9322" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_da44-7815-4fdd-981c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink><entryLink id="663f-29d7-844c-20f6" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2bfa-b203-47e2-a828</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a39b-8a3c-49cf-bf62</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2a05-07b3-49c5-8145</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f730-87fb-44bd-b68e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_2d0e-6c49-4493-a022</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2e2-50c1-40c3-b4dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6616-02c9-4875-afbf" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_5ad5-8701-42cd-b2b6</comment></categoryLink>
+        <categoryLink id="3d66-bc48-4161-a9ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_20a4-4346-4a3b-a7d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink><entryLink id="08a5-52b0-a090-3edb" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_773a-1ea4-41a0-b766</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_9d4d-6fb8-4131-a5a3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e3bc-02f8-4ece-a5ea</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c371-76d9-4a4d-bc00</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b4c6-d4ba-4b2e-9b99</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6c73-4990-42c7-a6bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6ea9-a7e5-437d-9e35</comment></categoryLink>
+        <categoryLink id="970a-9edf-4c1c-b79c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_3cec-f053-42ab-a6eb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink><entryLink id="212b-318d-8265-6776" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1e60-42ba-4c8b-9077</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9860-f593-425e-b89b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_c842-10e8-4509-8eda</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ea52-ff41-40f6-8cf3</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_51e6-c5e1-4003-96bc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a86b-38c3-4e72-9d82" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4d7c-201f-4c99-b89a</comment></categoryLink>
+        <categoryLink id="da23-291a-497a-97d8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_10f9-4718-4e07-bb32</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink><entryLink id="bb2a-2637-b2ee-1844" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d1cd-fd9f-4964-b849" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4e52-ad1b-48d4-8eed</comment></categoryLink>
+        <categoryLink id="6a9c-c4b6-4b1c-b3a3" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_6979-1ed3-4f1f-a025</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink><entryLink id="f7fe-4e6f-5ef4-d7ef" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry"><categoryLinks>
+        <categoryLink id="b22a-5512-468c-8ceb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6140-2404-46f9-bd42</comment></categoryLink>
+        <categoryLink id="2bf8-8280-4657-85e0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_1c86-fad8-46ec-a0b0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink><entryLink id="c533-12ff-a59b-a45e" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4729-bc86-456b-b73d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_cf0f-e3f4-4fb4-989d</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1cc8-5611-4d9a-9218</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_2e32-ca02-48f0-a8dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6c91-451c-4acf-8dc0" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_0af1-d052-4bd7-aab6</comment></categoryLink>
+        <categoryLink id="1adf-13a3-4578-9ec3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_45ce-e338-43c9-b63e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink><entryLink id="26f7-1f20-c5c3-9e68" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4dce-8632-4f7c-813e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_8a71-3995-4155-ac33</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d206-f2ce-41b8-945a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan">
+                  <comment>    node_id_2e02-cf1c-4a71-861c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ec81-bd33-45a8-8550</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_3344-743c-45d3-b930</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9a9c-e747-c23f-87ad" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="67c0-3dc2-2ea3-abb6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0055-ca71-4ca0-8415" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4272-9b9d-4c59-95f0</comment></categoryLink>
+        <categoryLink id="bf25-cc5a-40c3-a3ce" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_d85b-1ae7-40d5-9341</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
-    <entryLink id="cb9f-8965-41ef-bf1d" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7170-4acc-5e10-8723" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="ff6b-2b23-5bfd-ea84" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink><entryLink id="5605-e26d-48ea-85b9" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry"><categoryLinks>
+        <categoryLink id="3edf-965b-4594-beb2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ff9f-01cb-41b9-800e</comment></categoryLink>
+        <categoryLink id="863a-7a22-4c23-b426" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_1315-6051-4a46-b070</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
-    <entryLink id="bee2-cfa3-bc11-02cc" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink><entryLink id="3487-5202-a7aa-81a2" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry"><categoryLinks>
+        <categoryLink id="aafb-6034-4199-85d2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_b084-df23-4f99-812f</comment></categoryLink>
+        <categoryLink id="043f-e8db-48ed-903d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_84fc-9304-4e9e-ab78</comment></categoryLink>
+        <categoryLink id="11b4-bded-4f21-ad89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d06a-7939-4691-9aed</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="066a-5cab-4f41-bff3" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup"><comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+        <entryLink id="6cf6-ebbe-4931-beb2" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup"><comment>    template_id_741d-8c09-4211-ada6    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink><entryLink id="9a5d-e588-a1d9-012e" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_54a4-6ec8-4c61-9c3e</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_f7fd-2d16-4603-a065</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2a41-e97e-28d7-8029" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="a0e4-e39d-8717-fb6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="211c-01d9-4043-b82e" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_c0ac-4b8c-421c-a21b</comment></categoryLink>
+        <categoryLink id="7d6f-ec6d-4a46-8fd6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8db9-079e-4482-b200</comment></categoryLink>
+        <categoryLink id="db66-b57f-41d0-8c15" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_413c-9273-4308-b546</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
-    <entryLink id="19e8-8e05-0538-14ff" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4b7d-647d-15b3-be5b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="b40b-2c4d-5a56-fdde" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      <entryLinks>
+        <entryLink id="5dfe-f4ec-4e8c-842e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup"><comment>    template_id_bbc4-33fc-4664-a18e    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="981e-1e5f-4b90-a6eb" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup"><comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink><entryLink id="67e1-84f4-acad-0918" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry"><categoryLinks>
+        <categoryLink id="b85a-64b2-4869-b8f5" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_4c8d-96f6-48f9-9590</comment></categoryLink>
+        <categoryLink id="9912-fc51-467c-9a98" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_049c-0fa5-4575-8fa8</comment></categoryLink>
+        <categoryLink id="a11c-3e63-4c18-8971" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_7358-52d7-4aae-8e07</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
-    <entryLink id="81a5-dccd-497b-5fdc" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+      <entryLinks>
+        <entryLink id="d58c-d9bc-4d97-80f4" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="5e14-ad5c-00c3-8c3e" type="selectionEntryGroup"><comment>    template_id_4784-b370-444b-93ae    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="0353-51d9-45f5-b312" name="Retinue" hidden="false" collective="false" import="true" targetId="f822-e866-658f-a875" type="selectionEntryGroup"><comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink><entryLink id="3aea-1d09-75f3-7c3b" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_3c03-a823-4466-9bd6</comment>
           <conditionGroups>
-            <conditionGroup type="and">
+            <conditionGroup type="or">
+              <comment>    node_id_8bbb-f95b-413f-b6f4</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_41b0-6b0a-482a-919e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e1f7-3cc6-4794-8b6d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="31fc-f53d-cc58-ee5c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="b41a-1ca2-0f5f-f20f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="652e-4058-48b9-ba35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_05ce-cc31-40ad-9320</comment></categoryLink>
+        <categoryLink id="3a4e-f5ac-4f34-8dd3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f13c-f8e1-4a50-bfe3</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
-    <entryLink id="c302-bdce-f4a0-d98b" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="db4f-9e47-1049-421a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="ebcc-bc75-ed11-793e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
-    <entryLink id="147e-3ece-113b-567d" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e53a-dae5-c3e9-5061" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0c01-0e72-3014-2434" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
-        <categoryLink id="0a5a-8cd2-3b3e-9c07" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
-    <entryLink id="b9ea-66c3-d09e-aa03" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3c0d-c381-8a0a-9eda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1e47-889d-0e59-a1e5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
-    <entryLink id="0c9f-82a5-0ee7-4861" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink><entryLink id="8adf-0f8e-2ebd-ce86" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_db78-4d49-42ab-954a</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_f14d-9943-47b6-866c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a95-938f-4a07-9727</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_7775-78e1-44cc-87c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0143-1ded-415f-a99c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_b822-3417-4613-be37</comment></categoryLink>
+        <categoryLink id="b2bc-df2c-4d11-b602" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_25db-b03f-4881-b310</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink><entryLink id="3285-8801-b5ec-f34b" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry"><categoryLinks>
+        <categoryLink id="a2c1-7220-4740-a483" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_75a7-dc06-445b-b2dc</comment></categoryLink>
+        <categoryLink id="c52d-86e7-4c8c-b548" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_e21a-c03b-4885-ac46</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink><entryLink id="5970-2e1d-a74f-eb86" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9a08-5fe6-4010-bbc3</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_72cf-cfce-4e02-b379</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d673-3a28-e1fb-4cf8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="6af2-0361-ba7c-6762" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3965-e5e4-4436-8704" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_f55b-7555-444b-beee</comment></categoryLink>
+        <categoryLink id="9126-ad86-4977-8b12" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3386-c9ad-4d74-9474</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
-    <entryLink id="820c-10ee-b4f0-92a8" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8c3a-d87c-bc84-3421" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b1da-3607-ed7d-a268" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
-    <entryLink id="6537-127c-7018-6ed6" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink><entryLink id="65c5-3be0-7a3b-2473" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_a0f6-9606-4b75-a2f8</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_94b3-1331-474b-885b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="10d6-a2aa-a83e-eb5d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8406-3e04-d5b7-771b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="62e2-e26e-435f-81d4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_79fa-3370-4ae0-9e12</comment></categoryLink>
+        <categoryLink id="e4b5-1903-4ccf-bd36" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bb53-4e65-4fb6-9dd7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
-  </entryLinks>
-  <sharedSelectionEntries>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink><entryLink id="d63e-595f-771a-ce6f" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f8cc-833a-4ac1-bf89</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+              <comment>    node_id_5988-c012-4dad-9a66</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9689-5098-4a04-906f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_8d82-3279-4481-84bb</comment></categoryLink>
+        <categoryLink id="be1b-7ffa-454c-be84" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e25c-925e-4b96-8bb3</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink><entryLink id="e655-b121-a181-44bc" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6b73-b21c-4e2b-9d14</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_a7fe-cc62-4a6f-a781</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5be1-1937-4964-a455</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_da1d-b2bc-4117-82a4</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a640-9860-4ee3-a044" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7010-be56-4709-b058</comment></categoryLink>
+        <categoryLink id="1b62-3ec2-4fdc-8a24" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7379-a740-47ba-a054</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink><entryLink id="6bce-5278-9da0-819c" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_dd34-83cf-47d7-b557</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_be88-afef-49b3-bd1e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ef77-0845-49b6-bcb0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_944f-7420-4982-8ea9</comment></categoryLink>
+        <categoryLink id="0817-2167-4cf2-87ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ea80-0efe-457d-a450</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink><entryLink id="c9c5-6693-fc50-36b8" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><categoryLinks>
+        <categoryLink id="352c-5bf5-4d03-93e3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9a36-f261-43cc-9bd1</comment></categoryLink>
+        <categoryLink id="46ef-d42c-4b6e-8243" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a648-8396-442a-af59</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink><entryLink id="64f1-a9ad-60a6-5b54" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_cb81-0303-4b88-ae53</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9648-31e3-43aa-8cf3</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_0507-da81-4023-bfcf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0e84-54ff-488d-b066</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b6c8-1914-4e7e-9bc3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6ff-0977-4c92-bb28</comment></categoryLink>
+        <categoryLink id="7ca8-3da0-4e87-b3f2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f555-7d39-458f-84c9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink><entryLink id="f119-518a-0171-0785" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8203-5b00-497b-b939</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_40ee-3e71-4978-b1e4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f6a8-f660-46dc-b3c5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_d988-3af6-48bf-b0a8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f402-0952-4ebc-a8f5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_39e5-eda5-45d1-a643</comment></categoryLink>
+        <categoryLink id="3b4c-e788-42d8-87d5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_6416-21bb-4df4-9de8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink><entryLink id="3b27-9963-213a-e1c2" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b03e-5d91-4be3-8adc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_0443-29c0-46e9-ad1d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f2c9-7356-4c27-a22f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0e9-4a9e-4b2b-a9d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c572-444b-4ab0-b701" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5528-2dac-4be5-900c</comment></categoryLink>
+        <categoryLink id="e21b-6c90-4a45-b75f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_dc8f-d888-4585-991d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink><entryLink id="01d9-6649-d136-f394" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1d3c-8e17-489f-9002</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5725-8bee-4bcc-878d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_be47-0d6f-49f2-9f4b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_863c-f3a4-4802-b80c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d7cc-b7a7-4bf3-a709" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_899e-b052-4d5b-8c18</comment></categoryLink>
+        <categoryLink id="6d2b-1362-413e-910d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f5e9-cff6-41d2-a016</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink><entryLink id="0527-0258-ad43-036d" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_72da-1513-4e02-b595</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7a48-a3b0-4a26-849b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e232-25f3-4cb7-8ab2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_9aa4-5660-4697-8ab2</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2358-d7af-4843-807d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_09cd-2176-40af-bba6</comment></categoryLink>
+        <categoryLink id="26ce-8a41-4e9b-a667" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_05e6-7c63-4a35-9ba0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink><entryLink id="1826-9280-fbdf-5ef0" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry"><categoryLinks>
+        <categoryLink id="a1cc-b9f6-4590-906c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0dfa-4004-4751-8022</comment></categoryLink>
+        <categoryLink id="d65e-5d83-4e70-9aa6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a669-0f5d-4fd3-811b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink><entryLink id="5838-e0ae-041e-bf5b" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_09b5-4e3b-4c84-a574</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_32e5-ebba-41fb-9ff2</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_838e-0ccf-4d3a-aabd</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_dfef-0ec2-49fb-a534</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c884-bfda-44ac-ba79" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4f60-472b-45a9-ab9e</comment></categoryLink>
+        <categoryLink id="1b7c-5e89-4eaf-9a40" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e2e3-af36-45a6-a955</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink><entryLink id="6418-eab9-8cdf-e862" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_936f-1ef7-472e-840e</comment>
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+              <comment>    node_id_d73d-d52e-4c75-8ac0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="02a2-57b0-4bf9-b5da" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_7a55-ecb4-4e5d-b955</comment></categoryLink>
+        <categoryLink id="4147-7379-474e-bf55" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f28c-710e-4ff8-9810</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink><entryLink id="947b-263d-02a6-fce2" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_a743-0cc2-45ae-a7eb</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2721-e88d-41f7-bedc</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_e10f-1390-4b33-8fcc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2be4-1e7f-425d-8e0a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2008-f1c4-4285-a14f</comment></categoryLink>
+        <categoryLink id="69df-a7b3-4bb5-93b8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e88b-a95a-4647-af3b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink><entryLink id="3910-263b-0738-cbeb" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_25d8-330b-4574-b515</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7836-6878-47a8-8827</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_5ea9-46dd-4a11-9410</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_ab5d-961b-4924-a705</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7f24-41f1-4392-b23a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9189-836c-475d-a52e</comment></categoryLink>
+        <categoryLink id="ac79-7e28-43ba-8b16" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_e1fa-b7d8-47b0-a88a</comment></categoryLink>
+        <categoryLink id="f692-874b-490d-88e1" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_a137-e3c0-4d63-a48c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink><entryLink id="3d40-1429-b75f-54d5" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry"><categoryLinks>
+        <categoryLink id="1040-72f9-404f-8012" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b1d5-fd75-4f17-bbf4</comment></categoryLink>
+        <categoryLink id="2d97-534a-43a6-b34f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_f221-bf81-4045-849b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink><entryLink id="2e81-0ee8-0f22-b5a0" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_b743-7a00-43e4-beb8</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d12f-2c98-4e62-a716</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d4d7-ba67-47aa-962f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+                  <comment>    node_id_1637-edee-457a-bb0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9539-2b8d-4f3a-b628" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_f203-bc26-421f-b79e</comment></categoryLink>
+        <categoryLink id="196f-36a0-4616-8053" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_a53e-59d9-4ac2-a21f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink><entryLink id="8708-c58c-932c-3c46" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry"><categoryLinks>
+        <categoryLink id="a584-7580-4827-82f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_51af-a137-4a1c-97a4</comment></categoryLink>
+        <categoryLink id="b1ef-8bc8-4a33-9778" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ec1f-c326-40a8-9d1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink><entryLink id="31fb-3c0b-b74e-9dc6" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_c111-feb0-4012-98cd</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_63d7-8427-431d-9ae6</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0a71-f381-459f-a3db" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_e707-fde1-457f-91c4</comment></categoryLink>
+        <categoryLink id="373e-872b-47e3-b219" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ec67-8573-4460-89db</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink><entryLink id="c3ad-c410-87b0-d488" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3348-16e4-4a9a-a549</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_bea4-c4a8-4843-b9fe</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2970-17ff-4be1-91e5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_503a-46e7-40e7-bd07</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_4555-15e1-43ff-80a0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e490-1fe8-430f-974f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_fce3-801c-49c8-85d4</comment></categoryLink>
+        <categoryLink id="38f4-b195-4519-822a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0c2d-2349-44b6-9831</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink><entryLink id="cb9f-8965-41ef-bf1d" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry"><categoryLinks>
+        <categoryLink id="314a-13fd-4a61-a4a8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ac1c-b3bf-4011-918a</comment></categoryLink>
+        <categoryLink id="e90d-41a1-46d5-b541" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_589c-1d0e-4b7d-be6b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink><entryLink id="bee2-cfa3-bc11-02cc" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2f46-a0b6-48a5-a0ee</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_636f-0f8a-43f1-910b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c883-39c8-4a74-aeaa</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_0796-e467-4438-89b3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c289-4cdc-44a1-b482" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_5a04-9847-4c91-a49a</comment></categoryLink>
+        <categoryLink id="b88c-29d8-4659-87af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b4b4-daeb-483c-a306</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink><entryLink id="19e8-8e05-0538-14ff" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6087-a5e5-4d3c-9ebd</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c7e1-5f42-4528-bf07</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1950-08dc-4544-ab01</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_daf3-31ed-42c0-85dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8542-878b-45fd-a13e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_7d4f-547c-43ed-a520</comment></categoryLink>
+        <categoryLink id="f401-3dd6-4de2-9848" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f04e-04e8-4891-9b1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink><entryLink id="81a5-dccd-497b-5fdc" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_dfdc-f6f6-49d2-a7b3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_354c-c71f-472f-b268</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1127-c974-4663-874d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_0843-bef2-4767-8307</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f3a9-b153-4f37-90dc" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_28e0-91e7-4ada-9fac</comment></categoryLink>
+        <categoryLink id="ee33-f43b-4632-a68b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4448-a712-4dd7-bf6d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink><entryLink id="c302-bdce-f4a0-d98b" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d512-fd07-4a29-863a</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_55c6-a35f-485a-9f0d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d89e-cf1f-4ceb-b3de</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e2c9-0d01-403c-900e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_a7b8-c835-4cb2-b3d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a180-fd9a-4a3a-a2bb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_e22a-c5f8-4825-a45f</comment></categoryLink>
+        <categoryLink id="96b4-f846-4ff6-8ed7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03fc-6a7f-45a5-bcb8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink><entryLink id="147e-3ece-113b-567d" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry"><categoryLinks>
+        <categoryLink id="8471-599e-442f-a550" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0aff-4f6e-4b03-a23c</comment></categoryLink>
+        <categoryLink id="b5f2-5b3a-452a-8814" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"><comment>    template_id_7d5a-62e7-43ee-b79b</comment></categoryLink>
+        <categoryLink id="4890-f7fe-4150-90b8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_4986-9157-49f2-b670</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink><entryLink id="b9ea-66c3-d09e-aa03" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_319e-90d4-44a3-8e83</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_28db-d943-4099-9abd</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1a45-a592-49df-9465</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb31-d0b2-4677-928e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0ab3-359e-42d8-8497" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1b86-0977-4a8b-adac</comment></categoryLink>
+        <categoryLink id="f026-0f7e-4237-9864" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_b449-403a-4e42-9239</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink><entryLink id="0c9f-82a5-0ee7-4861" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafa-470f-4c2c-8be3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_e2ba-a855-4de2-9f46</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_0171-b30d-44ee-9389</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fdfb-119b-4774-934a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_3891-9a00-4f8f-b95f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1eab-afaf-4311-83c0" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e5df-17d4-4521-9d5b</comment></categoryLink>
+        <categoryLink id="2070-71b4-40f1-98e5" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"><comment>    template_id_0ecd-4873-4d3a-b28b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink><entryLink id="820c-10ee-b4f0-92a8" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_fbfa-8d78-4d6d-8a05</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_21f2-0916-46bf-b75a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_4fbd-633b-4dd6-9fdd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6b56-4e4f-465e-83fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4f71-446f-4cff-afda</comment></categoryLink>
+        <categoryLink id="b63e-5313-4eb3-a017" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_3f44-8647-43a4-ac22</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink><entryLink id="6537-127c-7018-6ed6" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af15-2c71-4f8b-833e</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_d95a-80b9-4463-af55</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f956-b934-4fcc-8491" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6b1-886e-4194-8bcd</comment></categoryLink>
+        <categoryLink id="ef91-b04b-4509-a296" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_51b5-f9c1-4587-8fc7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink><entryLink id="f9d5-d813-407d-b5c6" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
+    <entryLink id="5b6e-247a-4e59-ae8e" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
+    <entryLink id="5bac-17fa-4fd4-b332" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
+    <entryLink id="efa3-e43c-4888-85d9" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <entryLink id="232a-bd76-4595-93bd" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3531-57d1-4081-882d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_f233-2361-4177-8ba7</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b932-667a-4b43-8331</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <entryLink id="65e8-a17e-4151-9d1e" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <entryLink id="162f-65be-4d8d-8506" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3129-6f59-4365-906b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2bcb-0af1-4aea-9191" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <entryLink id="3bac-ae60-4ae0-83bd" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ede2-d453-4e34-8cda</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2907-3215-4b01-96ff</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_c90c-959f-40fb-a4cb</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ba2d-50ad-45f1-91c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0e88-485e-43c2-8bef" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <entryLink id="3964-7601-4145-8be1" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_409c-0a5d-4ef8-a871</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7078-c1c7-4af2-b43d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_9a69-0fdc-4957-8982</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1a4c-69b5-4219-8502" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fba0-3ea7-4eaf-b33a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <entryLink id="63fa-4185-408a-9b4b" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
+    <entryLink id="9b0e-33a1-418a-b4c8" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
+    <entryLink id="5d85-571c-432a-b752" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
+    <entryLink id="3f71-1d13-4973-8ade" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+  </entryLinks><sharedSelectionEntries>
     <selectionEntry id="a35d-8563-eb47-e985" name="Roboute Guilliman" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="7543-c1ba-1564-20a8" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />

--- a/2022 - LA - White Scars.cat
+++ b/2022 - LA - White Scars.cat
@@ -338,7 +338,7 @@
         <categoryLink id="7434-0033-1bac-79ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="bfe3-0067-8009-4fa2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
     <entryLink id="6dde-f11a-520f-8a04" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2bb9-a861-7c24-d694" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
@@ -767,7 +767,7 @@
         <categoryLink id="b026-9a7d-85d1-f88e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="60c9-2f7b-b176-b0cc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
     <entryLink id="c808-9d93-886d-7bb6" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
@@ -848,7 +848,7 @@
         <categoryLink id="83e0-4077-384f-5c37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="223d-ee24-ce15-2e49" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
     <entryLink id="58e4-9279-b4fe-9181" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7010-998a-102d-c4ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -860,7 +860,7 @@
         <categoryLink id="0108-5ce0-04b8-5a52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="d7bf-0c70-2d3e-fd68" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
     <entryLink id="a313-a7d9-3bbb-ad89" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="30e7-479c-024e-3fc0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -942,7 +942,7 @@
         <categoryLink id="e360-6e16-de90-6365" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="10ad-5d66-5e08-cdd1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
     <entryLink id="fedf-3842-0d53-044b" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -970,7 +970,7 @@
         <categoryLink id="db29-f70f-faa2-f64b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="5199-d4bd-e16e-210c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
     <entryLink id="fe07-50f6-8493-8dfc" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -1020,7 +1020,7 @@
         <categoryLink id="b52d-3c69-263a-c215" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
         <categoryLink id="c9ba-b826-f2e2-04b9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
     <entryLink id="31a0-5872-b0ee-0301" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3dc2-a68e-a2f7-5a92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />

--- a/2022 - LA - White Scars.cat
+++ b/2022 - LA - White Scars.cat
@@ -1,98 +1,97 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="caa9-c50e-8eed-2259" name="LA -   V: White Scars" revision="16" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="22" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="caa9-c50e-8eed-2259" name="LA -   V: White Scars" revision="16" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="22">
   <entryLinks>
     <entryLink id="a738-6a11-dfe7-286c" name="   V: White Scars" hidden="false" collective="false" import="false" targetId="e01e-5cdd-e512-8353" type="selectionEntry">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91db-4591-14fb-9b51" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e400-7749-453c-4152" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91db-4591-14fb-9b51" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e400-7749-453c-4152" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="0a52-da7d-b209-7c15" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="0a52-da7d-b209-7c15" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="2053-c79e-817a-32cb" name="Dark Sons of Death" hidden="false" collective="false" import="false" targetId="4372-ad51-04a6-97ce" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7689-dc44-a435-02ec" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="6621-bf90-3035-c248" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7689-dc44-a435-02ec" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="6621-bf90-3035-c248" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="ef8a-7d90-01fc-4eb4" name="Ebon Keshig Cohort" hidden="false" collective="false" import="false" targetId="eb44-e977-2ce5-b239" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2046-6c03-bfac-0631" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="981c-8d75-2230-8fc6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="2046-6c03-bfac-0631" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="981c-8d75-2230-8fc6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="f531-b3bf-a683-bbe1" name="Falcon&apos;s Claws" hidden="true" collective="false" import="false" targetId="c598-7fda-13d0-7523" type="selectionEntry">
+    <entryLink id="f531-b3bf-a683-bbe1" name="Falcon's Claws" hidden="true" collective="false" import="false" targetId="c598-7fda-13d0-7523" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1a18-cd46-d204-85ed" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="f3ec-1651-a78e-9b79" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1a18-cd46-d204-85ed" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="f3ec-1651-a78e-9b79" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="6d08-1a34-76e4-2256" name="Golden Keshig Squadron" hidden="false" collective="false" import="false" targetId="1d55-faa7-caa5-a132" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="98eb-50a0-d89c-664a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="90d1-acd8-eff5-467f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="98eb-50a0-d89c-664a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="90d1-acd8-eff5-467f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="866d-e6ce-71a2-0476" name="Kyzagan Assault Speeder Squadron" hidden="false" collective="false" import="false" targetId="e37e-09ea-50c6-2daa" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="395e-8bb9-faa9-afd6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="bfe2-c28e-eb07-add1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="395e-8bb9-faa9-afd6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="bfe2-c28e-eb07-add1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="23a4-cb25-4fc5-5c3c" name="Qin Xa" hidden="false" collective="false" import="false" targetId="6a77-940e-1109-4a29" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3282-02f6-67ab-9faf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="f73e-34e5-fa25-642e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9189-508b-565b-fd20" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="3282-02f6-67ab-9faf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="f73e-34e5-fa25-642e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9189-508b-565b-fd20" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="2159-2614-e411-5aa2" name="Jaghatai Khan" hidden="false" collective="false" import="false" targetId="910b-0c15-068a-e4fc" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cb05-ddea-48b7-7034" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
-        <categoryLink id="f969-cbdf-b170-b089" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="cb05-ddea-48b7-7034" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true" />
+        <categoryLink id="f969-cbdf-b170-b089" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="2b7a-a60d-fbc4-7000" name="Tsolmon Khan" hidden="false" collective="false" import="false" targetId="54fb-d060-193b-675d" type="selectionEntry">
@@ -101,148 +100,148 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a7da-28a9-5f15-d931" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="a7ae-0458-9ffb-c783" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a9bd-8e73-b3dc-7062" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="a7da-28a9-5f15-d931" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="a7ae-0458-9ffb-c783" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a9bd-8e73-b3dc-7062" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="299f-d34c-a868-371c" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6f4f-3b44-8d46-0119" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="568e-76a0-5b21-4ed9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6f4f-3b44-8d46-0119" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="568e-76a0-5b21-4ed9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
     <entryLink id="e8f7-44be-772a-b5e6" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="cd39-ad94-bbd3-1f92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="370e-f3bc-0a8a-6440" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="cd39-ad94-bbd3-1f92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="370e-f3bc-0a8a-6440" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
     <entryLink id="df73-276b-e085-14a0" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="846d-a94a-a9e8-427c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="c0c0-0996-70dd-5c54" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="75b9-70e1-389c-0300" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="846d-a94a-a9e8-427c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="c0c0-0996-70dd-5c54" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="75b9-70e1-389c-0300" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="cc27-6737-f9b6-3c82" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="89a2-9421-d2ee-b421" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="2cdf-6095-c347-533f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="89a2-9421-d2ee-b421" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="2cdf-6095-c347-533f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
     <entryLink id="cb4d-1b25-b467-792f" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0f93-492e-8169-7a87" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="1fdd-a3db-02b0-70bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0f93-492e-8169-7a87" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="1fdd-a3db-02b0-70bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
     <entryLink id="9a0a-94c1-0742-8bbc" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7c78-ebe2-dec5-947a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="f30a-b16c-ec43-1040" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ade5-bbdb-5c23-4546" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="7c78-ebe2-dec5-947a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="f30a-b16c-ec43-1040" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ade5-bbdb-5c23-4546" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
     <entryLink id="ec23-00d3-b79b-9815" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f581-5ba7-9650-cd16" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="4cae-27be-0ef7-876e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f581-5ba7-9650-cd16" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="4cae-27be-0ef7-876e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
     <entryLink id="bdc3-d995-0644-70d4" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6474-9336-0633-dd57" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="c2ab-3dd4-0949-c129" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6474-9336-0633-dd57" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="c2ab-3dd4-0949-c129" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
     <entryLink id="ce98-7103-e388-d6ba" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="cf1f-0c06-1891-9e12" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="0335-fe07-c912-bc5c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="845c-2244-6445-59a1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="cf1f-0c06-1891-9e12" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="0335-fe07-c912-bc5c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="845c-2244-6445-59a1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="71da-0538-3484-3fcc" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup"/>
+        <entryLink id="71da-0538-3484-3fcc" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup" />
         <entryLink id="66a2-e125-0934-2186" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
@@ -251,846 +250,846 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b6c-5897-3790-2940" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b6c-5897-3790-2940" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
     <entryLink id="f26b-1452-4a9d-a3af" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1f31-71d7-0745-2583" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c7ba-91e3-150b-4b92" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="1733-717d-caeb-2bf2" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="1f31-71d7-0745-2583" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c7ba-91e3-150b-4b92" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="1733-717d-caeb-2bf2" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="8340-5cb2-6d5b-4eb5" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup"/>
+        <entryLink id="8340-5cb2-6d5b-4eb5" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup" />
         <entryLink id="57b4-a015-03fa-24e6" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
     <entryLink id="20f5-8874-72c2-8759" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2424-b3fd-3c80-5213" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="782f-25d5-a6f7-dbb1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="ae30-c152-a838-a701" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="2424-b3fd-3c80-5213" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="782f-25d5-a6f7-dbb1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="ae30-c152-a838-a701" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="c81a-abc7-1c2b-6b23" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup"/>
+        <entryLink id="c81a-abc7-1c2b-6b23" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup" />
         <entryLink id="729f-ed4d-a5f2-c655" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
     <entryLink id="3c50-eb8f-cfcc-0a47" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="edc3-2bbb-67e2-efee" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="185e-1bfe-3d86-4a3d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="edc3-2bbb-67e2-efee" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="185e-1bfe-3d86-4a3d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
     <entryLink id="081e-dd7c-d5a8-972a" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3585-3a01-f360-d4d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="45e4-c713-1d81-80f0" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="3585-3a01-f360-d4d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="45e4-c713-1d81-80f0" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
     <entryLink id="d877-17ec-54b9-3ede" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1947-692c-1a3d-ee53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="96b8-3974-d7a0-d0cf" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="1947-692c-1a3d-ee53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="96b8-3974-d7a0-d0cf" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
     <entryLink id="099b-30ad-6545-a3a1" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="84d9-3ba5-f403-b090" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c265-3e86-c273-fd18" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="84d9-3ba5-f403-b090" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c265-3e86-c273-fd18" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
     <entryLink id="2ad2-8d27-6cfd-396c" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7434-0033-1bac-79ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bfe3-0067-8009-4fa2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="7434-0033-1bac-79ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bfe3-0067-8009-4fa2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
     <entryLink id="6dde-f11a-520f-8a04" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2bb9-a861-7c24-d694" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="54e9-f823-44ed-1b9c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="8ec7-001e-c109-b18a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2bb9-a861-7c24-d694" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="54e9-f823-44ed-1b9c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="8ec7-001e-c109-b18a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
     <entryLink id="ac3e-184c-90d8-73ea" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a000-9429-2d21-e082" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="6866-960c-b381-646d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a000-9429-2d21-e082" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="6866-960c-b381-646d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="0264-448e-8ee1-5b8f" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="28fa-46b5-7332-cc44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d121-bd21-c491-48b4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="28fa-46b5-7332-cc44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d121-bd21-c491-48b4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
     <entryLink id="4f05-7a4c-a312-a608" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="051e-f129-d3c3-0945" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="9072-d36e-9f9b-96b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="033f-3e9f-6806-6534" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="051e-f129-d3c3-0945" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="9072-d36e-9f9b-96b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="033f-3e9f-6806-6534" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="d8d9-6c37-28cb-0f90" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="96bf-5ca7-d682-cbdf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="403a-da58-9212-9a84" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="96bf-5ca7-d682-cbdf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="403a-da58-9212-9a84" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="d762-5ff7-fa8e-3b34" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a078-ffb9-9a0a-d4f9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="caeb-982b-1e37-c7c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a078-ffb9-9a0a-d4f9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="caeb-982b-1e37-c7c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
     <entryLink id="daa9-185a-9e5b-f35e" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="013f-38f9-6257-e5f7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="4e46-9cd2-88ed-a8bc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="013f-38f9-6257-e5f7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="4e46-9cd2-88ed-a8bc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
     <entryLink id="2d89-2165-4a7f-6410" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c23a-5abd-7b76-5252" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="8a04-51fc-b8b7-fd9b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c23a-5abd-7b76-5252" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="8a04-51fc-b8b7-fd9b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
     <entryLink id="16a6-8886-522c-4dee" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3983-b2a3-c87a-d71d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="59bc-00f9-965a-de17" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3983-b2a3-c87a-d71d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="59bc-00f9-965a-de17" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
     <entryLink id="64c1-e741-f838-fdb3" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="959f-590b-a3f1-ed30" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="e2dc-5969-cb8e-9420" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="959f-590b-a3f1-ed30" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="e2dc-5969-cb8e-9420" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
     <entryLink id="e5a3-7a87-cfa2-fd22" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0550-9e6a-7a96-8b06" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="4285-8053-3d28-58e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0550-9e6a-7a96-8b06" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="4285-8053-3d28-58e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
     <entryLink id="ae18-b372-a0a5-9d95" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="990a-f17e-0d92-6388" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3266-8d24-ca66-ff22" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="990a-f17e-0d92-6388" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3266-8d24-ca66-ff22" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
     <entryLink id="551c-ecf7-376d-0748" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3c60-179b-b3aa-aecb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="2e16-aaf7-cd29-6596" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3c60-179b-b3aa-aecb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="2e16-aaf7-cd29-6596" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
     <entryLink id="4963-35a2-5b08-9354" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a42b-a6d2-5300-3167" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="192e-2d44-ed98-3ffb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="a42b-a6d2-5300-3167" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="192e-2d44-ed98-3ffb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="79eb-63d7-75c4-1754" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e7a2-8243-d08b-8c88" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="8df7-94e6-e1fb-bc7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e7a2-8243-d08b-8c88" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="8df7-94e6-e1fb-bc7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
     <entryLink id="c459-96e5-dc0e-1add" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2928-f9a4-c4da-7a0e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="cf6e-6a7c-0943-15a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2928-f9a4-c4da-7a0e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="cf6e-6a7c-0943-15a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
     <entryLink id="4dce-f77a-5321-00b6" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="df3f-7495-8b53-8cfa" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="d4d0-cfc7-8bd0-7c71" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="df3f-7495-8b53-8cfa" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="d4d0-cfc7-8bd0-7c71" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
     <entryLink id="170a-eabb-89da-d73e" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2db6-57f1-4f43-a676" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="42a5-b62b-7923-4535" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="2db6-57f1-4f43-a676" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="42a5-b62b-7923-4535" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
     <entryLink id="6701-433c-cd31-7034" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5fb6-fdfd-5b0f-4a4a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bc58-6196-3e8b-97a3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="5fb6-fdfd-5b0f-4a4a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bc58-6196-3e8b-97a3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
     <entryLink id="9925-718c-0993-f2ae" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="485d-b1bb-da4e-8258" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c13b-90b7-3aca-2016" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="485d-b1bb-da4e-8258" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="c13b-90b7-3aca-2016" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
     <entryLink id="a03b-c860-f6ae-3219" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a719-b239-4f2a-a1fc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="73dd-7cff-c520-952e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a719-b239-4f2a-a1fc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="73dd-7cff-c520-952e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
     <entryLink id="3a7d-8fe1-bc8b-6d66" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e137-a2a8-92f8-2820" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="a90c-7700-3710-15b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e137-a2a8-92f8-2820" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="a90c-7700-3710-15b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
     <entryLink id="a9d7-957b-2341-89c1" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9989-3f8b-8932-43e6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="c135-dacf-b74c-bc04" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9989-3f8b-8932-43e6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="c135-dacf-b74c-bc04" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
     <entryLink id="71b3-d2f4-6a66-974c" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3ba4-3e92-ef8b-43d1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="49b4-b365-862a-29b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3ba4-3e92-ef8b-43d1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="49b4-b365-862a-29b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
     <entryLink id="6b2f-f8d1-3de4-7949" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8f73-ec0e-9877-2186" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="090e-a5e0-07d4-e3cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8f73-ec0e-9877-2186" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="090e-a5e0-07d4-e3cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
     <entryLink id="0365-3fdb-e2fa-90e2" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="13ad-3113-7bb8-786c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="fd74-cfc8-54f1-e367" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="13ad-3113-7bb8-786c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="fd74-cfc8-54f1-e367" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
     <entryLink id="e6cb-a174-5822-5467" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6041-1b54-20d4-31a9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="ea5e-673e-ee05-8b70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6041-1b54-20d4-31a9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="ea5e-673e-ee05-8b70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
     <entryLink id="f137-0415-8373-569b" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="31d3-45af-06f7-5a4b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="12dd-239f-9892-c85e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="31d3-45af-06f7-5a4b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="12dd-239f-9892-c85e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
     <entryLink id="eecd-f588-f45c-761a" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="821e-82f6-53f7-1a09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5211-46f6-076b-3fd3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="821e-82f6-53f7-1a09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5211-46f6-076b-3fd3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
     <entryLink id="e187-a2cc-f4ec-7471" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="75a2-2af8-9a65-9159" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="e524-3fb6-50a5-56da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="75a2-2af8-9a65-9159" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="e524-3fb6-50a5-56da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
     <entryLink id="0986-d5e7-7615-80e9" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d2b4-df48-cfdd-1055" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="670c-4811-e490-859f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d2b4-df48-cfdd-1055" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="670c-4811-e490-859f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
     <entryLink id="18b6-d821-8185-8e10" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="df19-3f0e-f2de-4946" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a48a-3d21-6c2b-1dc1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="df19-3f0e-f2de-4946" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a48a-3d21-6c2b-1dc1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="e02e-8507-15b9-5d32" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9e7b-fc82-ae5d-17b3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="d434-20c6-3e7a-2dcd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9e7b-fc82-ae5d-17b3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d434-20c6-3e7a-2dcd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
     <entryLink id="1307-82da-d8cd-2cb3" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3f9b-0d6c-3b4f-514e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="6e49-d7c6-8706-dfad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3f9b-0d6c-3b4f-514e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="6e49-d7c6-8706-dfad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="5bd3-92a5-4802-df7e" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f1c6-16e5-2153-d085" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8f73-bae4-81b3-2d08" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="f1c6-16e5-2153-d085" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8f73-bae4-81b3-2d08" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="109b-f4c1-4f21-88d9" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ae6b-8d1f-e038-d392" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="4e6a-8aa8-6b99-18b8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d1b2-c99c-3ec2-fa3d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="ae6b-8d1f-e038-d392" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="4e6a-8aa8-6b99-18b8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d1b2-c99c-3ec2-fa3d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="d3b4-211a-8010-b8c3" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup"/>
-        <entryLink id="6ee0-408f-3752-07ff" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup"/>
+        <entryLink id="d3b4-211a-8010-b8c3" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup" />
+        <entryLink id="6ee0-408f-3752-07ff" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
     <entryLink id="b59e-577b-2044-d67c" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="522b-908f-b3e7-eb59" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="39c5-3f02-23da-0246" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="76a3-a89e-b734-0572" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="522b-908f-b3e7-eb59" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="39c5-3f02-23da-0246" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="76a3-a89e-b734-0572" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="e072-3c45-4283-c6b7" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup"/>
-        <entryLink id="a6ec-b9b9-ca4e-d03e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup"/>
+        <entryLink id="e072-3c45-4283-c6b7" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup" />
+        <entryLink id="a6ec-b9b9-ca4e-d03e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
     <entryLink id="6321-544f-fda8-e2ce" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b127-1291-58ed-ff0d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="70c5-6739-9828-2e92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dc26-36ac-1e95-45aa" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="b127-1291-58ed-ff0d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="70c5-6739-9828-2e92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="dc26-36ac-1e95-45aa" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="6b02-3609-96d2-af21" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup"/>
-        <entryLink id="4705-a338-55a1-1a5b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup"/>
+        <entryLink id="6b02-3609-96d2-af21" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup" />
+        <entryLink id="4705-a338-55a1-1a5b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
     <entryLink id="b6bf-9ff7-5fad-3989" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c3fe-3f99-ed68-f9f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5e2e-ef66-a44a-6ce6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="c3fe-3f99-ed68-f9f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5e2e-ef66-a44a-6ce6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="6dff-25c9-c9e4-ac15" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d558-bd8b-f84f-0397" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="fa07-85b7-1a03-84ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d558-bd8b-f84f-0397" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="fa07-85b7-1a03-84ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
     <entryLink id="2e08-0b4c-4f01-e386" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b026-9a7d-85d1-f88e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="60c9-2f7b-b176-b0cc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="b026-9a7d-85d1-f88e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="60c9-2f7b-b176-b0cc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="c808-9d93-886d-7bb6" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ebdd-72ab-79a7-e559" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="bc13-5bc4-41ac-eff5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ebdd-72ab-79a7-e559" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="bc13-5bc4-41ac-eff5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
     <entryLink id="8ce8-1073-262c-ccbe" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8664-0697-1ef0-ac29" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="e4ba-9002-0339-c126" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8664-0697-1ef0-ac29" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="e4ba-9002-0339-c126" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
     <entryLink id="fa21-28be-7fe5-1153" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="acc2-f93d-17bc-eba4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="87da-2b57-922d-9885" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="acc2-f93d-17bc-eba4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="87da-2b57-922d-9885" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
     <entryLink id="c5ef-26c5-ffca-1760" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1fdf-0904-3d41-26d8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d127-5890-9fae-dc53" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="1fdf-0904-3d41-26d8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d127-5890-9fae-dc53" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
     <entryLink id="91c2-a324-1dfc-3dcd" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3194-3609-e54b-838f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="bc78-acbd-3fa8-4fad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3194-3609-e54b-838f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="bc78-acbd-3fa8-4fad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
     <entryLink id="5168-a1d3-1fa9-8c4d" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1ecb-45d7-7670-18c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c1d7-1ca5-cec9-a642" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="1ecb-45d7-7670-18c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c1d7-1ca5-cec9-a642" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
     <entryLink id="dc0e-3160-fd9e-5f98" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="576f-f7dd-303e-4ae1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1545-06cf-4200-e760" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="576f-f7dd-303e-4ae1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1545-06cf-4200-e760" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
     <entryLink id="b40a-43c4-3700-dca0" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8b2c-e02c-8f5b-b176" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d9e7-cc24-add1-e381" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="8b2c-e02c-8f5b-b176" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d9e7-cc24-add1-e381" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
     <entryLink id="b471-d4eb-cb5a-3285" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4328-bb57-5a8b-c984" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="206d-8eb5-50e4-ee6a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="4328-bb57-5a8b-c984" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="206d-8eb5-50e4-ee6a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
     <entryLink id="e81f-b70d-ed28-7417" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="83e0-4077-384f-5c37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="223d-ee24-ce15-2e49" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="83e0-4077-384f-5c37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="223d-ee24-ce15-2e49" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="58e4-9279-b4fe-9181" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7010-998a-102d-c4ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="44bf-7a60-a01d-d0b2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="7010-998a-102d-c4ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="44bf-7a60-a01d-d0b2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
     <entryLink id="6676-20b9-1be9-a262" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0108-5ce0-04b8-5a52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d7bf-0c70-2d3e-fd68" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="0108-5ce0-04b8-5a52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d7bf-0c70-2d3e-fd68" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="a313-a7d9-3bbb-ad89" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="30e7-479c-024e-3fc0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="4868-4812-3b0b-be23" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="30e7-479c-024e-3fc0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="4868-4812-3b0b-be23" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
     <entryLink id="1015-2244-ccff-9561" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3394-f475-3057-1cec" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="7ba9-262d-553a-6f62" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3394-f475-3057-1cec" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="7ba9-262d-553a-6f62" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
     <entryLink id="1cd4-f6bd-b976-14a6" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="58a9-9b66-45c9-1e34" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="54ef-68b4-3c40-1116" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="58a9-9b66-45c9-1e34" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="54ef-68b4-3c40-1116" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
     <entryLink id="93bb-da90-5011-43e7" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7bd9-4f37-ecdf-1146" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ab58-4733-0473-78b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="0a7b-c348-52ae-67ea" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="7bd9-4f37-ecdf-1146" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ab58-4733-0473-78b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0a7b-c348-52ae-67ea" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="3d2c-befa-6b15-3452" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="801d-bdaf-c537-977a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ed12-f35f-2310-093f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="801d-bdaf-c537-977a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ed12-f35f-2310-093f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
     <entryLink id="bf10-ec9b-e8b6-7b5c" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8abc-419a-7a26-bea0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="d20b-e93a-09d3-ae10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8abc-419a-7a26-bea0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="d20b-e93a-09d3-ae10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
     <entryLink id="9df2-67f2-a62f-d871" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2932-ded7-55ba-7e18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3783-6284-2cff-787f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="2932-ded7-55ba-7e18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3783-6284-2cff-787f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
     <entryLink id="662c-33b6-ab9f-b6ee" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e360-6e16-de90-6365" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="10ad-5d66-5e08-cdd1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e360-6e16-de90-6365" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="10ad-5d66-5e08-cdd1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="fedf-3842-0d53-044b" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cbff-b3a0-46b8-7839" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="f6e6-9660-af5c-a632" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="cbff-b3a0-46b8-7839" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="f6e6-9660-af5c-a632" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
     <entryLink id="8725-2b20-0868-5cb0" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="db29-f70f-faa2-f64b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="5199-d4bd-e16e-210c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="db29-f70f-faa2-f64b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="5199-d4bd-e16e-210c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="fe07-50f6-8493-8dfc" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8765-0907-c417-662b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="b11b-3f26-eea2-f176" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8765-0907-c417-662b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="b11b-3f26-eea2-f176" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
     <entryLink id="5dcb-7fcd-f9af-00e3" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1362-8c41-e977-2159" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="5568-5b0c-9d74-31d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1362-8c41-e977-2159" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="5568-5b0c-9d74-31d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
     <entryLink id="38fa-ae4f-b028-8090" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="505e-5f88-0ce8-9cdf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="ebff-02a3-2e0c-20a8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="505e-5f88-0ce8-9cdf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="ebff-02a3-2e0c-20a8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
     <entryLink id="6e42-d226-f62a-0a18" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7fc5-c47a-5786-e43f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="530b-8d6b-e028-1e0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7fc5-c47a-5786-e43f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="530b-8d6b-e028-1e0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
     <entryLink id="1f36-1727-5fb8-0be0" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7b26-07ba-c3c5-0280" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b52d-3c69-263a-c215" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="c9ba-b826-f2e2-04b9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="7b26-07ba-c3c5-0280" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b52d-3c69-263a-c215" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
+        <categoryLink id="c9ba-b826-f2e2-04b9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="31a0-5872-b0ee-0301" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3dc2-a68e-a2f7-5a92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="82b9-cc5e-a69a-822d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3dc2-a68e-a2f7-5a92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="82b9-cc5e-a69a-822d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
     <entryLink id="05ef-476f-9980-623f" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dfd7-3c46-5203-a621" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="dfd7-3c46-5203-a621" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
     <entryLink id="5d29-0596-7ae3-0826" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="502f-37ab-06b1-d362" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1250-5c32-da20-447c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="502f-37ab-06b1-d362" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1250-5c32-da20-447c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
     <entryLink id="f3d6-432a-0cfc-4f6e" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <infoLinks>
-        <infoLink id="2e72-a332-555b-872d" name="Legiones Astartes (White Scars) " hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule"/>
+        <infoLink id="2e72-a332-555b-872d" name="Legiones Astartes (White Scars) " hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b681-23f1-6a3b-97bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dcda-725c-cd42-c3e3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="b681-23f1-6a3b-97bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="dcda-725c-cd42-c3e3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="1d55-faa7-caa5-a132" name="Golden Keshig Squadron" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="e887-5cf7-ee58-54d8" name="Legiones Astartes (White Scars) " hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule"/>
-        <infoLink id="c8d3-862c-8c71-0d69" name="Hit &amp; Run" hidden="false" targetId="5986-e960-d432-affd" type="rule"/>
-        <infoLink id="3c4d-1ce4-e689-c196" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="e887-5cf7-ee58-54d8" name="Legiones Astartes (White Scars) " hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule" />
+        <infoLink id="c8d3-862c-8c71-0d69" name="Hit &amp; Run" hidden="false" targetId="5986-e960-d432-affd" type="rule" />
+        <infoLink id="3c4d-1ce4-e689-c196" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="1441-6471-603c-56df" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+            <modifier type="set" field="name" value="Hammer of Wrath (1)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4083-4f2a-5da9-39f9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="b4a8-ec8a-7485-af38" name="Cavalry Sub-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
-        <categoryLink id="7dc2-f06d-83d7-3f15" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="4083-4f2a-5da9-39f9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="b4a8-ec8a-7485-af38" name="Cavalry Sub-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false" />
+        <categoryLink id="7dc2-f06d-83d7-3f15" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c46b-3bf0-77df-39bb" name="Golden Keshig Rider" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e73-4232-d09b-6e61" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ccc-dfe2-8604-b692" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e73-4232-d09b-6e61" type="max" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ccc-dfe2-8604-b692" type="min" />
           </constraints>
           <profiles>
             <profile id="1129-c6a8-eeb6-2cca" name="Golden Keshig Rider" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Antigrav, Heavy)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">15&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">15"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1104,19 +1103,19 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="b55b-c197-71d3-9c84" name="Golden Keshig Champion" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e6e-d6be-8533-0527" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e7e-00b8-d83c-5b82" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e6e-d6be-8533-0527" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e7e-00b8-d83c-5b82" type="max" />
           </constraints>
           <profiles>
             <profile id="fad2-07ca-a41b-17d7" name="Golden Keshig Champion" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Antigrav, Heavy, Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">15&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">15"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1130,67 +1129,67 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="597d-1cf2-1be6-94af" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="597d-1cf2-1be6-94af" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="8126-aa08-3eb9-d49d" name="May exchange their Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a0d6-d7e7-83b1-cb65">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b46e-c4d9-ca76-13d7" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf28-d4d8-836a-0dff" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b46e-c4d9-ca76-13d7" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf28-d4d8-836a-0dff" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="86b7-6104-9b45-be96" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="b624-c3bf-eb93-9016" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="1af1-e366-390b-6e03" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="ee7d-5ca3-25bd-5843" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="86e4-d6af-8315-b714" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="19b5-858b-6297-9e9b" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="8874-b16c-1c6f-aaa7" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="a0d6-d7e7-83b1-cb65" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+                <entryLink id="a0d6-d7e7-83b1-cb65" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="9637-087c-e481-7838" name="One Golden Keshig Rider may take a Legion Vexilla" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f377-438e-370c-5bc7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f377-438e-370c-5bc7" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="bae9-9831-d4f6-052f" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry"/>
+            <entryLink id="bae9-9831-d4f6-052f" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry" />
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1199,52 +1198,52 @@
           <modifiers>
             <modifier type="increment" field="994a-cda5-7416-970b" value="1.0">
               <conditions>
-                <condition field="selections" scope="1d55-faa7-caa5-a132" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c46b-3bf0-77df-39bb" type="equalTo"/>
+                <condition field="selections" scope="1d55-faa7-caa5-a132" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c46b-3bf0-77df-39bb" type="equalTo" />
               </conditions>
             </modifier>
             <modifier type="increment" field="994a-cda5-7416-970b" value="2.0">
               <conditions>
-                <condition field="selections" scope="1d55-faa7-caa5-a132" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c46b-3bf0-77df-39bb" type="equalTo"/>
+                <condition field="selections" scope="1d55-faa7-caa5-a132" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c46b-3bf0-77df-39bb" type="equalTo" />
               </conditions>
             </modifier>
             <modifier type="increment" field="994a-cda5-7416-970b" value="3.0">
               <conditions>
-                <condition field="selections" scope="1d55-faa7-caa5-a132" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c46b-3bf0-77df-39bb" type="equalTo"/>
+                <condition field="selections" scope="1d55-faa7-caa5-a132" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c46b-3bf0-77df-39bb" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="994a-cda5-7416-970b" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="994a-cda5-7416-970b" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="50f8-fd08-245c-423d" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="2c6d-483c-e960-440b" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="ffef-6ce1-cdd7-f418" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="a7e1-c3c9-889f-612a" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="b45e-c625-1401-2b2d" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="1d5c-9a80-b18c-d980" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -1253,31 +1252,31 @@
       <entryLinks>
         <entryLink id="6847-cd7b-91b2-bdf7" name="Shamshir Jetbike" hidden="false" collective="false" import="true" targetId="567d-4386-3196-ca89" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eab3-f1a0-4a10-001e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8596-e30c-cc5a-71d4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eab3-f1a0-4a10-001e" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8596-e30c-cc5a-71d4" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="b46c-7212-bb0c-05d6" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6167-7c91-d4a5-ddbb" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c824-c3df-69ac-e3e1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6167-7c91-d4a5-ddbb" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c824-c3df-69ac-e3e1" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="29ac-e481-8b15-f657" name="Kontos Power Lance" hidden="false" collective="false" import="true" targetId="4b94-8a68-f284-604c" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2e4-05b8-96ab-bf4e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c79-d771-9cc0-9507" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2e4-05b8-96ab-bf4e" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c79-d771-9cc0-9507" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="25e2-2bc5-a36e-6249" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95fb-866c-c2a4-e3ab" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afe3-c472-a8cc-13b4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95fb-866c-c2a4-e3ab" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afe3-c472-a8cc-13b4" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="eb44-e977-2ce5-b239" name="Ebon Keshig Cohort" hidden="false" collective="false" import="true" type="unit">
@@ -1289,33 +1288,33 @@
       <infoLinks>
         <infoLink id="325c-8472-62d0-fdaa" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="1ba0-a67e-6d94-0648" name="Legiones Astartes (White Scars) " hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule"/>
-        <infoLink id="0916-f905-53e9-821a" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="3f6b-4aee-fc05-663c" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="1ba0-a67e-6d94-0648" name="Legiones Astartes (White Scars) " hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule" />
+        <infoLink id="0916-f905-53e9-821a" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="3f6b-4aee-fc05-663c" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
         <infoLink id="459b-c053-f14b-cc59" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+            <modifier type="set" field="name" value="Feel No Pain (5+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="3eca-813c-b5fa-62bb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="3cb7-2f9b-6a21-e130" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="3eca-813c-b5fa-62bb" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="3cb7-2f9b-6a21-e130" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a095-4971-0f84-f40b" name="Kharash" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f33e-7b06-1115-3b0d" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="635d-e9af-400a-4bd2" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f33e-7b06-1115-3b0d" type="max" />
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="635d-e9af-400a-4bd2" type="min" />
           </constraints>
           <profiles>
             <profile id="a138-c23f-03db-90fc" name="Kharash" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1329,7 +1328,7 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1338,108 +1337,108 @@
           <modifiers>
             <modifier type="increment" field="6692-52a1-e951-93fa" value="1.0">
               <repeats>
-                <repeat field="selections" scope="eb44-e977-2ce5-b239" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a095-4971-0f84-f40b" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="eb44-e977-2ce5-b239" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a095-4971-0f84-f40b" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6692-52a1-e951-93fa" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6692-52a1-e951-93fa" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="ac1b-e3ee-31e3-08be" name="Combi-bolter and power Weapon" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntryGroups>
                 <selectionEntryGroup id="7289-331a-7dcf-921d" name="Power Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="a786-a8ad-8c66-0207">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70a9-262f-fc7c-da08" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2813-bdfb-3095-b922" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70a9-262f-fc7c-da08" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2813-bdfb-3095-b922" type="max" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="a786-a8ad-8c66-0207" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
-                    <entryLink id="faef-8567-c889-844b" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
-                    <entryLink id="7e4c-7fcc-7d3b-7ce7" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
+                    <entryLink id="a786-a8ad-8c66-0207" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry" />
+                    <entryLink id="faef-8567-c889-844b" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry" />
+                    <entryLink id="7e4c-7fcc-7d3b-7ce7" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="b5a2-5b2e-91e9-d58a" name="May replace Combi-bolter with:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9dba-1cd3-1a8d-2630">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="244d-238f-7406-4edc" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97bf-99c3-26b8-a221" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="244d-238f-7406-4edc" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97bf-99c3-26b8-a221" type="max" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="9dba-1cd3-1a8d-2630" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                    <entryLink id="9dba-1cd3-1a8d-2630" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry" />
                     <entryLink id="ffc4-35ab-12e2-0484" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="5581-ad52-63b9-b6ff" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="bcb0-50c2-d13f-b600" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="ea2d-eaef-d69b-74ca" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="2a8d-7890-e54f-c2f4" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="587e-670b-ea82-d6e4" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="018e-faa6-a202-7a4f" name="Combi-bolter and Power Fist" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntryGroups>
                 <selectionEntryGroup id="aa36-e3ff-a0d3-f390" name="May replace Combi-bolter with:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9432-53d9-d9cb-9a8a">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d46-64f8-8a56-0320" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b93-28a0-7cf7-2b5c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d46-64f8-8a56-0320" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b93-28a0-7cf7-2b5c" type="max" />
                   </constraints>
                   <entryLinks>
-                    <entryLink id="9432-53d9-d9cb-9a8a" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                    <entryLink id="9432-53d9-d9cb-9a8a" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry" />
                     <entryLink id="6f00-7be5-8091-81fc" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="4c04-443d-6d69-000c" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="8dee-b436-0afd-c70a" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="b9e5-9e03-d972-d085" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="5e7d-d3e8-79e0-d7ee" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="5ed9-1bc3-4d8f-0826" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="f935-4760-7d53-7418" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="dd06-55b3-1c77-1e1d" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="c0a2-d725-a0bc-3136" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="8720-32c4-0099-63f4" type="selectionEntry">
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -1448,13 +1447,13 @@
               <entryLinks>
                 <entryLink id="20cd-e876-c305-6537" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef44-935b-1463-3505" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a80-5bf2-a2b4-7f50" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef44-935b-1463-3505" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a80-5bf2-a2b4-7f50" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1463,17 +1462,17 @@
           <modifiers>
             <modifier type="increment" field="7c2b-e61c-c23e-b9b3" value="1.0">
               <repeats>
-                <repeat field="selections" scope="eb44-e977-2ce5-b239" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a095-4971-0f84-f40b" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="eb44-e977-2ce5-b239" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a095-4971-0f84-f40b" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c2b-e61c-c23e-b9b3" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c2b-e61c-c23e-b9b3" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="fcf6-ca97-e5b8-6c7c" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -1482,55 +1481,55 @@
       <entryLinks>
         <entryLink id="31ab-88a1-49f3-397d" name="Power Glaive" hidden="false" collective="false" import="true" targetId="d917-8a5f-8459-8b0f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c623-7825-95fa-1118" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9491-a63d-fd3f-d236" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c623-7825-95fa-1118" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9491-a63d-fd3f-d236" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="6daa-1be2-cb94-a444" name="Tartaros Terminator Armour" hidden="false" collective="false" import="true" targetId="f850-d0af-8663-ccac" type="selectionEntry"/>
+        <entryLink id="6daa-1be2-cb94-a444" name="Tartaros Terminator Armour" hidden="false" collective="false" import="true" targetId="f850-d0af-8663-ccac" type="selectionEntry" />
         <entryLink id="50eb-2dfb-3a05-c127" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d239-ecbb-9075-ce33" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d239-ecbb-9075-ce33" type="max" />
           </constraints>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
           </costs>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="e37e-09ea-50c6-2daa" name="Kyzagan Assault Speeder Squadron" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="c506-b0b4-47ec-6f9d" name="Legiones Astartes (White Scars) " hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule"/>
-        <infoLink id="9346-5998-1eca-3eef" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
-        <infoLink id="eda2-b2ca-cb80-009e" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="c506-b0b4-47ec-6f9d" name="Legiones Astartes (White Scars) " hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule" />
+        <infoLink id="9346-5998-1eca-3eef" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule" />
+        <infoLink id="eda2-b2ca-cb80-009e" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="0525-14a3-f2e2-6605" name="Firing Protocols (X)" hidden="false" targetId="32a3-f599-5c92-2945" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Firing Protocols (4)"/>
+            <modifier type="set" field="name" value="Firing Protocols (4)" />
           </modifiers>
         </infoLink>
-        <infoLink id="14f6-8348-74ea-a0ff" name="Harbingers of the Legion" hidden="false" targetId="6ab3-174e-0869-da70" type="rule"/>
-        <infoLink id="be04-0e29-8c87-d11a" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule"/>
-        <infoLink id="f543-146d-d77f-dd23" name="Hit &amp; Run" hidden="false" targetId="5986-e960-d432-affd" type="rule"/>
+        <infoLink id="14f6-8348-74ea-a0ff" name="Harbingers of the Legion" hidden="false" targetId="6ab3-174e-0869-da70" type="rule" />
+        <infoLink id="be04-0e29-8c87-d11a" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule" />
+        <infoLink id="f543-146d-d77f-dd23" name="Hit &amp; Run" hidden="false" targetId="5986-e960-d432-affd" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="74d4-f605-7461-db43" name="Cavalry:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
-        <categoryLink id="ce3b-6d6a-0eca-ace7" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="0b3c-e0ff-0485-b240" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="059a-9e08-d32a-bc1f" name="Deep Strike:" hidden="false" targetId="0d4f-ff28-d819-a512" primary="false"/>
+        <categoryLink id="74d4-f605-7461-db43" name="Cavalry:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false" />
+        <categoryLink id="ce3b-6d6a-0eca-ace7" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="0b3c-e0ff-0485-b240" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="059a-9e08-d32a-bc1f" name="Deep Strike:" hidden="false" targetId="0d4f-ff28-d819-a512" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="60de-1577-35ed-5a0b" name="Kyzagan Assault Speeder" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dc9-d596-f8b3-9e8e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa71-5621-aff4-ac24" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dc9-d596-f8b3-9e8e" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa71-5621-aff4-ac24" type="min" />
           </constraints>
           <profiles>
             <profile id="a56d-7fe2-97b3-2b86" name="Kyzagan Assault Speeder" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Antigrav, Heavy)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">15&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">15"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1546,82 +1545,82 @@
           <entryLinks>
             <entryLink id="dead-c1f0-6ab4-7818" name="Hunter-Killer Missile" hidden="false" collective="false" import="true" targetId="1bf8-72f8-c331-6900" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b9ed-cea4-b9bb-281d" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b9ed-cea4-b9bb-281d" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="105.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="105.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="30c1-cb86-8f71-cc50" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b57-9f60-dbe7-576e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52ac-e3d6-ed6b-5309" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b57-9f60-dbe7-576e" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52ac-e3d6-ed6b-5309" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="5e37-c6f0-d1cb-6aeb" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4133-05e1-bbf4-9c45" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6750-e903-66ff-c153" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4133-05e1-bbf4-9c45" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6750-e903-66ff-c153" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="7ef1-87db-89ea-86b2" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b8d-1009-4e7f-d688" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="109e-c72e-b091-8d2b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b8d-1009-4e7f-d688" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="109e-c72e-b091-8d2b" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="77ad-648d-63a9-ca15" name="Reaper Autocannon" hidden="false" collective="false" import="true" targetId="b87f-48de-6ced-043b" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="name" value="2x Reaper Autocannons"/>
+            <modifier type="set" field="name" value="2x Reaper Autocannons" />
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3eb-63df-d025-f869" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3833-9402-4c5a-32fb" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3eb-63df-d025-f869" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3833-9402-4c5a-32fb" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="1313-619d-8661-8a60" name="Kheres Assault Cannon" hidden="false" collective="false" import="true" targetId="fe77-2e74-160d-c7af" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c7e-fc33-2e6a-ee98" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d340-3b7e-1ba9-b3b1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c7e-fc33-2e6a-ee98" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d340-3b7e-1ba9-b3b1" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
-    <selectionEntry id="c598-7fda-13d0-7523" name="Falcon&apos;s Claws" publicationId="d0df-7166-5cd3-89fd" page="57" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="c598-7fda-13d0-7523" name="Falcon's Claws" publicationId="d0df-7166-5cd3-89fd" page="57" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="b7b1-2c4d-80ea-3170" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule"/>
-        <infoLink id="82b2-4807-4e42-8935" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule"/>
-        <infoLink id="c526-4ba2-6495-6798" name="Marked For Death" hidden="false" targetId="4f41-4c04-9cd8-c5a1" type="rule"/>
+        <infoLink id="b7b1-2c4d-80ea-3170" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule" />
+        <infoLink id="82b2-4807-4e42-8935" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule" />
+        <infoLink id="c526-4ba2-6495-6798" name="Marked For Death" hidden="false" targetId="4f41-4c04-9cd8-c5a1" type="rule" />
         <infoLink id="b541-a0ac-5752-ac62" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Precision Strikes (5+)"/>
+            <modifier type="set" field="name" value="Precision Strikes (5+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0f7c-1949-3208-41d9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="9534-1164-ded8-a7e0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="2201-4a07-ab90-f50f" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-        <categoryLink id="3f32-f496-6141-bad9" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+        <categoryLink id="0f7c-1949-3208-41d9" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="9534-1164-ded8-a7e0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="2201-4a07-ab90-f50f" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false" />
+        <categoryLink id="3f32-f496-6141-bad9" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false" />
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="3726-92d5-2afe-1f1e" name="Falcon&apos;s Claws Champion" publicationId="817a-6288-e016-7469" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="3726-92d5-2afe-1f1e" name="Falcon's Claws Champion" publicationId="817a-6288-e016-7469" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9af-fd4b-a8a6-c880" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7672-8d4a-eb1c-b840" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9af-fd4b-a8a6-c880" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7672-8d4a-eb1c-b840" type="max" />
           </constraints>
           <profiles>
-            <profile id="3f9e-3df7-0bf7-af79" name="Falcon&apos;s Claws Champion" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+            <profile id="3f9e-3df7-0bf7-af79" name="Falcon's Claws Champion" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Light, Skirmish, Character)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">9*</characteristic>
@@ -1638,53 +1637,53 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="a649-b82b-acf1-3bc8" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-            <categoryLink id="b8fc-c2a0-ad60-21ba" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-            <categoryLink id="1f48-ae0c-22f4-235c" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
-            <categoryLink id="3df5-3e2a-1236-5e80" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+            <categoryLink id="a649-b82b-acf1-3bc8" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
+            <categoryLink id="b8fc-c2a0-ad60-21ba" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+            <categoryLink id="1f48-ae0c-22f4-235c" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false" />
+            <categoryLink id="3df5-3e2a-1236-5e80" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="c141-ae35-dee5-390a" name="May take:" hidden="false" collective="false" import="true">
               <entryLinks>
                 <entryLink id="123c-fd8c-5613-bcfc" name="Cyber Hawk" hidden="false" collective="false" import="true" targetId="2284-3de0-0f73-a311" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="843b-15a2-0997-a73d" name="May exchange one of his Lightning Claws for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="aa42-00fa-881d-cfd5">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5763-2112-4573-3d23" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af30-742e-3753-8153" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5763-2112-4573-3d23" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af30-742e-3753-8153" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="f5c6-eb8e-e822-0537" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="8d2c-614b-1508-f4ee" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="0576-32f8-8e9a-3c53" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="58cc-d9f6-61ea-9c79" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="b813-5f4c-3c6a-a003" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="aa42-00fa-881d-cfd5" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry"/>
+                <entryLink id="aa42-00fa-881d-cfd5" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -1693,32 +1692,32 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="3726-92d5-2afe-1f1e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6d2-b3a9-6d2c-1f6f" type="lessThan"/>
+                    <condition field="selections" scope="3726-92d5-2afe-1f1e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6d2-b3a9-6d2c-1f6f" type="lessThan" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="c0ff-b30c-41db-f64c" value="1.0">
                   <conditions>
-                    <condition field="selections" scope="3726-92d5-2afe-1f1e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6d2-b3a9-6d2c-1f6f" type="lessThan"/>
+                    <condition field="selections" scope="3726-92d5-2afe-1f1e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6d2-b3a9-6d2c-1f6f" type="lessThan" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91b6-3381-3f6b-dfec" type="max"/>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0ff-b30c-41db-f64c" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91b6-3381-3f6b-dfec" type="max" />
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0ff-b30c-41db-f64c" type="min" />
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
-        <selectionEntry id="edca-ef5b-9fd1-172d" name="Falcon&apos;s Claws" publicationId="817a-6288-e016-7469" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="edca-ef5b-9fd1-172d" name="Falcon's Claws" publicationId="817a-6288-e016-7469" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d7f-7a19-91e6-1757" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e57-f5d3-e638-32e1" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d7f-7a19-91e6-1757" type="min" />
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e57-f5d3-e638-32e1" type="max" />
           </constraints>
           <profiles>
-            <profile id="e5d4-61f8-f665-9fa2" name="Falcon&apos;s Claw" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+            <profile id="e5d4-61f8-f665-9fa2" name="Falcon's Claw" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Light, Skirmish)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">9*</characteristic>
@@ -1735,52 +1734,52 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="16.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="16.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="8f99-5ed0-a80f-403a" name="1) Falcon&apos;s Claws may take:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d8f3-309a-be79-0df1">
+        <selectionEntryGroup id="8f99-5ed0-a80f-403a" name="1) Falcon's Claws may take:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d8f3-309a-be79-0df1">
           <modifiers>
             <modifier type="increment" field="6b8a-1092-b1f4-c390" value="1.0">
               <repeats>
-                <repeat field="selections" scope="c598-7fda-13d0-7523" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="edca-ef5b-9fd1-172d" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="c598-7fda-13d0-7523" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="edca-ef5b-9fd1-172d" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
             <modifier type="increment" field="cdb8-54c5-2c0b-125b" value="1.0">
               <repeats>
-                <repeat field="selections" scope="c598-7fda-13d0-7523" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="edca-ef5b-9fd1-172d" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="c598-7fda-13d0-7523" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="edca-ef5b-9fd1-172d" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
-            <modifier type="decrement" field="6b8a-1092-b1f4-c390" value="4.0"/>
+            <modifier type="decrement" field="6b8a-1092-b1f4-c390" value="4.0" />
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdb8-54c5-2c0b-125b" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b8a-1092-b1f4-c390" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdb8-54c5-2c0b-125b" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b8a-1092-b1f4-c390" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="6d16-1236-9296-31d1" name="Power weapon and Bolt Pistol" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
                 <entryLink id="db48-9923-bb0c-6d0a" name="Bolt Pistol" hidden="false" collective="true" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3272-9959-70cc-94d9" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca4d-e9a0-78ae-c08e" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3272-9959-70cc-94d9" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca4d-e9a0-78ae-c08e" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="580f-79a7-b4ab-a4ca" name="Power Weapon (Basic)" hidden="false" collective="true" import="true" targetId="bd1f-b4a4-3517-31e4" type="selectionEntryGroup">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cd9-5970-0076-fdba" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="646b-9c54-24c2-99c4" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cd9-5970-0076-fdba" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="646b-9c54-24c2-99c4" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="d8f3-309a-be79-0df1" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry"/>
+            <entryLink id="d8f3-309a-be79-0df1" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="3d61-0e48-52b2-6550" name="2) The entire unit may take:" hidden="false" collective="false" import="true">
@@ -1789,12 +1788,12 @@
               <modifiers>
                 <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="c598-7fda-13d0-7523" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="c598-7fda-13d0-7523" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb15-2201-5cdf-e7f7" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb15-2201-5cdf-e7f7" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
@@ -1803,31 +1802,31 @@
       <entryLinks>
         <entryLink id="5c1c-7d94-a2c5-246e" name="Scout Armour" hidden="false" collective="false" import="true" targetId="b282-55aa-d1e2-ebe7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59bf-73f0-6196-fd4b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dfb-e654-5b80-f42e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59bf-73f0-6196-fd4b" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dfb-e654-5b80-f42e" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="35e5-41f6-b301-bf11" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6054-9ccd-1cae-d15d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d280-39e7-2be8-84f3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6054-9ccd-1cae-d15d" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d280-39e7-2be8-84f3" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="5cff-c694-8cff-7ca4" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00e4-54e2-7077-50c0" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a57-deb7-f96d-61c8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00e4-54e2-7077-50c0" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a57-deb7-f96d-61c8" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="bcf8-e7fd-5d17-461a" name="Shroud Bombs" hidden="false" collective="false" import="true" targetId="5d4d-36b7-6bf5-fc92" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c30-61a1-3266-643d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3771-7ae3-11e3-c65f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c30-61a1-3266-643d" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3771-7ae3-11e3-c65f" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="31.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="31.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="4372-ad51-04a6-97ce" name="Dark Sons of Death" publicationId="09b3-d525-cdea-260c" page="11" hidden="false" collective="false" import="true" type="unit">
@@ -1835,38 +1834,38 @@
         <rule id="7d33-191d-454e-acca" name="Shadow of Death" hidden="false">
           <description>A unit that includes any models with this special rule may only be joined by a Legion Centurion with the Legiones Consularis: Stormseer upgrade or a Legion Centurion with the Legiones Consularis: Moritat upgrade. Note that Legion Techmarines and Legion Apothecaries may not be assigned to a unit with this special rule unless they also have this special rule.</description>
         </rule>
-        <rule id="33f0-02c4-2542-63e2" name="Stormseer&apos;s Conclave" hidden="true">
-          <description>A Dark Sons of Death Squad may be selected as a Retinue Squad in a Detachment that includes a Legion Centurion with the Legiones Consularis: Stormseer upgrade and the Legiones Astartes (White Scars) special rules, instead of as an Elites choice. A unit selected as a ‘Retinue Squad’ must have one Legion Centurion with the Legiones Consularis: Stormseer upgrade and the Legiones Astartes (White Scars) special rules from the same Detachment selected by the controlling player as the Dark Sons of Death Squad’s Leader for the purposes of this special rule. A Dark Sons of Death Squad selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. A Dark Sons of Death Squad selected as a Retinue Squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Retinue Squad during play.</description>
+        <rule id="33f0-02c4-2542-63e2" name="Stormseer's Conclave" hidden="true">
+          <description>A Dark Sons of Death Squad may be selected as a Retinue Squad in a Detachment that includes a Legion Centurion with the Legiones Consularis: Stormseer upgrade and the Legiones Astartes (White Scars) special rules, instead of as an Elites choice. A unit selected as a &#8216;Retinue Squad&#8217; must have one Legion Centurion with the Legiones Consularis: Stormseer upgrade and the Legiones Astartes (White Scars) special rules from the same Detachment selected by the controlling player as the Dark Sons of Death Squad&#8217;s Leader for the purposes of this special rule. A Dark Sons of Death Squad selected as a Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as the model selected as its Leader. A Dark Sons of Death Squad selected as a Retinue Squad must be deployed with the model selected as its Leader deployed as part of the unit and the Leader may not voluntarily leave the Retinue Squad during play.</description>
         </rule>
         <rule id="089b-4708-a5a0-4d1b" name="Invocation of Razing Tempest" hidden="false">
           <description>A unit with at least one model with this special rule gains the Fleet (2) and Rage (2) special rules for the duration of the current Assault phase when attempting a Charge against an enemy unit that they outnumber at the point that the Charge is declared.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="1e86-1918-5926-cded" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="1e86-1918-5926-cded" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8607-29a7-0dba-bd62" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="cb68-2347-61ae-4a0b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="8607-29a7-0dba-bd62" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="cb68-2347-61ae-4a0b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="5102-02bb-c8d6-56d6" name="Death&apos;s Champion" publicationId="09b3-d525-cdea-260c" page="11" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="5102-02bb-c8d6-56d6" name="Death's Champion" publicationId="09b3-d525-cdea-260c" page="11" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09bd-ad4c-0228-00b5" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0411-7e6e-f95b-6538" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09bd-ad4c-0228-00b5" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0411-7e6e-f95b-6538" type="max" />
           </constraints>
           <profiles>
-            <profile id="0bd7-4e8a-d127-305c" name="Death&apos;s Champion" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
+            <profile id="0bd7-4e8a-d127-305c" name="Death's Champion" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="5102-02bb-c8d6-56d6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                    <condition field="selections" scope="5102-02bb-c8d6-56d6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1880,44 +1879,44 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="1aef-0993-2400-9738" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="1aef-0993-2400-9738" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="cc84-4808-e998-b656" name="1) Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4487-dbf4-fc92-9e1a">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="140d-2cbf-60d3-b342" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0465-9aba-d682-584d" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="140d-2cbf-60d3-b342" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0465-9aba-d682-584d" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="4487-dbf4-fc92-9e1a" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+                <entryLink id="4487-dbf4-fc92-9e1a" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
                 <entryLink id="c05b-e876-e02a-d06d" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="59ab-6184-99ef-4d8d" name="Charnabal Weapon" hidden="false" collective="false" import="true" targetId="2376-af96-e101-e712" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="8b6a-4cb8-6e2a-017b" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="c3b0-35f4-d55f-e3b0" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="d66a-d2c1-0128-0093" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="5fc1-1ae1-3ebb-b45e" name="Power Glaive" hidden="false" collective="false" import="true" targetId="d917-8a5f-8459-8b0f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1926,29 +1925,29 @@
               <modifiers>
                 <modifier type="set" field="7ea6-7c48-9d7e-5571" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="5102-02bb-c8d6-56d6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c3b0-35f4-d55f-e3b0" type="equalTo"/>
+                    <condition field="selections" scope="5102-02bb-c8d6-56d6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c3b0-35f4-d55f-e3b0" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="6126-6c8e-c302-f75e" value="0.0">
                   <conditions>
-                    <condition field="selections" scope="5102-02bb-c8d6-56d6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c3b0-35f4-d55f-e3b0" type="equalTo"/>
+                    <condition field="selections" scope="5102-02bb-c8d6-56d6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c3b0-35f4-d55f-e3b0" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ea6-7c48-9d7e-5571" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6126-6c8e-c302-f75e" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ea6-7c48-9d7e-5571" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6126-6c8e-c302-f75e" type="min" />
               </constraints>
               <entryLinks>
-                <entryLink id="f9ad-ddb4-eca1-48e0" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+                <entryLink id="f9ad-ddb4-eca1-48e0" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry" />
                 <entryLink id="20a1-2fa6-74a1-3189" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="5aef-b8d3-96c6-bbd1" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1957,31 +1956,31 @@
               <entryLinks>
                 <entryLink id="59d8-81b3-8356-c220" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da59-2359-b5d8-02ed" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da59-2359-b5d8-02ed" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="44e9-0b95-dddb-16bd" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e06f-b854-b99f-a262" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e06f-b854-b99f-a262" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="27c5-42f8-d8c8-35f0" name="Dark Son" publicationId="09b3-d525-cdea-260c" page="11" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf28-a4d6-3216-da4f" type="min"/>
-            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fad-25f9-d5d2-9db5" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf28-a4d6-3216-da4f" type="min" />
+            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fad-25f9-d5d2-9db5" type="max" />
           </constraints>
           <profiles>
             <profile id="f3ac-831d-b87c-d568" name="Dark Son" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
@@ -2001,7 +2000,7 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2010,40 +2009,40 @@
           <modifiers>
             <modifier type="increment" field="33c3-0919-d541-0af5" value="1.0">
               <repeats>
-                <repeat field="selections" scope="4372-ad51-04a6-97ce" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="27c5-42f8-d8c8-35f0" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="4372-ad51-04a6-97ce" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="27c5-42f8-d8c8-35f0" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
             <modifier type="increment" field="ddbd-3332-4520-5e9d" value="1.0">
               <repeats>
-                <repeat field="selections" scope="4372-ad51-04a6-97ce" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="27c5-42f8-d8c8-35f0" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="4372-ad51-04a6-97ce" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="27c5-42f8-d8c8-35f0" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
-            <modifier type="set" field="33c3-0919-d541-0af5" value="0.0"/>
+            <modifier type="set" field="33c3-0919-d541-0af5" value="0.0" />
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddbd-3332-4520-5e9d" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33c3-0919-d541-0af5" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddbd-3332-4520-5e9d" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33c3-0919-d541-0af5" type="min" />
           </constraints>
           <entryLinks>
-            <entryLink id="ea60-23ed-528f-287f" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+            <entryLink id="ea60-23ed-528f-287f" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
             <entryLink id="67d1-3551-6fbd-66d3" name="Power Glaive" hidden="false" collective="false" import="true" targetId="d917-8a5f-8459-8b0f" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
             <entryLink id="c1f9-3360-6afb-3035" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
             <entryLink id="8ebd-52a2-9a21-7393" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
             <entryLink id="20b7-20e9-0497-8b4e" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -2052,87 +2051,87 @@
           <modifiers>
             <modifier type="increment" field="7686-9f80-8adc-46e9" value="1.0">
               <repeats>
-                <repeat field="selections" scope="4372-ad51-04a6-97ce" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="4372-ad51-04a6-97ce" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7686-9f80-8adc-46e9" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7686-9f80-8adc-46e9" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="ff6c-1c47-fac1-c33b" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry"/>
-            <entryLink id="9fce-c27d-c58b-872c" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry"/>
+            <entryLink id="ff6c-1c47-fac1-c33b" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry" />
+            <entryLink id="9fce-c27d-c58b-872c" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="4d53-c834-d7e3-9c8e" name="3) For every 5 models, One Dark Son may take:" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="increment" field="c8f0-b9d7-6634-d36d" value="1.0">
               <repeats>
-                <repeat field="selections" scope="4372-ad51-04a6-97ce" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="4372-ad51-04a6-97ce" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8f0-b9d7-6634-d36d" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8f0-b9d7-6634-d36d" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="f818-e494-380b-2d94" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry"/>
-            <entryLink id="694a-3cca-ae84-6c89" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry"/>
-            <entryLink id="5240-6d3f-3409-4942" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry"/>
+            <entryLink id="f818-e494-380b-2d94" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry" />
+            <entryLink id="694a-3cca-ae84-6c89" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry" />
+            <entryLink id="5240-6d3f-3409-4942" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="8591-9af7-6146-4f8a" name="Warhawk Jump Pack" hidden="false" collective="false" import="true" targetId="a298-8584-70ed-18ce" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a62f-a946-d071-09ca" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f086-ccf2-6f37-7e98" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a62f-a946-d071-09ca" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f086-ccf2-6f37-7e98" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="40a3-7dff-e9f1-3f2e" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cdc-e276-f838-f4c3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63b7-3201-2eec-4112" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cdc-e276-f838-f4c3" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63b7-3201-2eec-4112" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="d23e-243b-330b-b7ae" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37db-7a9b-f762-37dd" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d180-b4f8-a803-78be" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37db-7a9b-f762-37dd" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d180-b4f8-a803-78be" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="c1aa-0438-d89a-91de" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f40-c286-19b0-b38d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37aa-876d-dbd7-021d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f40-c286-19b0-b38d" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37aa-876d-dbd7-021d" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="a9a9-489b-49d4-a867" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c5d-926f-c36f-265e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48fa-75b9-d4bf-b2b1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c5d-926f-c36f-265e" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48fa-75b9-d4bf-b2b1" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="c9ec-b1b6-c7c9-0a38" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1103-2e1c-7858-aea1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c707-f0c6-00b2-c6c3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1103-2e1c-7858-aea1" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c707-f0c6-00b2-c6c3" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="6a77-940e-1109-4a29" name="Qin Xa" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7fee-3931-9df6-260c" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7fee-3931-9df6-260c" type="max" />
       </constraints>
       <profiles>
         <profile id="750c-adce-4f03-5a0b" name="Qin Xa" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2146,36 +2145,36 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="f68a-abf7-8c0b-1645" name="Legiones Astartes (White Scars) " hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule"/>
+        <infoLink id="f68a-abf7-8c0b-1645" name="Legiones Astartes (White Scars) " hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule" />
         <infoLink id="d462-127e-1350-94f8" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
         <infoLink id="da02-44c8-1476-3778" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Counter Attack (2)"/>
+            <modifier type="set" field="name" value="Counter Attack (2)" />
           </modifiers>
         </infoLink>
         <infoLink id="d654-4c6a-f3bd-81e4" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Furious Charge (1)"/>
+            <modifier type="set" field="name" value="Furious Charge (1)" />
           </modifiers>
         </infoLink>
-        <infoLink id="05d6-7d9b-7c19-a97f" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="7a81-4ee1-2626-1bdb" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="05d6-7d9b-7c19-a97f" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="7a81-4ee1-2626-1bdb" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="54e2-d6ae-9451-cef4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="e3e9-8ad6-46b0-b979" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="5e67-a444-7e40-3af2" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="b6ea-20c7-9037-cfba" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="54e2-d6ae-9451-cef4" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="e3e9-8ad6-46b0-b979" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
+        <categoryLink id="5e67-a444-7e40-3af2" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="b6ea-20c7-9037-cfba" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a42b-18eb-0912-d5fc" name="The Tails of the Dragon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7776-a100-137a-c7cf" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c8f-bf03-6aec-51ff" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7776-a100-137a-c7cf" type="min" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c8f-bf03-6aec-51ff" type="max" />
           </constraints>
           <profiles>
             <profile id="00df-8dc0-8f7f-4e65" name="Split the Mountain" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2186,7 +2185,7 @@
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Unwieldy, Master-crafted</characteristic>
               </characteristics>
             </profile>
-            <profile id="733d-cc45-21bf-93c0" name="Part the Horse&apos;s Mane" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="733d-cc45-21bf-93c0" name="Part the Horse's Mane" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+1</characteristic>
@@ -2196,90 +2195,90 @@
             </profile>
             <profile id="4ce5-637b-bb3d-82e0" name="The Tails of the Dragon" hidden="false" typeId="b46c-270c-d29e-f0ff" typeName="Ability">
               <characteristics>
-                <characteristic name="Description" typeId="0982-427b-1d4a-d07c">The Tails of the Dragon are two separate but identical weapons, and the bonus for wielding two melee weapons has already been included in Qin Xa’s profile. When attacking with the Tails of the Dragon in close combat, select one of the profiles to use from those shown below for both weapons at the start of each of the controlling player’s Assault phases, before any attacks are made.</characteristic>
+                <characteristic name="Description" typeId="0982-427b-1d4a-d07c">The Tails of the Dragon are two separate but identical weapons, and the bonus for wielding two melee weapons has already been included in Qin Xa&#8217;s profile. When attacking with the Tails of the Dragon in close combat, select one of the profiles to use from those shown below for both weapons at the start of each of the controlling player&#8217;s Assault phases, before any attacks are made.</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="239b-550c-f298-e7a5" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
-            <infoLink id="e7a8-baa9-508f-0e20" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
-            <infoLink id="99a3-25ef-c544-71e9" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule"/>
+            <infoLink id="239b-550c-f298-e7a5" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
+            <infoLink id="e7a8-baa9-508f-0e20" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
+            <infoLink id="99a3-25ef-c544-71e9" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="f911-be65-a60f-e592" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47f9-d7fb-4331-efaf" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="515a-1b97-cb9c-ae27" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47f9-d7fb-4331-efaf" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="515a-1b97-cb9c-ae27" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="5870-ba64-3f4d-dd65" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ff4-3688-34c0-65b5" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ff4-3688-34c0-65b5" type="max" />
           </constraints>
           <profiles>
             <profile id="678e-285f-d6d0-91e8" name="Chosen of the Khagan" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If Qin Xa is the army’s Warlord, once per battle the controlling player may choose to either bring a single eligible friendly unit or group of friendly units assigned to a Deep Strike Assault or Flanking Assault into play from Reserve automatically instead of rolling or have it remain in Reserve for that turn (this may not be used to bring a unit or units into play on a turn when a Reserves roll could not normally be made for them). In addition, an army whose Warlord has this trait may make an additional Reaction during the Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If Qin Xa is the army&#8217;s Warlord, once per battle the controlling player may choose to either bring a single eligible friendly unit or group of friendly units assigned to a Deep Strike Assault or Flanking Assault into play from Reserve automatically instead of rolling or have it remain in Reserve for that turn (this may not be used to bring a unit or units into play on a turn when a Reserves roll could not normally be made for them). In addition, an army whose Warlord has this trait may make an additional Reaction during the Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
-        <entryLink id="531c-fc45-e403-e345" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup"/>
+        <entryLink id="531c-fc45-e403-e345" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup" />
         <entryLink id="f029-0fa7-6ec3-a724" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0497-c6b2-ed67-0259" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="424b-c674-9d06-5200" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0497-c6b2-ed67-0259" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="424b-c674-9d06-5200" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="f579-bfc3-6c3a-72e4" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="502f-48d4-a2dc-2bb3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d62-d672-370e-1410" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="502f-48d4-a2dc-2bb3" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d62-d672-370e-1410" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="a5a3-b52c-aa66-24ea" name="Tartaros Terminator Armour" hidden="false" collective="false" import="true" targetId="f850-d0af-8663-ccac" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6e0-7a87-37f0-3aa1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb8b-3ecd-1d67-6250" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6e0-7a87-37f0-3aa1" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb8b-3ecd-1d67-6250" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="54fb-d060-193b-675d" name="Tsolmon Khan" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="add" field="category" value="6d79-a3e4-381f-7b0f">
           <conditions>
-            <condition field="selections" scope="54fb-d060-193b-675d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+            <condition field="selections" scope="54fb-d060-193b-675d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
           <conditions>
-            <condition field="selections" scope="54fb-d060-193b-675d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
+            <condition field="selections" scope="54fb-d060-193b-675d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4965-5d02-18e1-a3a3" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4965-5d02-18e1-a3a3" type="max" />
       </constraints>
       <profiles>
         <profile id="4ebb-7196-7b91-feb3" name="Tsolmon Khan" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <modifiers>
             <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Character, Unique, Antigrav)">
               <conditions>
-                <condition field="selections" scope="54fb-d060-193b-675d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3605-35dd-fb05-16da" type="equalTo"/>
+                <condition field="selections" scope="54fb-d060-193b-675d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3605-35dd-fb05-16da" type="equalTo" />
               </conditions>
             </modifier>
             <modifier type="set" field="893e-2d76-8f04-44e5" value="16&quot;">
               <conditions>
-                <condition field="selections" scope="54fb-d060-193b-675d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3605-35dd-fb05-16da" type="equalTo"/>
+                <condition field="selections" scope="54fb-d060-193b-675d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3605-35dd-fb05-16da" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
@@ -2304,21 +2303,21 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="1291-95b0-e128-bb5f" name="Legiones Astartes (White Scars) " hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule"/>
-        <infoLink id="3ed4-f97d-0a0c-4f87" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="1291-95b0-e128-bb5f" name="Legiones Astartes (White Scars) " hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule" />
+        <infoLink id="3ed4-f97d-0a0c-4f87" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="41ee-5421-603b-a66a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="e395-ef58-e407-4efd" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="41ee-5421-603b-a66a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="e395-ef58-e407-4efd" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="664d-90dd-c50a-08d0" name="Tians&apos;han" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="664d-90dd-c50a-08d0" name="Tians'han" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="346c-937c-44bb-06fb" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aede-0df4-50f3-ee7b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="346c-937c-44bb-06fb" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aede-0df4-50f3-ee7b" type="min" />
           </constraints>
           <profiles>
-            <profile id="e7a8-e294-4daf-19b9" name="Tians&apos;han" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="e7a8-e294-4daf-19b9" name="Tians'han" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
@@ -2336,38 +2335,38 @@
             </profile>
             <profile id="5d41-b726-bb55-734a" name="Hammerhand" hidden="false" typeId="b46c-270c-d29e-f0ff" typeName="Ability">
               <characteristics>
-                <characteristic name="Description" typeId="0982-427b-1d4a-d07c">During any Fight sub-phase, Tsolmon Khan’s controlling player may choose to have Tsolmon Khan make a single attack at Initiative Step 10 with this profile instead of attacking normally (while using this option Tsolmon Khan may not gain bonus attacks for Charging, additional weapons or from any other special rule).</characteristic>
+                <characteristic name="Description" typeId="0982-427b-1d4a-d07c">During any Fight sub-phase, Tsolmon Khan&#8217;s controlling player may choose to have Tsolmon Khan make a single attack at Initiative Step 10 with this profile instead of attacking normally (while using this option Tsolmon Khan may not gain bonus attacks for Charging, additional weapons or from any other special rule).</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <infoLinks>
             <infoLink id="c287-41d1-fcf2-65de" name="Reaping Blow (X)" hidden="false" targetId="bd8c-4f52-d682-1b40" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Reaping Blow (1)"/>
+                <modifier type="set" field="name" value="Reaping Blow (1)" />
               </modifiers>
             </infoLink>
             <infoLink id="23e1-3a51-6dab-fc75" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Brutal (2)"/>
+                <modifier type="set" field="name" value="Brutal (2)" />
               </modifiers>
             </infoLink>
-            <infoLink id="2640-7801-5d7f-f828" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
-            <infoLink id="d079-303a-e4cc-0b2f" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
+            <infoLink id="2640-7801-5d7f-f828" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
+            <infoLink id="d079-303a-e4cc-0b2f" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="3605-35dd-fb05-16da" name="May take a Scimitar jetbike" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc77-427e-82bc-2bca" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc77-427e-82bc-2bca" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="4f36-bd54-c93f-856d" name="Scimitar Jetbike" hidden="false" collective="false" import="true" targetId="6fb4-adf6-dbe8-86af" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -2376,88 +2375,88 @@
       <entryLinks>
         <entryLink id="0db5-15aa-0cab-0bf0" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cebe-3f99-106a-03d8" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1fdf-52a8-3aaf-26d1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cebe-3f99-106a-03d8" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1fdf-52a8-3aaf-26d1" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="e466-7ea1-aba6-303c" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup"/>
+        <entryLink id="e466-7ea1-aba6-303c" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup" />
         <entryLink id="7285-6ecd-6e46-7617" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d82-7787-40e2-0b95" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7f9-60b8-bde4-bc2a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d82-7787-40e2-0b95" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7f9-60b8-bde4-bc2a" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="bdfe-1591-26c2-3536" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d688-3a32-9ff5-5ce2" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4710-9b23-e6b5-6634" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d688-3a32-9ff5-5ce2" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4710-9b23-e6b5-6634" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="ea35-2a06-84b6-02d3" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f34-2211-b53e-c05f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7acc-1920-b1fd-ba99" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f34-2211-b53e-c05f" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7acc-1920-b1fd-ba99" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="2de8-b8fe-1b0c-3e8f" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7222-4636-edc7-74f8" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2f8-c09f-9e60-202f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7222-4636-edc7-74f8" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2f8-c09f-9e60-202f" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="3bde-7c0c-9a31-641f" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="026a-5f6b-c1b1-28c6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7b9-3c6f-61b4-32d6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="026a-5f6b-c1b1-28c6" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7b9-3c6f-61b4-32d6" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="d06c-c3c1-49fa-8d72" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="59c3-2af5-ebe5-d512" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3627-b805-d3d7-5cb6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bea-0ef2-d46e-f68e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3627-b805-d3d7-5cb6" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bea-0ef2-d46e-f68e" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="5f80-531a-111e-dbd3" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c61-09c8-ac9c-b0f8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c61-09c8-ac9c-b0f8" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="993e-d97c-99a4-a9b1" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup"/>
+        <entryLink id="993e-d97c-99a4-a9b1" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="180.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="180.0" />
       </costs>
     </selectionEntry>
-    <selectionEntry id="30fc-6c09-9494-5928" name="Qin Xa&apos;s Command Squad, Tartaros " publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="30fc-6c09-9494-5928" name="Qin Xa's Command Squad, Tartaros " publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="b27d-ff1f-0ee6-d084" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
-        <infoLink id="e1f8-b20f-4f26-87b4" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-        <infoLink id="d0b1-8761-7968-754f" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule"/>
+        <infoLink id="b27d-ff1f-0ee6-d084" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
+        <infoLink id="e1f8-b20f-4f26-87b4" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
+        <infoLink id="d0b1-8761-7968-754f" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule" />
         <infoLink id="f9c1-9c0e-406d-ef09" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="8832-a1f5-ae84-f101" name="Retinue" hidden="false" targetId="6b79-ac44-4d89-2124" type="rule"/>
+        <infoLink id="8832-a1f5-ae84-f101" name="Retinue" hidden="false" targetId="6b79-ac44-4d89-2124" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0020-4301-b8cb-e152" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="1bd4-4a45-a9d6-fc0c" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="86cc-121b-a65c-422a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="0020-4301-b8cb-e152" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="1bd4-4a45-a9d6-fc0c" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
+        <categoryLink id="86cc-121b-a65c-422a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="db53-d618-c96b-4a8c" name="Dedicated Transport" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6992-1bbf-92c5-2386" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6992-1bbf-92c5-2386" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="46b5-f640-13b7-4b43" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry"/>
+            <entryLink id="46b5-f640-13b7-4b43" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="8edd-951a-e331-17bc" name="1) Legion Tartaros Standard Bearer" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b0fb-d8bc-4fa0-7f0a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3569-e887-ab4d-c981" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b0fb-d8bc-4fa0-7f0a" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3569-e887-ab4d-c981" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="90f2-2c49-d0f0-3116" name="Tartaros Standard Bearer w/Melee Weapon" hidden="false" collective="false" import="true" type="model">
@@ -2466,7 +2465,7 @@
                   <modifiers>
                     <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Psyker)">
                       <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo" />
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2486,24 +2485,24 @@
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="87b2-ff6b-75f6-d6d3" name="Terminator Melee Weapon" hidden="false" collective="false" import="true" targetId="e68f-0cee-6017-866a" type="selectionEntryGroup"/>
+                <entryLink id="87b2-ff6b-75f6-d6d3" name="Terminator Melee Weapon" hidden="false" collective="false" import="true" targetId="e68f-0cee-6017-866a" type="selectionEntryGroup" />
                 <entryLink id="ae8d-9aab-7e3f-6d71" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7af-51d6-9436-a551" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7af-51d6-9436-a551" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="e0cc-b0e4-6c87-a5f5" name="Legion Standard" hidden="false" collective="false" import="true" targetId="7e13-cc1f-6bd7-7ac6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9029-8e13-aa08-fbd3" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="835a-00ff-f8b8-be1a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9029-8e13-aa08-fbd3" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="835a-00ff-f8b8-be1a" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="ece0-e3d7-d62d-aafe" name="Tartaros Standard Bearer w/Ranged Weapon" hidden="false" collective="false" import="true" type="model">
@@ -2512,7 +2511,7 @@
                   <modifiers>
                     <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Psyker)">
                       <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo" />
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2532,32 +2531,32 @@
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="d208-5eac-58e2-d54a" name="Terminator Ranged Weapon" hidden="false" collective="false" import="true" targetId="bb49-6a88-7ffa-6aa7" type="selectionEntryGroup"/>
+                <entryLink id="d208-5eac-58e2-d54a" name="Terminator Ranged Weapon" hidden="false" collective="false" import="true" targetId="bb49-6a88-7ffa-6aa7" type="selectionEntryGroup" />
                 <entryLink id="66b0-5a26-9670-fc0d" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ce1-9fdb-abed-42d1" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ce1-9fdb-abed-42d1" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="c809-dd57-9861-7a23" name="Legion Standard" hidden="false" collective="false" import="true" targetId="7e13-cc1f-6bd7-7ac6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="797a-55c0-11a4-8798" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a371-4a17-f17c-1683" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="797a-55c0-11a4-8798" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a371-4a17-f17c-1683" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="2e7b-e5f2-d4fb-48df" name="2) Legion Tartaros Chosen" hidden="false" collective="false" import="true" defaultSelectionEntryId="1568-ca7f-fba1-e742">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cccb-6400-7eaa-f898" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d7f8-42e7-d709-4326" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cccb-6400-7eaa-f898" type="max" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d7f8-42e7-d709-4326" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="d38d-86df-0b37-f48a" name="Tartaros w/Lightning Claws" hidden="false" collective="false" import="true" type="model">
@@ -2566,7 +2565,7 @@
                   <modifiers>
                     <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Psyker)">
                       <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo" />
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2588,13 +2587,13 @@
               <entryLinks>
                 <entryLink id="9c70-ea5f-0d52-fd06" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7158-122c-20d2-cf54" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a383-7195-df4f-a789" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7158-122c-20d2-cf54" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a383-7195-df4f-a789" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="1568-ca7f-fba1-e742" name="Tartaros Chosen" hidden="false" collective="false" import="true" type="model">
@@ -2616,55 +2615,55 @@
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="ae26-7377-4e13-fe86" name="Terminator Ranged Weapon" hidden="false" collective="false" import="true" targetId="bb49-6a88-7ffa-6aa7" type="selectionEntryGroup"/>
-                <entryLink id="cb76-107b-11f5-8417" name="Terminator Melee Weapon" hidden="false" collective="false" import="true" targetId="e68f-0cee-6017-866a" type="selectionEntryGroup"/>
+                <entryLink id="ae26-7377-4e13-fe86" name="Terminator Ranged Weapon" hidden="false" collective="false" import="true" targetId="bb49-6a88-7ffa-6aa7" type="selectionEntryGroup" />
+                <entryLink id="cb76-107b-11f5-8417" name="Terminator Melee Weapon" hidden="false" collective="false" import="true" targetId="e68f-0cee-6017-866a" type="selectionEntryGroup" />
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="c87e-32fc-36c2-c230" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
+        <entryLink id="c87e-32fc-36c2-c230" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="910b-0c15-068a-e4fc" name="Jaghatai Khan" publicationId="817a-6288-e016-7469" page="182" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="add" field="category" value="6d79-a3e4-381f-7b0f">
           <conditions>
-            <condition field="selections" scope="910b-0c15-068a-e4fc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7afd-2248-2e02-e05f" type="equalTo"/>
+            <condition field="selections" scope="910b-0c15-068a-e4fc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7afd-2248-2e02-e05f" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
           <conditions>
-            <condition field="selections" scope="910b-0c15-068a-e4fc" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7afd-2248-2e02-e05f" type="equalTo"/>
+            <condition field="selections" scope="910b-0c15-068a-e4fc" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7afd-2248-2e02-e05f" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ede-c517-fa67-3073" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ede-c517-fa67-3073" type="max" />
       </constraints>
       <profiles>
         <profile id="a4cb-a293-a111-7298" name="Jaghatai Khan" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <modifiers>
             <modifier type="set" field="893e-2d76-8f04-44e5" value="18&quot;">
               <conditions>
-                <condition field="selections" scope="910b-0c15-068a-e4fc" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7afd-2248-2e02-e05f" type="greaterThan"/>
+                <condition field="selections" scope="910b-0c15-068a-e4fc" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7afd-2248-2e02-e05f" type="greaterThan" />
               </conditions>
             </modifier>
             <modifier type="set" field="57ee-1126-32a9-5672" value="7">
               <conditions>
-                <condition field="selections" scope="910b-0c15-068a-e4fc" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7afd-2248-2e02-e05f" type="greaterThan"/>
+                <condition field="selections" scope="910b-0c15-068a-e4fc" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7afd-2248-2e02-e05f" type="greaterThan" />
               </conditions>
             </modifier>
             <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Primarch (Unique, Antigrav)">
               <conditions>
-                <condition field="selections" scope="910b-0c15-068a-e4fc" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7afd-2248-2e02-e05f" type="greaterThan"/>
+                <condition field="selections" scope="910b-0c15-068a-e4fc" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7afd-2248-2e02-e05f" type="greaterThan" />
               </conditions>
             </modifier>
           </modifiers>
@@ -2685,70 +2684,70 @@
       </profiles>
       <rules>
         <rule id="cca0-d93e-8a32-4743" name="Lightning From Blue Skies" hidden="false">
-          <description>When held in Reserve, do not roll for Jaghatai Khan or any unit he is considered to be part of while in Reserve. Instead, at the beginning of any of the controlling player&apos;s turns except the first, Jaghatai Khan and any unit he has joined may be brought into play from Reserves without making a Reserves Roll. If Jaghatai Khan is part of a Flanking Assault then this rule applies to all units that are part of that Flanking Assault - but does not apply to a Deep Strike Assault, Drop Pod Assault, or Subterranean Assault that includes Jaghatai Khan. </description>
+          <description>When held in Reserve, do not roll for Jaghatai Khan or any unit he is considered to be part of while in Reserve. Instead, at the beginning of any of the controlling player's turns except the first, Jaghatai Khan and any unit he has joined may be brought into play from Reserves without making a Reserves Roll. If Jaghatai Khan is part of a Flanking Assault then this rule applies to all units that are part of that Flanking Assault - but does not apply to a Deep Strike Assault, Drop Pod Assault, or Subterranean Assault that includes Jaghatai Khan. </description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="768d-d03a-7695-339b" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule"/>
-        <infoLink id="0a34-2f3c-43da-dc08" name="Hit &amp; Run" hidden="false" targetId="5986-e960-d432-affd" type="rule"/>
-        <infoLink id="337f-0774-bea7-a762" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule"/>
-        <infoLink id="056d-2b1f-e7f3-4c45" name="Pathfinder" hidden="false" targetId="ec97-7aa8-49f5-b298" type="rule"/>
+        <infoLink id="768d-d03a-7695-339b" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule" />
+        <infoLink id="0a34-2f3c-43da-dc08" name="Hit &amp; Run" hidden="false" targetId="5986-e960-d432-affd" type="rule" />
+        <infoLink id="337f-0774-bea7-a762" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule" />
+        <infoLink id="056d-2b1f-e7f3-4c45" name="Pathfinder" hidden="false" targetId="ec97-7aa8-49f5-b298" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="f5c8-2bd1-122d-be0e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="afc4-8a34-2caa-f28a" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="f5c8-2bd1-122d-be0e" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="afc4-8a34-2caa-f28a" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7afd-2248-2e02-e05f" name="Sojutsu Pattern Voidbike" publicationId="817a-6288-e016-7469" page="183" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc52-5e3d-dc98-7047" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc52-5e3d-dc98-7047" type="max" />
           </constraints>
           <rules>
             <rule id="df8e-76c1-925f-f9d4" name="Sojutsu Pattern Voidbike" hidden="false">
-              <description>Falls Back 3D6&quot; instead of 2D6&quot;.
+              <description>Falls Back 3D6" instead of 2D6".
 May join units that include models with the Cavalry Unit Type despite the usual restrictions, and any rules that target the Cavalry Unit Type are considered to affect Jaghatai Khan as if he had that type. </description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="5eba-dc04-602e-d2b5" name="Antigrav Sub-type" hidden="false" targetId="e1d7-0fe8-59f4-af89" type="rule"/>
+            <infoLink id="5eba-dc04-602e-d2b5" name="Antigrav Sub-type" hidden="false" targetId="e1d7-0fe8-59f4-af89" type="rule" />
             <infoLink id="dbce-fb46-6ddd-4f34" name="Firing Protocols (X)" hidden="false" targetId="32a3-f599-5c92-2945" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Firing Protocols (3)"/>
+                <modifier type="set" field="name" value="Firing Protocols (3)" />
               </modifiers>
             </infoLink>
             <infoLink id="7744-747b-9fe1-e76d" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Hammer of Wrarth (2)"/>
+                <modifier type="set" field="name" value="Hammer of Wrarth (2)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <entryLinks>
             <entryLink id="e5a6-1c52-c7cc-52f1" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="07fd-c24a-9235-4206" type="selectionEntry">
               <modifiers>
-                <modifier type="append" field="name" value=" - Master-crafted"/>
+                <modifier type="append" field="name" value=" - Master-crafted" />
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e32a-44ae-ca4b-a357" type="max"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3967-086c-8dc4-f5c5" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e32a-44ae-ca4b-a357" type="max" />
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3967-086c-8dc4-f5c5" type="min" />
               </constraints>
               <infoLinks>
-                <infoLink id="61a8-c638-1816-a3f8" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                <infoLink id="61a8-c638-1816-a3f8" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
               </infoLinks>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
           </costs>
         </selectionEntry>
-        <selectionEntry id="31c2-3443-85fb-4253" name="Storm&apos;s Voice" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="31c2-3443-85fb-4253" name="Storm's Voice" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0528-2470-80b1-b78c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c12-861c-6712-6e06" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0528-2470-80b1-b78c" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c12-861c-6712-6e06" type="min" />
           </constraints>
           <profiles>
-            <profile id="c3f5-4e11-1e82-7294" name="Storm&apos;s Voice" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="c3f5-4e11-1e82-7294" name="Storm's Voice" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">12"</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 2, Rending (5+), Deflagrate, Concussive (1), Master-crafted</characteristic>
@@ -2758,25 +2757,25 @@ May join units that include models with the Cavalry Unit Type despite the usual 
           <infoLinks>
             <infoLink id="cd46-e98b-521d-fba8" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Rending (5+)"/>
+                <modifier type="set" field="name" value="Rending (5+)" />
               </modifiers>
             </infoLink>
-            <infoLink id="4f52-43cb-dfb8-a4a4" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
+            <infoLink id="4f52-43cb-dfb8-a4a4" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule" />
             <infoLink id="3c49-8994-09ad-6a01" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Concussive (1)"/>
+                <modifier type="set" field="name" value="Concussive (1)" />
               </modifiers>
             </infoLink>
-            <infoLink id="eb74-3ce9-f09d-8a25" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="eb74-3ce9-f09d-8a25" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="f95b-ca4e-c42a-6ffb" name="The White Tiger Dao" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecd4-5390-e597-2e38" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ee4-a501-507b-d8c4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecd4-5390-e597-2e38" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ee4-a501-507b-d8c4" type="max" />
           </constraints>
           <profiles>
             <profile id="a227-8769-0581-3d6d" name="The White Tiger Dao" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2784,36 +2783,36 @@ May join units that include models with the Cavalry Unit Type despite the usual 
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">-	</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+1</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Duellist&apos;s Edge (1), Furious Charge (2), Murderous Strike (5+), Master-crafted</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Duellist's Edge (1), Furious Charge (2), Murderous Strike (5+), Master-crafted</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="67b7-bcda-bed1-69c4" name="Duellist’s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule">
+            <infoLink id="67b7-bcda-bed1-69c4" name="Duellist&#8217;s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Duellist&apos;s Edge (1)"/>
+                <modifier type="set" field="name" value="Duellist's Edge (1)" />
               </modifiers>
             </infoLink>
             <infoLink id="1ac4-b76c-ce89-e287" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Furious Charge (2)"/>
+                <modifier type="set" field="name" value="Furious Charge (2)" />
               </modifiers>
             </infoLink>
             <infoLink id="6ca9-68e6-ea9d-04fa" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Murderous Strike (5+)"/>
+                <modifier type="set" field="name" value="Murderous Strike (5+)" />
               </modifiers>
             </infoLink>
-            <infoLink id="b017-b7a6-a82f-54ed" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="b017-b7a6-a82f-54ed" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="1eae-223a-27e3-5654" name="The Wildfire Panoply" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfe0-bde1-ae26-6091" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6dd9-ff54-a361-bf07" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfe0-bde1-ae26-6091" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6dd9-ff54-a361-bf07" type="max" />
           </constraints>
           <profiles>
             <profile id="3448-fe86-6154-9764" name="The Wildfire Panoply" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
@@ -2823,40 +2822,40 @@ May join units that include models with the Cavalry Unit Type despite the usual 
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="1603-e006-2f8b-2668" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02a8-6e71-c95a-231e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a55d-31bd-7243-50d5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02a8-6e71-c95a-231e" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a55d-31bd-7243-50d5" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="fa2f-1ae4-e965-014b" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9085-0c81-a3a2-21e8" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e2c-6aad-0e6f-0faa" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9085-0c81-a3a2-21e8" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e2c-6aad-0e6f-0faa" type="max" />
           </constraints>
           <profiles>
             <profile id="68d9-4dc9-4642-d60e" name="Sire of the White Scars" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All Infantry and Cavalry models with the Legiones Astartes (White Scars) special rule in the same army as Jaghatai Khan, including Jaghatai Khan, gain the Furious Charge (1) special rule on any turn in which they have moved. In addition, an army with the Jaghatai Khan as it&apos;s Warlord may make an additional Reaction in the opposing player&apos;s Movement phase as long as Jaghatai Khan has not been removed as a casualty. </characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All Infantry and Cavalry models with the Legiones Astartes (White Scars) special rule in the same army as Jaghatai Khan, including Jaghatai Khan, gain the Furious Charge (1) special rule on any turn in which they have moved. In addition, an army with the Jaghatai Khan as it's Warlord may make an additional Reaction in the opposing player's Movement phase as long as Jaghatai Khan has not been removed as a casualty. </characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
-        <entryLink id="8924-02af-956a-10e1" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup"/>
+        <entryLink id="8924-02af-956a-10e1" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup" />
         <entryLink id="7100-2838-ba4f-de13" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e22-7929-d52b-0ca3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cd2-78c2-aba7-0964" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e22-7929-d52b-0ca3" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cd2-78c2-aba7-0964" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="440.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="440.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -2865,123 +2864,123 @@ May join units that include models with the Cavalry Unit Type despite the usual 
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="3906-3da2-6b8b-86c1" value="1.0">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c905-666e-5fe8-6c80" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3906-3da2-6b8b-86c1" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c905-666e-5fe8-6c80" type="max" />
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3906-3da2-6b8b-86c1" type="min" />
       </constraints>
       <selectionEntryGroups>
         <selectionEntryGroup id="43cc-4717-31a0-fd05" name="  V: White Scars" publicationId="817a-6288-e016-7469" page="178" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c9a5-2984-1293-7617" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1af0-4a7f-6777-6b24" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c9a5-2984-1293-7617" type="max" />
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1af0-4a7f-6777-6b24" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="f2e4-fa63-10fa-b2df" name="Heroes Never Die (Loyalist only)" publicationId="817a-6288-e016-7469" page="178" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ebc-2ef4-f502-608b" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bcd0-97ec-aa0e-dd5f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ebc-2ef4-f502-608b" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bcd0-97ec-aa0e-dd5f" type="max" />
               </constraints>
               <profiles>
                 <profile id="1830-2b53-e2ae-b0b9" name="Heroes Never Die" publicationId="817a-6288-e016-7469" page="178" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and all models in any unit he joins, gains the Stubborn special rule. Furthermore, if the Warlord is removed as a casualty, all models in any friendly unit composed entirely of models with the Legiones Astartes (White Scars) special rule, from which one or more models can draw a line of sight to the Warlord at the point when he is removed as a casualty, gain the Fearless special rule for the remainder of the battle. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty. </characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and all models in any unit he joins, gains the Stubborn special rule. Furthermore, if the Warlord is removed as a casualty, all models in any friendly unit composed entirely of models with the Legiones Astartes (White Scars) special rule, from which one or more models can draw a line of sight to the Warlord at the point when he is removed as a casualty, gain the Fearless special rule for the remainder of the battle. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Assault phase as long as the Warlord has not been removed as a casualty. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="1b30-724a-2474-391b" name="Born to the Saddle" publicationId="817a-6288-e016-7469" page="178" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7476-4bf7-77b5-4b33" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1656-e829-6096-b3df" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7476-4bf7-77b5-4b33" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1656-e829-6096-b3df" type="max" />
               </constraints>
               <profiles>
                 <profile id="24d7-a60f-0442-675d" name="Born to the Saddle" publicationId="817a-6288-e016-7469" page="178" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord and all models in the same army with the Legiones Astartes (White Scars) special rule and the Cavalry Unit Type ignore all the effects of Difficult Terrain and gain a 4+ Invulnerable Save against all Wounds inflicted by failed Dangerous Terrain tests they are called upon to make. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord and all models in the same army with the Legiones Astartes (White Scars) special rule and the Cavalry Unit Type ignore all the effects of Difficult Terrain and gain a 4+ Invulnerable Save against all Wounds inflicted by failed Dangerous Terrain tests they are called upon to make. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="6ad2-3f84-f172-fff2" name="The Forgotten Sons (Traitor only)" publicationId="817a-6288-e016-7469" page="178" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6739-1ea1-8f4e-6a75" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b0a6-04d0-d3f6-ecb7" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6739-1ea1-8f4e-6a75" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b0a6-04d0-d3f6-ecb7" type="max" />
               </constraints>
               <profiles>
                 <profile id="f328-d758-127a-51b7" name="The Forgotten Sons" publicationId="817a-6288-e016-7469" page="178" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If an army whose Warlord has this Trait includes an Allied Detachment with the Legiones Astartes (Sons of Horus) special rule, the Warlord and any unit he joins automatically pass any Morale checks or Pinning tests they are called upon to make without any dice being rolled as long as at least one friendly unit with the Legiones Astartes (Sons of Horus) special rule can draw line of sight to the Warlord or his unit. In addition, the Warlord, and any unit he has joined, may make the Death Dealers Reaction (this Advanced Reaction is detailed in Liber Hereticus) without expending a point from the controlling player’s Reaction Allotment and counting all models in that unit that have the Legiones Astartes (White Scars) special rule as though they also had the Legiones Astartes (Sons of Horus) special rule (though they gain none of the benefits of that special rule) – this Advanced Reaction may still only be used once per battle. </characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If an army whose Warlord has this Trait includes an Allied Detachment with the Legiones Astartes (Sons of Horus) special rule, the Warlord and any unit he joins automatically pass any Morale checks or Pinning tests they are called upon to make without any dice being rolled as long as at least one friendly unit with the Legiones Astartes (Sons of Horus) special rule can draw line of sight to the Warlord or his unit. In addition, the Warlord, and any unit he has joined, may make the Death Dealers Reaction (this Advanced Reaction is detailed in Liber Hereticus) without expending a point from the controlling player&#8217;s Reaction Allotment and counting all models in that unit that have the Legiones Astartes (White Scars) special rule as though they also had the Legiones Astartes (Sons of Horus) special rule (though they gain none of the benefits of that special rule) &#8211; this Advanced Reaction may still only be used once per battle. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="999f-066e-f20c-7d72" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+        <entryLink id="999f-066e-f20c-7d72" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="f874-317d-d582-11d5" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="6552-af51-1e7a-1399" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="6552-af51-1e7a-1399" type="max" />
       </constraints>
       <entryLinks>
         <entryLink id="dd19-c562-7b59-f446" name="Command Squad, Cataphractii" hidden="false" collective="false" import="true" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="1a14-86f1-f796-58a7" name="Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
-        <entryLink id="2e7d-30fd-0293-6039" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
-        <entryLink id="1984-b8ae-b7c4-786d" name="Qin Xa&apos;s Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="30fc-6c09-9494-5928" type="selectionEntry">
+        <entryLink id="1a14-86f1-f796-58a7" name="Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
+        <entryLink id="2e7d-30fd-0293-6039" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
+        <entryLink id="1984-b8ae-b7c4-786d" name="Qin Xa's Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="30fc-6c09-9494-5928" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6a77-940e-1109-4a29" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6a77-940e-1109-4a29" type="notInstanceOf" />
               </conditions>
             </modifier>
           </modifiers>
@@ -2992,18 +2991,18 @@ May join units that include models with the Cavalry Unit Type despite the usual 
       <modifiers>
         <modifier type="set" field="12ef-2b1a-0954-657e" value="0.0">
           <conditions>
-            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf84-ba90-0a9c-fc3d" type="equalTo"/>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf84-ba90-0a9c-fc3d" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="0279-dba5-32bb-abe8" value="0.0">
           <conditions>
-            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf84-ba90-0a9c-fc3d" type="equalTo"/>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf84-ba90-0a9c-fc3d" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12ef-2b1a-0954-657e" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0279-dba5-32bb-abe8" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12ef-2b1a-0954-657e" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0279-dba5-32bb-abe8" type="max" />
       </constraints>
       <entryLinks>
         <entryLink id="d8fc-fc4c-6dd8-6ae8" name="Paragon Blade" hidden="true" collective="false" import="true" targetId="2ab9-0e45-405e-056b" type="selectionEntry">
@@ -3012,20 +3011,20 @@ May join units that include models with the Cavalry Unit Type despite the usual 
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="de73-2d79-156f-6f64" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2f0-15d9-2b7a-2204" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="de73-2d79-156f-6f64" type="instanceOf" />
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2f0-15d9-2b7a-2204" type="instanceOf" />
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
           </costs>
         </entryLink>
         <entryLink id="2d71-71ed-8ced-d269" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
           </costs>
         </entryLink>
         <entryLink id="7f91-ed71-10a1-5f98" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
@@ -3034,45 +3033,45 @@ May join units that include models with the Cavalry Unit Type despite the usual 
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="de73-2d79-156f-6f64" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2f0-15d9-2b7a-2204" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="de73-2d79-156f-6f64" type="instanceOf" />
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2f0-15d9-2b7a-2204" type="instanceOf" />
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
           </costs>
         </entryLink>
         <entryLink id="00b9-ab7f-03df-3a75" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
           </costs>
         </entryLink>
-        <entryLink id="bf48-0cda-8aec-9387" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry"/>
+        <entryLink id="bf48-0cda-8aec-9387" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry" />
         <entryLink id="d287-203f-e90d-8a25" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
           </costs>
         </entryLink>
         <entryLink id="970a-1865-2d94-4ff6" name="Power Glaive" hidden="false" collective="false" import="true" targetId="d917-8a5f-8459-8b0f" type="selectionEntry">
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
           </costs>
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="0dfa-aefe-956c-6178" name=" Retinue (Stormseer)" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="440f-ff26-8930-f934" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="440f-ff26-8930-f934" type="max" />
       </constraints>
       <entryLinks>
-        <entryLink id="885e-3d4a-b721-7266" name="Dark Sons of Death" hidden="false" collective="false" import="true" targetId="4372-ad51-04a6-97ce" type="selectionEntry"/>
+        <entryLink id="885e-3d4a-b721-7266" name="Dark Sons of Death" hidden="false" collective="false" import="true" targetId="4372-ad51-04a6-97ce" type="selectionEntry" />
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - White Scars.cat
+++ b/2022 - LA - White Scars.cat
@@ -1,6 +1,5 @@
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="caa9-c50e-8eed-2259" name="LA -   V: White Scars" revision="16" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="22">
-  <entryLinks>
-    <entryLink id="a738-6a11-dfe7-286c" name="   V: White Scars" hidden="false" collective="false" import="false" targetId="e01e-5cdd-e512-8353" type="selectionEntry">
+  <entryLinks><entryLink id="a738-6a11-dfe7-286c" name="   V: White Scars" hidden="false" collective="false" import="false" targetId="e01e-5cdd-e512-8353" type="selectionEntry">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91db-4591-14fb-9b51" type="min" />
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e400-7749-453c-4152" type="max" />
@@ -113,956 +112,1957 @@
         <categoryLink id="a9bd-8e73-b3dc-7062" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="299f-d34c-a868-371c" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6f4f-3b44-8d46-0119" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="568e-76a0-5b21-4ed9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <entryLink id="299f-d34c-a868-371c" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="289e-b283-498c-a825" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6d4-581f-4746-bec3</comment></categoryLink>
+        <categoryLink id="8091-97ee-4d68-9337" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_2489-ee2a-45dd-b384</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
-    <entryLink id="e8f7-44be-772a-b5e6" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="cd39-ad94-bbd3-1f92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="370e-f3bc-0a8a-6440" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
-    <entryLink id="df73-276b-e085-14a0" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink><entryLink id="e8f7-44be-772a-b5e6" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b02f-e65f-4a88-a175</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_b87b-bf35-4238-b7c6</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1aff-27af-435e-8102</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_fdf9-4906-4180-a39d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="846d-a94a-a9e8-427c" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="c0c0-0996-70dd-5c54" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="75b9-70e1-389c-0300" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="5c11-39a1-4b48-a798" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8378-ede4-476d-b657</comment></categoryLink>
+        <categoryLink id="7edf-f266-46cf-95af" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_d64f-ad19-426c-adf7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
-    <entryLink id="cc27-6737-f9b6-3c82" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="89a2-9421-d2ee-b421" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="2cdf-6095-c347-533f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
-    <entryLink id="cb4d-1b25-b467-792f" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0f93-492e-8169-7a87" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="1fdd-a3db-02b0-70bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
-    <entryLink id="9a0a-94c1-0742-8bbc" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink><entryLink id="df73-276b-e085-14a0" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_7fd1-8ce8-4d10-82e7</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_eaae-8c43-4d30-898c</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_f67d-8cf3-424f-b491</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_b949-6414-4f3d-b268</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7c78-ebe2-dec5-947a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="f30a-b16c-ec43-1040" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ade5-bbdb-5c23-4546" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="c145-1f75-4ddf-acb4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_ac26-e639-4d53-9b8b</comment></categoryLink>
+        <categoryLink id="e33a-37fa-4260-9f19" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_49af-0d08-4c7e-8ce6</comment></categoryLink>
+        <categoryLink id="8b2f-141c-4278-a6a2" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_b606-de16-4659-95cd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
-    <entryLink id="ec23-00d3-b79b-9815" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink><entryLink id="cc27-6737-f9b6-3c82" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="f581-5ba7-9650-cd16" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="4cae-27be-0ef7-876e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
-    <entryLink id="bdc3-d995-0644-70d4" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7583-6fa0-4089-a19e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_0e5c-99ab-41d3-a42e</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c296-e8e8-4a7a-989a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_8868-5bcb-4604-ba8e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fa54-84fb-42c6-8749" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a009-a597-4b51-b228</comment></categoryLink>
+        <categoryLink id="d329-b109-4bf5-91cb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_24f4-9145-4016-80d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink><entryLink id="cb4d-1b25-b467-792f" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_e732-7499-47bf-9748</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_81a5-a959-46b7-baa4</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7ec3-447a-4644-b012</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_71e2-c430-4c99-a559</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_df7b-3fb9-4f65-9165</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ecf9-e1ca-407c-ad08" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c165-3906-463a-9c73</comment></categoryLink>
+        <categoryLink id="5d72-4ae6-460d-8a4c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6d1-d14c-473f-be09</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink><entryLink id="9a0a-94c1-0742-8bbc" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_27a3-1e4c-4b76-a594</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_d59a-dcd0-44fd-b866</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_0c8b-2b92-49ed-98c7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_bafe-f799-41d9-ac85</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_6369-288c-4fec-a640</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_fe53-8858-41dc-8ec4</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6474-9336-0633-dd57" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="c2ab-3dd4-0949-c129" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b7db-f98e-45de-b6f1" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_3a22-caae-4eea-9bc5</comment></categoryLink>
+        <categoryLink id="1987-38c2-421a-beb5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f759-f33e-4698-9f8a</comment></categoryLink>
+        <categoryLink id="80ff-d3cc-4fab-a2bf" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_c624-3ae0-46c0-9b06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
-    <entryLink id="ce98-7103-e388-d6ba" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink><entryLink id="ec23-00d3-b79b-9815" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_13b3-ce1e-4f9d-8319</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d681-9d81-4abd-b11b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a57-e48b-4534-bca5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_1859-5641-4674-9097</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="cf1f-0c06-1891-9e12" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="0335-fe07-c912-bc5c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="845c-2244-6445-59a1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="c5c7-65e1-406a-92ab" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_251a-df5b-4bfd-ad63</comment></categoryLink>
+        <categoryLink id="60b2-73cf-455c-af18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4644-98ab-4e3f-b1fd</comment></categoryLink>
       </categoryLinks>
-      <entryLinks>
-        <entryLink id="71da-0538-3484-3fcc" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup" />
-        <entryLink id="66a2-e125-0934-2186" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink><entryLink id="bdc3-d995-0644-70d4" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_591d-d028-4663-918d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_0482-c5f9-4c95-9597</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_75a7-971d-4978-a83f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_a7d5-2bfe-4621-ac0c</comment>
+                </condition>
               </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-        <entryLink id="ac12-0513-0f1c-a95f" name=" Retinue (Stormseer)" hidden="false" collective="false" import="true" targetId="0dfa-aefe-956c-6178" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b6c-5897-3790-2940" type="lessThan" />
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
-    <entryLink id="f26b-1452-4a9d-a3af" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
-      <modifiers>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9f13-b460-4f27-b0cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_31fc-e265-45a7-bb5b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1f31-71d7-0745-2583" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c7ba-91e3-150b-4b92" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="1733-717d-caeb-2bf2" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="8998-8f1f-4754-908c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_67c2-df43-44fc-92d1</comment></categoryLink>
+        <categoryLink id="7b6c-6d45-42aa-8bb5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4136-bb4e-4dd4-99f9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink><entryLink id="ce98-7103-e388-d6ba" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry"><categoryLinks>
+        <categoryLink id="6a1a-7d8d-4cc0-b69c" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_2599-24e3-44e5-9568</comment></categoryLink>
+        <categoryLink id="bc53-9afb-4c67-b300" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_285f-6e56-473b-b2fe</comment></categoryLink>
+        <categoryLink id="87f4-5436-4e3a-b3bc" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_685e-022f-4e2f-a568</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="8340-5cb2-6d5b-4eb5" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup" />
-        <entryLink id="57b4-a015-03fa-24e6" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup">
+        <entryLink id="d557-e600-4aba-ba19" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup"><comment>    template_id_2a38-6544-4267-b584    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="9966-c1c7-4e83-961a" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_8287-16ff-46ba-9838</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_81c1-fca9-44dc-ba4c</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_6e59-4592-47ef-b76d    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
-    <entryLink id="20f5-8874-72c2-8759" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2424-b3fd-3c80-5213" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="782f-25d5-a6f7-dbb1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="ae30-c152-a838-a701" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="c81a-abc7-1c2b-6b23" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup" />
-        <entryLink id="729f-ed4d-a5f2-c655" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
-    <entryLink id="3c50-eb8f-cfcc-0a47" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="edc3-2bbb-67e2-efee" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="185e-1bfe-3d86-4a3d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
-    <entryLink id="081e-dd7c-d5a8-972a" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3585-3a01-f360-d4d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="45e4-c713-1d81-80f0" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
-    <entryLink id="d877-17ec-54b9-3ede" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink><entryLink id="f26b-1452-4a9d-a3af" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ad5d-3c79-4239-9116</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_60b1-049b-4a5f-85c2</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1947-692c-1a3d-ee53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="96b8-3974-d7a0-d0cf" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="00d5-f71e-44b4-836f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bd6a-0cda-4e0f-80ae</comment></categoryLink>
+        <categoryLink id="1af3-daa3-4d76-bf71" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_ae75-7cca-4701-9d56</comment></categoryLink>
+        <categoryLink id="a1cf-ddf6-4895-a1ea" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_e517-62d4-48f7-8174</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
-    <entryLink id="099b-30ad-6545-a3a1" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
+      <entryLinks>
+        <entryLink id="229e-419f-4750-8e2a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup"><comment>    template_id_fafb-6414-474a-8a09    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="19e0-3888-46fa-a27d" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_1e43-c980-4508-8ec2</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_4140-36a7-4203-b5e9</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_a6a6-9bc7-4d4e-86a7    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink><entryLink id="20f5-8874-72c2-8759" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry"><categoryLinks>
+        <categoryLink id="36c4-2f97-480c-8283" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fc9d-03d1-4bbd-a1c4</comment></categoryLink>
+        <categoryLink id="bbac-c683-478d-a383" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_f51c-73d7-4f29-be1c</comment></categoryLink>
+        <categoryLink id="1d4d-efe9-4327-8d9b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_257d-78c0-4bab-ba65</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="52fb-b832-4fbd-9c65" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup"><comment>    template_id_ac26-33db-40a7-bdba    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="721c-3a69-4f3e-ab22" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_189b-db75-4db6-9fe9</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_cbdb-2500-4e13-876a</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_dc8e-2801-46d6-84f8    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink><entryLink id="3c50-eb8f-cfcc-0a47" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b43b-547f-472e-9076</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8ff9-0498-4540-8552</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fbfe-931a-489b-a589</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f4c3-5aa6-4caa-abf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_17f8-f055-4c9c-b757</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="84d9-3ba5-f403-b090" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c265-3e86-c273-fd18" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="9104-a0ba-49c0-b65c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f1c8-27fd-4f98-8527</comment></categoryLink>
+        <categoryLink id="728d-68de-44ef-b45c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2b20-1a8b-4753-b657</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
-    <entryLink id="2ad2-8d27-6cfd-396c" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink><entryLink id="081e-dd7c-d5a8-972a" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry"><categoryLinks>
+        <categoryLink id="f1f0-3f92-424c-9ec5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4207-8d8f-4b1a-836b</comment></categoryLink>
+        <categoryLink id="dd80-d15b-4502-ab2e" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_2b34-077f-4279-86fb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink><entryLink id="d877-17ec-54b9-3ede" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="7434-0033-1bac-79ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="bfe3-0067-8009-4fa2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="baf9-a8e8-49d8-888e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6577-e0fb-4fda-834e</comment></categoryLink>
+        <categoryLink id="b4de-198c-4985-8b94" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_5d59-09bf-4566-b7e1</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
-    <entryLink id="6dde-f11a-520f-8a04" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink><entryLink id="099b-30ad-6545-a3a1" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"><categoryLinks>
+        <categoryLink id="36f1-9eb0-4446-bb32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_aa93-057d-42f6-82d7</comment></categoryLink>
+        <categoryLink id="9517-26ca-451f-b7e7" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_403c-4e9c-4af5-84ec</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink><entryLink id="2ad2-8d27-6cfd-396c" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_23fa-06dd-49f9-a7db</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5b26-059e-40b3-9d93</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f7bf-3a1c-4103-aed8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="2bb9-a861-7c24-d694" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="54e9-f823-44ed-1b9c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
-        <categoryLink id="8ec7-001e-c109-b18a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="97e5-50ac-4899-aac1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dd44-e0a8-42a8-bdcc</comment></categoryLink>
+        <categoryLink id="396b-d400-4401-acf0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_c5b0-f9ae-468d-924a</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
-    <entryLink id="ac3e-184c-90d8-73ea" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink><entryLink id="6dde-f11a-520f-8a04" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8396-e51c-4e2b-bada</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_13bb-9fb5-4580-92cf</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_bfb8-8125-4548-92f5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25e3-b8f5-4448-a7c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e0f0-cda1-48d4-aacb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_f926-27fd-4a92-97a1</comment></categoryLink>
+        <categoryLink id="48c7-78d6-4680-9bed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_82e3-36e1-4e85-8fcb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink><entryLink id="ac3e-184c-90d8-73ea" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a000-9429-2d21-e082" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
         <categoryLink id="6866-960c-b381-646d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="0264-448e-8ee1-5b8f" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
-      <modifiers>
+    <entryLink id="0264-448e-8ee1-5b8f" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_658f-b1ad-4347-a998</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_12bc-3db2-4d28-abce</comment>
+            </condition>
           </conditions>
         </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="28fa-46b5-7332-cc44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d121-bd21-c491-48b4" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
-    <entryLink id="4f05-7a4c-a312-a608" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_9d83-7691-41d6-8dad</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_add7-ba48-46d4-8a02</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_1fb0-2421-40a4-9e49</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="051e-f129-d3c3-0945" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="9072-d36e-9f9b-96b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="033f-3e9f-6806-6534" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="a3fe-1ca4-4a2f-9d8a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7004-b00d-481f-b740</comment></categoryLink>
+        <categoryLink id="edf5-a171-4195-99b7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4f88-2fc3-491c-bfb7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
-    <entryLink id="d8d9-6c37-28cb-0f90" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="96bf-5ca7-d682-cbdf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="403a-da58-9212-9a84" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
-    <entryLink id="d762-5ff7-fa8e-3b34" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a078-ffb9-9a0a-d4f9" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="caeb-982b-1e37-c7c3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
-    <entryLink id="daa9-185a-9e5b-f35e" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="013f-38f9-6257-e5f7" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="4e46-9cd2-88ed-a8bc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
-    <entryLink id="2d89-2165-4a7f-6410" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c23a-5abd-7b76-5252" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="8a04-51fc-b8b7-fd9b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
-    <entryLink id="16a6-8886-522c-4dee" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3983-b2a3-c87a-d71d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="59bc-00f9-965a-de17" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
-    <entryLink id="64c1-e741-f838-fdb3" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="959f-590b-a3f1-ed30" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="e2dc-5969-cb8e-9420" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
-    <entryLink id="e5a3-7a87-cfa2-fd22" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0550-9e6a-7a96-8b06" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="4285-8053-3d28-58e0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
-    <entryLink id="ae18-b372-a0a5-9d95" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="990a-f17e-0d92-6388" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3266-8d24-ca66-ff22" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
-    <entryLink id="551c-ecf7-376d-0748" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3c60-179b-b3aa-aecb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="2e16-aaf7-cd29-6596" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
-    <entryLink id="4963-35a2-5b08-9354" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a42b-a6d2-5300-3167" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="192e-2d44-ed98-3ffb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
-    <entryLink id="79eb-63d7-75c4-1754" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e7a2-8243-d08b-8c88" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="8df7-94e6-e1fb-bc7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
-    <entryLink id="c459-96e5-dc0e-1add" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="2928-f9a4-c4da-7a0e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="cf6e-6a7c-0943-15a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
-    <entryLink id="4dce-f77a-5321-00b6" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="df3f-7495-8b53-8cfa" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="d4d0-cfc7-8bd0-7c71" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
-    <entryLink id="170a-eabb-89da-d73e" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2db6-57f1-4f43-a676" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="42a5-b62b-7923-4535" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
-    <entryLink id="6701-433c-cd31-7034" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5fb6-fdfd-5b0f-4a4a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="bc58-6196-3e8b-97a3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
-    <entryLink id="9925-718c-0993-f2ae" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="485d-b1bb-da4e-8258" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="c13b-90b7-3aca-2016" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
-    <entryLink id="a03b-c860-f6ae-3219" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="a719-b239-4f2a-a1fc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="73dd-7cff-c520-952e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
-    <entryLink id="3a7d-8fe1-bc8b-6d66" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e137-a2a8-92f8-2820" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="a90c-7700-3710-15b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
-    <entryLink id="a9d7-957b-2341-89c1" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9989-3f8b-8932-43e6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="c135-dacf-b74c-bc04" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
-    <entryLink id="71b3-d2f4-6a66-974c" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3ba4-3e92-ef8b-43d1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="49b4-b365-862a-29b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
-    <entryLink id="6b2f-f8d1-3de4-7949" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8f73-ec0e-9877-2186" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="090e-a5e0-07d4-e3cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
-    <entryLink id="0365-3fdb-e2fa-90e2" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="13ad-3113-7bb8-786c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="fd74-cfc8-54f1-e367" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
-    <entryLink id="e6cb-a174-5822-5467" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6041-1b54-20d4-31a9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="ea5e-673e-ee05-8b70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
-    <entryLink id="f137-0415-8373-569b" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="31d3-45af-06f7-5a4b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="12dd-239f-9892-c85e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
-    <entryLink id="eecd-f588-f45c-761a" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="821e-82f6-53f7-1a09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5211-46f6-076b-3fd3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
-    <entryLink id="e187-a2cc-f4ec-7471" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="75a2-2af8-9a65-9159" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="e524-3fb6-50a5-56da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
-    <entryLink id="0986-d5e7-7615-80e9" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d2b4-df48-cfdd-1055" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="670c-4811-e490-859f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
-    <entryLink id="18b6-d821-8185-8e10" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="df19-3f0e-f2de-4946" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a48a-3d21-6c2b-1dc1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
-    <entryLink id="e02e-8507-15b9-5d32" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9e7b-fc82-ae5d-17b3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="d434-20c6-3e7a-2dcd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
-    <entryLink id="1307-82da-d8cd-2cb3" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3f9b-0d6c-3b4f-514e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="6e49-d7c6-8706-dfad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
-    <entryLink id="5bd3-92a5-4802-df7e" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f1c6-16e5-2153-d085" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8f73-bae4-81b3-2d08" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
-    <entryLink id="109b-f4c1-4f21-88d9" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ae6b-8d1f-e038-d392" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="4e6a-8aa8-6b99-18b8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d1b2-c99c-3ec2-fa3d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="d3b4-211a-8010-b8c3" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup" />
-        <entryLink id="6ee0-408f-3752-07ff" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
-    <entryLink id="b59e-577b-2044-d67c" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="522b-908f-b3e7-eb59" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="39c5-3f02-23da-0246" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="76a3-a89e-b734-0572" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="e072-3c45-4283-c6b7" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup" />
-        <entryLink id="a6ec-b9b9-ca4e-d03e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
-    <entryLink id="6321-544f-fda8-e2ce" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b127-1291-58ed-ff0d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="70c5-6739-9828-2e92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="dc26-36ac-1e95-45aa" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="6b02-3609-96d2-af21" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup" />
-        <entryLink id="4705-a338-55a1-1a5b" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
-    <entryLink id="b6bf-9ff7-5fad-3989" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c3fe-3f99-ed68-f9f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5e2e-ef66-a44a-6ce6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
-    <entryLink id="6dff-25c9-c9e4-ac15" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d558-bd8b-f84f-0397" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="fa07-85b7-1a03-84ce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
-    <entryLink id="2e08-0b4c-4f01-e386" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b026-9a7d-85d1-f88e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="60c9-2f7b-b176-b0cc" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
-    <entryLink id="c808-9d93-886d-7bb6" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="ebdd-72ab-79a7-e559" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="bc13-5bc4-41ac-eff5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
-    <entryLink id="8ce8-1073-262c-ccbe" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8664-0697-1ef0-ac29" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="e4ba-9002-0339-c126" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
-    <entryLink id="fa21-28be-7fe5-1153" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="acc2-f93d-17bc-eba4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="87da-2b57-922d-9885" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
-    <entryLink id="c5ef-26c5-ffca-1760" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1fdf-0904-3d41-26d8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d127-5890-9fae-dc53" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
-    <entryLink id="91c2-a324-1dfc-3dcd" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3194-3609-e54b-838f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="bc78-acbd-3fa8-4fad" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
-    <entryLink id="5168-a1d3-1fa9-8c4d" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1ecb-45d7-7670-18c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c1d7-1ca5-cec9-a642" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
-    <entryLink id="dc0e-3160-fd9e-5f98" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="576f-f7dd-303e-4ae1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1545-06cf-4200-e760" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
-    <entryLink id="b40a-43c4-3700-dca0" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8b2c-e02c-8f5b-b176" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d9e7-cc24-add1-e381" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
-    <entryLink id="b471-d4eb-cb5a-3285" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="4328-bb57-5a8b-c984" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="206d-8eb5-50e4-ee6a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
-    <entryLink id="e81f-b70d-ed28-7417" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="83e0-4077-384f-5c37" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="223d-ee24-ce15-2e49" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
-    <entryLink id="58e4-9279-b4fe-9181" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7010-998a-102d-c4ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="44bf-7a60-a01d-d0b2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
-    <entryLink id="6676-20b9-1be9-a262" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="0108-5ce0-04b8-5a52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d7bf-0c70-2d3e-fd68" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
-    <entryLink id="a313-a7d9-3bbb-ad89" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="30e7-479c-024e-3fc0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="4868-4812-3b0b-be23" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
-    <entryLink id="1015-2244-ccff-9561" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3394-f475-3057-1cec" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="7ba9-262d-553a-6f62" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
-    <entryLink id="1cd4-f6bd-b976-14a6" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="58a9-9b66-45c9-1e34" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="54ef-68b4-3c40-1116" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
-    <entryLink id="93bb-da90-5011-43e7" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink><entryLink id="4f05-7a4c-a312-a608" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_8ed4-376d-4030-9439</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_8a11-c2a0-4335-99ef</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_fa8e-1af7-4d41-ac8c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_94bd-c771-4a85-8581</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7bd9-4f37-ecdf-1146" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ab58-4733-0473-78b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="0a7b-c348-52ae-67ea" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="73b3-8094-446b-be54" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_361e-fb90-4b0e-ac3d</comment></categoryLink>
+        <categoryLink id="630d-9245-4dfa-8b97" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d4ef-1074-45a9-959e</comment></categoryLink>
+        <categoryLink id="8ddc-a5e1-4788-8718" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_febb-f536-4d25-a8ab</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
-    <entryLink id="3d2c-befa-6b15-3452" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="801d-bdaf-c537-977a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ed12-f35f-2310-093f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink><entryLink id="d8d9-6c37-28cb-0f90" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d628-91d2-4bb2-9e59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_473b-e812-4158-9416</comment></categoryLink>
+        <categoryLink id="5446-1d19-4192-a135" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_00a2-63ff-4698-a35b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
-    <entryLink id="bf10-ec9b-e8b6-7b5c" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink><entryLink id="d762-5ff7-fa8e-3b34" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7cf3-8a72-4f82-8cdc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_228c-5681-4ce8-b726</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_01bb-8abd-4253-9a4d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8abc-419a-7a26-bea0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="d20b-e93a-09d3-ae10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bb39-1479-492e-9300" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2a08-4432-42ad-bfdb</comment></categoryLink>
+        <categoryLink id="0afe-b61a-44d2-932d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_422e-0808-4897-8630</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
-    <entryLink id="9df2-67f2-a62f-d871" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink><entryLink id="daa9-185a-9e5b-f35e" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1af8-4459-4717-8e3b</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_06b4-92b9-438c-b1a5</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6c8d-8b28-417b-9a7c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_715d-8186-4aa6-b40c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_390e-358c-4f8e-ade8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="2932-ded7-55ba-7e18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="3783-6284-2cff-787f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="a7bf-57a8-4c5b-ad80" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f4c0-4396-4f39-a34f</comment></categoryLink>
+        <categoryLink id="ae3f-4e55-469a-abff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1301-8415-490e-8f06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
-    <entryLink id="662c-33b6-ab9f-b6ee" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink><entryLink id="2d89-2165-4a7f-6410" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d0c9-9a26-4324-b030</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4e9e-a61d-42f2-bacb</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ed9e-b634-4bec-9eb0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4614-ad0f-4fba-adaf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_8d08-24f6-41be-8931</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7fbf-07c7-40ea-83c8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_caf6-5548-4b89-8102</comment></categoryLink>
+        <categoryLink id="7d47-ec64-4735-9146" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_63a3-be61-428d-ab29</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink><entryLink id="16a6-8886-522c-4dee" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f318-4b03-4767-8c7f</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b8ef-7245-4df8-a8c4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_6bce-ec44-48cb-873a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a8ce-68cb-4788-a653" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0678-4fdd-48e6-8f61</comment></categoryLink>
+        <categoryLink id="44e5-98cb-4375-b866" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0d82-10a9-4de2-8ad7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink><entryLink id="64c1-e741-f838-fdb3" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ada1-1e18-4cbc-9598</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b1d1-ac44-47dd-9159</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5d64-f00c-4464-891b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25f0-f825-4a83-8f0d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_64b1-9e36-44da-b36a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="95c7-56fa-4301-ba7e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_d53e-113f-4a40-a3d5</comment></categoryLink>
+        <categoryLink id="f05f-ed48-4df2-a563" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1939-76b5-4279-9f8c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink><entryLink id="e5a3-7a87-cfa2-fd22" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d765-3bb2-4b48-bd12</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_0ca1-cfb4-4a56-ab3b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e360-6e16-de90-6365" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="10ad-5d66-5e08-cdd1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="af3f-d43d-4302-8802" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e6f7-a6ca-4825-bfc5</comment></categoryLink>
+        <categoryLink id="dab5-9031-481c-b813" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dbec-e027-4ec1-8514</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
-    <entryLink id="fedf-3842-0d53-044b" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink><entryLink id="ae18-b372-a0a5-9d95" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d8ee-81ed-45f9-8b79</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_8f4e-e8cb-4ac9-a415</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="549b-07d6-4197-aa48" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_cefb-cfd7-4dc8-99c4</comment></categoryLink>
+        <categoryLink id="5cef-4c60-4132-a476" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a9fd-9d16-4a5e-855c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink><entryLink id="551c-ecf7-376d-0748" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e76b-46ca-4ab8-a93d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8035-75b8-43bb-97c9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_71a4-31e7-4927-a0ab</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5934-5e3d-4f32-a811" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_a56d-347b-4b09-a918</comment></categoryLink>
+        <categoryLink id="4c99-d7a9-47cf-96f7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_96e5-4531-4213-903e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink><entryLink id="4963-35a2-5b08-9354" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1fb5-2375-4c22-b41e</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7d7c-255d-49b6-96b9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5321-254b-4890-9bf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ddf8-b8b7-4afb-b6dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="25e0-94be-4cc2-9aac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9441-d79b-4720-9667</comment></categoryLink>
+        <categoryLink id="12f1-58c4-444f-aca8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7d7e-32d3-4692-b401</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink><entryLink id="79eb-63d7-75c4-1754" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_99fc-5fe7-4b37-a62f</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_25f4-f6b8-4b44-8350</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_81f7-2311-4cce-95bc</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_09aa-af2a-4012-91d1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_00ae-fad3-4df6-9cb9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68d8-0ec6-431e-9c02" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f65b-8958-49b3-92a5</comment></categoryLink>
+        <categoryLink id="de1e-49ce-4f1a-a01a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0451-1929-4942-8c3f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink><entryLink id="c459-96e5-dc0e-1add" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_edc4-4915-40ba-bbf0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_105f-ba26-4146-bc54</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7a2c-a76c-421c-a8a2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_05c9-0543-47ee-ba81</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e6ad-f0d7-4627-921b</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0cf1-1139-435f-9f71" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c6a8-22a8-4d41-b969</comment></categoryLink>
+        <categoryLink id="b50b-3d3e-4b2b-bd2a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03ca-12cc-4e0a-b628</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink><entryLink id="4dce-f77a-5321-00b6" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ae67-ef52-4cac-958c</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fc61-7306-4d99-acde</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1be0-67e7-45a1-bdbb</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_42a8-7fda-4e05-af0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4bfc-1e13-4d8f-8af7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_565a-1592-491f-8b9b</comment></categoryLink>
+        <categoryLink id="b16c-c81f-4a52-977e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_81d5-c14a-42ab-bdde</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink><entryLink id="170a-eabb-89da-d73e" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1ae7-c41b-4818-be71</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_08a5-b1bb-4ba1-ba42</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d677-b5ad-4838-8746</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_537f-bc1f-4aaa-b0dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c1dd-f6fe-4dca-93a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bc67-ce1f-4004-aeb7</comment></categoryLink>
+        <categoryLink id="b98e-e3c6-4a39-8add" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_9a45-9699-4475-aeef</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink><entryLink id="6701-433c-cd31-7034" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_c28f-4109-44c4-ab64</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fdc1-a894-48bc-9e7c</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_4936-a68c-4524-9088</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb37-ac0c-49ae-9d6f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0dfe-2a51-4d68-b53b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3afe-cfc0-4da6-a985</comment></categoryLink>
+        <categoryLink id="be7c-86d3-4ec9-93b6" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_04a8-6aae-45ae-bd4c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink><entryLink id="9925-718c-0993-f2ae" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ae19-30c0-43c5-920e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_6ebe-1bf3-4d78-9dd0</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1887-152d-48b7-b13f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_a7c4-ee6a-4f0b-8ab0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bd85-fa90-47ff-9f84</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_7bd6-9043-4d7e-ba37</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e0e8-435e-495a-8e31" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3610-c975-4d55-bdfe</comment></categoryLink>
+        <categoryLink id="65d6-0611-48d7-98ef" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2fc2-f636-4c80-9608</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink><entryLink id="a03b-c860-f6ae-3219" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_85c5-d4d9-4b23-9e4d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_80e8-d50b-4906-8153</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_b93b-d4f1-45eb-8a69</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e183-f183-4db7-83b5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0f39-204a-4217-b896</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_eee9-7bfd-4fea-a1bd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="46ba-7743-4f30-a582" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f81d-9435-4f11-99c1</comment></categoryLink>
+        <categoryLink id="33d0-fd52-4377-96db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9568-6142-4fdd-be3a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink><entryLink id="3a7d-8fe1-bc8b-6d66" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_005e-6607-4e2c-8dd2</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_7745-260c-4c36-b719</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_ba25-a4b2-4ba9-b023</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ddeb-f4c8-4091-9153</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4904-fd2f-429f-9cf7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_faea-b21b-43c5-b918</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1375-edf8-438c-939e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_b24f-3ae0-4cbb-b016</comment></categoryLink>
+        <categoryLink id="2113-e9e4-4f5e-aeea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fd26-8e6b-4521-92b9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink><entryLink id="a9d7-957b-2341-89c1" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6ecb-28e2-43ed-a6a0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_c067-1118-4d96-b28b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_250e-23c0-4e43-bf74</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1553-a6e6-4291-853f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_aab6-797b-427a-9fd8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1949-8541-4232-bf7e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c77f-0819-473b-a8a2</comment></categoryLink>
+        <categoryLink id="87ea-dd9d-4a65-86f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_89fb-c924-4daf-923d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink><entryLink id="71b3-d2f4-6a66-974c" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d72c-519a-451f-81b6</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_3d16-444c-42c9-aad1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_f4b2-6371-494b-863a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_797f-a84b-42f6-8e66</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0d78-fe38-4829-9b12</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="22a6-d553-4837-adce" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0397-c837-4fea-a527</comment></categoryLink>
+        <categoryLink id="b503-34c4-4c3c-b354" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_060b-bccb-4776-bd83</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink><entryLink id="6b2f-f8d1-3de4-7949" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3c84-6d74-4c42-b38d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_5b15-7aa4-4897-aaf1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_3326-31ed-4151-9b37</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6a0e-1b65-4057-ba5d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f8c7-abc9-45ec-955f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_2538-8dc5-446c-8344</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3938-2aa3-41d6-b41b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_c1cf-cea4-4278-8f27</comment></categoryLink>
+        <categoryLink id="7ee8-f9b8-4aaf-b24b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5f51-2734-4a46-9f72</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink><entryLink id="0365-3fdb-e2fa-90e2" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af71-f3ff-49b1-83e9</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_1c9e-b3bf-4e88-a43f</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_6d0d-1b1d-4065-89cf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d0b7-8686-491e-9d33</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_7db8-0874-487a-be6f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1034-29a0-44b1-a85f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7b9d-4b05-4a85-b7e4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_0c16-6841-42b2-b02d</comment></categoryLink>
+        <categoryLink id="850d-efec-4383-b11d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_602d-2d2d-4ff4-a82a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink><entryLink id="e6cb-a174-5822-5467" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_22bd-baae-45f9-b366</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_52bd-55de-4d53-ba55</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_df1b-7476-4ab8-8d2f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_49fa-0dcf-4a61-a5b1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0ea-1443-4993-86e7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2a8-3fbe-448c-9902</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b03e-3980-4ee0-930a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3632-0b5d-4622-ae33</comment></categoryLink>
+        <categoryLink id="a926-0682-4119-b9fc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_da44-7815-4fdd-981c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink><entryLink id="f137-0415-8373-569b" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2bfa-b203-47e2-a828</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a39b-8a3c-49cf-bf62</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2a05-07b3-49c5-8145</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f730-87fb-44bd-b68e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_2d0e-6c49-4493-a022</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2e2-50c1-40c3-b4dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b680-8015-4cac-805f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_5ad5-8701-42cd-b2b6</comment></categoryLink>
+        <categoryLink id="35cc-95b9-4bdd-9022" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_20a4-4346-4a3b-a7d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink><entryLink id="eecd-f588-f45c-761a" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_773a-1ea4-41a0-b766</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_9d4d-6fb8-4131-a5a3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e3bc-02f8-4ece-a5ea</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c371-76d9-4a4d-bc00</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b4c6-d4ba-4b2e-9b99</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5e60-7373-4159-9cfc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6ea9-a7e5-437d-9e35</comment></categoryLink>
+        <categoryLink id="8f4e-b703-466e-9fad" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_3cec-f053-42ab-a6eb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink><entryLink id="e187-a2cc-f4ec-7471" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1e60-42ba-4c8b-9077</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9860-f593-425e-b89b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_c842-10e8-4509-8eda</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ea52-ff41-40f6-8cf3</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_51e6-c5e1-4003-96bc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="074e-d71d-4a7c-b4d4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4d7c-201f-4c99-b89a</comment></categoryLink>
+        <categoryLink id="d666-4fdf-42f5-afee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_10f9-4718-4e07-bb32</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink><entryLink id="0986-d5e7-7615-80e9" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9688-a99d-4b20-b1f4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4e52-ad1b-48d4-8eed</comment></categoryLink>
+        <categoryLink id="2425-7f12-48be-a486" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_6979-1ed3-4f1f-a025</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink><entryLink id="18b6-d821-8185-8e10" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry"><categoryLinks>
+        <categoryLink id="7af2-d755-408f-a22f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6140-2404-46f9-bd42</comment></categoryLink>
+        <categoryLink id="a1ab-4074-4240-b781" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_1c86-fad8-46ec-a0b0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink><entryLink id="e02e-8507-15b9-5d32" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4729-bc86-456b-b73d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_cf0f-e3f4-4fb4-989d</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1cc8-5611-4d9a-9218</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_2e32-ca02-48f0-a8dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="200f-8403-4cad-878f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_0af1-d052-4bd7-aab6</comment></categoryLink>
+        <categoryLink id="942b-92dd-49fd-9487" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_45ce-e338-43c9-b63e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink><entryLink id="1307-82da-d8cd-2cb3" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4dce-8632-4f7c-813e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_8a71-3995-4155-ac33</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d206-f2ce-41b8-945a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan">
+                  <comment>    node_id_2e02-cf1c-4a71-861c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ec81-bd33-45a8-8550</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_3344-743c-45d3-b930</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="cbff-b3a0-46b8-7839" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="f6e6-9660-af5c-a632" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0e11-7ea3-4b57-b646" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4272-9b9d-4c59-95f0</comment></categoryLink>
+        <categoryLink id="86ca-2f69-431d-afaa" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_d85b-1ae7-40d5-9341</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
-    <entryLink id="8725-2b20-0868-5cb0" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="db29-f70f-faa2-f64b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="5199-d4bd-e16e-210c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink><entryLink id="5bd3-92a5-4802-df7e" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry"><categoryLinks>
+        <categoryLink id="b657-fecd-42af-8021" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ff9f-01cb-41b9-800e</comment></categoryLink>
+        <categoryLink id="b525-b105-4ad7-a79d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_1315-6051-4a46-b070</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
-    <entryLink id="fe07-50f6-8493-8dfc" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink><entryLink id="109b-f4c1-4f21-88d9" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry"><categoryLinks>
+        <categoryLink id="29ed-35b6-4122-9b0b" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_b084-df23-4f99-812f</comment></categoryLink>
+        <categoryLink id="ff42-a777-48f1-84d4" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_84fc-9304-4e9e-ab78</comment></categoryLink>
+        <categoryLink id="72a8-9796-45a1-91c5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d06a-7939-4691-9aed</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="93b8-e455-4433-a660" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup"><comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+        <entryLink id="720a-7196-49fe-b25f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup"><comment>    template_id_741d-8c09-4211-ada6    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink><entryLink id="b59e-577b-2044-d67c" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_54a4-6ec8-4c61-9c3e</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_f7fd-2d16-4603-a065</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8765-0907-c417-662b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="b11b-3f26-eea2-f176" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5358-c1e0-4add-8774" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_c0ac-4b8c-421c-a21b</comment></categoryLink>
+        <categoryLink id="c661-874d-4e6b-86f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8db9-079e-4482-b200</comment></categoryLink>
+        <categoryLink id="68af-41be-400f-8dd8" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_413c-9273-4308-b546</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
-    <entryLink id="5dcb-7fcd-f9af-00e3" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1362-8c41-e977-2159" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="5568-5b0c-9d74-31d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      <entryLinks>
+        <entryLink id="ce28-9e43-42ec-be04" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup"><comment>    template_id_bbc4-33fc-4664-a18e    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="2d61-6c87-4b44-a982" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup"><comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink><entryLink id="6321-544f-fda8-e2ce" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry"><categoryLinks>
+        <categoryLink id="255f-2989-4a8f-950c" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_4c8d-96f6-48f9-9590</comment></categoryLink>
+        <categoryLink id="3237-b0d7-49a9-ae9f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_049c-0fa5-4575-8fa8</comment></categoryLink>
+        <categoryLink id="e602-1f35-4867-bb1e" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_7358-52d7-4aae-8e07</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
-    <entryLink id="38fa-ae4f-b028-8090" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+      <entryLinks>
+        <entryLink id="93ec-b863-42c4-9407" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="834b-fcb6-78e5-2099" type="selectionEntryGroup"><comment>    template_id_4784-b370-444b-93ae    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="a56f-03cf-43f1-8c94" name="Retinue" hidden="false" collective="false" import="true" targetId="f874-317d-d582-11d5" type="selectionEntryGroup"><comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink><entryLink id="b6bf-9ff7-5fad-3989" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_3c03-a823-4466-9bd6</comment>
           <conditionGroups>
-            <conditionGroup type="and">
+            <conditionGroup type="or">
+              <comment>    node_id_8bbb-f95b-413f-b6f4</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_41b0-6b0a-482a-919e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e1f7-3cc6-4794-8b6d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="505e-5f88-0ce8-9cdf" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="ebff-02a3-2e0c-20a8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a63f-bd36-4d0a-b06d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_05ce-cc31-40ad-9320</comment></categoryLink>
+        <categoryLink id="bce9-7a5e-471b-9e35" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f13c-f8e1-4a50-bfe3</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
-    <entryLink id="6e42-d226-f62a-0a18" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7fc5-c47a-5786-e43f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="530b-8d6b-e028-1e0e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
-    <entryLink id="1f36-1727-5fb8-0be0" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7b26-07ba-c3c5-0280" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b52d-3c69-263a-c215" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
-        <categoryLink id="c9ba-b826-f2e2-04b9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
-    <entryLink id="31a0-5872-b0ee-0301" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3dc2-a68e-a2f7-5a92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="82b9-cc5e-a69a-822d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
-    <entryLink id="05ef-476f-9980-623f" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink><entryLink id="6dff-25c9-c9e4-ac15" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_db78-4d49-42ab-954a</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_f14d-9943-47b6-866c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a95-938f-4a07-9727</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_7775-78e1-44cc-87c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="767e-63be-41b3-a4a8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_b822-3417-4613-be37</comment></categoryLink>
+        <categoryLink id="40ac-cdc3-40fe-8fca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_25db-b03f-4881-b310</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink><entryLink id="2e08-0b4c-4f01-e386" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry"><categoryLinks>
+        <categoryLink id="02eb-7629-4214-8374" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_75a7-dc06-445b-b2dc</comment></categoryLink>
+        <categoryLink id="d20d-097a-4c04-8730" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_e21a-c03b-4885-ac46</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink><entryLink id="c808-9d93-886d-7bb6" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9a08-5fe6-4010-bbc3</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_72cf-cfce-4e02-b379</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="dfd7-3c46-5203-a621" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="7ded-5004-44b0-952d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_f55b-7555-444b-beee</comment></categoryLink>
+        <categoryLink id="b806-f9bc-4283-b3bf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3386-c9ad-4d74-9474</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
-    <entryLink id="5d29-0596-7ae3-0826" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="502f-37ab-06b1-d362" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1250-5c32-da20-447c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
-    <entryLink id="f3d6-432a-0cfc-4f6e" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink><entryLink id="8ce8-1073-262c-ccbe" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_a0f6-9606-4b75-a2f8</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_94b3-1331-474b-885b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
-      <infoLinks>
-        <infoLink id="2e72-a332-555b-872d" name="Legiones Astartes (White Scars) " hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule" />
-      </infoLinks>
       <categoryLinks>
-        <categoryLink id="b681-23f1-6a3b-97bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="dcda-725c-cd42-c3e3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="d71c-4ffe-4f01-9386" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_79fa-3370-4ae0-9e12</comment></categoryLink>
+        <categoryLink id="c671-400a-4f8d-bd3d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bb53-4e65-4fb6-9dd7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
-  </entryLinks>
-  <sharedSelectionEntries>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink><entryLink id="fa21-28be-7fe5-1153" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f8cc-833a-4ac1-bf89</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+              <comment>    node_id_5988-c012-4dad-9a66</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e5a4-b2c2-4a8c-aeb4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_8d82-3279-4481-84bb</comment></categoryLink>
+        <categoryLink id="a241-ad5e-4b59-92a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e25c-925e-4b96-8bb3</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink><entryLink id="c5ef-26c5-ffca-1760" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6b73-b21c-4e2b-9d14</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_a7fe-cc62-4a6f-a781</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5be1-1937-4964-a455</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_da1d-b2bc-4117-82a4</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4a67-5f67-4c86-8843" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7010-be56-4709-b058</comment></categoryLink>
+        <categoryLink id="91b2-abd0-4c7d-b6cd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7379-a740-47ba-a054</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink><entryLink id="91c2-a324-1dfc-3dcd" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_dd34-83cf-47d7-b557</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_be88-afef-49b3-bd1e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8359-d710-4df8-b10e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_944f-7420-4982-8ea9</comment></categoryLink>
+        <categoryLink id="f65c-c7c1-4559-b9b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ea80-0efe-457d-a450</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink><entryLink id="5168-a1d3-1fa9-8c4d" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><categoryLinks>
+        <categoryLink id="173b-f118-43e7-8385" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9a36-f261-43cc-9bd1</comment></categoryLink>
+        <categoryLink id="38e5-9a64-42d8-a4cc" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a648-8396-442a-af59</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink><entryLink id="dc0e-3160-fd9e-5f98" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_cb81-0303-4b88-ae53</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9648-31e3-43aa-8cf3</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_0507-da81-4023-bfcf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0e84-54ff-488d-b066</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e791-345a-4868-859a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6ff-0977-4c92-bb28</comment></categoryLink>
+        <categoryLink id="4caf-b886-4185-b350" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f555-7d39-458f-84c9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink><entryLink id="b40a-43c4-3700-dca0" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8203-5b00-497b-b939</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_40ee-3e71-4978-b1e4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f6a8-f660-46dc-b3c5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_d988-3af6-48bf-b0a8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8039-0e71-4a2a-9646" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_39e5-eda5-45d1-a643</comment></categoryLink>
+        <categoryLink id="38f6-48fc-47c1-9c62" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_6416-21bb-4df4-9de8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink><entryLink id="b471-d4eb-cb5a-3285" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b03e-5d91-4be3-8adc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_0443-29c0-46e9-ad1d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f2c9-7356-4c27-a22f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0e9-4a9e-4b2b-a9d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8476-2e3c-4e1d-9492" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5528-2dac-4be5-900c</comment></categoryLink>
+        <categoryLink id="2db8-abbe-45b5-8371" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_dc8f-d888-4585-991d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink><entryLink id="e81f-b70d-ed28-7417" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1d3c-8e17-489f-9002</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5725-8bee-4bcc-878d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_be47-0d6f-49f2-9f4b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_863c-f3a4-4802-b80c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c809-b47f-4cb8-98b6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_899e-b052-4d5b-8c18</comment></categoryLink>
+        <categoryLink id="f928-d7b0-4131-b162" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f5e9-cff6-41d2-a016</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink><entryLink id="58e4-9279-b4fe-9181" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_72da-1513-4e02-b595</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7a48-a3b0-4a26-849b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e232-25f3-4cb7-8ab2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_9aa4-5660-4697-8ab2</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4c04-3837-4f2c-bcc1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_09cd-2176-40af-bba6</comment></categoryLink>
+        <categoryLink id="08c3-599c-473d-884f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_05e6-7c63-4a35-9ba0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink><entryLink id="6676-20b9-1be9-a262" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry"><categoryLinks>
+        <categoryLink id="5afc-e0d1-4c85-944c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0dfa-4004-4751-8022</comment></categoryLink>
+        <categoryLink id="6e00-c284-49a2-84e2" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a669-0f5d-4fd3-811b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink><entryLink id="a313-a7d9-3bbb-ad89" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_09b5-4e3b-4c84-a574</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_32e5-ebba-41fb-9ff2</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_838e-0ccf-4d3a-aabd</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_dfef-0ec2-49fb-a534</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dd0c-a1f6-4597-b2f5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4f60-472b-45a9-ab9e</comment></categoryLink>
+        <categoryLink id="0605-2bf5-4d69-8da7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e2e3-af36-45a6-a955</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink><entryLink id="1015-2244-ccff-9561" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_936f-1ef7-472e-840e</comment>
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+              <comment>    node_id_d73d-d52e-4c75-8ac0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c51b-3451-4d27-a21c" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_7a55-ecb4-4e5d-b955</comment></categoryLink>
+        <categoryLink id="f749-36c2-4b3a-ab32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f28c-710e-4ff8-9810</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink><entryLink id="1cd4-f6bd-b976-14a6" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_a743-0cc2-45ae-a7eb</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2721-e88d-41f7-bedc</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_e10f-1390-4b33-8fcc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c06b-621c-4c91-9cf1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2008-f1c4-4285-a14f</comment></categoryLink>
+        <categoryLink id="6077-5676-48cd-921e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e88b-a95a-4647-af3b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink><entryLink id="93bb-da90-5011-43e7" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_25d8-330b-4574-b515</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7836-6878-47a8-8827</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_5ea9-46dd-4a11-9410</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_ab5d-961b-4924-a705</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="bf2f-cd7d-4280-9707" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9189-836c-475d-a52e</comment></categoryLink>
+        <categoryLink id="383d-0950-46ee-bf66" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_e1fa-b7d8-47b0-a88a</comment></categoryLink>
+        <categoryLink id="6e3f-fc98-450b-a2bb" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_a137-e3c0-4d63-a48c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink><entryLink id="3d2c-befa-6b15-3452" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry"><categoryLinks>
+        <categoryLink id="eeb0-11b6-4a53-8e78" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b1d5-fd75-4f17-bbf4</comment></categoryLink>
+        <categoryLink id="2972-221e-444f-b992" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_f221-bf81-4045-849b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink><entryLink id="bf10-ec9b-e8b6-7b5c" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_b743-7a00-43e4-beb8</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d12f-2c98-4e62-a716</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d4d7-ba67-47aa-962f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+                  <comment>    node_id_1637-edee-457a-bb0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7868-650e-41a5-a0ad" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_f203-bc26-421f-b79e</comment></categoryLink>
+        <categoryLink id="b284-c2d4-4cb9-bd88" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_a53e-59d9-4ac2-a21f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink><entryLink id="9df2-67f2-a62f-d871" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry"><categoryLinks>
+        <categoryLink id="8e95-1e63-463e-b6d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_51af-a137-4a1c-97a4</comment></categoryLink>
+        <categoryLink id="dfbc-c2d3-4f58-acc9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ec1f-c326-40a8-9d1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink><entryLink id="662c-33b6-ab9f-b6ee" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_c111-feb0-4012-98cd</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_63d7-8427-431d-9ae6</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9044-054e-4fde-a606" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_e707-fde1-457f-91c4</comment></categoryLink>
+        <categoryLink id="7a1b-0578-47e5-b1cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ec67-8573-4460-89db</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink><entryLink id="fedf-3842-0d53-044b" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3348-16e4-4a9a-a549</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_bea4-c4a8-4843-b9fe</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2970-17ff-4be1-91e5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_503a-46e7-40e7-bd07</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_4555-15e1-43ff-80a0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="028a-c3a0-47ee-ae1b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_fce3-801c-49c8-85d4</comment></categoryLink>
+        <categoryLink id="92e8-c290-45c9-8017" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0c2d-2349-44b6-9831</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink><entryLink id="8725-2b20-0868-5cb0" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry"><categoryLinks>
+        <categoryLink id="39e8-ba67-4021-967b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ac1c-b3bf-4011-918a</comment></categoryLink>
+        <categoryLink id="2100-9b51-4678-8930" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_589c-1d0e-4b7d-be6b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink><entryLink id="fe07-50f6-8493-8dfc" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2f46-a0b6-48a5-a0ee</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_636f-0f8a-43f1-910b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c883-39c8-4a74-aeaa</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_0796-e467-4438-89b3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2291-dee1-4a75-a7d1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_5a04-9847-4c91-a49a</comment></categoryLink>
+        <categoryLink id="c7da-2d47-4bbf-82b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b4b4-daeb-483c-a306</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink><entryLink id="5dcb-7fcd-f9af-00e3" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6087-a5e5-4d3c-9ebd</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c7e1-5f42-4528-bf07</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1950-08dc-4544-ab01</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_daf3-31ed-42c0-85dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ed7a-10f2-488d-ab7d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_7d4f-547c-43ed-a520</comment></categoryLink>
+        <categoryLink id="7215-0c6d-472c-a188" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f04e-04e8-4891-9b1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink><entryLink id="38fa-ae4f-b028-8090" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_dfdc-f6f6-49d2-a7b3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_354c-c71f-472f-b268</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1127-c974-4663-874d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_0843-bef2-4767-8307</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2ae4-a33d-498b-8eed" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_28e0-91e7-4ada-9fac</comment></categoryLink>
+        <categoryLink id="2347-6411-4685-9262" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4448-a712-4dd7-bf6d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink><entryLink id="6e42-d226-f62a-0a18" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d512-fd07-4a29-863a</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_55c6-a35f-485a-9f0d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d89e-cf1f-4ceb-b3de</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e2c9-0d01-403c-900e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_a7b8-c835-4cb2-b3d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="bf14-c810-4aba-bb9e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_e22a-c5f8-4825-a45f</comment></categoryLink>
+        <categoryLink id="9062-89b8-4086-a7dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03fc-6a7f-45a5-bcb8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink><entryLink id="1f36-1727-5fb8-0be0" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry"><categoryLinks>
+        <categoryLink id="e505-c162-4418-bfcf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0aff-4f6e-4b03-a23c</comment></categoryLink>
+        <categoryLink id="24b1-a152-471d-805b" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"><comment>    template_id_7d5a-62e7-43ee-b79b</comment></categoryLink>
+        <categoryLink id="8dbb-cbed-40a9-a358" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_4986-9157-49f2-b670</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink><entryLink id="31a0-5872-b0ee-0301" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_319e-90d4-44a3-8e83</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_28db-d943-4099-9abd</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1a45-a592-49df-9465</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb31-d0b2-4677-928e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b99f-0a7a-4ace-8425" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1b86-0977-4a8b-adac</comment></categoryLink>
+        <categoryLink id="c305-31cb-4f65-a994" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_b449-403a-4e42-9239</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink><entryLink id="05ef-476f-9980-623f" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafa-470f-4c2c-8be3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_e2ba-a855-4de2-9f46</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_0171-b30d-44ee-9389</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fdfb-119b-4774-934a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_3891-9a00-4f8f-b95f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0025-4248-4676-951f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e5df-17d4-4521-9d5b</comment></categoryLink>
+        <categoryLink id="8035-4cfe-4b8c-aeb5" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"><comment>    template_id_0ecd-4873-4d3a-b28b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink><entryLink id="5d29-0596-7ae3-0826" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_fbfa-8d78-4d6d-8a05</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_21f2-0916-46bf-b75a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_4fbd-633b-4dd6-9fdd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f4c8-3a6d-4135-bb5a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4f71-446f-4cff-afda</comment></categoryLink>
+        <categoryLink id="929b-bce1-4868-a7d0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_3f44-8647-43a4-ac22</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink><entryLink id="f3d6-432a-0cfc-4f6e" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af15-2c71-4f8b-833e</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_d95a-80b9-4463-af55</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1816-4afe-469d-b749" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6b1-886e-4194-8bcd</comment></categoryLink>
+        <categoryLink id="1021-1e8f-4d6c-b7e0" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_51b5-f9c1-4587-8fc7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink><entryLink id="508a-1c5b-4fed-8e99" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
+    <entryLink id="0db5-bf0f-4ab7-9c62" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
+    <entryLink id="d7c3-cdab-42b1-881b" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
+    <entryLink id="2164-1e3a-45bd-95b6" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <entryLink id="71d7-220b-4299-8719" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3531-57d1-4081-882d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_f233-2361-4177-8ba7</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b932-667a-4b43-8331</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <entryLink id="a1a7-a686-4727-9886" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <entryLink id="1c70-979e-4078-b74a" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3129-6f59-4365-906b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2bcb-0af1-4aea-9191" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <entryLink id="a4e4-4626-46b4-b24b" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ede2-d453-4e34-8cda</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2907-3215-4b01-96ff</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_c90c-959f-40fb-a4cb</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ba2d-50ad-45f1-91c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0e88-485e-43c2-8bef" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <entryLink id="3ac8-593a-4fd3-8145" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_409c-0a5d-4ef8-a871</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7078-c1c7-4af2-b43d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_9a69-0fdc-4957-8982</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1a4c-69b5-4219-8502" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fba0-3ea7-4eaf-b33a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <entryLink id="556a-81f9-45bb-b209" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
+    <entryLink id="91d5-33bf-4b2c-8acc" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
+    <entryLink id="c28c-0218-4755-8be1" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
+    <entryLink id="ad7e-1f84-4b3c-a800" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+  </entryLinks><sharedSelectionEntries>
     <selectionEntry id="1d55-faa7-caa5-a132" name="Golden Keshig Squadron" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="e887-5cf7-ee58-54d8" name="Legiones Astartes (White Scars) " hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule" />

--- a/2022 - LA - White Scars.cat
+++ b/2022 - LA - White Scars.cat
@@ -2959,7 +2959,7 @@ May join units that include models with the Cavalry Unit Type despite the usual 
       <entryLinks>
         <entryLink id="999f-066e-f20c-7d72" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_7dee-602c-4b47-be09</comment></selectionEntryGroup>
     <selectionEntryGroup id="f874-317d-d582-11d5" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="6552-af51-1e7a-1399" type="max" />
@@ -2986,7 +2986,7 @@ May join units that include models with the Cavalry Unit Type despite the usual 
           </modifiers>
         </entryLink>
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_be38-a066-4f8e-ae54</comment></selectionEntryGroup>
     <selectionEntryGroup id="e68f-0cee-6017-866a" name="Terminator Melee Weapon" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="12ef-2b1a-0954-657e" value="0.0">

--- a/2022 - LA - Word Bearers.cat
+++ b/2022 - LA - Word Bearers.cat
@@ -1,6 +1,5 @@
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="1df7-bbbc-b70e-6a3f" name="LA -  XVII: Word Bearers" revision="11" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26">
-  <entryLinks>
-    <entryLink id="70a7-c1ee-bf88-94ab" name="  XVII: Word Bearers" hidden="false" collective="false" import="false" targetId="9dbf-0760-d7ae-f125" type="selectionEntry">
+  <entryLinks><entryLink id="70a7-c1ee-bf88-94ab" name="  XVII: Word Bearers" hidden="false" collective="false" import="false" targetId="9dbf-0760-d7ae-f125" type="selectionEntry">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97e6-a0b1-0c5a-4dbe" type="min" />
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ab9-5824-231d-74b3" type="max" />
@@ -126,930 +125,1681 @@
         <categoryLink id="6d34-d904-7880-c2c1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="59e4-6029-ff9d-6b1d" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="bd8e-137b-ede8-e381" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4003-8f11-9424-331a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <entryLink id="59e4-6029-ff9d-6b1d" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="38ba-ae8c-4ff6-a453" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6d4-581f-4746-bec3</comment></categoryLink>
+        <categoryLink id="0f2d-ffbe-4e19-9870" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_2489-ee2a-45dd-b384</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
-    <entryLink id="c0fc-238b-19bd-2b19" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="40b1-4e44-8c7f-1c2c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d25e-9193-33fe-064e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
-    <entryLink id="9b66-5b73-5cf5-c120" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink><entryLink id="c0fc-238b-19bd-2b19" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b02f-e65f-4a88-a175</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_b87b-bf35-4238-b7c6</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1aff-27af-435e-8102</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_fdf9-4906-4180-a39d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3881-8858-afbc-3835" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="2ccb-d039-d379-2946" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="d892-a8ac-9e8f-5269" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="fd68-ce28-48d6-a5fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8378-ede4-476d-b657</comment></categoryLink>
+        <categoryLink id="e31c-9380-478e-9404" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_d64f-ad19-426c-adf7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
-    <entryLink id="4a7a-7807-4b01-35d6" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="fe44-255e-1c63-6474" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="fc99-5ffe-0b98-118e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
-    <entryLink id="87af-5910-74ac-ce46" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="f5a6-5b65-0b2e-121f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="e3c1-ba4b-1b2c-c991" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
-    <entryLink id="69a5-9e26-74af-d7c1" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink><entryLink id="9b66-5b73-5cf5-c120" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_7fd1-8ce8-4d10-82e7</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_eaae-8c43-4d30-898c</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_f67d-8cf3-424f-b491</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_b949-6414-4f3d-b268</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1699-edcf-65bb-138b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="eaa2-4659-9648-0fce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2f1c-493d-03a3-141e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="7650-2278-40fc-b535" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_ac26-e639-4d53-9b8b</comment></categoryLink>
+        <categoryLink id="9eca-c601-4a5f-b83e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_49af-0d08-4c7e-8ce6</comment></categoryLink>
+        <categoryLink id="51d4-b7c8-41f7-8a72" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_b606-de16-4659-95cd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
-    <entryLink id="6258-c860-141f-4b94" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink><entryLink id="4a7a-7807-4b01-35d6" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="748d-c1ae-0853-8e04" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="a4db-4996-d2c5-eac8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
-    <entryLink id="01c5-27f2-1f7e-649f" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7583-6fa0-4089-a19e</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_0e5c-99ab-41d3-a42e</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c296-e8e8-4a7a-989a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_8868-5bcb-4604-ba8e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5064-bf87-42ba-b7db" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a009-a597-4b51-b228</comment></categoryLink>
+        <categoryLink id="dac3-c855-4e46-84b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_24f4-9145-4016-80d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink><entryLink id="87af-5910-74ac-ce46" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_e732-7499-47bf-9748</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_81a5-a959-46b7-baa4</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7ec3-447a-4644-b012</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_71e2-c430-4c99-a559</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_df7b-3fb9-4f65-9165</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9eb5-0502-452d-ba5d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c165-3906-463a-9c73</comment></categoryLink>
+        <categoryLink id="15c9-02a4-4b33-a7fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6d1-d14c-473f-be09</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink><entryLink id="69a5-9e26-74af-d7c1" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_27a3-1e4c-4b76-a594</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_d59a-dcd0-44fd-b866</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_0c8b-2b92-49ed-98c7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_bafe-f799-41d9-ac85</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_6369-288c-4fec-a640</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_fe53-8858-41dc-8ec4</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7c7e-6d1a-d083-b5db" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="4998-ef2b-ea3b-467d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ad19-c918-4dfd-afb5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_3a22-caae-4eea-9bc5</comment></categoryLink>
+        <categoryLink id="050d-98da-4697-9725" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f759-f33e-4698-9f8a</comment></categoryLink>
+        <categoryLink id="b347-3fb1-4cbd-917f" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_c624-3ae0-46c0-9b06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
-    <entryLink id="2477-7c9d-2648-d8f5" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e968-2174-d1ff-86a9" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="d4b0-5174-9214-f8ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c7dc-4c91-5562-f4ef" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="4630-9003-85e9-2bec" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup" />
-        <entryLink id="1cd1-a6f5-4243-4d12" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink><entryLink id="6258-c860-141f-4b94" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_13b3-ce1e-4f9d-8319</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d681-9d81-4abd-b11b</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a57-e48b-4534-bca5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_1859-5641-4674-9097</comment>
+                </condition>
               </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
-    <entryLink id="01b8-fd47-8703-476a" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
-      <modifiers>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7394-c259-4934-9bdd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_251a-df5b-4bfd-ad63</comment></categoryLink>
+        <categoryLink id="9cca-6bc0-466d-9a8f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4644-98ab-4e3f-b1fd</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink><entryLink id="01c5-27f2-1f7e-649f" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_591d-d028-4663-918d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_0482-c5f9-4c95-9597</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_75a7-971d-4978-a83f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_a7d5-2bfe-4621-ac0c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9f13-b460-4f27-b0cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_31fc-e265-45a7-bb5b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3da3-b2ae-2ae6-491d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="bbcb-f514-6155-1608" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="127e-c277-1c51-5ead" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="d9e7-3f7e-4815-875a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_67c2-df43-44fc-92d1</comment></categoryLink>
+        <categoryLink id="050a-53ee-424a-8951" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4136-bb4e-4dd4-99f9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink><entryLink id="2477-7c9d-2648-d8f5" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry"><categoryLinks>
+        <categoryLink id="9f57-3017-48e8-b16f" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_2599-24e3-44e5-9568</comment></categoryLink>
+        <categoryLink id="377d-3af5-4bee-8e68" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_285f-6e56-473b-b2fe</comment></categoryLink>
+        <categoryLink id="ce6e-c87e-4feb-85dc" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_685e-022f-4e2f-a568</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="9a06-b962-d2bd-f9f1" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup" />
-        <entryLink id="2847-bb8c-6005-21c7" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup">
+        <entryLink id="8f0b-7014-4582-a191" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup"><comment>    template_id_2a38-6544-4267-b584    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="f9b4-2a37-4bbc-a87e" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_8287-16ff-46ba-9838</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_81c1-fca9-44dc-ba4c</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_6e59-4592-47ef-b76d    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
-    <entryLink id="285a-6c65-0722-5a81" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6d03-391c-8b48-0f63" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="698f-a1ea-f08b-0918" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="6fc0-57fb-2646-f4bb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="dc26-a8e5-1760-7e16" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup" />
-        <entryLink id="0cf3-e436-8f14-2b50" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-      </entryLinks>
-    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
-    <entryLink id="67b4-19de-4c99-ec88" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="22c1-4709-7318-b94d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="d881-25df-ba20-dd93" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
-    <entryLink id="749b-143d-7a74-ec6f" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="90a4-a531-d654-d809" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="927c-bf82-0e5c-7bc2" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
-    <entryLink id="a41b-9b79-b4e5-7065" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink><entryLink id="01b8-fd47-8703-476a" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ad5d-3c79-4239-9116</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_60b1-049b-4a5f-85c2</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="92e4-6a0a-db65-0f70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="1a32-177c-2fcd-9a9e" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="7a70-622e-4a34-852d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bd6a-0cda-4e0f-80ae</comment></categoryLink>
+        <categoryLink id="b71e-0ff3-4c10-8f9a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_ae75-7cca-4701-9d56</comment></categoryLink>
+        <categoryLink id="4b1e-f529-4c64-8293" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_e517-62d4-48f7-8174</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
-    <entryLink id="7305-0ef6-b303-8748" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
+      <entryLinks>
+        <entryLink id="32fb-8c26-4955-981d" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup"><comment>    template_id_fafb-6414-474a-8a09    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="7691-f409-462e-8321" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_1e43-c980-4508-8ec2</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_4140-36a7-4203-b5e9</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_a6a6-9bc7-4d4e-86a7    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink><entryLink id="285a-6c65-0722-5a81" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry"><categoryLinks>
+        <categoryLink id="0b1c-2b5e-4ec3-b767" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fc9d-03d1-4bbd-a1c4</comment></categoryLink>
+        <categoryLink id="001a-4f5b-4e84-8bb2" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_f51c-73d7-4f29-be1c</comment></categoryLink>
+        <categoryLink id="2ffd-ea2b-4b13-afc7" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_257d-78c0-4bab-ba65</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="15e5-5b61-47c4-837a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup"><comment>    template_id_ac26-33db-40a7-bdba    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="a263-8db0-4a5c-9303" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_189b-db75-4db6-9fe9</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_cbdb-2500-4e13-876a</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        <comment>    template_id_dc8e-2801-46d6-84f8    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink><entryLink id="67b4-19de-4c99-ec88" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b43b-547f-472e-9076</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8ff9-0498-4540-8552</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fbfe-931a-489b-a589</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f4c3-5aa6-4caa-abf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_17f8-f055-4c9c-b757</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="0230-e674-df35-87be" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b2f2-22b7-4385-c004" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="cd71-eb72-4acc-94fb" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f1c8-27fd-4f98-8527</comment></categoryLink>
+        <categoryLink id="0a43-5492-46ca-8d97" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2b20-1a8b-4753-b657</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
-    <entryLink id="8606-bbed-7404-9d60" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink><entryLink id="749b-143d-7a74-ec6f" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry"><categoryLinks>
+        <categoryLink id="f260-84c4-4970-b80f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4207-8d8f-4b1a-836b</comment></categoryLink>
+        <categoryLink id="524a-36cb-4e32-8ace" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_2b34-077f-4279-86fb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink><entryLink id="a41b-9b79-b4e5-7065" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="711d-1592-c05c-995a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="30a0-c954-2208-2f2a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="a538-6661-45cf-aaa5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6577-e0fb-4fda-834e</comment></categoryLink>
+        <categoryLink id="b3d2-ffd7-408b-abe7" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_5d59-09bf-4566-b7e1</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
-    <entryLink id="c1c3-fd36-d3cc-eeb1" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink><entryLink id="7305-0ef6-b303-8748" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"><categoryLinks>
+        <categoryLink id="277c-aaa1-4b01-aee4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_aa93-057d-42f6-82d7</comment></categoryLink>
+        <categoryLink id="e196-0c0f-4866-b47b" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_403c-4e9c-4af5-84ec</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink><entryLink id="8606-bbed-7404-9d60" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_23fa-06dd-49f9-a7db</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5b26-059e-40b3-9d93</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f7bf-3a1c-4103-aed8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="fd94-3ba7-c0db-afe3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="f051-b8e1-4cd9-84b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="49cd-55f6-49cc-9d3b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dd44-e0a8-42a8-bdcc</comment></categoryLink>
+        <categoryLink id="c947-bd2d-407a-8c57" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_c5b0-f9ae-468d-924a</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
-    <entryLink id="5caf-765c-0591-fe37" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink><entryLink id="c1c3-fd36-d3cc-eeb1" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8396-e51c-4e2b-bada</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_13bb-9fb5-4580-92cf</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_bfb8-8125-4548-92f5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25e3-b8f5-4448-a7c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="96db-46a7-4a8b-a8fb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_f926-27fd-4a92-97a1</comment></categoryLink>
+        <categoryLink id="e68f-8beb-4686-be3c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_82e3-36e1-4e85-8fcb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink><entryLink id="5caf-765c-0591-fe37" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e119-c21f-7bda-82ce" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
         <categoryLink id="c79a-4d9e-71ab-83b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="e65e-d29d-2b81-643c" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
-      <modifiers>
+    <entryLink id="e65e-d29d-2b81-643c" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_658f-b1ad-4347-a998</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_12bc-3db2-4d28-abce</comment>
+            </condition>
           </conditions>
         </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0396-6f5a-3079-d2d6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="414e-2eef-8952-2f01" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
-    <entryLink id="548a-db08-c96f-8f76" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_9d83-7691-41d6-8dad</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_add7-ba48-46d4-8a02</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_1fb0-2421-40a4-9e49</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fc9e-9b32-f6e8-9d9b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="7a98-a76b-b593-89f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7cf0-9a11-d6e8-164d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="d26a-5804-4226-91fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7004-b00d-481f-b740</comment></categoryLink>
+        <categoryLink id="b067-71c5-4b2d-b253" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4f88-2fc3-491c-bfb7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
-    <entryLink id="a5ca-582a-ebf4-e72e" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1a5c-69c9-a1a5-a336" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="444d-3dbb-6095-9705" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
-    <entryLink id="7af8-af9d-da7f-aacc" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ce22-2ca7-3f07-1653" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="8012-7182-f884-09c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
-    <entryLink id="5d81-b075-d037-42e0" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3aab-a7f5-e68c-e9bd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="9de9-0c76-8a1c-c9a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
-    <entryLink id="d752-5db5-a92a-b8c9" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c33a-390b-16b4-0ff2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="e979-7f00-70f4-4c8e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
-    <entryLink id="a37a-0e15-f6bc-ca4e" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b25e-e15c-74c8-9700" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="16c5-e434-f27e-7ee3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
-    <entryLink id="8dba-4de2-0398-98fd" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3609-6015-c84c-8622" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="a5cb-f13d-79c7-d9d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
-    <entryLink id="8f59-c585-338b-e312" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="ee02-4bc0-fcfc-bf06" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="244a-04a3-473c-5dc4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
-    <entryLink id="de96-b9e1-880f-7dfa" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="5b92-5478-0424-e242" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="de29-f137-1c66-5fd0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
-    <entryLink id="5b85-ea84-e207-f538" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="aaf9-31fe-32c1-83de" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="d53e-696d-aea1-67ef" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
-    <entryLink id="03fe-74d7-7df7-db38" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3e6f-e72d-4f58-6798" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="540d-0a96-8d16-9b6f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
-    <entryLink id="9790-2c85-453c-36db" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e272-c79b-01c2-78a7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="9085-9917-1dcb-7709" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
-    <entryLink id="0c2d-50a3-6b6f-47ec" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3244-769b-0943-7782" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="6182-323c-8a71-0fff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
-    <entryLink id="d01a-8d0a-658c-7b30" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a39d-a744-77e2-5c2a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="e796-78be-2ae2-4532" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
-    <entryLink id="865d-5620-f1e1-d9b4" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c232-9ad5-cde1-870e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="caaa-d78d-d5b0-e614" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
-    <entryLink id="2047-7b61-589b-fbff" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="bdc9-8d41-a3a8-b8fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f0e7-1c34-32c9-1644" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
-    <entryLink id="6a9c-29bf-c319-42c4" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1e9e-0a41-4f57-2485" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="674d-1283-4504-1ea1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
-    <entryLink id="c54a-f2f6-3bc4-be9f" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="4e5e-cd04-9a92-a82d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="ca91-3ccd-d822-c4a1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
-    <entryLink id="e3bd-780b-dd71-5667" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="25d2-9349-74be-a2f9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="93f2-d28d-d466-b15e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
-    <entryLink id="282a-3460-008f-cb4c" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0335-aeed-6a45-bd6c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="c243-8742-ba25-a471" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
-    <entryLink id="9fac-8136-e9b6-ba52" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="28e2-1865-2aac-28fb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="3bcd-27f6-9955-c6a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
-    <entryLink id="7628-209a-0916-8ef6" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8a27-0690-39dc-185c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="096d-3ae8-b1b5-2f94" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
-    <entryLink id="31b6-8fca-30a5-026c" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6abe-4d98-04b8-be27" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="0bbb-5bec-cfc1-5ee8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
-    <entryLink id="5c71-a511-085a-98e9" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="a6c2-ed05-7ab6-c49f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="074a-67ee-b638-16d0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
-    <entryLink id="da76-e9b3-4058-0a1e" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6385-ad6d-55ab-9c55" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="45c7-ec87-ba10-ae92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
-    <entryLink id="cff8-0677-a8ef-76f2" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="bf77-9e11-ba8d-f6e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="774f-68c3-65ac-5750" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
-    <entryLink id="298a-064a-13f2-2b5c" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b68c-caf0-8215-6aa0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="6fa0-c15a-1c43-2fe7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
-    <entryLink id="c8e1-9692-62e0-b3ba" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="63ca-023d-72bf-52d3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="af40-5e2c-a2c4-f2b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
-    <entryLink id="6539-871b-6268-f8ed" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="85c4-cd55-077b-2187" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ea12-f34f-cc83-7e65" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
-    <entryLink id="4b4d-786b-2555-3d21" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="5540-7324-1309-3ab6" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="a65b-2e5b-3e2e-d6e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
-    <entryLink id="74a9-9c82-a335-5ead" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6154-812c-005a-28e4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="b149-78f9-9196-55ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
-    <entryLink id="f1db-a17d-57fb-4f13" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="fd11-c281-8020-3748" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="95c3-a625-adab-f5c7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
-    <entryLink id="3155-2264-5a56-7fc5" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7e9c-0266-d3a5-c97c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="58df-04ee-15fb-db00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e600-fe00-1403-3593" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="c612-19af-7bac-a751" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup" />
-        <entryLink id="1cac-1663-33a7-9024" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
-    <entryLink id="f0f2-7fd8-50e9-cafc" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="3916-619e-e0c1-9081" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="84de-dc99-56e3-5814" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="25ff-917e-3c92-4d59" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="70d5-43da-554d-5e8a" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup" />
-        <entryLink id="a6ff-af59-edf5-99a1" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
-    <entryLink id="27de-92fe-d49b-c679" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3a1d-ff47-11c5-2bbe" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="3972-e3b8-3f39-8194" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ec60-336b-52be-a89a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="9e91-f17b-bab8-01ff" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup" />
-        <entryLink id="d0ab-285d-6681-4893" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
-    <entryLink id="9069-cdcb-c212-0b5b" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="631f-ad8d-edbf-2341" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="a142-cd08-5668-c2cc" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
-    <entryLink id="0110-82c7-540b-43c1" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="74a6-aaf7-8361-c209" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="c96e-efc9-92a3-3091" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
-    <entryLink id="4b22-aee5-2689-e9c8" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f76e-0c27-c11b-0aee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9b56-a4f4-8f87-6d22" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
-    <entryLink id="b97d-6b5b-d94c-fa81" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="b047-875d-2bef-d5e7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="dcf4-bf45-e0e3-ca21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
-    <entryLink id="8d99-1055-fa44-86fe" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="5b36-7f37-ac16-b8e2" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="e7ba-1e2d-fd98-3788" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
-    <entryLink id="2568-2dca-66f5-abaa" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ee69-9eab-f564-bebe" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="4041-1722-8123-5d03" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
-    <entryLink id="600f-a9b6-af7f-cdc6" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3d8b-4843-8df5-81f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="dcd1-8ece-6459-e1f8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
-    <entryLink id="6560-0faa-293c-1c02" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="b863-dbe9-afd0-cf4b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="6d4b-8e54-f734-59aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
-    <entryLink id="99ee-cfab-e34d-bfed" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6fbd-bfcd-6464-77fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="119f-3c22-a007-6b33" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
-    <entryLink id="f286-e716-e069-1122" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ebb0-9a6e-e28b-9361" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2f4f-7d54-ecfb-24ff" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
-    <entryLink id="70f8-f2fb-eaef-8f09" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7d3d-96b2-8093-f228" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="af32-30e4-ea99-66e8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
-    <entryLink id="0cb9-6d10-1883-5ed4" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="765e-0628-9cfa-8b1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7ee9-6f43-c305-f029" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
-    <entryLink id="5d10-4ec4-fd7f-c4fe" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9c53-79ba-20b4-0c38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e3f1-775a-11cb-e0e0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
-    <entryLink id="1086-c952-53b5-306d" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="04a8-cab8-3e18-f9ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ae42-d705-f633-6ef3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
-    <entryLink id="239b-4e03-118a-6783" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="fb8d-d233-78c4-fa96" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f9a4-f9d8-0177-56c4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
-    <entryLink id="df73-2b98-e82c-c9ed" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ca2c-dbe5-4243-7fb5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="c3ab-62fd-d965-1d70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
-    <entryLink id="ccf0-7f32-d119-382b" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="6e13-7985-a73d-a28f" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="8b0a-4561-03b6-ba7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
-    <entryLink id="ad5c-55be-00df-6d99" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8dbb-a7d3-f20f-6e29" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="97a9-34e3-1d79-ae00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
-    <entryLink id="c1e5-b58d-63bb-b4dd" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink><entryLink id="548a-db08-c96f-8f76" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_8ed4-376d-4030-9439</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_8a11-c2a0-4335-99ef</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_fa8e-1af7-4d41-ac8c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_94bd-c771-4a85-8581</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b479-a6c4-cd52-41b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="02b3-909a-4794-a59d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="25d2-e77d-fbd7-90a2" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="b778-2304-4690-ab0e" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_361e-fb90-4b0e-ac3d</comment></categoryLink>
+        <categoryLink id="504b-c418-46a4-bb7f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d4ef-1074-45a9-959e</comment></categoryLink>
+        <categoryLink id="b2f2-0ba7-4b19-b40e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_febb-f536-4d25-a8ab</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
-    <entryLink id="0b2a-3725-027c-925f" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="254c-7a80-ad2b-4b4c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9ad1-390e-b878-4341" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink><entryLink id="a5ca-582a-ebf4-e72e" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="0688-6cf0-46a8-b09b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_473b-e812-4158-9416</comment></categoryLink>
+        <categoryLink id="d8a4-e825-444f-ba36" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_00a2-63ff-4698-a35b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
-    <entryLink id="7375-e856-ed41-2cd2" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink><entryLink id="7af8-af9d-da7f-aacc" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7cf3-8a72-4f82-8cdc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_228c-5681-4ce8-b726</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_01bb-8abd-4253-9a4d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2eb8-ab14-8b83-4687" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="33c6-6162-3a63-3ff0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52ca-05e7-4752-98ef" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2a08-4432-42ad-bfdb</comment></categoryLink>
+        <categoryLink id="2f02-b32f-452d-b14f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_422e-0808-4897-8630</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
-    <entryLink id="e8be-7cae-4e60-4acf" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink><entryLink id="5d81-b075-d037-42e0" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1af8-4459-4717-8e3b</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_06b4-92b9-438c-b1a5</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6c8d-8b28-417b-9a7c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_715d-8186-4aa6-b40c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_390e-358c-4f8e-ade8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="1da3-9979-de16-ff35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="aa2c-18ff-b755-52e9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="07ad-ac0c-485f-9b62" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f4c0-4396-4f39-a34f</comment></categoryLink>
+        <categoryLink id="8750-ffee-4b99-a721" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1301-8415-490e-8f06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
-    <entryLink id="3d77-9cdd-8666-9ee5" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink><entryLink id="d752-5db5-a92a-b8c9" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d0c9-9a26-4324-b030</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4e9e-a61d-42f2-bacb</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ed9e-b634-4bec-9eb0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4614-ad0f-4fba-adaf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_8d08-24f6-41be-8931</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="289d-8dcf-4ee6-98c8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_caf6-5548-4b89-8102</comment></categoryLink>
+        <categoryLink id="46cf-929c-4713-b219" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_63a3-be61-428d-ab29</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink><entryLink id="a37a-0e15-f6bc-ca4e" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f318-4b03-4767-8c7f</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b8ef-7245-4df8-a8c4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_6bce-ec44-48cb-873a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f1bf-4473-4126-8453" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0678-4fdd-48e6-8f61</comment></categoryLink>
+        <categoryLink id="8962-7547-402f-94ff" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0d82-10a9-4de2-8ad7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink><entryLink id="8dba-4de2-0398-98fd" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ada1-1e18-4cbc-9598</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b1d1-ac44-47dd-9159</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5d64-f00c-4464-891b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25f0-f825-4a83-8f0d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_64b1-9e36-44da-b36a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5d10-11fe-47c3-ab5b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_d53e-113f-4a40-a3d5</comment></categoryLink>
+        <categoryLink id="7246-027c-494e-aa45" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1939-76b5-4279-9f8c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink><entryLink id="8f59-c585-338b-e312" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d765-3bb2-4b48-bd12</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_0ca1-cfb4-4a56-ab3b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="49db-a82b-7fc3-5d4a" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="f963-0674-47dd-bfd5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6ffe-6631-4d41-9dc1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e6f7-a6ca-4825-bfc5</comment></categoryLink>
+        <categoryLink id="6238-2bd9-4b6b-85b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dbec-e027-4ec1-8514</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
-    <entryLink id="4ccd-314e-e135-ff8f" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink><entryLink id="de96-b9e1-880f-7dfa" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d8ee-81ed-45f9-8b79</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_8f4e-e8cb-4ac9-a415</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ac5e-5ffa-4c4d-b11b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_cefb-cfd7-4dc8-99c4</comment></categoryLink>
+        <categoryLink id="918b-bf23-48d9-9a39" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a9fd-9d16-4a5e-855c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink><entryLink id="5b85-ea84-e207-f538" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e76b-46ca-4ab8-a93d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8035-75b8-43bb-97c9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_71a4-31e7-4927-a0ab</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f05e-ea51-486e-bcd6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_a56d-347b-4b09-a918</comment></categoryLink>
+        <categoryLink id="4730-a78d-4d46-b9b1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_96e5-4531-4213-903e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink><entryLink id="03fe-74d7-7df7-db38" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1fb5-2375-4c22-b41e</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7d7c-255d-49b6-96b9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5321-254b-4890-9bf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ddf8-b8b7-4afb-b6dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2a95-7064-45ae-b5da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9441-d79b-4720-9667</comment></categoryLink>
+        <categoryLink id="f990-d1ce-4e8c-9867" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7d7e-32d3-4692-b401</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink><entryLink id="9790-2c85-453c-36db" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_99fc-5fe7-4b37-a62f</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_25f4-f6b8-4b44-8350</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_81f7-2311-4cce-95bc</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_09aa-af2a-4012-91d1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_00ae-fad3-4df6-9cb9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2837-042d-4788-be32" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f65b-8958-49b3-92a5</comment></categoryLink>
+        <categoryLink id="9b0e-9d66-44e3-b752" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0451-1929-4942-8c3f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink><entryLink id="0c2d-50a3-6b6f-47ec" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_edc4-4915-40ba-bbf0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_105f-ba26-4146-bc54</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7a2c-a76c-421c-a8a2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_05c9-0543-47ee-ba81</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e6ad-f0d7-4627-921b</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e846-96b3-4fc8-a5a0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c6a8-22a8-4d41-b969</comment></categoryLink>
+        <categoryLink id="ef7f-b4cd-429e-b2c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03ca-12cc-4e0a-b628</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink><entryLink id="d01a-8d0a-658c-7b30" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ae67-ef52-4cac-958c</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fc61-7306-4d99-acde</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1be0-67e7-45a1-bdbb</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_42a8-7fda-4e05-af0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4f09-2075-4897-99b8" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_565a-1592-491f-8b9b</comment></categoryLink>
+        <categoryLink id="863c-fd8a-4181-bb89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_81d5-c14a-42ab-bdde</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink><entryLink id="865d-5620-f1e1-d9b4" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1ae7-c41b-4818-be71</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_08a5-b1bb-4ba1-ba42</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d677-b5ad-4838-8746</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_537f-bc1f-4aaa-b0dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b884-ec31-4138-9ab0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bc67-ce1f-4004-aeb7</comment></categoryLink>
+        <categoryLink id="ff12-b477-4f8c-b0d1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_9a45-9699-4475-aeef</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink><entryLink id="2047-7b61-589b-fbff" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_c28f-4109-44c4-ab64</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fdc1-a894-48bc-9e7c</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_4936-a68c-4524-9088</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb37-ac0c-49ae-9d6f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c07f-4474-4024-a902" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3afe-cfc0-4da6-a985</comment></categoryLink>
+        <categoryLink id="137a-4976-47cf-9cd3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_04a8-6aae-45ae-bd4c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink><entryLink id="6a9c-29bf-c319-42c4" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ae19-30c0-43c5-920e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_6ebe-1bf3-4d78-9dd0</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1887-152d-48b7-b13f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_a7c4-ee6a-4f0b-8ab0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bd85-fa90-47ff-9f84</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_7bd6-9043-4d7e-ba37</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c807-93f8-4309-9c4c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3610-c975-4d55-bdfe</comment></categoryLink>
+        <categoryLink id="c2f9-e4d3-4801-9a3e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2fc2-f636-4c80-9608</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink><entryLink id="c54a-f2f6-3bc4-be9f" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_85c5-d4d9-4b23-9e4d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_80e8-d50b-4906-8153</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_b93b-d4f1-45eb-8a69</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e183-f183-4db7-83b5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0f39-204a-4217-b896</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_eee9-7bfd-4fea-a1bd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c8df-3ba7-48a2-9bff" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f81d-9435-4f11-99c1</comment></categoryLink>
+        <categoryLink id="ff01-c3be-42d0-8be0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9568-6142-4fdd-be3a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink><entryLink id="e3bd-780b-dd71-5667" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_005e-6607-4e2c-8dd2</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_7745-260c-4c36-b719</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_ba25-a4b2-4ba9-b023</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ddeb-f4c8-4091-9153</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4904-fd2f-429f-9cf7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_faea-b21b-43c5-b918</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f078-519b-4742-80b5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_b24f-3ae0-4cbb-b016</comment></categoryLink>
+        <categoryLink id="fdce-c0ab-4221-b24a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fd26-8e6b-4521-92b9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink><entryLink id="282a-3460-008f-cb4c" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6ecb-28e2-43ed-a6a0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_c067-1118-4d96-b28b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_250e-23c0-4e43-bf74</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1553-a6e6-4291-853f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_aab6-797b-427a-9fd8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2d23-1328-4c11-8dec" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c77f-0819-473b-a8a2</comment></categoryLink>
+        <categoryLink id="071d-6302-415d-b911" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_89fb-c924-4daf-923d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink><entryLink id="9fac-8136-e9b6-ba52" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d72c-519a-451f-81b6</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_3d16-444c-42c9-aad1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_f4b2-6371-494b-863a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_797f-a84b-42f6-8e66</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0d78-fe38-4829-9b12</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="19d6-911d-423e-bd2b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0397-c837-4fea-a527</comment></categoryLink>
+        <categoryLink id="80d1-ff4d-4247-a808" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_060b-bccb-4776-bd83</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink><entryLink id="7628-209a-0916-8ef6" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3c84-6d74-4c42-b38d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_5b15-7aa4-4897-aaf1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_3326-31ed-4151-9b37</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6a0e-1b65-4057-ba5d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f8c7-abc9-45ec-955f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_2538-8dc5-446c-8344</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5d0c-4de3-4299-b4cd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_c1cf-cea4-4278-8f27</comment></categoryLink>
+        <categoryLink id="0064-9c7b-49b5-957f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5f51-2734-4a46-9f72</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink><entryLink id="31b6-8fca-30a5-026c" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af71-f3ff-49b1-83e9</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_1c9e-b3bf-4e88-a43f</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_6d0d-1b1d-4065-89cf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d0b7-8686-491e-9d33</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_7db8-0874-487a-be6f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1034-29a0-44b1-a85f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="330f-dd39-4117-bb94" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_0c16-6841-42b2-b02d</comment></categoryLink>
+        <categoryLink id="c19f-a972-40d4-8815" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_602d-2d2d-4ff4-a82a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink><entryLink id="5c71-a511-085a-98e9" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_22bd-baae-45f9-b366</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_52bd-55de-4d53-ba55</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_df1b-7476-4ab8-8d2f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_49fa-0dcf-4a61-a5b1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0ea-1443-4993-86e7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2a8-3fbe-448c-9902</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="88d0-38d6-4847-b2f9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3632-0b5d-4622-ae33</comment></categoryLink>
+        <categoryLink id="a7b4-c37c-4206-9a18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_da44-7815-4fdd-981c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink><entryLink id="da76-e9b3-4058-0a1e" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2bfa-b203-47e2-a828</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a39b-8a3c-49cf-bf62</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2a05-07b3-49c5-8145</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f730-87fb-44bd-b68e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_2d0e-6c49-4493-a022</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2e2-50c1-40c3-b4dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8328-83e9-478a-ba0d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_5ad5-8701-42cd-b2b6</comment></categoryLink>
+        <categoryLink id="d31a-6363-417f-9688" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_20a4-4346-4a3b-a7d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink><entryLink id="cff8-0677-a8ef-76f2" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_773a-1ea4-41a0-b766</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_9d4d-6fb8-4131-a5a3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e3bc-02f8-4ece-a5ea</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c371-76d9-4a4d-bc00</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b4c6-d4ba-4b2e-9b99</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="59b3-7f66-4d8f-9235" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6ea9-a7e5-437d-9e35</comment></categoryLink>
+        <categoryLink id="cb99-0e23-4345-8ea0" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_3cec-f053-42ab-a6eb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink><entryLink id="298a-064a-13f2-2b5c" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1e60-42ba-4c8b-9077</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9860-f593-425e-b89b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_c842-10e8-4509-8eda</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ea52-ff41-40f6-8cf3</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_51e6-c5e1-4003-96bc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="410f-552e-4584-9f4b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4d7c-201f-4c99-b89a</comment></categoryLink>
+        <categoryLink id="bc98-41d5-4056-bfff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_10f9-4718-4e07-bb32</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink><entryLink id="c8e1-9692-62e0-b3ba" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3be3-feb5-4342-be75" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4e52-ad1b-48d4-8eed</comment></categoryLink>
+        <categoryLink id="5841-9a6d-4a53-b784" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_6979-1ed3-4f1f-a025</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink><entryLink id="6539-871b-6268-f8ed" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry"><categoryLinks>
+        <categoryLink id="63e0-ab97-456a-81ca" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6140-2404-46f9-bd42</comment></categoryLink>
+        <categoryLink id="c12c-1cab-4a7d-b144" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_1c86-fad8-46ec-a0b0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink><entryLink id="4b4d-786b-2555-3d21" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4729-bc86-456b-b73d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_cf0f-e3f4-4fb4-989d</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1cc8-5611-4d9a-9218</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_2e32-ca02-48f0-a8dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7f30-45d9-4739-bf3a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_0af1-d052-4bd7-aab6</comment></categoryLink>
+        <categoryLink id="5cb8-37da-4861-b341" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_45ce-e338-43c9-b63e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink><entryLink id="74a9-9c82-a335-5ead" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4dce-8632-4f7c-813e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_8a71-3995-4155-ac33</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d206-f2ce-41b8-945a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan">
+                  <comment>    node_id_2e02-cf1c-4a71-861c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ec81-bd33-45a8-8550</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_3344-743c-45d3-b930</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="058d-05f1-5f39-3edc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="1c81-c897-ae05-6c44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="503a-ab7b-42a8-8398" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4272-9b9d-4c59-95f0</comment></categoryLink>
+        <categoryLink id="e27a-48b5-4cb1-aedd" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_d85b-1ae7-40d5-9341</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
-    <entryLink id="c16a-a744-396d-f9e8" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="33f9-6907-1a15-62f6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="77a4-ff21-107b-cdfc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink><entryLink id="f1db-a17d-57fb-4f13" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry"><categoryLinks>
+        <categoryLink id="0162-4a58-4b61-9dd6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ff9f-01cb-41b9-800e</comment></categoryLink>
+        <categoryLink id="d928-baa2-4c63-be0b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_1315-6051-4a46-b070</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
-    <entryLink id="6435-2676-8f7e-2c0b" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink><entryLink id="3155-2264-5a56-7fc5" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry"><categoryLinks>
+        <categoryLink id="6fb1-e112-47cc-a237" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_b084-df23-4f99-812f</comment></categoryLink>
+        <categoryLink id="5c34-c101-45d2-854a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_84fc-9304-4e9e-ab78</comment></categoryLink>
+        <categoryLink id="19b4-84f0-4736-b0ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d06a-7939-4691-9aed</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="1244-ccee-461a-aff0" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup"><comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+        <entryLink id="5302-5682-445c-90a6" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup"><comment>    template_id_741d-8c09-4211-ada6    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink><entryLink id="f0f2-7fd8-50e9-cafc" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_54a4-6ec8-4c61-9c3e</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_f7fd-2d16-4603-a065</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c189-fb02-5b3a-9081" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="696c-ac91-71ca-2de9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="fef6-5301-4eb4-9785" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_c0ac-4b8c-421c-a21b</comment></categoryLink>
+        <categoryLink id="3e12-0658-4bac-bcde" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8db9-079e-4482-b200</comment></categoryLink>
+        <categoryLink id="36e1-8d48-43ad-b4c9" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_413c-9273-4308-b546</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
-    <entryLink id="e112-71dc-7994-2f71" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9938-0256-9406-57a1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="372d-5596-4075-e149" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      <entryLinks>
+        <entryLink id="b792-ed77-4c6d-b73a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup"><comment>    template_id_bbc4-33fc-4664-a18e    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="e5ac-82c5-4557-a2ec" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup"><comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink><entryLink id="27de-92fe-d49b-c679" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry"><categoryLinks>
+        <categoryLink id="fe70-113b-4701-b53f" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_4c8d-96f6-48f9-9590</comment></categoryLink>
+        <categoryLink id="ba24-f21c-4d7d-a610" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_049c-0fa5-4575-8fa8</comment></categoryLink>
+        <categoryLink id="6f0e-3a95-446d-9497" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_7358-52d7-4aae-8e07</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
-    <entryLink id="f178-f071-3715-9e89" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+      <entryLinks>
+        <entryLink id="2496-ca67-4f77-8dec" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup"><comment>    template_id_4784-b370-444b-93ae    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="1659-18bf-4a93-b3d3" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup"><comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink><entryLink id="9069-cdcb-c212-0b5b" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_3c03-a823-4466-9bd6</comment>
           <conditionGroups>
-            <conditionGroup type="and">
+            <conditionGroup type="or">
+              <comment>    node_id_8bbb-f95b-413f-b6f4</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_41b0-6b0a-482a-919e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e1f7-3cc6-4794-8b6d</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0c74-a575-4357-8ece" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="c356-2599-20e9-47b0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="20f8-aa32-4f7b-a240" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_05ce-cc31-40ad-9320</comment></categoryLink>
+        <categoryLink id="1a5c-8ecd-4c12-9ce5" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f13c-f8e1-4a50-bfe3</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
-    <entryLink id="f698-283f-9e0a-7a5b" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1708-8a76-2904-1441" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="b07f-2afe-ded2-2109" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
-    <entryLink id="a547-033b-bcab-34dd" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6b4e-91c8-4ae8-43a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="bb97-d8e3-94a0-8908" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
-        <categoryLink id="301e-6e66-90ce-3341" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
-    <entryLink id="612a-b741-c7ac-a4f6" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="44ef-cd08-40cc-d5de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4d5b-ee3c-de02-4e37" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
-    <entryLink id="9ddc-5d16-a7ab-4a97" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink><entryLink id="0110-82c7-540b-43c1" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_db78-4d49-42ab-954a</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_f14d-9943-47b6-866c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a95-938f-4a07-9727</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_7775-78e1-44cc-87c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4166-989f-4734-bb6f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_b822-3417-4613-be37</comment></categoryLink>
+        <categoryLink id="5d71-3082-44f3-990c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_25db-b03f-4881-b310</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink><entryLink id="4b22-aee5-2689-e9c8" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry"><categoryLinks>
+        <categoryLink id="72e0-9500-4f80-bd79" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_75a7-dc06-445b-b2dc</comment></categoryLink>
+        <categoryLink id="50bf-7a3f-4fda-8d6d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_e21a-c03b-4885-ac46</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink><entryLink id="b97d-6b5b-d94c-fa81" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9a08-5fe6-4010-bbc3</comment>
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_72cf-cfce-4e02-b379</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8f21-44df-bac1-25ef" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="66a7-be4c-7b7b-b5f8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3e5e-307e-43ed-8cae" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_f55b-7555-444b-beee</comment></categoryLink>
+        <categoryLink id="d421-e162-47e0-ada3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3386-c9ad-4d74-9474</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
-    <entryLink id="844d-9ee1-1e02-2fa8" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink><entryLink id="8d99-1055-fa44-86fe" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_a0f6-9606-4b75-a2f8</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_94b3-1331-474b-885b</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="6c3b-475f-21dc-70f9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="0f38-66ff-d5e4-e000" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="a4a7-81dd-421e-b835" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_79fa-3370-4ae0-9e12</comment></categoryLink>
+        <categoryLink id="e292-df9e-40f9-a0f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bb53-4e65-4fb6-9dd7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
-    <entryLink id="f98a-c47f-c564-7cfc" name="Procurators" hidden="false" collective="false" import="false" targetId="9cca-47d5-0779-79a2" type="selectionEntry">
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink><entryLink id="2568-2dca-66f5-abaa" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f8cc-833a-4ac1-bf89</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+              <comment>    node_id_5988-c012-4dad-9a66</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="34c0-7d3c-40e5-8d5a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_8d82-3279-4481-84bb</comment></categoryLink>
+        <categoryLink id="6573-a566-42a1-b032" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e25c-925e-4b96-8bb3</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink><entryLink id="600f-a9b6-af7f-cdc6" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6b73-b21c-4e2b-9d14</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_a7fe-cc62-4a6f-a781</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5be1-1937-4964-a455</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_da1d-b2bc-4117-82a4</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4b04-a31c-4bbd-ada1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7010-be56-4709-b058</comment></categoryLink>
+        <categoryLink id="db38-f8e5-4b5b-bd1a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7379-a740-47ba-a054</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink><entryLink id="6560-0faa-293c-1c02" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_dd34-83cf-47d7-b557</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_be88-afef-49b3-bd1e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7afc-60b6-4731-b1fb" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_944f-7420-4982-8ea9</comment></categoryLink>
+        <categoryLink id="be61-ba6e-40bb-98e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ea80-0efe-457d-a450</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink><entryLink id="99ee-cfab-e34d-bfed" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><categoryLinks>
+        <categoryLink id="ffda-0e95-4b2d-a56f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9a36-f261-43cc-9bd1</comment></categoryLink>
+        <categoryLink id="5128-6c7b-4476-a6fd" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a648-8396-442a-af59</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink><entryLink id="f286-e716-e069-1122" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_cb81-0303-4b88-ae53</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9648-31e3-43aa-8cf3</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_0507-da81-4023-bfcf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0e84-54ff-488d-b066</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e1e2-97c0-4721-9e46" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6ff-0977-4c92-bb28</comment></categoryLink>
+        <categoryLink id="d413-732c-4937-a778" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f555-7d39-458f-84c9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink><entryLink id="70f8-f2fb-eaef-8f09" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8203-5b00-497b-b939</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_40ee-3e71-4978-b1e4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f6a8-f660-46dc-b3c5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_d988-3af6-48bf-b0a8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d63a-af8f-498a-98ed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_39e5-eda5-45d1-a643</comment></categoryLink>
+        <categoryLink id="aed4-42fe-420d-bcf5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_6416-21bb-4df4-9de8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink><entryLink id="0cb9-6d10-1883-5ed4" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b03e-5d91-4be3-8adc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_0443-29c0-46e9-ad1d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f2c9-7356-4c27-a22f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0e9-4a9e-4b2b-a9d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c05c-6a69-46ca-8a9e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5528-2dac-4be5-900c</comment></categoryLink>
+        <categoryLink id="fd52-3c14-4a44-95bb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_dc8f-d888-4585-991d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink><entryLink id="5d10-4ec4-fd7f-c4fe" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1d3c-8e17-489f-9002</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5725-8bee-4bcc-878d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_be47-0d6f-49f2-9f4b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_863c-f3a4-4802-b80c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="87fe-4a46-4cfa-bc1b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_899e-b052-4d5b-8c18</comment></categoryLink>
+        <categoryLink id="7442-d9a4-4ceb-9163" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f5e9-cff6-41d2-a016</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink><entryLink id="1086-c952-53b5-306d" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_72da-1513-4e02-b595</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7a48-a3b0-4a26-849b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e232-25f3-4cb7-8ab2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_9aa4-5660-4697-8ab2</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1816-eec5-4443-941b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_09cd-2176-40af-bba6</comment></categoryLink>
+        <categoryLink id="4511-8e18-4895-a09d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_05e6-7c63-4a35-9ba0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink><entryLink id="239b-4e03-118a-6783" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry"><categoryLinks>
+        <categoryLink id="e3f5-97fd-4b10-b015" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0dfa-4004-4751-8022</comment></categoryLink>
+        <categoryLink id="ad8e-bbbc-4d15-be38" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a669-0f5d-4fd3-811b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink><entryLink id="df73-2b98-e82c-c9ed" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_09b5-4e3b-4c84-a574</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_32e5-ebba-41fb-9ff2</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_838e-0ccf-4d3a-aabd</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_dfef-0ec2-49fb-a534</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b7d8-0c7b-49d8-965a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4f60-472b-45a9-ab9e</comment></categoryLink>
+        <categoryLink id="bf93-d55d-4d6d-88c2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e2e3-af36-45a6-a955</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink><entryLink id="ccf0-7f32-d119-382b" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_936f-1ef7-472e-840e</comment>
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+              <comment>    node_id_d73d-d52e-4c75-8ac0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d635-bbfb-4d71-965f" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_7a55-ecb4-4e5d-b955</comment></categoryLink>
+        <categoryLink id="c1f7-05db-4412-9015" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f28c-710e-4ff8-9810</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink><entryLink id="ad5c-55be-00df-6d99" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_a743-0cc2-45ae-a7eb</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2721-e88d-41f7-bedc</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_e10f-1390-4b33-8fcc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9174-fe4c-495b-90ca" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2008-f1c4-4285-a14f</comment></categoryLink>
+        <categoryLink id="f627-d3d1-4330-bfff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e88b-a95a-4647-af3b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink><entryLink id="c1e5-b58d-63bb-b4dd" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_25d8-330b-4574-b515</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7836-6878-47a8-8827</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_5ea9-46dd-4a11-9410</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_ab5d-961b-4924-a705</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="338c-0b4b-4a7b-878e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9189-836c-475d-a52e</comment></categoryLink>
+        <categoryLink id="1dd4-bfa2-4077-aaa5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_e1fa-b7d8-47b0-a88a</comment></categoryLink>
+        <categoryLink id="0c29-0d6d-4149-8bb4" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_a137-e3c0-4d63-a48c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink><entryLink id="0b2a-3725-027c-925f" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry"><categoryLinks>
+        <categoryLink id="3560-f623-4d28-b903" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b1d5-fd75-4f17-bbf4</comment></categoryLink>
+        <categoryLink id="47a6-90d0-4221-86a4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_f221-bf81-4045-849b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink><entryLink id="7375-e856-ed41-2cd2" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_b743-7a00-43e4-beb8</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d12f-2c98-4e62-a716</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d4d7-ba67-47aa-962f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+                  <comment>    node_id_1637-edee-457a-bb0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fa50-1c66-43d6-8c26" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_f203-bc26-421f-b79e</comment></categoryLink>
+        <categoryLink id="ef2f-d8a9-46a9-8a52" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_a53e-59d9-4ac2-a21f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink><entryLink id="e8be-7cae-4e60-4acf" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry"><categoryLinks>
+        <categoryLink id="5fbe-8d39-4341-a196" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_51af-a137-4a1c-97a4</comment></categoryLink>
+        <categoryLink id="6fc0-b363-429a-9f3f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ec1f-c326-40a8-9d1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink><entryLink id="3d77-9cdd-8666-9ee5" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_c111-feb0-4012-98cd</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_63d7-8427-431d-9ae6</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b936-d6c1-46f3-ba39" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_e707-fde1-457f-91c4</comment></categoryLink>
+        <categoryLink id="a858-f3cc-49a2-8fec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ec67-8573-4460-89db</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink><entryLink id="4ccd-314e-e135-ff8f" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3348-16e4-4a9a-a549</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_bea4-c4a8-4843-b9fe</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2970-17ff-4be1-91e5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_503a-46e7-40e7-bd07</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_4555-15e1-43ff-80a0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e805-41f9-4c03-a3d9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_fce3-801c-49c8-85d4</comment></categoryLink>
+        <categoryLink id="529e-17eb-4dc3-abe4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0c2d-2349-44b6-9831</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink><entryLink id="c16a-a744-396d-f9e8" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry"><categoryLinks>
+        <categoryLink id="5efd-e6bb-4584-a4a0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ac1c-b3bf-4011-918a</comment></categoryLink>
+        <categoryLink id="1de9-3e8f-4336-bf0a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_589c-1d0e-4b7d-be6b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink><entryLink id="6435-2676-8f7e-2c0b" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2f46-a0b6-48a5-a0ee</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_636f-0f8a-43f1-910b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c883-39c8-4a74-aeaa</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_0796-e467-4438-89b3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8406-ee81-48c7-b070" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_5a04-9847-4c91-a49a</comment></categoryLink>
+        <categoryLink id="35f7-d254-4056-bf1c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b4b4-daeb-483c-a306</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink><entryLink id="e112-71dc-7994-2f71" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6087-a5e5-4d3c-9ebd</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c7e1-5f42-4528-bf07</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1950-08dc-4544-ab01</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_daf3-31ed-42c0-85dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d932-6acd-4191-8921" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_7d4f-547c-43ed-a520</comment></categoryLink>
+        <categoryLink id="ec43-1ce2-4eb8-a9d1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f04e-04e8-4891-9b1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink><entryLink id="f178-f071-3715-9e89" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_dfdc-f6f6-49d2-a7b3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_354c-c71f-472f-b268</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1127-c974-4663-874d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_0843-bef2-4767-8307</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="457c-55f7-4f06-8d81" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_28e0-91e7-4ada-9fac</comment></categoryLink>
+        <categoryLink id="d9c4-2343-4fc5-aa07" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4448-a712-4dd7-bf6d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink><entryLink id="f698-283f-9e0a-7a5b" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d512-fd07-4a29-863a</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_55c6-a35f-485a-9f0d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d89e-cf1f-4ceb-b3de</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e2c9-0d01-403c-900e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_a7b8-c835-4cb2-b3d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b96e-2c80-43a7-98ff" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_e22a-c5f8-4825-a45f</comment></categoryLink>
+        <categoryLink id="cba5-20cc-463e-b72b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03fc-6a7f-45a5-bcb8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink><entryLink id="a547-033b-bcab-34dd" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry"><categoryLinks>
+        <categoryLink id="c019-0d18-4d99-b7a0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0aff-4f6e-4b03-a23c</comment></categoryLink>
+        <categoryLink id="d07f-2987-4afd-b11a" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"><comment>    template_id_7d5a-62e7-43ee-b79b</comment></categoryLink>
+        <categoryLink id="b1a2-4419-449e-9494" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_4986-9157-49f2-b670</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink><entryLink id="612a-b741-c7ac-a4f6" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_319e-90d4-44a3-8e83</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_28db-d943-4099-9abd</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1a45-a592-49df-9465</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb31-d0b2-4677-928e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1ec6-cbee-48b4-b4ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1b86-0977-4a8b-adac</comment></categoryLink>
+        <categoryLink id="8929-e05b-47f4-8b7a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_b449-403a-4e42-9239</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink><entryLink id="9ddc-5d16-a7ab-4a97" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafa-470f-4c2c-8be3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_e2ba-a855-4de2-9f46</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_0171-b30d-44ee-9389</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fdfb-119b-4774-934a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_3891-9a00-4f8f-b95f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="960b-c441-43c4-ba98" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e5df-17d4-4521-9d5b</comment></categoryLink>
+        <categoryLink id="b852-3fcb-4edf-8dca" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"><comment>    template_id_0ecd-4873-4d3a-b28b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink><entryLink id="844d-9ee1-1e02-2fa8" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_fbfa-8d78-4d6d-8a05</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_21f2-0916-46bf-b75a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_4fbd-633b-4dd6-9fdd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3cc7-35c7-4683-af47" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4f71-446f-4cff-afda</comment></categoryLink>
+        <categoryLink id="517d-706e-4479-84a8" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_3f44-8647-43a4-ac22</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink><entryLink id="f98a-c47f-c564-7cfc" name="Procurators" hidden="false" collective="false" import="false" targetId="9cca-47d5-0779-79a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -1067,21 +1817,283 @@
         <categoryLink id="0abe-7863-06fb-b202" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="db3a-34bf-5577-b933" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <modifiers>
+    <entryLink id="db3a-34bf-5577-b933" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af15-2c71-4f8b-833e</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_d95a-80b9-4463-af55</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b14-7b30-0fe2-af56" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4977-f50e-a0dd-5ed7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="3fac-f25b-41fa-9cd6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6b1-886e-4194-8bcd</comment></categoryLink>
+        <categoryLink id="a67d-355e-4474-97fa" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_51b5-f9c1-4587-8fc7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
-  </entryLinks>
-  <sharedSelectionEntries>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink><entryLink id="0631-6bf6-48a2-a005" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
+    <entryLink id="c449-b7c0-40f0-b354" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
+    <entryLink id="71a6-f025-49bf-88bc" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
+    <entryLink id="a378-17b5-4d67-a4d2" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <entryLink id="0344-d90b-4fda-9c0b" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3531-57d1-4081-882d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_f233-2361-4177-8ba7</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b932-667a-4b43-8331</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <entryLink id="9cea-c3c3-4e6b-adc8" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <entryLink id="7ca5-b5f9-4a4b-9b3b" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3129-6f59-4365-906b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2bcb-0af1-4aea-9191" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <entryLink id="1c80-fc70-49d3-984d" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ede2-d453-4e34-8cda</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2907-3215-4b01-96ff</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_c90c-959f-40fb-a4cb</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ba2d-50ad-45f1-91c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0e88-485e-43c2-8bef" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <entryLink id="9fce-62ed-4335-a20e" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_409c-0a5d-4ef8-a871</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7078-c1c7-4af2-b43d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_9a69-0fdc-4957-8982</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1a4c-69b5-4219-8502" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fba0-3ea7-4eaf-b33a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <entryLink id="f9ec-13b6-4049-ad70" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
+    <entryLink id="d57e-5cf9-415f-84d2" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
+    <entryLink id="dfcb-47c4-40c0-bc75" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
+    <entryLink id="e860-cae8-4aa3-a9c2" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+  </entryLinks><sharedSelectionEntries>
     <selectionEntry id="be3a-5acc-b4bd-8621" name="Gal Vorbak Squad" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="3b29-2a62-fba6-fefd" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">

--- a/2022 - LA - Word Bearers.cat
+++ b/2022 - LA - Word Bearers.cat
@@ -3089,7 +3089,7 @@ A Warlord with this Trait modifies his Strength and Toughness by a value determi
       <entryLinks>
         <entryLink id="e11c-5670-41f6-91b9" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_7dee-602c-4b47-be09</comment></selectionEntryGroup>
     <selectionEntryGroup id="bda8-b52d-c914-4ac2" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="6b8d-d97a-f0f9-44d9" type="max" />
@@ -3107,7 +3107,7 @@ A Warlord with this Trait modifies his Strength and Toughness by a value determi
         <entryLink id="c7ee-48e2-28ad-8039" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
         <entryLink id="8464-3082-bdad-e73d" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_be38-a066-4f8e-ae54</comment></selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
     <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />

--- a/2022 - LA - Word Bearers.cat
+++ b/2022 - LA - Word Bearers.cat
@@ -1,80 +1,79 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="1df7-bbbc-b70e-6a3f" name="LA -  XVII: Word Bearers" revision="11" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="1df7-bbbc-b70e-6a3f" name="LA -  XVII: Word Bearers" revision="11" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26">
   <entryLinks>
     <entryLink id="70a7-c1ee-bf88-94ab" name="  XVII: Word Bearers" hidden="false" collective="false" import="false" targetId="9dbf-0760-d7ae-f125" type="selectionEntry">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97e6-a0b1-0c5a-4dbe" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ab9-5824-231d-74b3" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97e6-a0b1-0c5a-4dbe" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ab9-5824-231d-74b3" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="52bf-cac2-d2f1-1f9a" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="52bf-cac2-d2f1-1f9a" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="6414-8db6-98c1-1319" name="Zardu Layak" hidden="false" collective="false" import="false" targetId="f511-e558-6bff-6543" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a725-f9c9-3ca4-1df3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3854-9b1c-75be-f251" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="7c61-d840-15bb-ea6a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="a725-f9c9-3ca4-1df3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3854-9b1c-75be-f251" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="7c61-d840-15bb-ea6a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="3b20-7c83-a696-2ba4" name="Gal Vorbak Squad" hidden="false" collective="false" import="false" targetId="be3a-5acc-b4bd-8621" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1fcf-b3c5-58b8-44a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="009d-e41c-1c69-eb35" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1fcf-b3c5-58b8-44a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="009d-e41c-1c69-eb35" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="929e-1f4c-fdb0-60f9" name="Lorgar " hidden="false" collective="false" import="false" targetId="9289-65f7-e452-51a5" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bd80-e5c5-9f6b-9c59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bc01-7a4b-4350-fc46" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="bd80-e5c5-9f6b-9c59" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bc01-7a4b-4350-fc46" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="b296-2ad3-1158-0110" name="High Chaplain Erebus" hidden="false" collective="false" import="false" targetId="18c4-d715-caba-b450" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2fef-2b84-70db-e88a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dc7f-c1ed-8d5f-37b1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="3d0d-10b5-3bbb-912b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="2fef-2b84-70db-e88a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="dc7f-c1ed-8d5f-37b1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="3d0d-10b5-3bbb-912b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="60bb-a1e2-77b8-fe35" name="Ashen Circle" hidden="false" collective="false" import="false" targetId="f4e7-a798-a322-dc10" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f650-e375-34c8-f203" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3c53-062a-658c-c195" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="f650-e375-34c8-f203" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3c53-062a-658c-c195" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="4c0b-a7fa-7fed-aed2" name="Kor Phaeron" hidden="false" collective="false" import="false" targetId="e61d-db78-6f56-3c05" type="selectionEntry">
@@ -83,1043 +82,1043 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="82bc-9ae6-b57c-75d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1486-4d78-4dea-482d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="d622-620e-8c28-3450" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="82bc-9ae6-b57c-75d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1486-4d78-4dea-482d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d622-620e-8c28-3450" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="b76f-2807-520c-e6d4" name="Mhara Gal Dreadnought" hidden="false" collective="false" import="false" targetId="5254-5c76-10d4-c909" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="26be-c491-05b1-9289" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f382-d484-61fa-673f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="26be-c491-05b1-9289" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f382-d484-61fa-673f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="eb38-8626-fa8a-1c9d" name="Argel Tal" hidden="false" collective="false" import="false" targetId="6be5-394d-9d79-344b" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5c45-7a13-99ff-7ae8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="3c39-038c-1967-b7d8" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="6d34-d904-7880-c2c1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="5c45-7a13-99ff-7ae8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="3c39-038c-1967-b7d8" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="6d34-d904-7880-c2c1" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="59e4-6029-ff9d-6b1d" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="bd8e-137b-ede8-e381" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4003-8f11-9424-331a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="bd8e-137b-ede8-e381" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4003-8f11-9424-331a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
     <entryLink id="c0fc-238b-19bd-2b19" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="40b1-4e44-8c7f-1c2c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d25e-9193-33fe-064e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="40b1-4e44-8c7f-1c2c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d25e-9193-33fe-064e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
     <entryLink id="9b66-5b73-5cf5-c120" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3881-8858-afbc-3835" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="2ccb-d039-d379-2946" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="d892-a8ac-9e8f-5269" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="3881-8858-afbc-3835" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2ccb-d039-d379-2946" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="d892-a8ac-9e8f-5269" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="4a7a-7807-4b01-35d6" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fe44-255e-1c63-6474" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="fc99-5ffe-0b98-118e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fe44-255e-1c63-6474" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="fc99-5ffe-0b98-118e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
     <entryLink id="87af-5910-74ac-ce46" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f5a6-5b65-0b2e-121f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="e3c1-ba4b-1b2c-c991" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f5a6-5b65-0b2e-121f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="e3c1-ba4b-1b2c-c991" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
     <entryLink id="69a5-9e26-74af-d7c1" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1699-edcf-65bb-138b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="eaa2-4659-9648-0fce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2f1c-493d-03a3-141e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="1699-edcf-65bb-138b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="eaa2-4659-9648-0fce" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2f1c-493d-03a3-141e" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
     <entryLink id="6258-c860-141f-4b94" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="748d-c1ae-0853-8e04" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="a4db-4996-d2c5-eac8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="748d-c1ae-0853-8e04" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="a4db-4996-d2c5-eac8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
     <entryLink id="01c5-27f2-1f7e-649f" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7c7e-6d1a-d083-b5db" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="4998-ef2b-ea3b-467d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7c7e-6d1a-d083-b5db" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4998-ef2b-ea3b-467d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
     <entryLink id="2477-7c9d-2648-d8f5" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e968-2174-d1ff-86a9" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="d4b0-5174-9214-f8ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c7dc-4c91-5562-f4ef" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="e968-2174-d1ff-86a9" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d4b0-5174-9214-f8ba" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c7dc-4c91-5562-f4ef" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="4630-9003-85e9-2bec" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup"/>
+        <entryLink id="4630-9003-85e9-2bec" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup" />
         <entryLink id="1cd1-a6f5-4243-4d12" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
     <entryLink id="01b8-fd47-8703-476a" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3da3-b2ae-2ae6-491d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bbcb-f514-6155-1608" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="127e-c277-1c51-5ead" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="3da3-b2ae-2ae6-491d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bbcb-f514-6155-1608" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="127e-c277-1c51-5ead" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="9a06-b962-d2bd-f9f1" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup"/>
+        <entryLink id="9a06-b962-d2bd-f9f1" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup" />
         <entryLink id="2847-bb8c-6005-21c7" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
     <entryLink id="285a-6c65-0722-5a81" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6d03-391c-8b48-0f63" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="698f-a1ea-f08b-0918" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="6fc0-57fb-2646-f4bb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="6d03-391c-8b48-0f63" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="698f-a1ea-f08b-0918" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="6fc0-57fb-2646-f4bb" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="dc26-a8e5-1760-7e16" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup"/>
+        <entryLink id="dc26-a8e5-1760-7e16" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup" />
         <entryLink id="0cf3-e436-8f14-2b50" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
     <entryLink id="67b4-19de-4c99-ec88" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="22c1-4709-7318-b94d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="d881-25df-ba20-dd93" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="22c1-4709-7318-b94d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="d881-25df-ba20-dd93" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
     <entryLink id="749b-143d-7a74-ec6f" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="90a4-a531-d654-d809" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="927c-bf82-0e5c-7bc2" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="90a4-a531-d654-d809" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="927c-bf82-0e5c-7bc2" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
     <entryLink id="a41b-9b79-b4e5-7065" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="92e4-6a0a-db65-0f70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1a32-177c-2fcd-9a9e" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="92e4-6a0a-db65-0f70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a32-177c-2fcd-9a9e" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
     <entryLink id="7305-0ef6-b303-8748" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0230-e674-df35-87be" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b2f2-22b7-4385-c004" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="0230-e674-df35-87be" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b2f2-22b7-4385-c004" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
     <entryLink id="8606-bbed-7404-9d60" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="711d-1592-c05c-995a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="30a0-c954-2208-2f2a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="711d-1592-c05c-995a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="30a0-c954-2208-2f2a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
     <entryLink id="c1c3-fd36-d3cc-eeb1" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fd94-3ba7-c0db-afe3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="f051-b8e1-4cd9-84b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="fd94-3ba7-c0db-afe3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="f051-b8e1-4cd9-84b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
     <entryLink id="5caf-765c-0591-fe37" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e119-c21f-7bda-82ce" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="c79a-4d9e-71ab-83b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e119-c21f-7bda-82ce" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="c79a-4d9e-71ab-83b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="e65e-d29d-2b81-643c" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0396-6f5a-3079-d2d6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="414e-2eef-8952-2f01" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="0396-6f5a-3079-d2d6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="414e-2eef-8952-2f01" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
     <entryLink id="548a-db08-c96f-8f76" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fc9e-9b32-f6e8-9d9b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="7a98-a76b-b593-89f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7cf0-9a11-d6e8-164d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="fc9e-9b32-f6e8-9d9b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="7a98-a76b-b593-89f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7cf0-9a11-d6e8-164d" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="a5ca-582a-ebf4-e72e" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1a5c-69c9-a1a5-a336" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="444d-3dbb-6095-9705" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1a5c-69c9-a1a5-a336" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="444d-3dbb-6095-9705" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="7af8-af9d-da7f-aacc" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ce22-2ca7-3f07-1653" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="8012-7182-f884-09c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ce22-2ca7-3f07-1653" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="8012-7182-f884-09c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
     <entryLink id="5d81-b075-d037-42e0" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3aab-a7f5-e68c-e9bd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="9de9-0c76-8a1c-c9a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3aab-a7f5-e68c-e9bd" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="9de9-0c76-8a1c-c9a2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
     <entryLink id="d752-5db5-a92a-b8c9" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c33a-390b-16b4-0ff2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="e979-7f00-70f4-4c8e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c33a-390b-16b4-0ff2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="e979-7f00-70f4-4c8e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
     <entryLink id="a37a-0e15-f6bc-ca4e" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b25e-e15c-74c8-9700" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="16c5-e434-f27e-7ee3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="b25e-e15c-74c8-9700" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="16c5-e434-f27e-7ee3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
     <entryLink id="8dba-4de2-0398-98fd" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3609-6015-c84c-8622" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="a5cb-f13d-79c7-d9d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3609-6015-c84c-8622" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="a5cb-f13d-79c7-d9d9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
     <entryLink id="8f59-c585-338b-e312" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ee02-4bc0-fcfc-bf06" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="244a-04a3-473c-5dc4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ee02-4bc0-fcfc-bf06" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="244a-04a3-473c-5dc4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
     <entryLink id="de96-b9e1-880f-7dfa" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b92-5478-0424-e242" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="de29-f137-1c66-5fd0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="5b92-5478-0424-e242" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="de29-f137-1c66-5fd0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
     <entryLink id="5b85-ea84-e207-f538" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="aaf9-31fe-32c1-83de" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="d53e-696d-aea1-67ef" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="aaf9-31fe-32c1-83de" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="d53e-696d-aea1-67ef" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
     <entryLink id="03fe-74d7-7df7-db38" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3e6f-e72d-4f58-6798" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="540d-0a96-8d16-9b6f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3e6f-e72d-4f58-6798" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="540d-0a96-8d16-9b6f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="9790-2c85-453c-36db" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e272-c79b-01c2-78a7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="9085-9917-1dcb-7709" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e272-c79b-01c2-78a7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="9085-9917-1dcb-7709" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
     <entryLink id="0c2d-50a3-6b6f-47ec" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3244-769b-0943-7782" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="6182-323c-8a71-0fff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3244-769b-0943-7782" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="6182-323c-8a71-0fff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
     <entryLink id="d01a-8d0a-658c-7b30" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a39d-a744-77e2-5c2a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="e796-78be-2ae2-4532" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a39d-a744-77e2-5c2a" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="e796-78be-2ae2-4532" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
     <entryLink id="865d-5620-f1e1-d9b4" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c232-9ad5-cde1-870e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="caaa-d78d-d5b0-e614" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="c232-9ad5-cde1-870e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="caaa-d78d-d5b0-e614" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
     <entryLink id="2047-7b61-589b-fbff" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="bdc9-8d41-a3a8-b8fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f0e7-1c34-32c9-1644" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="bdc9-8d41-a3a8-b8fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f0e7-1c34-32c9-1644" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
     <entryLink id="6a9c-29bf-c319-42c4" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1e9e-0a41-4f57-2485" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="674d-1283-4504-1ea1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1e9e-0a41-4f57-2485" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="674d-1283-4504-1ea1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
     <entryLink id="c54a-f2f6-3bc4-be9f" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4e5e-cd04-9a92-a82d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="ca91-3ccd-d822-c4a1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4e5e-cd04-9a92-a82d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="ca91-3ccd-d822-c4a1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
     <entryLink id="e3bd-780b-dd71-5667" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="25d2-9349-74be-a2f9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="93f2-d28d-d466-b15e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="25d2-9349-74be-a2f9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="93f2-d28d-d466-b15e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
     <entryLink id="282a-3460-008f-cb4c" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0335-aeed-6a45-bd6c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="c243-8742-ba25-a471" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0335-aeed-6a45-bd6c" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="c243-8742-ba25-a471" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
     <entryLink id="9fac-8136-e9b6-ba52" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="28e2-1865-2aac-28fb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="3bcd-27f6-9955-c6a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="28e2-1865-2aac-28fb" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="3bcd-27f6-9955-c6a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
     <entryLink id="7628-209a-0916-8ef6" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8a27-0690-39dc-185c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="096d-3ae8-b1b5-2f94" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8a27-0690-39dc-185c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="096d-3ae8-b1b5-2f94" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
     <entryLink id="31b6-8fca-30a5-026c" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6abe-4d98-04b8-be27" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="0bbb-5bec-cfc1-5ee8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6abe-4d98-04b8-be27" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="0bbb-5bec-cfc1-5ee8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
     <entryLink id="5c71-a511-085a-98e9" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a6c2-ed05-7ab6-c49f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="074a-67ee-b638-16d0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a6c2-ed05-7ab6-c49f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="074a-67ee-b638-16d0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
     <entryLink id="da76-e9b3-4058-0a1e" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6385-ad6d-55ab-9c55" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="45c7-ec87-ba10-ae92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6385-ad6d-55ab-9c55" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="45c7-ec87-ba10-ae92" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
     <entryLink id="cff8-0677-a8ef-76f2" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="bf77-9e11-ba8d-f6e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="774f-68c3-65ac-5750" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="bf77-9e11-ba8d-f6e5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="774f-68c3-65ac-5750" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
     <entryLink id="298a-064a-13f2-2b5c" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b68c-caf0-8215-6aa0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="6fa0-c15a-1c43-2fe7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b68c-caf0-8215-6aa0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="6fa0-c15a-1c43-2fe7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
     <entryLink id="c8e1-9692-62e0-b3ba" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="63ca-023d-72bf-52d3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="af40-5e2c-a2c4-f2b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="63ca-023d-72bf-52d3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="af40-5e2c-a2c4-f2b5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
     <entryLink id="6539-871b-6268-f8ed" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="85c4-cd55-077b-2187" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ea12-f34f-cc83-7e65" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="85c4-cd55-077b-2187" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ea12-f34f-cc83-7e65" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="4b4d-786b-2555-3d21" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5540-7324-1309-3ab6" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="a65b-2e5b-3e2e-d6e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5540-7324-1309-3ab6" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="a65b-2e5b-3e2e-d6e9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
     <entryLink id="74a9-9c82-a335-5ead" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6154-812c-005a-28e4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="b149-78f9-9196-55ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6154-812c-005a-28e4" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="b149-78f9-9196-55ab" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="f1db-a17d-57fb-4f13" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fd11-c281-8020-3748" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="95c3-a625-adab-f5c7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="fd11-c281-8020-3748" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="95c3-a625-adab-f5c7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="3155-2264-5a56-7fc5" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7e9c-0266-d3a5-c97c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="58df-04ee-15fb-db00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e600-fe00-1403-3593" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="7e9c-0266-d3a5-c97c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="58df-04ee-15fb-db00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e600-fe00-1403-3593" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="c612-19af-7bac-a751" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup"/>
-        <entryLink id="1cac-1663-33a7-9024" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup"/>
+        <entryLink id="c612-19af-7bac-a751" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup" />
+        <entryLink id="1cac-1663-33a7-9024" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
     <entryLink id="f0f2-7fd8-50e9-cafc" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3916-619e-e0c1-9081" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="84de-dc99-56e3-5814" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="25ff-917e-3c92-4d59" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="3916-619e-e0c1-9081" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="84de-dc99-56e3-5814" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="25ff-917e-3c92-4d59" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="70d5-43da-554d-5e8a" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup"/>
-        <entryLink id="a6ff-af59-edf5-99a1" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup"/>
+        <entryLink id="70d5-43da-554d-5e8a" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup" />
+        <entryLink id="a6ff-af59-edf5-99a1" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
     <entryLink id="27de-92fe-d49b-c679" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3a1d-ff47-11c5-2bbe" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="3972-e3b8-3f39-8194" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ec60-336b-52be-a89a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="3a1d-ff47-11c5-2bbe" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="3972-e3b8-3f39-8194" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ec60-336b-52be-a89a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="9e91-f17b-bab8-01ff" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup"/>
-        <entryLink id="d0ab-285d-6681-4893" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup"/>
+        <entryLink id="9e91-f17b-bab8-01ff" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup" />
+        <entryLink id="d0ab-285d-6681-4893" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ac0-fbef-d266-a924" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
     <entryLink id="9069-cdcb-c212-0b5b" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="631f-ad8d-edbf-2341" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="a142-cd08-5668-c2cc" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="631f-ad8d-edbf-2341" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="a142-cd08-5668-c2cc" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="0110-82c7-540b-43c1" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="74a6-aaf7-8361-c209" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="c96e-efc9-92a3-3091" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="74a6-aaf7-8361-c209" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="c96e-efc9-92a3-3091" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
     <entryLink id="4b22-aee5-2689-e9c8" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f76e-0c27-c11b-0aee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9b56-a4f4-8f87-6d22" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="f76e-0c27-c11b-0aee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9b56-a4f4-8f87-6d22" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="b97d-6b5b-d94c-fa81" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b047-875d-2bef-d5e7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="dcf4-bf45-e0e3-ca21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b047-875d-2bef-d5e7" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="dcf4-bf45-e0e3-ca21" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
     <entryLink id="8d99-1055-fa44-86fe" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b36-7f37-ac16-b8e2" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="e7ba-1e2d-fd98-3788" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5b36-7f37-ac16-b8e2" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="e7ba-1e2d-fd98-3788" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
     <entryLink id="2568-2dca-66f5-abaa" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ee69-9eab-f564-bebe" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="4041-1722-8123-5d03" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ee69-9eab-f564-bebe" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="4041-1722-8123-5d03" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
     <entryLink id="600f-a9b6-af7f-cdc6" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3d8b-4843-8df5-81f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dcd1-8ece-6459-e1f8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3d8b-4843-8df5-81f4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="dcd1-8ece-6459-e1f8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
     <entryLink id="6560-0faa-293c-1c02" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b863-dbe9-afd0-cf4b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="6d4b-8e54-f734-59aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b863-dbe9-afd0-cf4b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="6d4b-8e54-f734-59aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
     <entryLink id="99ee-cfab-e34d-bfed" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6fbd-bfcd-6464-77fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="119f-3c22-a007-6b33" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="6fbd-bfcd-6464-77fb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="119f-3c22-a007-6b33" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
     <entryLink id="f286-e716-e069-1122" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ebb0-9a6e-e28b-9361" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2f4f-7d54-ecfb-24ff" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="ebb0-9a6e-e28b-9361" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2f4f-7d54-ecfb-24ff" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
     <entryLink id="70f8-f2fb-eaef-8f09" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7d3d-96b2-8093-f228" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="af32-30e4-ea99-66e8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="7d3d-96b2-8093-f228" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="af32-30e4-ea99-66e8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
     <entryLink id="0cb9-6d10-1883-5ed4" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="765e-0628-9cfa-8b1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7ee9-6f43-c305-f029" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="765e-0628-9cfa-8b1a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7ee9-6f43-c305-f029" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
     <entryLink id="5d10-4ec4-fd7f-c4fe" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9c53-79ba-20b4-0c38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e3f1-775a-11cb-e0e0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="9c53-79ba-20b4-0c38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e3f1-775a-11cb-e0e0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="1086-c952-53b5-306d" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="04a8-cab8-3e18-f9ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ae42-d705-f633-6ef3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="04a8-cab8-3e18-f9ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ae42-d705-f633-6ef3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
     <entryLink id="239b-4e03-118a-6783" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fb8d-d233-78c4-fa96" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f9a4-f9d8-0177-56c4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="fb8d-d233-78c4-fa96" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f9a4-f9d8-0177-56c4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="df73-2b98-e82c-c9ed" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ca2c-dbe5-4243-7fb5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c3ab-62fd-d965-1d70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ca2c-dbe5-4243-7fb5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="c3ab-62fd-d965-1d70" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
     <entryLink id="ccf0-7f32-d119-382b" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6e13-7985-a73d-a28f" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="8b0a-4561-03b6-ba7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6e13-7985-a73d-a28f" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="8b0a-4561-03b6-ba7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
     <entryLink id="ad5c-55be-00df-6d99" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8dbb-a7d3-f20f-6e29" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="97a9-34e3-1d79-ae00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8dbb-a7d3-f20f-6e29" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="97a9-34e3-1d79-ae00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
     <entryLink id="c1e5-b58d-63bb-b4dd" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b479-a6c4-cd52-41b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="02b3-909a-4794-a59d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="25d2-e77d-fbd7-90a2" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="b479-a6c4-cd52-41b2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="02b3-909a-4794-a59d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="25d2-e77d-fbd7-90a2" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="0b2a-3725-027c-925f" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="254c-7a80-ad2b-4b4c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9ad1-390e-b878-4341" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="254c-7a80-ad2b-4b4c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9ad1-390e-b878-4341" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
     <entryLink id="7375-e856-ed41-2cd2" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="2eb8-ab14-8b83-4687" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="33c6-6162-3a63-3ff0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2eb8-ab14-8b83-4687" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="33c6-6162-3a63-3ff0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
     <entryLink id="e8be-7cae-4e60-4acf" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1da3-9979-de16-ff35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="aa2c-18ff-b755-52e9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1da3-9979-de16-ff35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="aa2c-18ff-b755-52e9" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
     <entryLink id="3d77-9cdd-8666-9ee5" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="49db-a82b-7fc3-5d4a" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="f963-0674-47dd-bfd5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="49db-a82b-7fc3-5d4a" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="f963-0674-47dd-bfd5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="4ccd-314e-e135-ff8f" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="058d-05f1-5f39-3edc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="1c81-c897-ae05-6c44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="058d-05f1-5f39-3edc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="1c81-c897-ae05-6c44" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
     <entryLink id="c16a-a744-396d-f9e8" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="33f9-6907-1a15-62f6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="77a4-ff21-107b-cdfc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="33f9-6907-1a15-62f6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="77a4-ff21-107b-cdfc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="6435-2676-8f7e-2c0b" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c189-fb02-5b3a-9081" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="696c-ac91-71ca-2de9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c189-fb02-5b3a-9081" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="696c-ac91-71ca-2de9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
     <entryLink id="e112-71dc-7994-2f71" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9938-0256-9406-57a1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="372d-5596-4075-e149" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9938-0256-9406-57a1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="372d-5596-4075-e149" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
     <entryLink id="f178-f071-3715-9e89" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0c74-a575-4357-8ece" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="c356-2599-20e9-47b0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0c74-a575-4357-8ece" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c356-2599-20e9-47b0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
     <entryLink id="f698-283f-9e0a-7a5b" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1708-8a76-2904-1441" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="b07f-2afe-ded2-2109" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1708-8a76-2904-1441" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="b07f-2afe-ded2-2109" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
     <entryLink id="a547-033b-bcab-34dd" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6b4e-91c8-4ae8-43a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bb97-d8e3-94a0-8908" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="301e-6e66-90ce-3341" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="6b4e-91c8-4ae8-43a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bb97-d8e3-94a0-8908" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
+        <categoryLink id="301e-6e66-90ce-3341" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="612a-b741-c7ac-a4f6" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="44ef-cd08-40cc-d5de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4d5b-ee3c-de02-4e37" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="44ef-cd08-40cc-d5de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4d5b-ee3c-de02-4e37" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
     <entryLink id="9ddc-5d16-a7ab-4a97" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8f21-44df-bac1-25ef" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="66a7-be4c-7b7b-b5f8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8f21-44df-bac1-25ef" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="66a7-be4c-7b7b-b5f8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
     <entryLink id="844d-9ee1-1e02-2fa8" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6c3b-475f-21dc-70f9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0f38-66ff-d5e4-e000" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="6c3b-475f-21dc-70f9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0f38-66ff-d5e4-e000" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
     <entryLink id="f98a-c47f-c564-7cfc" name="Procurators" hidden="false" collective="false" import="false" targetId="9cca-47d5-0779-79a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3150-7c35-659c-1e26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="0abe-7863-06fb-b202" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="3150-7c35-659c-1e26" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0abe-7863-06fb-b202" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="db3a-34bf-5577-b933" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5b14-7b30-0fe2-af56" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4977-f50e-a0dd-5ed7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="5b14-7b30-0fe2-af56" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4977-f50e-a0dd-5ed7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="be3a-5acc-b4bd-8621" name="Gal Vorbak Squad" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="3b29-2a62-fba6-fefd" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="34bf-88aa-1a7c-07d4" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
+        <infoLink id="34bf-88aa-1a7c-07d4" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
         <infoLink id="1e65-002f-7815-a87d" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+            <modifier type="set" field="name" value="Feel No Pain (5+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="12f8-17d8-7c7a-08a7" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule"/>
+        <infoLink id="12f8-17d8-7c7a-08a7" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule" />
         <infoLink id="847b-bdb6-d29d-0d3b" name="Rage (X)" hidden="false" targetId="564d-3550-ae44-2f99" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Rage (2)"/>
+            <modifier type="set" field="name" value="Rage (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="5720-f12e-d335-bd3d" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="5720-f12e-d335-bd3d" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8bb5-03cb-13d0-5b68" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="01a3-36e3-0dee-8337" name="Corrupted:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
-        <categoryLink id="9fc7-089c-acfd-0f40" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="8bb5-03cb-13d0-5b68" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="01a3-36e3-0dee-8337" name="Corrupted:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false" />
+        <categoryLink id="9fc7-089c-acfd-0f40" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d8be-b33c-a74b-e600" name="Dark Brethren" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11f9-2d4d-391a-c32f" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecfd-fc23-9c51-7dec" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11f9-2d4d-391a-c32f" type="max" />
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecfd-fc23-9c51-7dec" type="min" />
           </constraints>
           <profiles>
             <profile id="2b7d-be52-3e19-31de" name="Dark Brethren" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Corrupted)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">5</characteristic>
@@ -1133,10 +1132,10 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="572a-eac2-319b-3a13" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+            <categoryLink id="572a-eac2-319b-3a13" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false" />
           </categoryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1145,28 +1144,28 @@
           <modifiers>
             <modifier type="increment" field="dc40-004e-d273-92d9" value="1.0">
               <repeats>
-                <repeat field="selections" scope="be3a-5acc-b4bd-8621" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="be3a-5acc-b4bd-8621" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dc40-004e-d273-92d9" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dc40-004e-d273-92d9" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="8dae-1559-85be-630e" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
               </costs>
             </entryLink>
             <entryLink id="d560-e4b9-5c66-4cb0" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
-            <entryLink id="e1e2-e308-292a-c076" name="Tainted Talons" hidden="false" collective="false" import="true" targetId="5986-86cf-f767-7f7b" type="selectionEntry"/>
+            <entryLink id="e1e2-e308-292a-c076" name="Tainted Talons" hidden="false" collective="false" import="true" targetId="5986-86cf-f767-7f7b" type="selectionEntry" />
             <entryLink id="5845-4e57-0ebc-8ce0" name="Warpfire Blaster" hidden="false" collective="false" import="true" targetId="76c7-1d7c-206a-32a5" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
@@ -1175,98 +1174,98 @@
           <modifiers>
             <modifier type="increment" field="c5dc-d4b6-3aa8-e086" value="1.0">
               <repeats>
-                <repeat field="selections" scope="be3a-5acc-b4bd-8621" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="be3a-5acc-b4bd-8621" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c5dc-d4b6-3aa8-e086" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c5dc-d4b6-3aa8-e086" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="b593-fcef-5d33-6393" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </entryLink>
-            <entryLink id="f6a9-1ef9-8d22-6493" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
-            <entryLink id="7484-75af-ff45-de92" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
-            <entryLink id="942c-ab85-75d2-a3c8" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
+            <entryLink id="f6a9-1ef9-8d22-6493" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry" />
+            <entryLink id="7484-75af-ff45-de92" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry" />
+            <entryLink id="942c-ab85-75d2-a3c8" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="929a-a188-d505-c98b" name="Boltspitter" hidden="false" collective="false" import="true" targetId="9221-5c79-0c8f-f3f3" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06f0-1c0f-f85c-2744" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f24e-5024-4660-1d4d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06f0-1c0f-f85c-2744" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f24e-5024-4660-1d4d" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="2e93-2752-8495-0abc" name="Tainted Talons" hidden="false" collective="false" import="true" targetId="5986-86cf-f767-7f7b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca6f-4f8b-2e72-b5f1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0a9-dfe3-e525-79d8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca6f-4f8b-2e72-b5f1" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0a9-dfe3-e525-79d8" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="b3bb-3f67-1200-c3f2" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c244-1dac-bc05-b807" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ed4-80e4-8a5d-8f84" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c244-1dac-bc05-b807" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ed4-80e4-8a5d-8f84" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="55fb-aaa4-d5a5-6628" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e2e-e740-37f0-2244" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1641-d397-2ab5-ae95" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e2e-e740-37f0-2244" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1641-d397-2ab5-ae95" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="974e-9721-516c-dcbd" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5ff-5413-2323-b44f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a39b-415d-c38d-40d9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5ff-5413-2323-b44f" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a39b-415d-c38d-40d9" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="9289-65f7-e452-51a5" name="Lorgar " hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="add" field="category" value="9055-7410-8ffd-b8e7">
           <conditions>
-            <condition field="selections" scope="9289-65f7-e452-51a5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="86f6-6646-2bef-31ee" type="equalTo"/>
+            <condition field="selections" scope="9289-65f7-e452-51a5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="86f6-6646-2bef-31ee" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ba96-d53f-37f7-984b" type="max"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cbbb-98c1-fb5c-7844" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ba96-d53f-37f7-984b" type="max" />
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cbbb-98c1-fb5c-7844" type="max" />
       </constraints>
       <rules>
         <rule id="06a1-0713-e45f-c817" name="The Power of the Word" hidden="false">
-          <description>Any Legion Command Squad, Legion Cataphractii Command Squad or Legion Tartaros Command Squad selected as a Retinue Squad with Lorgar as it&apos;s leader gains the Fearless and Feel No Pain (4+) special rules.
+          <description>Any Legion Command Squad, Legion Cataphractii Command Squad or Legion Tartaros Command Squad selected as a Retinue Squad with Lorgar as it's leader gains the Fearless and Feel No Pain (4+) special rules.
 
-In addition, once per battle, one friendly unit composed entirely of models with the Infantry or Cavalry Unit Type with at least one model within 18&quot; of Lorgar (But not a unit that includes Lorgar himself) may be selected at the start of any Game Turn. The chosen units gain the Fearless and Feel No Pain (4+) special rules for the duration of that Game Turn.</description>
+In addition, once per battle, one friendly unit composed entirely of models with the Infantry or Cavalry Unit Type with at least one model within 18" of Lorgar (But not a unit that includes Lorgar himself) may be selected at the start of any Game Turn. The chosen units gain the Fearless and Feel No Pain (4+) special rules for the duration of that Game Turn.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="c8e6-41aa-79ad-6b40" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule"/>
+        <infoLink id="c8e6-41aa-79ad-6b40" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule" />
         <infoLink id="3938-493e-bb35-e406" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="It Will Not Die (4+)"/>
+            <modifier type="set" field="name" value="It Will Not Die (4+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="4267-a70f-490a-90e8" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule"/>
+        <infoLink id="4267-a70f-490a-90e8" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="26e2-2438-3fe6-0af3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="69cd-1ac9-f49d-16e1" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
-        <categoryLink id="5a9e-fc41-ec12-1b8f" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="26e2-2438-3fe6-0af3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="69cd-1ac9-f49d-16e1" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false" />
+        <categoryLink id="5a9e-fc41-ec12-1b8f" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="42b4-8e18-3d94-a2c1" name="Lorgar Choice:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b851-3073-1d88-4c68">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8cf-abf6-4754-de77" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8cf-abf6-4754-de77" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="b851-3073-1d88-4c68" name="Lorgar" hidden="false" collective="false" import="true" type="model">
@@ -1274,7 +1273,7 @@ In addition, once per battle, one friendly unit composed entirely of models with
                 <profile id="bcce-4c26-e086-5779" name="Lorgar" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Primarch (Psyker, Unique)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">6</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
@@ -1290,13 +1289,13 @@ In addition, once per battle, one friendly unit composed entirely of models with
               <selectionEntries>
                 <selectionEntry id="580d-f719-30eb-d878" name="Devotion" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5877-a6c2-bdd7-991b" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb48-fb45-01eb-43a9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5877-a6c2-bdd7-991b" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb48-fb45-01eb-43a9" type="min" />
                   </constraints>
                   <profiles>
                     <profile id="6142-21b6-9311-5507" name="Devotion" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                       <characteristics>
-                        <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+                        <characteristic name="Range" typeId="95ba-cda7-b831-6066">12"</characteristic>
                         <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
                         <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
                         <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 1, Concussive (2), Graviton Pulse, Haywire, Master-crafted</characteristic>
@@ -1304,18 +1303,18 @@ In addition, once per battle, one friendly unit composed entirely of models with
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink id="984d-3149-69f9-6590" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule"/>
-                    <infoLink id="8194-206f-b15e-4d2e" name="Graviton Pulse" hidden="false" targetId="5b9c-2738-616c-abdf" type="rule"/>
-                    <infoLink id="4d6f-29b4-20a0-15e1" name="Haywire" hidden="false" targetId="1dd4-7a75-5c59-8425" type="rule"/>
+                    <infoLink id="984d-3149-69f9-6590" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule" />
+                    <infoLink id="8194-206f-b15e-4d2e" name="Graviton Pulse" hidden="false" targetId="5b9c-2738-616c-abdf" type="rule" />
+                    <infoLink id="4d6f-29b4-20a0-15e1" name="Haywire" hidden="false" targetId="1dd4-7a75-5c59-8425" type="rule" />
                   </infoLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4dd8-ebdd-1395-f138" name="Illuminarum" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a2c-069d-94f3-586b" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed2f-2c5e-e6c7-a67d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a2c-069d-94f3-586b" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed2f-2c5e-e6c7-a67d" type="max" />
                   </constraints>
                   <profiles>
                     <profile id="dd77-b27e-bc94-a5a2" name="Illuminarum" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1328,37 +1327,37 @@ In addition, once per battle, one friendly unit composed entirely of models with
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink id="6b2a-bc41-089f-3845" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
-                    <infoLink id="76c6-caad-6e6d-7e28" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule"/>
-                    <infoLink id="7225-23a2-5dac-df75" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule"/>
+                    <infoLink id="6b2a-bc41-089f-3845" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
+                    <infoLink id="76c6-caad-6e6d-7e28" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule" />
+                    <infoLink id="7225-23a2-5dac-df75" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule" />
                   </infoLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
                 <entryLink id="86cc-b915-8718-4bf2" name="Aetheric Lightning" hidden="false" collective="false" import="true" targetId="b477-d985-8b95-69de" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cde0-7251-99cc-2a30" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6324-355d-e89c-a80c" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cde0-7251-99cc-2a30" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6324-355d-e89c-a80c" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="3e9a-890a-c219-a9ed" name="Psychic Discipline: Divination" hidden="false" collective="false" import="true" targetId="0c22-a776-e7e3-2981" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c7ee-9623-94ed-d031" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7cf-87a3-61f5-f118" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c7ee-9623-94ed-d031" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7cf-87a3-61f5-f118" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="19cd-1f76-49d1-8fdf" name="Psychic Discipline: Thaumaturgy" hidden="false" collective="false" import="true" targetId="f7ab-1fb2-91b0-028d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3233-e28e-5b77-7454" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea53-04e2-505d-ee84" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3233-e28e-5b77-7454" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea53-04e2-505d-ee84" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="86f6-6646-2bef-31ee" name="Lorgar Transfigured" hidden="false" collective="false" import="true" type="upgrade">
@@ -1366,7 +1365,7 @@ In addition, once per battle, one friendly unit composed entirely of models with
                 <profile id="c365-b617-08c4-4cad" name="Lorgar Transfigured" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Primarch (Psyker, Unique, Corrupted)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">6</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
@@ -1387,27 +1386,27 @@ In addition, once per battle, one friendly unit composed entirely of models with
               <entryLinks>
                 <entryLink id="8521-c59d-0844-ea91" name="Psychic Discipline: Anathemata" hidden="false" collective="false" import="true" targetId="c6ec-edc0-034e-ed45" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5cc6-78a6-17c8-c662" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5441-6776-963e-d456" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5cc6-78a6-17c8-c662" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5441-6776-963e-d456" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="816c-e774-eae3-5cd8" name="Psychic Discipline: Diabolism" hidden="false" collective="false" import="true" targetId="cc56-0599-fe21-9352" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3b9-16bc-12b5-b645" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="77ae-9d37-22eb-568b" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3b9-16bc-12b5-b645" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="77ae-9d37-22eb-568b" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="4e33-1f03-3cdb-d05f" name="Aetheric Lightning" hidden="false" collective="false" import="true" targetId="b477-d985-8b95-69de" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f5e-97d5-b646-8e02" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6544-b492-8f95-448a" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f5e-97d5-b646-8e02" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6544-b492-8f95-448a" type="min" />
                   </constraints>
                 </entryLink>
-                <entryLink id="6feb-3285-8e03-cde7" name="Devotion" hidden="false" collective="false" import="true" targetId="580d-f719-30eb-d878" type="selectionEntry"/>
-                <entryLink id="9843-329d-51b4-2149" name="Illuminarum" hidden="false" collective="false" import="true" targetId="4dd8-ebdd-1395-f138" type="selectionEntry"/>
+                <entryLink id="6feb-3285-8e03-cde7" name="Devotion" hidden="false" collective="false" import="true" targetId="580d-f719-30eb-d878" type="selectionEntry" />
+                <entryLink id="9843-329d-51b4-2149" name="Illuminarum" hidden="false" collective="false" import="true" targetId="4dd8-ebdd-1395-f138" type="selectionEntry" />
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1416,57 +1415,57 @@ In addition, once per battle, one friendly unit composed entirely of models with
       <entryLinks>
         <entryLink id="d992-5eae-5058-4e12" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="453d-e166-73f7-f6d1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a20c-ff6b-e270-f4dc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="453d-e166-73f7-f6d1" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a20c-ff6b-e270-f4dc" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="9550-237d-de9f-70d7" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2012-f29c-8ce7-aed9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a756-61a2-be02-3f38" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2012-f29c-8ce7-aed9" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a756-61a2-be02-3f38" type="max" />
           </constraints>
           <profiles>
             <profile id="a4de-1e33-e151-c6f2" name="Sire of the Word Bearers" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All units composed entirely of models which have the Legiones Astartes (Word Bearers) special rule and which can draw line of sight to Lorgar add +1 to the Result of Charge Distance rolls made for them, and may use Lorgar&apos;s Leadership in all Leadership tests, Morale checks and Pinning tests made for them. In addition, an army with Lorgar as its Warlord gains an extra Reaction in the Opposing player&apos;s Assault Phase, as long as Lorgar has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All units composed entirely of models which have the Legiones Astartes (Word Bearers) special rule and which can draw line of sight to Lorgar add +1 to the Result of Charge Distance rolls made for them, and may use Lorgar's Leadership in all Leadership tests, Morale checks and Pinning tests made for them. In addition, an army with Lorgar as its Warlord gains an extra Reaction in the Opposing player's Assault Phase, as long as Lorgar has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="415.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="415.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="f4e7-a798-a322-dc10" name="Ashen Circle" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="86c5-bc44-0e58-b21e" name="Scorched Earth" hidden="false">
-          <description>If a model with this special rule ends its Charge Move in base or hull contact with any enemy models, it immediately inflicts one Hit on each enemy model it is in contact with. These attacks hit automatically and are resolved at Strength 5 and with AP-. These attacks do not benefit from any of the model’s special rules and count as flame attacks for rules which modify such attacks. If a model with this special rule has charged a Vehicle of any kind or a Building, the hits are resolved against the Armour Value of the Facing the charging model is touching. If the model is in contact with two or more Facings, the player controlling the target model chooses a Facing upon which the attacks are resolved. If a model with this special rule Charges a Building or Vehicle that is a Transport, the hits are resolved against the Building or Vehicle, not the unit Embarked within the Building or Vehicle.</description>
+          <description>If a model with this special rule ends its Charge Move in base or hull contact with any enemy models, it immediately inflicts one Hit on each enemy model it is in contact with. These attacks hit automatically and are resolved at Strength 5 and with AP-. These attacks do not benefit from any of the model&#8217;s special rules and count as flame attacks for rules which modify such attacks. If a model with this special rule has charged a Vehicle of any kind or a Building, the hits are resolved against the Armour Value of the Facing the charging model is touching. If the model is in contact with two or more Facings, the player controlling the target model chooses a Facing upon which the attacks are resolved. If a model with this special rule Charges a Building or Vehicle that is a Transport, the hits are resolved against the Building or Vehicle, not the unit Embarked within the Building or Vehicle.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="2491-36b8-7d5a-7c77" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule"/>
-        <infoLink id="a5dc-f9d8-3807-fe8d" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule"/>
-        <infoLink id="cae7-eb7f-0e1d-20bc" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
+        <infoLink id="2491-36b8-7d5a-7c77" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule" />
+        <infoLink id="a5dc-f9d8-3807-fe8d" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule" />
+        <infoLink id="cae7-eb7f-0e1d-20bc" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="768a-11a0-1cb1-d896" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="75a1-c482-1a18-e139" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="1937-18d3-3af6-806c" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="fd96-34a3-5cd2-680a" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
+        <categoryLink id="768a-11a0-1cb1-d896" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="75a1-c482-1a18-e139" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="1937-18d3-3af6-806c" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="fd96-34a3-5cd2-680a" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9109-0ac9-239f-f762" name="Iconoclast" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f86-eaf4-fb52-7bc7" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5d8-0c62-bb4f-e5e6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f86-eaf4-fb52-7bc7" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5d8-0c62-bb4f-e5e6" type="max" />
           </constraints>
           <profiles>
             <profile id="7221-535a-57b4-b7f3" name="Iconoclast" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="f4e7-a798-a322-dc10" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6651-c234-37db-6cbf" type="equalTo"/>
+                    <condition field="selections" scope="f4e7-a798-a322-dc10" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6651-c234-37db-6cbf" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1474,7 +1473,7 @@ In addition, once per battle, one friendly unit composed entirely of models with
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)
 
 </characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1488,24 +1487,24 @@ In addition, once per battle, one friendly unit composed entirely of models with
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="1092-6e5f-5e97-f956" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="1092-6e5f-5e97-f956" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="d4d3-c315-f02b-1c9c" name="1) Pistol Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0496-d93a-e5cb-12a5">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f265-aefc-0b4f-2b48" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbec-5e57-5cee-1f88" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f265-aefc-0b4f-2b48" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbec-5e57-5cee-1f88" type="max" />
               </constraints>
               <entryLinks>
-                <entryLink id="0496-d93a-e5cb-12a5" name="Akkadic Hand Flamer" hidden="false" collective="false" import="true" targetId="0480-9726-cc82-7565" type="selectionEntry"/>
+                <entryLink id="0496-d93a-e5cb-12a5" name="Akkadic Hand Flamer" hidden="false" collective="false" import="true" targetId="0480-9726-cc82-7565" type="selectionEntry" />
                 <entryLink id="4c21-7ee9-3803-fb0e" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="24a7-9982-ddee-b063" name="Inferno Pistol" hidden="false" collective="false" import="true" targetId="dcd1-8b2a-9d97-40ef" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1514,41 +1513,41 @@ In addition, once per battle, one friendly unit composed entirely of models with
               <entryLinks>
                 <entryLink id="6651-c234-37db-6cbf" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d85e-69a7-3f77-1f45" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d85e-69a7-3f77-1f45" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="bedb-27af-3955-3151" name="Phosphex Bomb" hidden="false" collective="false" import="true" targetId="4188-13ff-cb03-109e" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="One Phospex Bomb"/>
+                    <modifier type="set" field="name" value="One Phospex Bomb" />
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ba8-a7b4-da6b-2c41" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ba8-a7b4-da6b-2c41" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="9d7c-a887-22cf-340e" name="Incendiary" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78e1-0935-a81e-da07" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f22f-8a57-0da8-4583" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78e1-0935-a81e-da07" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f22f-8a57-0da8-4583" type="min" />
           </constraints>
           <profiles>
             <profile id="18db-a15e-26d3-d4e8" name="Incendiary" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)
 </characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1562,56 +1561,56 @@ In addition, once per battle, one friendly unit composed entirely of models with
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="243f-743b-3033-6160" name="Axe-Rake" hidden="false" collective="false" import="true" targetId="5013-4199-fed6-8690" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa73-01b3-c210-493f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1eb-21e3-ee33-b99f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa73-01b3-c210-493f" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1eb-21e3-ee33-b99f" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="a42b-e5eb-b8db-b10d" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d0e-eed8-b1fd-dbaa" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3d4-9347-fb57-5c88" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d0e-eed8-b1fd-dbaa" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3d4-9347-fb57-5c88" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="c8a2-78a9-21e7-89db" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52de-4a10-e00a-6e04" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe59-d160-aef1-fe6c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52de-4a10-e00a-6e04" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe59-d160-aef1-fe6c" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="0403-bc11-647a-86ff" name="Warhawk Jump Pack" hidden="false" collective="false" import="true" targetId="a298-8584-70ed-18ce" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03ff-56d9-9582-148f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b69-23c2-6751-a35f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03ff-56d9-9582-148f" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b69-23c2-6751-a35f" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="e5bb-3894-2c70-57f6" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d93a-3069-14ed-0976" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="949f-4f0c-4f66-440d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d93a-3069-14ed-0976" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="949f-4f0c-4f66-440d" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="03c8-674d-da0e-aa34" name="Akkadic Hand Flamer" hidden="false" collective="false" import="true" targetId="0480-9726-cc82-7565" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7dd-0a44-e42a-9920" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b59-140d-b4a9-d8c8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7dd-0a44-e42a-9920" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b59-140d-b4a9-d8c8" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="ee56-93b6-88ec-2269" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="779b-ca3e-3b79-971e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afd5-7d1e-1f97-a626" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="779b-ca3e-3b79-971e" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afd5-7d1e-1f97-a626" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="5254-5c76-10d4-c909" name="Mhara Gal Dreadnought" hidden="false" collective="false" import="true" type="unit">
@@ -1635,96 +1634,96 @@ In addition, once per battle, one friendly unit composed entirely of models with
       </profiles>
       <rules>
         <rule id="bc78-fcfb-5f3c-4784" name="Accursed" hidden="false">
-          <description>All models with the Daemon unit type and/or Psyker or Corrupted sub-type must reduce their Toughness and Strength by -1 while they are within 6” of a model with this special rule. Models that also have this special rule are immune to its effects.</description>
+          <description>All models with the Daemon unit type and/or Psyker or Corrupted sub-type must reduce their Toughness and Strength by -1 while they are within 6&#8221; of a model with this special rule. Models that also have this special rule are immune to its effects.</description>
         </rule>
         <rule id="45ab-1eab-709c-3d1f" name="Shroud of Dark Fire" hidden="false">
-          <description>Any Hit allocated to a model with this special rule from a plasma, flame, melta or volkite weapon has its Strength reduced by -1. In addition, a model with this special rule gains a 5+ Invulnerable Save and should it suffer an unsaved Wound with the Instant Death special rule is not immediately removed as a casualty, but instead loses D3 Wounds instead of one for each unsaved Wound with the Instant Death special rule inflicted on it. If a model with this special rule loses its last Wound or Hull Point, but before it is removed as a casualty, all models both friendly and enemy within D6+6” suffer an automatic Hit at Strength 8 and with an AP of -.</description>
+          <description>Any Hit allocated to a model with this special rule from a plasma, flame, melta or volkite weapon has its Strength reduced by -1. In addition, a model with this special rule gains a 5+ Invulnerable Save and should it suffer an unsaved Wound with the Instant Death special rule is not immediately removed as a casualty, but instead loses D3 Wounds instead of one for each unsaved Wound with the Instant Death special rule inflicted on it. If a model with this special rule loses its last Wound or Hull Point, but before it is removed as a casualty, all models both friendly and enemy within D6+6&#8221; suffer an automatic Hit at Strength 8 and with an AP of -.</description>
         </rule>
       </rules>
       <infoLinks>
         <infoLink id="d406-bab6-da4c-c881" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="It Will Not Die (5+)"/>
+            <modifier type="set" field="name" value="It Will Not Die (5+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="f808-4dfb-bd9c-feea" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule"/>
-        <infoLink id="7ffd-4693-498f-94e1" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule"/>
-        <infoLink id="8b49-a766-9b4e-ba01" name="Pathfinder" hidden="false" targetId="ec97-7aa8-49f5-b298" type="rule"/>
+        <infoLink id="f808-4dfb-bd9c-feea" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule" />
+        <infoLink id="7ffd-4693-498f-94e1" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule" />
+        <infoLink id="8b49-a766-9b4e-ba01" name="Pathfinder" hidden="false" targetId="ec97-7aa8-49f5-b298" type="rule" />
         <infoLink id="ff63-62a3-a7f3-a409" name="Rampage (X)" hidden="false" targetId="3efb-2a2c-2d0b-92fc" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Rampage (2)"/>
+            <modifier type="set" field="name" value="Rampage (2)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="384c-208d-03b6-bd42" name="Corrupted:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
-        <categoryLink id="03be-92b3-01a3-c1ff" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="e23d-5f58-c4d7-7506" name="Dreadnought:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false"/>
+        <categoryLink id="384c-208d-03b6-bd42" name="Corrupted:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false" />
+        <categoryLink id="03be-92b3-01a3-c1ff" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="e23d-5f58-c4d7-7506" name="Dreadnought:" hidden="false" targetId="4280-4963-02b5-e31d" primary="false" />
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="41a2-9e23-99ea-0e6d" name="Exchange Warpfire cannon for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ed3c-bdac-aec7-ab09">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d29-0fae-31e2-812c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e32-ca01-a57c-e89d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d29-0fae-31e2-812c" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e32-ca01-a57c-e89d" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="bd4e-d716-6791-34f2" name="Tainted claw with in-built Boltspitter" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
-                <infoLink id="a122-ef27-eecb-0cba" name="Tainted Claw " hidden="false" targetId="c224-1900-ea6f-43e7" type="profile"/>
-                <infoLink id="ef6b-9e7e-6c74-8bf2" name="Boltspitter" hidden="false" targetId="f5db-b3b0-4d9b-11b5" type="profile"/>
-                <infoLink id="d97a-e441-6426-4fba" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule"/>
-                <infoLink id="ee79-46fb-367a-cbf2" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule"/>
+                <infoLink id="a122-ef27-eecb-0cba" name="Tainted Claw " hidden="false" targetId="c224-1900-ea6f-43e7" type="profile" />
+                <infoLink id="ef6b-9e7e-6c74-8bf2" name="Boltspitter" hidden="false" targetId="f5db-b3b0-4d9b-11b5" type="profile" />
+                <infoLink id="d97a-e441-6426-4fba" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule" />
+                <infoLink id="ee79-46fb-367a-cbf2" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="7b5b-2ad8-a740-fb45" name="Gravis Autocannon" hidden="false" collective="false" import="true" targetId="8a23-e57d-b4a8-14a9" type="selectionEntry"/>
+            <entryLink id="7b5b-2ad8-a740-fb45" name="Gravis Autocannon" hidden="false" collective="false" import="true" targetId="8a23-e57d-b4a8-14a9" type="selectionEntry" />
             <entryLink id="0f38-887f-2bc7-dae8" name="Gravis Lascannon" hidden="false" collective="false" import="true" targetId="1fe0-7c96-5200-0e39" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
-            <entryLink id="a0c0-b6bd-069f-8856" name="Gravis Melta Cannon" hidden="false" collective="false" import="true" targetId="ef6c-f656-171a-03e1" type="selectionEntry"/>
-            <entryLink id="d744-0d0f-bf86-19f2" name="Greater Boltspitter" hidden="false" collective="false" import="true" targetId="983a-164a-2164-4895" type="selectionEntry"/>
-            <entryLink id="ed3c-bdac-aec7-ab09" name="Warpfire Cannon" hidden="false" collective="false" import="true" targetId="2d54-6e68-4830-4ef3" type="selectionEntry"/>
+            <entryLink id="a0c0-b6bd-069f-8856" name="Gravis Melta Cannon" hidden="false" collective="false" import="true" targetId="ef6c-f656-171a-03e1" type="selectionEntry" />
+            <entryLink id="d744-0d0f-bf86-19f2" name="Greater Boltspitter" hidden="false" collective="false" import="true" targetId="983a-164a-2164-4895" type="selectionEntry" />
+            <entryLink id="ed3c-bdac-aec7-ab09" name="Warpfire Cannon" hidden="false" collective="false" import="true" targetId="2d54-6e68-4830-4ef3" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="83c0-6b3a-1e95-7176" name="Exchange Tainted claw with in-built Boltspitter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="bfab-ba0b-27a7-ea8b">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="645b-fd4d-ea55-d60e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="810e-df1e-ae18-5afe" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="645b-fd4d-ea55-d60e" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="810e-df1e-ae18-5afe" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="bfab-ba0b-27a7-ea8b" name="Tainted claw with in-built Boltspitter" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
-                <infoLink id="1617-79a4-b101-e7c2" name="Tainted Claw " hidden="false" targetId="c224-1900-ea6f-43e7" type="profile"/>
-                <infoLink id="d6a2-d577-01cb-df73" name="Boltspitter" hidden="false" targetId="f5db-b3b0-4d9b-11b5" type="profile"/>
-                <infoLink id="7f0d-1da6-2510-fcf3" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule"/>
-                <infoLink id="f7d9-bf25-b9ce-c981" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule"/>
+                <infoLink id="1617-79a4-b101-e7c2" name="Tainted Claw " hidden="false" targetId="c224-1900-ea6f-43e7" type="profile" />
+                <infoLink id="d6a2-d577-01cb-df73" name="Boltspitter" hidden="false" targetId="f5db-b3b0-4d9b-11b5" type="profile" />
+                <infoLink id="7f0d-1da6-2510-fcf3" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule" />
+                <infoLink id="f7d9-bf25-b9ce-c981" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="94b4-0b25-cae1-4134" name="Gravis Autocannon" hidden="false" collective="false" import="true" targetId="8a23-e57d-b4a8-14a9" type="selectionEntry"/>
+            <entryLink id="94b4-0b25-cae1-4134" name="Gravis Autocannon" hidden="false" collective="false" import="true" targetId="8a23-e57d-b4a8-14a9" type="selectionEntry" />
             <entryLink id="c862-af2c-64aa-d371" name="Gravis Lascannon" hidden="false" collective="false" import="true" targetId="1fe0-7c96-5200-0e39" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
-            <entryLink id="e698-e8e1-57fb-80d8" name="Gravis Melta Cannon" hidden="false" collective="false" import="true" targetId="ef6c-f656-171a-03e1" type="selectionEntry"/>
-            <entryLink id="5b21-8dd5-9160-6429" name="Greater Boltspitter" hidden="false" collective="false" import="true" targetId="983a-164a-2164-4895" type="selectionEntry"/>
-            <entryLink id="dfbf-34da-050b-a0d6" name="Warpfire Cannon" hidden="false" collective="false" import="true" targetId="2d54-6e68-4830-4ef3" type="selectionEntry"/>
+            <entryLink id="e698-e8e1-57fb-80d8" name="Gravis Melta Cannon" hidden="false" collective="false" import="true" targetId="ef6c-f656-171a-03e1" type="selectionEntry" />
+            <entryLink id="5b21-8dd5-9160-6429" name="Greater Boltspitter" hidden="false" collective="false" import="true" targetId="983a-164a-2164-4895" type="selectionEntry" />
+            <entryLink id="dfbf-34da-050b-a0d6" name="Warpfire Cannon" hidden="false" collective="false" import="true" targetId="2d54-6e68-4830-4ef3" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="240.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="240.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="4f8e-79b2-b286-d40e" name="Anaktis Kul Blade Slave" hidden="false" collective="false" import="true" type="model">
@@ -1732,7 +1731,7 @@ In addition, once per battle, one friendly unit composed entirely of models with
         <profile id="49fb-4398-38a2-49f4" name="Anaktis Kul Blade Slave" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Corrupted)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
@@ -1748,33 +1747,33 @@ In addition, once per battle, one friendly unit composed entirely of models with
       <infoLinks>
         <infoLink id="e6e4-6276-06a4-b33a" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="5dce-d32f-91ba-72ef" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
+        <infoLink id="5dce-d32f-91ba-72ef" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
         <infoLink id="82a6-1abf-7b24-e3bf" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+            <modifier type="set" field="name" value="Feel No Pain (5+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="c931-1ba9-f2c0-2391" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule"/>
+        <infoLink id="c931-1ba9-f2c0-2391" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule" />
         <infoLink id="ff28-8f90-6f6b-7d5d" name="Rage (X)" hidden="false" targetId="564d-3550-ae44-2f99" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Rage (1)"/>
+            <modifier type="set" field="name" value="Rage (1)" />
           </modifiers>
         </infoLink>
-        <infoLink id="80b6-d93b-76ac-ef8e" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="80b6-d93b-76ac-ef8e" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="12b2-c421-a2f1-8907" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
-        <categoryLink id="f886-4ca2-1868-07e2" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="52a9-15b7-149f-b6d7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="12b2-c421-a2f1-8907" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false" />
+        <categoryLink id="f886-4ca2-1868-07e2" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="52a9-15b7-149f-b6d7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0dd6-4f8c-91d1-ee32" name="Anaktis Blade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4baa-25d9-ad8e-3932" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f0a-b4ee-7410-aec7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4baa-25d9-ad8e-3932" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f0a-b4ee-7410-aec7" type="max" />
           </constraints>
           <profiles>
             <profile id="96f6-1291-83a2-7383" name="Anaktis Blade" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1787,68 +1786,68 @@ In addition, once per battle, one friendly unit composed entirely of models with
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="1b3a-4f9d-f481-09b9" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule"/>
+            <infoLink id="1b3a-4f9d-f481-09b9" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="f6cd-171c-62c9-1443" name="The Panoply of Flame" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43ad-bf46-8c92-7a8c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfe7-a867-a3d8-9010" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43ad-bf46-8c92-7a8c" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfe7-a867-a3d8-9010" type="max" />
           </constraints>
           <profiles>
             <profile id="5734-497e-467b-3e02" name="The Panoply of Flame" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
               <characteristics>
-                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">All models with the Legiones Astartes (Word Bearers) special rule within 12&quot; of the Panoply of Flame add a +1 modifier to their score when determining victory in assaults and +1 to their Sweeping Advance rolls.</characteristic>
+                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">All models with the Legiones Astartes (Word Bearers) special rule within 12" of the Panoply of Flame add a +1 modifier to their score when determining victory in assaults and +1 to their Sweeping Advance rolls.</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="227c-cf38-e86b-1ced" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c91-441b-937b-f466" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da4b-e834-a112-61e0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c91-441b-937b-f466" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da4b-e834-a112-61e0" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="31a6-802b-5b32-0496" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5847-ced8-d71e-ac87" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2380-3e49-63cf-c4ca" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5847-ced8-d71e-ac87" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2380-3e49-63cf-c4ca" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="23cf-9544-4c61-bfc2" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60d5-d93e-a232-4c5b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d27c-92da-2697-d0dd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60d5-d93e-a232-4c5b" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d27c-92da-2697-d0dd" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="dd9e-4012-1835-3811" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ee8-040d-a75f-d2cb" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bd7-8d1e-a6be-98af" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ee8-040d-a75f-d2cb" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bd7-8d1e-a6be-98af" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="6be5-394d-9d79-344b" name="Argel Tal" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8333-54c1-daf4-046d" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8333-54c1-daf4-046d" type="max" />
       </constraints>
       <profiles>
         <profile id="da51-6ca2-c7d5-451e" name="Argel Tal" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique, Corrupted)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">5</characteristic>
@@ -1862,35 +1861,35 @@ In addition, once per battle, one friendly unit composed entirely of models with
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="ffa0-9f4e-7e5d-6619" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule"/>
-        <infoLink id="ffdd-6053-13a6-d7b9" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="ffa0-9f4e-7e5d-6619" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule" />
+        <infoLink id="ffdd-6053-13a6-d7b9" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="9fde-c520-0252-d486" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+            <modifier type="set" field="name" value="Feel No Pain (5+)" />
           </modifiers>
         </infoLink>
         <infoLink id="7bce-6997-e994-9a4a" name="Rage (X)" hidden="false" targetId="564d-3550-ae44-2f99" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Rage (2)"/>
+            <modifier type="set" field="name" value="Rage (2)" />
           </modifiers>
         </infoLink>
         <infoLink id="aece-1b86-be7e-da13" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (3)"/>
+            <modifier type="set" field="name" value="Bulky (3)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="cba8-9fd4-5e85-e6ed" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="a847-6e8a-66a4-fa17" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="c096-bb42-1c27-67a6" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
-        <categoryLink id="5230-23dd-655d-ab3a" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
+        <categoryLink id="cba8-9fd4-5e85-e6ed" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="a847-6e8a-66a4-fa17" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="c096-bb42-1c27-67a6" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false" />
+        <categoryLink id="5230-23dd-655d-ab3a" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="14c5-57da-1235-56d4" name="Two Daemonic Talons" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9103-5e64-6f91-adec" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fed1-dc52-707d-8621" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9103-5e64-6f91-adec" type="min" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fed1-dc52-707d-8621" type="max" />
           </constraints>
           <profiles>
             <profile id="2383-7302-7e86-ac11" name="Daemonic Talons" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1903,80 +1902,80 @@ In addition, once per battle, one friendly unit composed entirely of models with
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="e3db-eb54-8106-7aad" name="Umbral Pinions" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e0d-18be-78c1-9079" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c05-1de4-d6f4-5787" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e0d-18be-78c1-9079" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c05-1de4-d6f4-5787" type="max" />
           </constraints>
           <profiles>
             <profile id="712c-b5e0-e925-51af" name="Umbral Pinions" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
               <characteristics>
-                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Argel Tal’s Movement Characteristic may be set to a value of 14 for the duration of the controlling player’s turn. This allows Argel Tal to move up to 14”, regardless of the Movement Characteristic shown on his profile and gain any other benefits of a Movement Characteristic of 14 (Including the bonus to Charge Distance). In addition Argel Tal ignores terrain while Moving and Charging. If Argel Tal ends or begins his movement or a Charge in Dangerous Terrain then he will still need to take Dangerous Terrain tests as normal, even when employing the Umbral Pinions, and treats all Difficult Terrain as Dangerous Terrain.
+                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Argel Tal&#8217;s Movement Characteristic may be set to a value of 14 for the duration of the controlling player&#8217;s turn. This allows Argel Tal to move up to 14&#8221;, regardless of the Movement Characteristic shown on his profile and gain any other benefits of a Movement Characteristic of 14 (Including the bonus to Charge Distance). In addition Argel Tal ignores terrain while Moving and Charging. If Argel Tal ends or begins his movement or a Charge in Dangerous Terrain then he will still need to take Dangerous Terrain tests as normal, even when employing the Umbral Pinions, and treats all Difficult Terrain as Dangerous Terrain.
 
 Argel Tal may not Run in any Turn in which the Umbral Pinions have been activated, and may not activate them to gain any bonus to their Movement Characteristic during a Reaction.</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="15cf-a315-df36-43ba" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc11-069b-a415-ca93" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6000-f42b-0597-7a3f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc11-069b-a415-ca93" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6000-f42b-0597-7a3f" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="498a-5635-eb71-d0a4" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d471-16e4-b281-4b2e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03c4-6d2d-1e83-279c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d471-16e4-b281-4b2e" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03c4-6d2d-1e83-279c" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="0ca8-3b56-d38a-72b0" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2d5-2e5a-6825-4488" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d13b-0608-0335-7f6e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2d5-2e5a-6825-4488" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d13b-0608-0335-7f6e" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="6635-545d-23ab-3baa" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8560-823a-ce8b-bf74" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fda1-dfe2-7f3a-85ca" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8560-823a-ce8b-bf74" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fda1-dfe2-7f3a-85ca" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="a829-8b74-095d-4fc2" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1214-8e81-38aa-82c4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1214-8e81-38aa-82c4" type="max" />
           </constraints>
           <profiles>
             <profile id="255a-78db-9c70-7802" name="The Crimson Lord" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If Argel Tal is the army’s Warlord, then all models with the Corrupted Unit sub-type gain the Line unit sub-type and both Argel Tal and any Gal Vorbak unit he joins gain a 5+ Invulnerable Save. In addition, an army with Argel Tal as its Warlord may make an additional Reaction during the Assault phase as long as Argel Tal has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If Argel Tal is the army&#8217;s Warlord, then all models with the Corrupted Unit sub-type gain the Line unit sub-type and both Argel Tal and any Gal Vorbak unit he joins gain a 5+ Invulnerable Save. In addition, an army with Argel Tal as its Warlord may make an additional Reaction during the Assault phase as long as Argel Tal has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
-        <entryLink id="63cc-2149-3026-c07c" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup"/>
+        <entryLink id="63cc-2149-3026-c07c" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="240.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="240.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="18c4-d715-caba-b450" name="High Chaplain Erebus" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9578-e447-6e7c-4ba2" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9578-e447-6e7c-4ba2" type="max" />
       </constraints>
       <profiles>
         <profile id="af3e-ad7a-2a90-23a2" name="High Chaplain Erebus" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Psyker, Corrupted, Unique)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1999,26 +1998,26 @@ Psychic Weapon</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="23f1-7536-3061-594b" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule"/>
-        <infoLink id="5e6c-d7ca-c540-02cd" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="23f1-7536-3061-594b" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule" />
+        <infoLink id="5e6c-d7ca-c540-02cd" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="098f-81d0-dd22-0e26" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hatred (Loyalists)"/>
+            <modifier type="set" field="name" value="Hatred (Loyalists)" />
           </modifiers>
         </infoLink>
-        <infoLink id="a94d-4b88-ece7-d111" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
+        <infoLink id="a94d-4b88-ece7-d111" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="d3d0-99c4-cb4c-969c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="35e4-8e2b-e655-7bba" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="9acc-39e7-b768-439f" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
-        <categoryLink id="c6bf-c6ef-ae4a-4995" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false"/>
+        <categoryLink id="d3d0-99c4-cb4c-969c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="35e4-8e2b-e655-7bba" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="9acc-39e7-b768-439f" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false" />
+        <categoryLink id="c6bf-c6ef-ae4a-4995" name="Psyker:" hidden="false" targetId="6e0c-29ba-a445-8321" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="20eb-1d18-ef3b-6a39" name="Crux Malifica" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="102e-a68c-252b-d192" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2438-f695-c7be-4576" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="102e-a68c-252b-d192" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2438-f695-c7be-4576" type="max" />
           </constraints>
           <profiles>
             <profile id="a7a7-dccb-d0b1-fff7" name="Crux Malifica" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2031,104 +2030,104 @@ Psychic Weapon</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="bf4e-4ff9-adeb-d35e" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule"/>
-            <infoLink id="4eee-8d94-70e1-9c89" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+            <infoLink id="bf4e-4ff9-adeb-d35e" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule" />
+            <infoLink id="4eee-8d94-70e1-9c89" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="7be1-f090-72cf-92c7" name="Psychic Powers" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef0c-a210-76a1-206b" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ba6-097f-ac2b-b2bc" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef0c-a210-76a1-206b" type="min" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ba6-097f-ac2b-b2bc" type="max" />
           </constraints>
           <infoLinks>
-            <infoLink id="fa2b-fab1-23f2-7c45" name="Aetheric Lightning (P3P ZW)" hidden="false" targetId="3d0c-e779-247f-0332" type="profile"/>
-            <infoLink id="65c2-fadf-e952-777c" name="Breach the Veil (P3P ZW) (Move to GST)" hidden="false" targetId="8d74-fa05-de93-4f22" type="profile"/>
-            <infoLink id="f36a-f00d-292e-a1f8" name="Force" hidden="false" targetId="f39e-4c3b-38e0-0050" type="rule"/>
+            <infoLink id="fa2b-fab1-23f2-7c45" name="Aetheric Lightning (P3P ZW)" hidden="false" targetId="3d0c-e779-247f-0332" type="profile" />
+            <infoLink id="65c2-fadf-e952-777c" name="Breach the Veil (P3P ZW) (Move to GST)" hidden="false" targetId="8d74-fa05-de93-4f22" type="profile" />
+            <infoLink id="f36a-f00d-292e-a1f8" name="Force" hidden="false" targetId="f39e-4c3b-38e0-0050" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="050f-3cb4-36dc-cfb7" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3e4-b2ff-7ed6-1332" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7506-2a56-4053-57a2" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3e4-b2ff-7ed6-1332" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7506-2a56-4053-57a2" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="c5e7-8711-5b50-d004" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="236c-11ca-6133-7c81" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b83-6970-09fe-89cd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="236c-11ca-6133-7c81" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b83-6970-09fe-89cd" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="dd04-b41d-00ee-50bb" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99ec-f607-d77e-7013" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53e2-56ce-a7ca-e597" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99ec-f607-d77e-7013" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53e2-56ce-a7ca-e597" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="4f52-4380-3d0c-462e" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e36-a1bf-54ba-ad30" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed3b-fe29-f353-b1d6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e36-a1bf-54ba-ad30" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed3b-fe29-f353-b1d6" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="548f-c855-be9e-7c54" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed6e-4129-9b24-dbea" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6fc-e7ac-5589-4144" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed6e-4129-9b24-dbea" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6fc-e7ac-5589-4144" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="1c07-8c65-38db-8e1b" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="188f-1714-0ae3-6994" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d41-bd04-d570-f142" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="188f-1714-0ae3-6994" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d41-bd04-d570-f142" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="111b-6330-219c-3ea7" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a0d-1d7f-367f-f186" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a0d-1d7f-367f-f186" type="max" />
           </constraints>
           <profiles>
             <profile id="5d3e-cf76-89c6-3574" name="Shadow Behind the Throne" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When High Chaplain Erebus is the army’s Warlord and is part of a unit composed entirely of models with any version of the Legiones Astartes special rule, no Wounds may be allocated to him, regardless of the attacking models rules or effects, as long as there is another model in the unit. If High Chaplain Erebus is engaged in a Challenge then this rule does not apply, however if High Chaplain Erebus’ controlling player chooses to refuse a Challenge for a unit that includes High Chaplain Erebus then the opposing player loses the option to stop one model from participating in the combat. In addition, an army whose Warlord is High Chaplain Erebus may make an additional Reaction in any one Phase, chosen by the controlling player at the start of the turn, as long as High Chaplain Erebus has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When High Chaplain Erebus is the army&#8217;s Warlord and is part of a unit composed entirely of models with any version of the Legiones Astartes special rule, no Wounds may be allocated to him, regardless of the attacking models rules or effects, as long as there is another model in the unit. If High Chaplain Erebus is engaged in a Challenge then this rule does not apply, however if High Chaplain Erebus&#8217; controlling player chooses to refuse a Challenge for a unit that includes High Chaplain Erebus then the opposing player loses the option to stop one model from participating in the combat. In addition, an army whose Warlord is High Chaplain Erebus may make an additional Reaction in any one Phase, chosen by the controlling player at the start of the turn, as long as High Chaplain Erebus has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
-        <entryLink id="ea81-799d-c4ba-16ab" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup"/>
+        <entryLink id="ea81-799d-c4ba-16ab" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="165.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="165.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="e61d-db78-6f56-3c05" name="Kor Phaeron" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="196c-7b3c-c0f9-8008" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="196c-7b3c-c0f9-8008" type="max" />
       </constraints>
       <profiles>
         <profile id="55c8-44f1-be1e-ef48" name="Kor Phaeron" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <modifiers>
             <modifier type="set" field="e8a6-1da9-d384-8727" value="9">
               <conditions>
-                <condition field="selections" scope="e61d-db78-6f56-3c05" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f677-7297-31a2-e16a" type="equalTo"/>
+                <condition field="selections" scope="e61d-db78-6f56-3c05" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f677-7297-31a2-e16a" type="equalTo" />
               </conditions>
             </modifier>
             <modifier type="set" field="cc42-7ed5-7092-5c84" value="6">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9289-65f7-e452-51a5" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9289-65f7-e452-51a5" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character, Corrupted, Unique)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
@@ -2147,32 +2146,32 @@ Psychic Weapon</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="1660-a198-cd2c-8131" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule"/>
-        <infoLink id="f253-3730-fa9f-31b4" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="1660-a198-cd2c-8131" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule" />
+        <infoLink id="f253-3730-fa9f-31b4" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="44e6-b4da-5993-1c6b" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
         <infoLink id="b4fa-ed89-b1c6-9cab" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+            <modifier type="set" field="name" value="Feel No Pain (5+)" />
           </modifiers>
         </infoLink>
         <infoLink id="2a90-9fd3-91f8-b3a3" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="It Will Not Die (5+)"/>
+            <modifier type="set" field="name" value="It Will Not Die (5+)" />
           </modifiers>
         </infoLink>
         <infoLink id="6c02-a57a-95b5-bc2d" name="Hatred (X)" hidden="true" targetId="dc0b-fe69-6b71-e0a4" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hatred (Everything)"/>
+            <modifier type="set" field="name" value="Hatred (Everything)" />
             <modifier type="set" field="hidden" value="false">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="e61d-db78-6f56-3c05" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f677-7297-31a2-e16a" type="equalTo"/>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9289-65f7-e452-51a5" type="equalTo"/>
+                    <condition field="selections" scope="e61d-db78-6f56-3c05" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f677-7297-31a2-e16a" type="equalTo" />
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9289-65f7-e452-51a5" type="equalTo" />
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -2181,13 +2180,13 @@ Psychic Weapon</description>
         </infoLink>
       </infoLinks>
       <selectionEntries>
-        <selectionEntry id="ad6c-f113-0852-4c72" name="Patriarch&apos;s Claws" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="ad6c-f113-0852-4c72" name="Patriarch's Claws" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7fa-9e34-8327-e5e5" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5291-a957-51f4-85e1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7fa-9e34-8327-e5e5" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5291-a957-51f4-85e1" type="max" />
           </constraints>
           <profiles>
-            <profile id="505c-9791-57e2-c25c" name="Patriarch&apos;s Claws" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="505c-9791-57e2-c25c" name="Patriarch's Claws" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">User</characteristic>
@@ -2195,23 +2194,23 @@ Psychic Weapon</description>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Shred</characteristic>
               </characteristics>
             </profile>
-            <profile id="8149-0fed-1719-faa6" name="Patriarch&apos;s Claws" hidden="false" typeId="b46c-270c-d29e-f0ff" typeName="Ability">
+            <profile id="8149-0fed-1719-faa6" name="Patriarch's Claws" hidden="false" typeId="b46c-270c-d29e-f0ff" typeName="Ability">
               <characteristics>
-                <characteristic name="Description" typeId="0982-427b-1d4a-d07c">The Patriarch’s Claws are a pair of two weapons and as such Kor Phaeron gains a bonus attack when using them.</characteristic>
+                <characteristic name="Description" typeId="0982-427b-1d4a-d07c">The Patriarch&#8217;s Claws are a pair of two weapons and as such Kor Phaeron gains a bonus attack when using them.</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="d631-9ae4-7bd4-1c6d" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+            <infoLink id="d631-9ae4-7bd4-1c6d" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="f58b-4210-b646-52d8" name="Digi-flamer" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff96-a112-83cd-130e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a458-edc2-2fd7-93e9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff96-a112-83cd-130e" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a458-edc2-2fd7-93e9" type="max" />
           </constraints>
           <profiles>
             <profile id="ee04-910a-79a5-a492" name="Digi-flamer" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2224,16 +2223,16 @@ Psychic Weapon</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="dee1-a478-fbff-183b" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
+            <infoLink id="dee1-a478-fbff-183b" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="6d79-2cb7-5d31-566e" name="The Terminus Consolaris" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46de-3ee9-2246-2c54" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e77-b83c-7501-cf4d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46de-3ee9-2246-2c54" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e77-b83c-7501-cf4d" type="max" />
           </constraints>
           <profiles>
             <profile id="35a2-8fbd-c9c5-b143" name="The Terminus Consolaris" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
@@ -2243,48 +2242,48 @@ Psychic Weapon</description>
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="304d-d174-0763-4504" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup"/>
+        <entryLink id="304d-d174-0763-4504" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup" />
         <entryLink id="f677-7297-31a2-e16a" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e98b-d051-15be-6ec3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e98b-d051-15be-6ec3" type="max" />
           </constraints>
           <profiles>
             <profile id="5810-68a1-b0b7-9ffc" name="Dark Oratory" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
                 <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When Kor Phaeron is the Warlord of the army then the controlling player can choose one of the following two options at the beginning of each of their own turns:
 
-Cruel Invective - All enemy units with at least one model within 12” of Kor Phaeron at the start of the controlling player’s turn (before any models are moved) must make an immediate Pinning check, and become Pinned if the Check is failed.
+Cruel Invective - All enemy units with at least one model within 12&#8221; of Kor Phaeron at the start of the controlling player&#8217;s turn (before any models are moved) must make an immediate Pinning check, and become Pinned if the Check is failed.
 
-Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearless special rule until the start of the controlling player’s next turn, but all model’s other than Kor Phaeron in the unit reduce their WS and BS by -1 until the start of the controlling player’s next turn. In addition, an army with Kor Phaeron as its Warlord may make an additional Reaction during the Assault phase as long as Kor Phaeron has not been removed as a casualty.</characteristic>
+Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearless special rule until the start of the controlling player&#8217;s next turn, but all model&#8217;s other than Kor Phaeron in the unit reduce their WS and BS by -1 until the start of the controlling player&#8217;s next turn. In addition, an army with Kor Phaeron as its Warlord may make an additional Reaction during the Assault phase as long as Kor Phaeron has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
         <entryLink id="bea0-460f-f887-e995" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5237-6f28-fccf-c8c0" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62c9-289f-804d-e69b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5237-6f28-fccf-c8c0" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62c9-289f-804d-e69b" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="f511-e558-6bff-6543" name="Zardu Layak" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="574e-7e54-7db7-60a3" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="574e-7e54-7db7-60a3" type="max" />
       </constraints>
       <profiles>
         <profile id="e53d-63ae-2ac4-427a" name="Zardu Layak" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Corrupted, Psyker, Character, Unique)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2307,29 +2306,29 @@ as the Aetheric Lightning Psychic Weapon</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="db32-9305-1735-81ce" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
+        <infoLink id="db32-9305-1735-81ce" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule" />
         <infoLink id="3f82-2136-2167-9280" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hatred (Loyalists)"/>
+            <modifier type="set" field="name" value="Hatred (Loyalists)" />
           </modifiers>
         </infoLink>
-        <infoLink id="d324-8719-89c0-dd00" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule"/>
-        <infoLink id="8932-28c5-60c8-9155" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="d324-8719-89c0-dd00" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule" />
+        <infoLink id="8932-28c5-60c8-9155" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="cd36-7aef-4bad-b59e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="49db-339f-dd98-686b" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="9ace-0389-f30c-2062" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="d74c-384e-1128-4d7a" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false"/>
+        <categoryLink id="cd36-7aef-4bad-b59e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="49db-339f-dd98-686b" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="9ace-0389-f30c-2062" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="d74c-384e-1128-4d7a" name="Corrupted Sub-type:" hidden="false" targetId="9055-7410-8ffd-b8e7" primary="false" />
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="2bac-34cb-8346-fc49" name="The Azurda Char&apos;is" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="2bac-34cb-8346-fc49" name="The Azurda Char'is" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="458a-3cdf-6796-7fdb" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bc8-736e-db57-ff3e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="458a-3cdf-6796-7fdb" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bc8-736e-db57-ff3e" type="max" />
           </constraints>
           <profiles>
-            <profile id="1644-a08d-3d43-69c2" name="The Azurda Char&apos;is" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="1644-a08d-3d43-69c2" name="The Azurda Char'is" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">User</characteristic>
@@ -2339,18 +2338,18 @@ as the Aetheric Lightning Psychic Weapon</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="eb5d-a5ee-f43d-7588" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
-            <infoLink id="d33a-11be-8ef2-38d7" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule"/>
-            <infoLink id="2ce9-4b45-c54a-d86d" name="Force" hidden="false" targetId="f39e-4c3b-38e0-0050" type="rule"/>
+            <infoLink id="eb5d-a5ee-f43d-7588" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
+            <infoLink id="d33a-11be-8ef2-38d7" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule" />
+            <infoLink id="2ce9-4b45-c54a-d86d" name="Force" hidden="false" targetId="f39e-4c3b-38e0-0050" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="d140-8485-d80d-776d" name="Psychic Powers" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4916-f9ab-baa9-940d" type="max"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fecb-7caa-683d-efcb" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4916-f9ab-baa9-940d" type="max" />
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fecb-7caa-683d-efcb" type="min" />
           </constraints>
           <profiles>
             <profile id="f21f-a89f-7ef3-8c57" name="Soul Binding" hidden="false" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power">
@@ -2360,7 +2359,7 @@ as the Aetheric Lightning Psychic Weapon</description>
             </profile>
             <profile id="b97e-e053-1d25-7c6c" name="Telepathetic Chains" hidden="false" typeId="cede-0217-1b10-2a34" typeName="Psychic Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="62ec-fbf5-5252-0d17">36&quot;</characteristic>
+                <characteristic name="Range" typeId="62ec-fbf5-5252-0d17">36"</characteristic>
                 <characteristic name="Strength" typeId="17ff-12e7-77d3-2fbe">2</characteristic>
                 <characteristic name="AP" typeId="f431-a7b9-d9d0-36c9">-</characteristic>
                 <characteristic name="Type" typeId="2159-62b6-4337-d516">Assault 4, Pinning, Shell Shock (3), Psychic Focus</characteristic>
@@ -2368,115 +2367,115 @@ as the Aetheric Lightning Psychic Weapon</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="2134-e504-4914-b32b" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
-            <infoLink id="cfe9-099f-507f-59fb" name="Shell Shock (X)" hidden="false" targetId="46b7-63a1-941c-96a5" type="rule"/>
-            <infoLink id="145c-e9ea-573c-d626" name="Psychic Focus (?? Where is this?)" hidden="false" targetId="bff3-3548-b2b8-72f1" type="rule"/>
-            <infoLink id="7b11-f06b-2d7f-b154" name="Aetheric Lightning" hidden="false" targetId="3d0c-e779-247f-0332" type="profile"/>
-            <infoLink id="5f77-9fc0-d5db-4414" name="Force" hidden="false" targetId="f39e-4c3b-38e0-0050" type="rule"/>
+            <infoLink id="2134-e504-4914-b32b" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule" />
+            <infoLink id="cfe9-099f-507f-59fb" name="Shell Shock (X)" hidden="false" targetId="46b7-63a1-941c-96a5" type="rule" />
+            <infoLink id="145c-e9ea-573c-d626" name="Psychic Focus (?? Where is this?)" hidden="false" targetId="bff3-3548-b2b8-72f1" type="rule" />
+            <infoLink id="7b11-f06b-2d7f-b154" name="Aetheric Lightning" hidden="false" targetId="3d0c-e779-247f-0332" type="profile" />
+            <infoLink id="5f77-9fc0-d5db-4414" name="Force" hidden="false" targetId="f39e-4c3b-38e0-0050" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="3b92-8095-5a9a-dcff" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a761-32ff-8ff0-4afc" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e69-9487-a71f-22d3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a761-32ff-8ff0-4afc" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e69-9487-a71f-22d3" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="ca5c-4aa0-6c2c-d943" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dbe-96ce-3634-37d0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad3e-e5d2-e8a8-bd66" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dbe-96ce-3634-37d0" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad3e-e5d2-e8a8-bd66" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="0a3e-810b-7322-e95c" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a107-8fd0-7d30-1935" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29cd-c991-f512-b45a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a107-8fd0-7d30-1935" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29cd-c991-f512-b45a" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="58dc-e7d6-0a68-9ea1" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0bb-d45d-5a9d-e7e9" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b49e-727d-424e-1579" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0bb-d45d-5a9d-e7e9" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b49e-727d-424e-1579" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="0aae-a75f-0fcb-2ea9" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="387b-4914-44d3-7ab3" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80f0-f530-e36f-fed5" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="387b-4914-44d3-7ab3" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80f0-f530-e36f-fed5" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="e63d-82ae-8198-c313" name="Anaktis Kul Blade Slave" hidden="false" collective="false" import="true" targetId="4f8e-79b2-b286-d40e" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="name" value="2x Anaktis Kul Blade Slaves"/>
+            <modifier type="set" field="name" value="2x Anaktis Kul Blade Slaves" />
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2bdb-0c9e-4aed-7ea9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5145-21fc-4e0b-ec56" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2bdb-0c9e-4aed-7ea9" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5145-21fc-4e0b-ec56" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="d587-decb-35ed-dfc0" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="325c-ea43-855f-9130" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e406-18af-5d76-117a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="325c-ea43-855f-9130" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e406-18af-5d76-117a" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="74da-bce0-f635-a5bb" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9b9-403b-0c76-ef8f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9b9-403b-0c76-ef8f" type="max" />
           </constraints>
           <rules>
             <rule id="b2c4-083a-57e1-5b34" name="Warlord: Reign of Fire" hidden="false">
-              <description>If Zardu Layak is the army’s Warlord, then all models in an Ashen Circle Squad and all models with the Corrupted unit sub-type gain the Line unit sub-type. In addition, an army with Zardu Layak as its Warlord may make an additional Reaction during the Assault phase as long as Zardu Layak has not been removed as a casualty.</description>
+              <description>If Zardu Layak is the army&#8217;s Warlord, then all models in an Ashen Circle Squad and all models with the Corrupted unit sub-type gain the Line unit sub-type. In addition, an army with Zardu Layak as its Warlord may make an additional Reaction during the Assault phase as long as Zardu Layak has not been removed as a casualty.</description>
             </rule>
           </rules>
         </entryLink>
-        <entryLink id="fa9b-e07e-79bd-bf59" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup"/>
+        <entryLink id="fa9b-e07e-79bd-bf59" name="Retinue" hidden="false" collective="false" import="true" targetId="bda8-b52d-c914-4ac2" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="300.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="300.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="9cca-47d5-0779-79a2" name="Procurators" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="35e0-1a83-5ae2-f9f0" name="Flesh Harvesters" hidden="false">
-          <description>Friendly models with the Psychic Disciplines Harbingers of Chaos, Diabolism, or Anathemata within 6&quot; of a model with this special rule may roll an additional D6 and discard the highest result when making Psychic checks. Additionally, in missions that use Victory points the controlling player gains an additional +1 Victory point for every enemy unit that is removed as a casualty as a result of a Sweeping Advance made by a unit made up of models with this special rule.</description>
+          <description>Friendly models with the Psychic Disciplines Harbingers of Chaos, Diabolism, or Anathemata within 6" of a model with this special rule may roll an additional D6 and discard the highest result when making Psychic checks. Additionally, in missions that use Victory points the controlling player gains an additional +1 Victory point for every enemy unit that is removed as a casualty as a result of a Sweeping Advance made by a unit made up of models with this special rule.</description>
         </rule>
         <rule id="9af7-796f-c6db-fb17" name="Grim Purpose" hidden="false">
           <description>A unit that includes any models with this special rule may not be joined by any model that does not also have this special rule (this includes Legion Techmarines and Legion Apothecaries, which may not be assigned to a unit with this special rule unless they also have this special rule).</description>
         </rule>
       </rules>
       <categoryLinks>
-        <categoryLink id="5aff-13d0-9bfc-03ef" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="c840-64ca-a73b-7f3c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="5aff-13d0-9bfc-03ef" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="c840-64ca-a73b-7f3c" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9229-d848-0adf-91c7" name="2) Procurants" hidden="false" collective="false" import="true" defaultSelectionEntryId="9c94-e8e3-2c5a-6f24">
           <modifiers>
             <modifier type="decrement" field="bd1a-1c3c-ab42-efc3" value="1.0">
               <repeats>
-                <repeat field="selections" scope="9cca-47d5-0779-79a2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2a4f-a2f9-4371-342c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="9cca-47d5-0779-79a2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2a4f-a2f9-4371-342c" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd1a-1c3c-ab42-efc3" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f90-fa40-741c-b283" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd1a-1c3c-ab42-efc3" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f90-fa40-741c-b283" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="9c94-e8e3-2c5a-6f24" name="Procurant" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ff7-9116-e737-adbd" type="max"/>
+                <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ff7-9116-e737-adbd" type="max" />
               </constraints>
               <profiles>
                 <profile id="d1bb-8ac0-f862-ee3c" name="Procurant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2492,19 +2491,19 @@ as the Aetheric Lightning Psychic Weapon</description>
               <entryLinks>
                 <entryLink id="0c43-e1e2-2338-a62b" name="Chainsword" hidden="false" collective="false" import="true" targetId="b5b7-b50a-ac86-9173" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b25-edb6-3e6f-d4af" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97cc-7ae4-a7ad-eb88" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b25-edb6-3e6f-d4af" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97cc-7ae4-a7ad-eb88" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="a325-0862-8dbb-ece3" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03d8-bbe5-ab0b-6ef1" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32be-54b9-22c2-98e9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03d8-bbe5-ab0b-6ef1" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32be-54b9-22c2-98e9" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2513,18 +2512,18 @@ as the Aetheric Lightning Psychic Weapon</description>
               <modifiers>
                 <modifier type="increment" field="a275-c5a1-0592-8660" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="9cca-47d5-0779-79a2" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="9cca-47d5-0779-79a2" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
                 <modifier type="decrement" field="a275-c5a1-0592-8660" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="9cca-47d5-0779-79a2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b608-957e-2fdb-6765" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="9cca-47d5-0779-79a2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="23cb-25e0-acbf-1185" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="9cca-47d5-0779-79a2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b608-957e-2fdb-6765" repeats="1" roundUp="false" />
+                    <repeat field="selections" scope="9cca-47d5-0779-79a2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="23cb-25e0-acbf-1185" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a275-c5a1-0592-8660" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a275-c5a1-0592-8660" type="max" />
               </constraints>
               <selectionEntries>
                 <selectionEntry id="4695-5344-75ce-87a2" name="Procurant w/Power Fist &amp; Bolt Pistol" hidden="false" collective="false" import="true" type="model">
@@ -2532,7 +2531,7 @@ as the Aetheric Lightning Psychic Weapon</description>
                     <profile id="a7bb-abb3-af34-587d" name="Procurant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                       <characteristics>
                         <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                         <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                         <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                         <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2548,19 +2547,19 @@ as the Aetheric Lightning Psychic Weapon</description>
                   <entryLinks>
                     <entryLink id="2c30-5f03-0d27-4c2e" name="Power Fist" hidden="false" collective="false" import="true" targetId="a472-3ded-51a3-44a0" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9588-4713-e1aa-4d24" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8696-b760-feec-5808" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9588-4713-e1aa-4d24" type="min" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8696-b760-feec-5808" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="d758-d9e1-638e-6d8c" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ced7-2d87-4b9d-fb35" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6dd7-d65a-fbb3-6c80" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ced7-2d87-4b9d-fb35" type="min" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6dd7-d65a-fbb3-6c80" type="max" />
                       </constraints>
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0" />
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7aa9-1e13-3b38-84f5" name="Procurant w/Chainsword &amp; Hand Flamer" hidden="false" collective="false" import="true" type="model">
@@ -2568,7 +2567,7 @@ as the Aetheric Lightning Psychic Weapon</description>
                     <profile id="141c-23a2-e6ac-4eb8" name="Procurant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                       <characteristics>
                         <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                         <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                         <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                         <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2584,19 +2583,19 @@ as the Aetheric Lightning Psychic Weapon</description>
                   <entryLinks>
                     <entryLink id="e9be-0362-0e49-3449" name="Chainsword" hidden="false" collective="false" import="true" targetId="b5b7-b50a-ac86-9173" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7509-5653-518c-1079" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc85-08c0-c63f-7881" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7509-5653-518c-1079" type="min" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc85-08c0-c63f-7881" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="ae61-3d18-78a3-02a4" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="6b5f-d62d-7568-38b6" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d91-9351-cc3c-a409" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00d7-1a71-38bc-dc84" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d91-9351-cc3c-a409" type="min" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00d7-1a71-38bc-dc84" type="max" />
                       </constraints>
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4c19-9c4c-1370-f9f2" name="Procurant w/Chainsword &amp; Plasma Pistol" hidden="false" collective="false" import="true" type="model">
@@ -2604,7 +2603,7 @@ as the Aetheric Lightning Psychic Weapon</description>
                     <profile id="46b8-23ae-ab0c-c735" name="Procurant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                       <characteristics>
                         <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                         <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                         <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                         <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2620,19 +2619,19 @@ as the Aetheric Lightning Psychic Weapon</description>
                   <entryLinks>
                     <entryLink id="df0c-168e-1837-31f0" name="Chainsword" hidden="false" collective="false" import="true" targetId="b5b7-b50a-ac86-9173" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="739c-38e2-892d-5ecf" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4a7-8ed0-c665-d2ce" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="739c-38e2-892d-5ecf" type="min" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4a7-8ed0-c665-d2ce" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="56b4-5772-4710-3678" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="1a7b-4418-8346-66a7" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec18-0ff7-12a7-aa9d" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7638-2c10-6cc5-c2ad" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec18-0ff7-12a7-aa9d" type="min" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7638-2c10-6cc5-c2ad" type="max" />
                       </constraints>
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0" />
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="23cb-25e0-acbf-1185" name="Procurant w/Power Fist &amp; Hand Flamer" hidden="false" collective="false" import="true" type="model">
@@ -2640,7 +2639,7 @@ as the Aetheric Lightning Psychic Weapon</description>
                     <profile id="28f6-ce6d-08ea-191d" name="Procurant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                       <characteristics>
                         <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                         <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                         <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                         <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2656,19 +2655,19 @@ as the Aetheric Lightning Psychic Weapon</description>
                   <entryLinks>
                     <entryLink id="6f26-f36a-11c0-4f0d" name="Power Fist" hidden="false" collective="false" import="true" targetId="a472-3ded-51a3-44a0" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64a6-a1a9-36e2-3e10" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dac-668b-ec21-7881" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64a6-a1a9-36e2-3e10" type="min" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dac-668b-ec21-7881" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="b2cf-6577-4ebe-eeaf" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="6b5f-d62d-7568-38b6" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53c1-68dd-86f2-91e9" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9246-5d23-4057-1ca4" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53c1-68dd-86f2-91e9" type="min" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9246-5d23-4057-1ca4" type="max" />
                       </constraints>
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0" />
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="b608-957e-2fdb-6765" name="Procurant w/Power Fist &amp; Plasma Pistol" hidden="false" collective="false" import="true" type="model">
@@ -2676,7 +2675,7 @@ as the Aetheric Lightning Psychic Weapon</description>
                     <profile id="3b42-aa7d-a68d-55e4" name="Procurant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                       <characteristics>
                         <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                         <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                         <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                         <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2692,19 +2691,19 @@ as the Aetheric Lightning Psychic Weapon</description>
                   <entryLinks>
                     <entryLink id="b99a-56f1-8870-2e6d" name="Power Fist" hidden="false" collective="false" import="true" targetId="a472-3ded-51a3-44a0" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06a4-2a33-4401-1412" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fa3-9355-85d0-a2ec" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06a4-2a33-4401-1412" type="min" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fa3-9355-85d0-a2ec" type="max" />
                       </constraints>
                     </entryLink>
                     <entryLink id="935e-7d65-012d-883a" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="1a7b-4418-8346-66a7" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0953-fec7-2218-3575" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f098-b635-845a-a2bb" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0953-fec7-2218-3575" type="min" />
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f098-b635-845a-a2bb" type="max" />
                       </constraints>
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0" />
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -2715,24 +2714,24 @@ as the Aetheric Lightning Psychic Weapon</description>
           <modifiers>
             <modifier type="increment" field="8bec-e43b-a5c6-384c" value="1.0">
               <repeats>
-                <repeat field="selections" scope="9cca-47d5-0779-79a2" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="9cca-47d5-0779-79a2" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cee-cf2f-ab31-c85b" type="min"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bec-e43b-a5c6-384c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cee-cf2f-ab31-c85b" type="min" />
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bec-e43b-a5c6-384c" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="b968-baee-7de1-4459" name="Procurator w/Heavy Chainsword" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae45-e6bc-1909-6efa" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae45-e6bc-1909-6efa" type="max" />
               </constraints>
               <profiles>
                 <profile id="e9a3-33ee-2737-65dd" name="Procurator" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2746,47 +2745,47 @@ as the Aetheric Lightning Psychic Weapon</description>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="384d-b725-6479-5ea1" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink id="384d-b725-6479-5ea1" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
               </categoryLinks>
               <entryLinks>
                 <entryLink id="a942-20ce-69fd-b7be" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af78-8b21-463b-1422" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="428f-9814-213f-bf02" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af78-8b21-463b-1422" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="428f-9814-213f-bf02" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="b5e7-4e5a-7618-c0d2" name="Narthecium" hidden="false" collective="false" import="true" targetId="71d6-0c79-4eb4-c4fb" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb5e-934a-fb9b-4e8d" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc50-a782-812d-7ebc" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb5e-934a-fb9b-4e8d" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc50-a782-812d-7ebc" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="a5d7-3a7e-23ae-1f3e" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="9196-3af7-9545-e62b" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a67e-4e53-34b5-fc42" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f40-ef4e-49e0-2f8e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a67e-4e53-34b5-fc42" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f40-ef4e-49e0-2f8e" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="bf4b-eda7-20ad-aeb5" name="Heavy Chainsword" hidden="false" collective="false" import="true" targetId="a997-efd7-a0a9-759d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d82-fbb8-c97e-170a" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aebc-41b2-b55d-a157" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d82-fbb8-c97e-170a" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aebc-41b2-b55d-a157" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="0093-deca-ecdb-e523" name="Procurator" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cc7-7898-8aed-c5d0" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cc7-7898-8aed-c5d0" type="max" />
               </constraints>
               <profiles>
                 <profile id="b052-989a-d426-cf7b" name="Procurator" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2800,47 +2799,47 @@ as the Aetheric Lightning Psychic Weapon</description>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="ba79-3660-600e-be94" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink id="ba79-3660-600e-be94" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
               </categoryLinks>
               <entryLinks>
                 <entryLink id="2b31-c194-fb92-4627" name="Narthecium" hidden="false" collective="false" import="true" targetId="71d6-0c79-4eb4-c4fb" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8db6-7fb8-5778-e48e" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe16-4c56-68ae-5745" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8db6-7fb8-5778-e48e" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe16-4c56-68ae-5745" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="c2c3-6382-5cb4-6429" name="Chainsword" hidden="false" collective="false" import="true" targetId="b5b7-b50a-ac86-9173" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7dd-3bbf-ce8c-155c" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5093-1289-6d6b-86b3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7dd-3bbf-ce8c-155c" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5093-1289-6d6b-86b3" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="9707-28a2-8a8e-e363" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="9196-3af7-9545-e62b" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f82b-366f-d002-f984" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="945a-c217-94be-adf0" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f82b-366f-d002-f984" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="945a-c217-94be-adf0" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="1df3-6711-a5cc-0a82" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ed5-4a5d-219d-0459" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45ab-1ce9-81db-9433" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ed5-4a5d-219d-0459" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45ab-1ce9-81db-9433" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="be32-8bb5-848f-95ea" name="Procurator w/Power Weapon" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33f5-bbc2-a09a-13f6" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33f5-bbc2-a09a-13f6" type="max" />
               </constraints>
               <profiles>
                 <profile id="f939-be80-94b8-971b" name="Procurator" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2854,47 +2853,47 @@ as the Aetheric Lightning Psychic Weapon</description>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="579f-b3ec-1d33-b6d8" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink id="579f-b3ec-1d33-b6d8" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
               </categoryLinks>
               <entryLinks>
                 <entryLink id="6fbf-d5fa-0de6-cd9b" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5663-5f9c-61d1-431f" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d31e-9104-bd28-2ba3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5663-5f9c-61d1-431f" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d31e-9104-bd28-2ba3" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="69d7-5232-fc97-5e06" name="Narthecium" hidden="false" collective="false" import="true" targetId="71d6-0c79-4eb4-c4fb" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32df-4db9-89e8-05d5" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e71f-83c0-c9d1-728d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32df-4db9-89e8-05d5" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e71f-83c0-c9d1-728d" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="98d0-58e1-7b70-a489" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="9196-3af7-9545-e62b" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5299-d9f7-2f13-68a9" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57b3-2d52-a2f3-e806" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5299-d9f7-2f13-68a9" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57b3-2d52-a2f3-e806" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="e576-0f5d-6030-7f35" name="Power Weapon" hidden="false" collective="false" import="true" targetId="36a7-1c39-670c-5fec" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a81-6522-1c9a-b2d4" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56bd-c5d4-5d24-cbe0" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a81-6522-1c9a-b2d4" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56bd-c5d4-5d24-cbe0" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="e33d-c6af-7d36-4f8d" name="Procurator w/Tainted Weapon" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae71-7d9c-6f26-4aa4" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae71-7d9c-6f26-4aa4" type="max" />
               </constraints>
               <profiles>
                 <profile id="31c9-47d5-4d7e-91c1" name="Procurator" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2908,36 +2907,36 @@ as the Aetheric Lightning Psychic Weapon</description>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="46d1-5e43-aa83-5479" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+                <categoryLink id="46d1-5e43-aa83-5479" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
               </categoryLinks>
               <entryLinks>
                 <entryLink id="7c43-19e1-a709-03e5" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4f2-3b31-61ef-cb56" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbd4-d11e-a26f-0e4e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4f2-3b31-61ef-cb56" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbd4-d11e-a26f-0e4e" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="ff25-01d0-877a-47b8" name="Narthecium" hidden="false" collective="false" import="true" targetId="71d6-0c79-4eb4-c4fb" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9201-82f7-0932-a5c3" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dce9-cb6e-ae52-1a2e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9201-82f7-0932-a5c3" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dce9-cb6e-ae52-1a2e" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="33de-461b-a963-ba21" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="9196-3af7-9545-e62b" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3963-2159-bfee-01c0" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9b5-d821-bc26-500e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3963-2159-bfee-01c0" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9b5-d821-bc26-500e" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="7694-9de2-7e6a-0e12" name="Tainted Weapon" hidden="false" collective="false" import="true" targetId="e01b-5f42-a67b-c97f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b07-4c86-0b85-ead3" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3cc3-f940-9d18-42a5" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b07-4c86-0b85-ead3" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3cc3-f940-9d18-42a5" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2948,12 +2947,12 @@ as the Aetheric Lightning Psychic Weapon</description>
               <modifiers>
                 <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="10.0">
                   <repeats>
-                    <repeat field="selections" scope="9cca-47d5-0779-79a2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="9cca-47d5-0779-79a2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6e1-fb16-7cef-cb76" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6e1-fb16-7cef-cb76" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
@@ -2962,25 +2961,25 @@ as the Aetheric Lightning Psychic Weapon</description>
       <entryLinks>
         <entryLink id="d842-faa2-ab0a-1500" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84f6-8599-1783-14b9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ba7-6199-d417-f742" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84f6-8599-1783-14b9" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ba7-6199-d417-f742" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="3d4c-7aaa-08ef-7caf" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8a0-2b0f-60b5-a5d2" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b98-e1fc-476a-e65b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8a0-2b0f-60b5-a5d2" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b98-e1fc-476a-e65b" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="8576-7c62-044a-ee40" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f13-b393-74e9-5202" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4582-8aae-d775-65f3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f13-b393-74e9-5202" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4582-8aae-d775-65f3" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="71d6-0c79-4eb4-c4fb" name="Narthecium" hidden="false" collective="true" import="true" type="upgrade">
@@ -2992,7 +2991,7 @@ as the Aetheric Lightning Psychic Weapon</description>
         </profile>
       </profiles>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -3001,116 +3000,116 @@ as the Aetheric Lightning Psychic Weapon</description>
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="277f-9b27-d733-b849" value="1.0">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="757f-7293-0383-a35b" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="277f-9b27-d733-b849" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="757f-7293-0383-a35b" type="max" />
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="277f-9b27-d733-b849" type="min" />
       </constraints>
       <selectionEntryGroups>
         <selectionEntryGroup id="b11f-f32c-2b32-da1b" name=" XVII: Word Bearers" publicationId="09c5-eeae-f398-b653" page="304" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9dbf-0760-d7ae-f125" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9dbf-0760-d7ae-f125" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2444-1422-cca1-48df" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5c98-ceae-d0cf-7623" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2444-1422-cca1-48df" type="max" />
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5c98-ceae-d0cf-7623" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="cdd6-c3d6-14b3-5b0b" name="Enslaved by Darkness (Traitor only)" publicationId="09c5-eeae-f398-b653" page="304" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f6fc-46fe-5796-3682" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ad9-e6de-b819-8875" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f6fc-46fe-5796-3682" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ad9-e6de-b819-8875" type="max" />
               </constraints>
               <profiles>
                 <profile id="9ff4-0c46-c647-3994" name="Enslaved by Darkness" publicationId="09c5-eeae-f398-b653" page="304" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
                     <characteristic name="Text" typeId="c68e-2cda-b67b-baca">This Warlord Trait may only be selected by a model with the Traitor Allegiance and the Corrupted Unit Sub-type.
-A Warlord with this Trait modifies his Strength and Toughness by a value determined by the current Game Turn: +1 on Game Turns 1, 2 &amp; 3 , no modifier on turns 4 &amp; 5, and -1 on Game Turns 6+. When targeted by any weapon or special rule that targets the Daemon Unit Type, this Warlord is counted as though it had that Unit Type. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
+A Warlord with this Trait modifies his Strength and Toughness by a value determined by the current Game Turn: +1 on Game Turns 1, 2 &amp; 3 , no modifier on turns 4 &amp; 5, and -1 on Game Turns 6+. When targeted by any weapon or special rule that targets the Daemon Unit Type, this Warlord is counted as though it had that Unit Type. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="b9ed-fa9d-eb34-96d0" name="Unswerving Devotion" publicationId="09c5-eeae-f398-b653" page="304" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f187-e0e7-c738-317f" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d912-79c7-6da8-21f3" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f187-e0e7-c738-317f" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d912-79c7-6da8-21f3" type="max" />
               </constraints>
               <profiles>
                 <profile id="1197-c7cc-8278-c08d" name="Unswerving Devotion" publicationId="09c5-eeae-f398-b653" page="304" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any units that include at least one model with the Legiones Astartes (Word Bearers) special rule and have at least one model within 6&quot; of a Warlord with this Trait (including the Warlord himself and any unit he has joined) automatically pass the first failed Morale check or Pinning test they are called upon to make each turn. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any units that include at least one model with the Legiones Astartes (Word Bearers) special rule and have at least one model within 6" of a Warlord with this Trait (including the Warlord himself and any unit he has joined) automatically pass the first failed Morale check or Pinning test they are called upon to make each turn. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="b625-91b0-8993-e11e" name="Iconoclast" publicationId="09c5-eeae-f398-b653" page="304" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="adf8-5a53-ab49-83f8" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8077-1a0d-ab10-e7e2" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="adf8-5a53-ab49-83f8" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8077-1a0d-ab10-e7e2" type="max" />
               </constraints>
               <profiles>
                 <profile id="9737-1d61-5075-e5ef" name="Iconoclast" publicationId="09c5-eeae-f398-b653" page="304" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and any unit he has joined, gain a bonus of +1 Attack when locked in combat with an enemy unit that includes at least one model with the Independent Character special rule, a Legion vexilla or a Legion standard. When making a Shooting Attack or Melee Attack targeting a Fortification, Building or other Terrain piece with a Toughness Characteristic, they gain a bonus of +2 to their Strength or the Strength of any weapons used. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait, and any unit he has joined, gain a bonus of +1 Attack when locked in combat with an enemy unit that includes at least one model with the Independent Character special rule, a Legion vexilla or a Legion standard. When making a Shooting Attack or Melee Attack targeting a Fortification, Building or other Terrain piece with a Toughness Characteristic, they gain a bonus of +2 to their Strength or the Strength of any weapons used. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="e11c-5670-41f6-91b9" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+        <entryLink id="e11c-5670-41f6-91b9" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="bda8-b52d-c914-4ac2" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="6b8d-d97a-f0f9-44d9" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="6b8d-d97a-f0f9-44d9" type="max" />
       </constraints>
       <entryLinks>
         <entryLink id="0b8a-a450-0fc0-f745" name="Command Squad, Cataphractii" hidden="false" collective="false" import="true" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="c7ee-48e2-28ad-8039" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
-        <entryLink id="8464-3082-bdad-e73d" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="c7ee-48e2-28ad-8039" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
+        <entryLink id="8464-3082-bdad-e73d" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA - Word Bearers.cat
+++ b/2022 - LA - Word Bearers.cat
@@ -342,7 +342,7 @@
         <categoryLink id="711d-1592-c05c-995a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="30a0-c954-2208-2f2a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
     <entryLink id="c1c3-fd36-d3cc-eeb1" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="fd94-3ba7-c0db-afe3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
@@ -770,7 +770,7 @@
         <categoryLink id="f76e-0c27-c11b-0aee" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="9b56-a4f4-8f87-6d22" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
     <entryLink id="b97d-6b5b-d94c-fa81" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
@@ -851,7 +851,7 @@
         <categoryLink id="9c53-79ba-20b4-0c38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="e3f1-775a-11cb-e0e0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
     <entryLink id="1086-c952-53b5-306d" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="04a8-cab8-3e18-f9ac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -863,7 +863,7 @@
         <categoryLink id="fb8d-d233-78c4-fa96" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="f9a4-f9d8-0177-56c4" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
     <entryLink id="df73-2b98-e82c-c9ed" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ca2c-dbe5-4243-7fb5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -945,7 +945,7 @@
         <categoryLink id="49db-a82b-7fc3-5d4a" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="f963-0674-47dd-bfd5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
     <entryLink id="4ccd-314e-e135-ff8f" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -973,7 +973,7 @@
         <categoryLink id="33f9-6907-1a15-62f6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="77a4-ff21-107b-cdfc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
     <entryLink id="6435-2676-8f7e-2c0b" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -1023,7 +1023,7 @@
         <categoryLink id="bb97-d8e3-94a0-8908" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
         <categoryLink id="301e-6e66-90ce-3341" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
     <entryLink id="612a-b741-c7ac-a4f6" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="44ef-cd08-40cc-d5de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />

--- a/2022 - LA - World Eaters.cat
+++ b/2022 - LA - World Eaters.cat
@@ -2960,7 +2960,7 @@
       <entryLinks>
         <entryLink id="0ceb-a305-b862-dd39" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_7dee-602c-4b47-be09</comment></selectionEntryGroup>
     <selectionEntryGroup id="a01f-cd9e-bd21-853e" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="099f-d31e-9178-0276" type="max" />
@@ -2978,7 +2978,7 @@
         <entryLink id="2b36-986b-95a5-212d" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
         <entryLink id="6f6c-6a79-ac41-8a7d" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
       </entryLinks>
-    </selectionEntryGroup>
+    <comment>    template_id_be38-a066-4f8e-ae54</comment></selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedProfiles>
     <profile id="7415-f2c4-4eb5-609d" name="Gorechild" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">

--- a/2022 - LA - World Eaters.cat
+++ b/2022 - LA - World Eaters.cat
@@ -136,7 +136,7 @@
         <categoryLink id="83d9-15d2-ab92-e520" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
         <categoryLink id="dcad-743d-7ffc-e6f1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
     <entryLink id="cb9e-4257-d7e5-23f2" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3cfd-be32-1879-77b2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
@@ -185,7 +185,7 @@
         <categoryLink id="943b-f22e-7486-e366" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="7ab8-5171-4b59-cccf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
     <entryLink id="7c3d-c611-42a7-6dbf" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -220,7 +220,7 @@
         <categoryLink id="514d-df3d-f6f8-a6ba" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
         <categoryLink id="fb98-343f-1289-c47e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
     <entryLink id="13da-0633-d7ed-4341" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c39f-d745-c6c6-b16e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -295,7 +295,7 @@
         <categoryLink id="fbed-9f8b-078f-bdb5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="52e0-e2ff-5775-07cb" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
     <entryLink id="f17e-a880-1691-ab93" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3588-c002-d691-c403" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -307,7 +307,7 @@
         <categoryLink id="7e51-4152-a467-fecf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="4794-1343-9e4b-fc1a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
     <entryLink id="d714-b115-e4d2-d5fb" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a08e-eb29-5ada-b325" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
@@ -388,7 +388,7 @@
         <categoryLink id="8009-cc0b-18e2-2fe2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="4cd7-ef9f-2c8d-11d5" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
     <entryLink id="7329-5a4d-921c-c1c2" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
@@ -822,7 +822,7 @@
         <categoryLink id="7b5e-e260-f34d-7799" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
         <categoryLink id="068e-a93b-4ea2-bb7b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
     <entryLink id="319b-3912-a5ce-cece" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">

--- a/2022 - LA - World Eaters.cat
+++ b/2022 - LA - World Eaters.cat
@@ -1,6 +1,5 @@
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="d901-0eca-48b5-304a" name="LA -  XII: World Eaters" revision="12" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26">
-  <entryLinks>
-    <entryLink id="d647-fd99-73e0-bd57" name="Angron" hidden="false" collective="false" import="false" targetId="6352-8efa-0cc4-cfa7" type="selectionEntry">
+  <entryLinks><entryLink id="d647-fd99-73e0-bd57" name="Angron" hidden="false" collective="false" import="false" targetId="6352-8efa-0cc4-cfa7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -105,947 +104,1957 @@
         <categoryLink id="a155-7b9c-da9f-525b" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="a3bb-0abc-4d37-1e09" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="69cd-d34a-6980-b92d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="b59f-a5bb-fc27-6f74" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
-    <entryLink id="ea50-9e6b-0827-8392" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="b686-7fdf-ec1f-956e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="7bdc-02ef-f4d8-d8b8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
-    <entryLink id="7fb6-9ea7-83ab-efa1" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5117-96f2-2f9d-7427" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="90b9-5b4d-168c-059f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
-    <entryLink id="4445-7144-41dc-b8c6" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="00b1-fd9c-c21c-dc88" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="83d9-15d2-ab92-e520" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
-        <categoryLink id="dcad-743d-7ffc-e6f1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink>
-    <entryLink id="cb9e-4257-d7e5-23f2" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3cfd-be32-1879-77b2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="f12b-b3c2-781a-5805" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
-    <entryLink id="8eb6-4832-e4be-14ca" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="f2a5-57f6-54b2-d012" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="2ac8-59f2-4876-fbac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
-    <entryLink id="1528-2655-0329-c2df" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c697-ac01-974f-d163" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="2559-d869-f135-c64e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
-    <entryLink id="15d3-53a0-372e-6a1c" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8027-3dbc-b54b-93b1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="cdc0-bf28-15b5-aa47" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
-    <entryLink id="22ed-bf80-0f24-060e" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="943b-f22e-7486-e366" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="7ab8-5171-4b59-cccf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink>
-    <entryLink id="7c3d-c611-42a7-6dbf" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7862-9fa1-f510-7267" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="e887-aae5-f55b-4a9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
-    <entryLink id="c4af-98b6-a14f-1afb" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="514d-df3d-f6f8-a6ba" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="fb98-343f-1289-c47e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink>
-    <entryLink id="13da-0633-d7ed-4341" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c39f-d745-c6c6-b16e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="29ba-b9ae-d3b6-352b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
-    <entryLink id="ee64-116b-826e-ef0e" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1d3a-0f50-83b4-6e54" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="07a3-482d-516b-2be1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
-    <entryLink id="f0ce-7db6-96e5-bac7" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="200a-9ca8-8e4a-5fc4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="af15-adc3-ed2c-5cb6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
-    <entryLink id="8d00-818a-411f-bb94" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+    <entryLink id="a3bb-0abc-4d37-1e09" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_fbfa-8d78-4d6d-8a05</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_21f2-0916-46bf-b75a</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_4fbd-633b-4dd6-9fdd</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="86a1-96aa-bd3c-e50f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6e8e-a6d2-2b0a-b9ce" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="8ad0-d035-63bf-527a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="9906-2748-4666-b4be" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4f71-446f-4cff-afda</comment></categoryLink>
+        <categoryLink id="fb88-a79f-4c52-b486" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_3f44-8647-43a4-ac22</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
-    <entryLink id="92d0-ae38-6ae1-02df" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c094-c914-ef71-1891" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="b5c0-55d7-e2ea-b98a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
-    <entryLink id="17b5-4ae6-c333-9348" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink><entryLink id="ea50-9e6b-0827-8392" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d767-283f-08d5-889c" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="f8cd-d548-3ea0-19eb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
-    <entryLink id="9978-135b-f50a-2126" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="2465-7881-2bd9-3642" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="1fd0-9b05-a903-2341" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
-    <entryLink id="18fe-4c30-5218-5261" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="fbed-9f8b-078f-bdb5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="52e0-e2ff-5775-07cb" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink>
-    <entryLink id="f17e-a880-1691-ab93" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="3588-c002-d691-c403" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="c799-41c1-a25b-a4d0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
-    <entryLink id="3c94-7378-be96-61ab" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7e51-4152-a467-fecf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4794-1343-9e4b-fc1a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink>
-    <entryLink id="d714-b115-e4d2-d5fb" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a08e-eb29-5ada-b325" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="01b2-0923-b1db-6a48" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
-    <entryLink id="ba49-9bef-dacf-bc65" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="46c8-5118-d4d7-4f93" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2806-6ea9-5f33-5cd3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
-    <entryLink id="a5f0-a76a-0e95-27cf" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d722-74d2-0c64-ca9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="cf52-8187-7800-27fe" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
-    <entryLink id="8b3b-fbf0-f2ac-01a9" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8723-ed96-8dcc-8165" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="cb81-812d-2c7c-2dd5" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
-    <entryLink id="1ab4-66a8-0366-7069" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="93a1-4b84-ee73-f8ba" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="a205-053b-6086-3c22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
-    <entryLink id="76df-2fab-57fd-3c6b" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="45ba-b099-01d8-66f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="eed4-8fa5-2f10-5415" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
-    <entryLink id="9ee4-95eb-fa45-1e3a" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d33f-1dd9-a196-ed64" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="7116-c17e-b7a0-c1ef" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
-    <entryLink id="9066-3ed5-196e-e303" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="db66-fe0b-23a3-15be" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="11e0-6037-2a25-b59f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
-    <entryLink id="4168-0cff-5897-4ef9" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7fda-3e55-a1cb-ae2c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="9933-e221-e720-bb95" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
-    <entryLink id="dd2f-dd94-d07b-9168" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8009-cc0b-18e2-2fe2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4cd7-ef9f-2c8d-11d5" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink>
-    <entryLink id="7329-5a4d-921c-c1c2" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="4589-77db-937c-daa0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="cee5-6147-325c-9993" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
-    <entryLink id="42a7-c5ce-89f7-2336" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="c210-b2f4-1aeb-ca09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="91b4-475a-07ac-3879" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
-    <entryLink id="384b-033e-4f9d-31b1" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="b3fa-47fb-8dc4-4dda" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="d9d4-f5a4-7d12-61dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="6c24-6d75-811a-35c4" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="7e41-eeb9-2cd9-7299" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup" />
-        <entryLink id="95a7-2e60-d093-ed01" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
-    <entryLink id="a3d1-8135-0daa-681c" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="f7e6-a58d-03a7-561d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="4846-af2d-dca7-20a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2601-43d3-d2b2-4ad7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="136e-7ef0-c7e6-8596" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup" />
-        <entryLink id="4119-40a8-f853-c537" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
-    <entryLink id="792c-37c2-8548-693c" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f133-4181-01b0-2dba" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="7e56-a7e7-81d6-2564" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="08f0-ed00-c3f3-6804" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-      </categoryLinks>
-      <entryLinks>
-        <entryLink id="e158-25a7-106c-2275" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup" />
-        <entryLink id="1f22-039e-67ff-d438" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup" />
-      </entryLinks>
-    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
-    <entryLink id="fa17-8a0d-0cef-8628" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="38e5-d9a0-d98d-476a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="8ce0-8334-fd87-7093" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
-    <entryLink id="f0a5-8b7d-9e04-4da5" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafa-470f-4c2c-8be3</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_e2ba-a855-4de2-9f46</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1c3c-74c9-a467-2fa2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="450d-2eb0-29bb-569c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
-    <entryLink id="ddf1-7b2e-082b-d775" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_0171-b30d-44ee-9389</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fdfb-119b-4774-934a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_3891-9a00-4f8f-b95f</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a532-a446-7136-3ebd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="ec1d-0fdf-bb03-e0dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="70df-2b20-49c7-ac2d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e5df-17d4-4521-9d5b</comment></categoryLink>
+        <categoryLink id="b5c3-4ece-4dcb-b959" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"><comment>    template_id_0ecd-4873-4d3a-b28b</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
-    <entryLink id="24e2-5293-cf94-a83c" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1399-ad92-ebaf-8da4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="af20-71d5-f3e4-db27" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
-    <entryLink id="c204-13d1-4189-9724" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7535-aed8-898c-8204" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="6e39-6251-3836-aa4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
-    <entryLink id="d1f7-b7cc-38ae-b34a" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1f66-aa58-e689-3240" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="909f-9f57-88f0-24a1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
-    <entryLink id="944d-5882-4dfe-0bfa" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="fc77-8d84-d247-3ff3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="dfb0-7d73-2d4b-61f9" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
-    <entryLink id="d09c-0e11-efa3-c62c" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="11e9-079d-a166-a603" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="0f33-287a-934e-2d4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
-    <entryLink id="1f97-bf58-5325-e7c8" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1f8f-9637-18bb-84b3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="a051-c87b-3ceb-359c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
-    <entryLink id="78c0-bd86-99b4-3d35" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8dc6-172d-2f5d-6e2e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="37a3-1063-c0e7-15b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
-    <entryLink id="0605-ec8d-6663-886f" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="ac65-732d-6f09-1134" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="4404-f0ac-038e-2e4a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
-    <entryLink id="1066-95b0-0f9d-0653" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="b776-a7a7-8b94-4301" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="21ba-0b57-1524-6fe2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
-    <entryLink id="97d7-de29-6a7f-1679" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8891-1509-ead6-744b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="bb9d-d126-8ca6-1474" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
-    <entryLink id="0d49-ca54-940c-0756" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0987-83e4-d785-47c3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="c230-5e6a-5266-4c5d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
-    <entryLink id="3951-5694-c7f3-15cf" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="5c5a-ea18-1ae9-dcf3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="5642-51a6-3b4f-ffea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
-    <entryLink id="0a1c-5ad3-c7fc-494d" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="29d8-6c54-d110-d283" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="780e-8505-eb88-ff08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
-    <entryLink id="f6dd-6d5b-c299-0673" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ecbf-851b-6db6-8689" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7dda-a998-312b-0c4d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
-    <entryLink id="2f64-52bf-468a-22a5" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9291-3aac-d55b-0dae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4e0b-638d-e3f8-86d5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
-    <entryLink id="aae0-3c7f-2d80-7468" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ce31-3586-f2c9-3178" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="316f-98ee-d8d2-834d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
-    <entryLink id="c2c6-e375-9435-7000" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="ca49-ab6d-6502-5714" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="2ef3-3d3e-4bac-cea8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
-    <entryLink id="ab94-44fe-ecc0-a5ad" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="607b-9250-7230-0849" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="962a-3b0a-3838-4559" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
-    <entryLink id="b5a1-3cbb-1d82-91a3" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9914-f6ab-61ec-5965" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7ca9-e2d8-10a0-862a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
-    <entryLink id="fb95-27dc-5539-f106" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e7bc-8e1a-ff75-556f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="f61c-8cba-7b30-c7f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
-    <entryLink id="114f-1a49-372f-2fc0" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0d55-953c-1e62-3f90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2128-489a-8bb8-b2f7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
-    <entryLink id="2354-d46f-49c8-4630" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
-      <modifiers>
-        <modifier type="append" field="name" value="(Reserve Only)">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0345-9787-6c67-a8dd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="5196-536f-74ab-15a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
-    <entryLink id="1a75-cc22-6e04-d9f3" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="9e7e-7589-e7ab-dfb8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="5e83-c9e9-095d-704e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
-    <entryLink id="1c75-2909-9649-b8c8" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="6984-e026-6945-1404" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f953-c46b-6a7c-e883" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
-    <entryLink id="c815-dbde-58b4-87cc" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="ef6c-fbc2-9e91-32b4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="faaf-6c80-46a5-8abb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
-    <entryLink id="a0ad-db6b-ce33-f849" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="8527-a3ab-a2d2-6d13" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="c8df-a444-27c0-44d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
-    <entryLink id="8be5-dd6c-2276-908d" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5e1f-4881-1e04-f96e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="6790-3a53-a02a-43c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-      </categoryLinks>
-    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
-    <entryLink id="6c53-3a25-88ea-4e3b" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="876c-84df-d9ff-e23f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="da9f-58a8-a3e5-c202" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
-    <entryLink id="8fca-6360-d5ba-c5a2" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
-      <modifiers>
-        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink><entryLink id="7fb6-9ea7-83ab-efa1" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_319e-90d4-44a3-8e83</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_28db-d943-4099-9abd</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1a45-a592-49df-9465</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb31-d0b2-4677-928e</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3256-8276-77bb-1575" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="823b-d94a-5ab2-90a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="f907-d096-a1f6-b1db" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="c68c-7dee-4cdd-9a38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1b86-0977-4a8b-adac</comment></categoryLink>
+        <categoryLink id="aa40-e785-4bda-872e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_b449-403a-4e42-9239</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
-    <entryLink id="88a1-d2dc-6a48-8aaa" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink><entryLink id="4445-7144-41dc-b8c6" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d68e-9ccd-45df-9bfe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0aff-4f6e-4b03-a23c</comment></categoryLink>
+        <categoryLink id="3bbf-e84f-44f8-a95a" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"><comment>    template_id_7d5a-62e7-43ee-b79b</comment></categoryLink>
+        <categoryLink id="b2fc-c7ce-4eac-8638" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_4986-9157-49f2-b670</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9d03-74fb-4e04-91f4</comment></entryLink><entryLink id="cb9e-4257-d7e5-23f2" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d512-fd07-4a29-863a</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_55c6-a35f-485a-9f0d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d89e-cf1f-4ceb-b3de</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e2c9-0d01-403c-900e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_a7b8-c835-4cb2-b3d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="968e-ddc3-44b4-b009" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_e22a-c5f8-4825-a45f</comment></categoryLink>
+        <categoryLink id="1b8a-49fe-4e6f-8d4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03fc-6a7f-45a5-bcb8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink><entryLink id="8eb6-4832-e4be-14ca" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_dfdc-f6f6-49d2-a7b3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_354c-c71f-472f-b268</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1127-c974-4663-874d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_0843-bef2-4767-8307</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a2fd-5071-4a72-9c68" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_28e0-91e7-4ada-9fac</comment></categoryLink>
+        <categoryLink id="e23d-347b-4cb2-a7eb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4448-a712-4dd7-bf6d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink><entryLink id="1528-2655-0329-c2df" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6087-a5e5-4d3c-9ebd</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c7e1-5f42-4528-bf07</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1950-08dc-4544-ab01</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_daf3-31ed-42c0-85dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7e70-2f31-4a98-ba63" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_7d4f-547c-43ed-a520</comment></categoryLink>
+        <categoryLink id="92cb-4ea6-4d60-87df" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f04e-04e8-4891-9b1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink><entryLink id="15d3-53a0-372e-6a1c" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2f46-a0b6-48a5-a0ee</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_636f-0f8a-43f1-910b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c883-39c8-4a74-aeaa</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_0796-e467-4438-89b3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3d06-792c-4e7e-966a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_5a04-9847-4c91-a49a</comment></categoryLink>
+        <categoryLink id="b843-7a9b-4738-a702" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b4b4-daeb-483c-a306</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink><entryLink id="22ed-bf80-0f24-060e" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry"><categoryLinks>
+        <categoryLink id="795a-3e05-4e46-961b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ac1c-b3bf-4011-918a</comment></categoryLink>
+        <categoryLink id="ef4b-fec9-4089-b211" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_589c-1d0e-4b7d-be6b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0848-4e03-417a-b224</comment></entryLink><entryLink id="7c3d-c611-42a7-6dbf" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3348-16e4-4a9a-a549</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_bea4-c4a8-4843-b9fe</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2970-17ff-4be1-91e5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_503a-46e7-40e7-bd07</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_4555-15e1-43ff-80a0</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d3ce-f8f2-9773-ced0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="5239-2986-33e4-6efb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="e160-fcdc-4231-9388" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_fce3-801c-49c8-85d4</comment></categoryLink>
+        <categoryLink id="06f9-73c1-4112-94a3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0c2d-2349-44b6-9831</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
-    <entryLink id="d5bd-81d6-7a03-5796" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink><entryLink id="c4af-98b6-a14f-1afb" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_c111-feb0-4012-98cd</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_63d7-8427-431d-9ae6</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="28e1-27fb-4073-aac8" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_e707-fde1-457f-91c4</comment></categoryLink>
+        <categoryLink id="8cd5-6730-4711-809e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ec67-8573-4460-89db</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec78-3ba9-438b-a7e8</comment></entryLink><entryLink id="13da-0633-d7ed-4341" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry"><categoryLinks>
+        <categoryLink id="213e-80fe-48be-9ca4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_51af-a137-4a1c-97a4</comment></categoryLink>
+        <categoryLink id="1123-7ffa-413e-9529" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_ec1f-c326-40a8-9d1f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink><entryLink id="ee64-116b-826e-ef0e" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_b743-7a00-43e4-beb8</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d12f-2c98-4e62-a716</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d4d7-ba67-47aa-962f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+                  <comment>    node_id_1637-edee-457a-bb0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="75ed-64c2-4675-9b83" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_f203-bc26-421f-b79e</comment></categoryLink>
+        <categoryLink id="bd9d-794a-47bd-8478" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_a53e-59d9-4ac2-a21f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink><entryLink id="f0ce-7db6-96e5-bac7" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry"><categoryLinks>
+        <categoryLink id="74bb-6d4b-4338-a21a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b1d5-fd75-4f17-bbf4</comment></categoryLink>
+        <categoryLink id="5792-0536-4799-8839" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_f221-bf81-4045-849b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink><entryLink id="8d00-818a-411f-bb94" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_25d8-330b-4574-b515</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7836-6878-47a8-8827</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_5ea9-46dd-4a11-9410</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_ab5d-961b-4924-a705</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6557-38f9-4549-8b9a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9189-836c-475d-a52e</comment></categoryLink>
+        <categoryLink id="4f8c-72c5-4c09-bbf2" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_e1fa-b7d8-47b0-a88a</comment></categoryLink>
+        <categoryLink id="4b23-5d46-4ef7-b4bd" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_a137-e3c0-4d63-a48c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink><entryLink id="92d0-ae38-6ae1-02df" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_a743-0cc2-45ae-a7eb</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2721-e88d-41f7-bedc</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_e10f-1390-4b33-8fcc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ae4b-d9e1-4f8a-a468" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2008-f1c4-4285-a14f</comment></categoryLink>
+        <categoryLink id="db6b-c6db-439b-ac96" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e88b-a95a-4647-af3b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink><entryLink id="17b5-4ae6-c333-9348" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_936f-1ef7-472e-840e</comment>
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+              <comment>    node_id_d73d-d52e-4c75-8ac0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="087e-0e42-4168-96dc" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_7a55-ecb4-4e5d-b955</comment></categoryLink>
+        <categoryLink id="6dfa-8d8d-4050-8fdd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f28c-710e-4ff8-9810</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink><entryLink id="9978-135b-f50a-2126" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_09b5-4e3b-4c84-a574</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_32e5-ebba-41fb-9ff2</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_838e-0ccf-4d3a-aabd</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_dfef-0ec2-49fb-a534</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="29df-de3b-4c1b-8d51" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4f60-472b-45a9-ab9e</comment></categoryLink>
+        <categoryLink id="c261-a6f6-41d7-8990" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e2e3-af36-45a6-a955</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink><entryLink id="18fe-4c30-5218-5261" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry"><categoryLinks>
+        <categoryLink id="d7be-ce1c-4e25-8043" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0dfa-4004-4751-8022</comment></categoryLink>
+        <categoryLink id="0c88-5989-488b-9e70" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a669-0f5d-4fd3-811b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e940-cd57-49e9-a428</comment></entryLink><entryLink id="f17e-a880-1691-ab93" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_72da-1513-4e02-b595</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7a48-a3b0-4a26-849b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e232-25f3-4cb7-8ab2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_9aa4-5660-4697-8ab2</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="eb1a-b2fa-45b9-993a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_09cd-2176-40af-bba6</comment></categoryLink>
+        <categoryLink id="de86-3e93-4460-a3e1" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_05e6-7c63-4a35-9ba0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink><entryLink id="3c94-7378-be96-61ab" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1d3c-8e17-489f-9002</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5725-8bee-4bcc-878d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_be47-0d6f-49f2-9f4b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_863c-f3a4-4802-b80c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c470-596f-42f6-b736" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_899e-b052-4d5b-8c18</comment></categoryLink>
+        <categoryLink id="2c37-4f6d-4ad4-acb6" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f5e9-cff6-41d2-a016</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7f16-dadb-4bbc-bad7</comment></entryLink><entryLink id="d714-b115-e4d2-d5fb" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b03e-5d91-4be3-8adc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_0443-29c0-46e9-ad1d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f2c9-7356-4c27-a22f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0e9-4a9e-4b2b-a9d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="582b-ae28-420c-8e4e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5528-2dac-4be5-900c</comment></categoryLink>
+        <categoryLink id="a2c8-3815-4aac-8edc" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_dc8f-d888-4585-991d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink><entryLink id="ba49-9bef-dacf-bc65" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8203-5b00-497b-b939</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_40ee-3e71-4978-b1e4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f6a8-f660-46dc-b3c5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_d988-3af6-48bf-b0a8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5322-11b6-48cc-980e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_39e5-eda5-45d1-a643</comment></categoryLink>
+        <categoryLink id="8935-e320-463f-82ea" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_6416-21bb-4df4-9de8</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink><entryLink id="a5f0-a76a-0e95-27cf" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_cb81-0303-4b88-ae53</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9648-31e3-43aa-8cf3</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_0507-da81-4023-bfcf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0e84-54ff-488d-b066</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5ca3-1d6b-46bd-b736" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6ff-0977-4c92-bb28</comment></categoryLink>
+        <categoryLink id="b9ee-7987-4eda-8ca9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f555-7d39-458f-84c9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink><entryLink id="8b3b-fbf0-f2ac-01a9" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><categoryLinks>
+        <categoryLink id="2962-839a-4094-86c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9a36-f261-43cc-9bd1</comment></categoryLink>
+        <categoryLink id="c037-353b-4840-af80" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a648-8396-442a-af59</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink><entryLink id="1ab4-66a8-0366-7069" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_dd34-83cf-47d7-b557</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_be88-afef-49b3-bd1e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f021-5ff1-4742-b7c7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_944f-7420-4982-8ea9</comment></categoryLink>
+        <categoryLink id="334d-83aa-4809-b7f3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ea80-0efe-457d-a450</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink><entryLink id="76df-2fab-57fd-3c6b" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6b73-b21c-4e2b-9d14</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_a7fe-cc62-4a6f-a781</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5be1-1937-4964-a455</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_da1d-b2bc-4117-82a4</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7cc5-00d0-44d9-84a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7010-be56-4709-b058</comment></categoryLink>
+        <categoryLink id="87d9-5924-4ba5-a78e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7379-a740-47ba-a054</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink><entryLink id="9ee4-95eb-fa45-1e3a" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f8cc-833a-4ac1-bf89</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+              <comment>    node_id_5988-c012-4dad-9a66</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cb6c-3c85-49c7-9b97" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_8d82-3279-4481-84bb</comment></categoryLink>
+        <categoryLink id="edca-14fd-4829-9d71" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_e25c-925e-4b96-8bb3</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink><entryLink id="9066-3ed5-196e-e303" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry"><modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_a0f6-9606-4b75-a2f8</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_94b3-1331-474b-885b</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="00ad-23dd-4764-b9da" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_79fa-3370-4ae0-9e12</comment></categoryLink>
+        <categoryLink id="8c4b-954a-4cbb-a6fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bb53-4e65-4fb6-9dd7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink><entryLink id="4168-0cff-5897-4ef9" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9a08-5fe6-4010-bbc3</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_72cf-cfce-4e02-b379</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="aa3e-3fa4-4779-8d35" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_f55b-7555-444b-beee</comment></categoryLink>
+        <categoryLink id="16ff-840c-477d-b735" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3386-c9ad-4d74-9474</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink><entryLink id="dd2f-dd94-d07b-9168" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry"><categoryLinks>
+        <categoryLink id="40d0-28db-497a-ba03" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_75a7-dc06-445b-b2dc</comment></categoryLink>
+        <categoryLink id="5f4b-2851-4f2a-b8a6" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_e21a-c03b-4885-ac46</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7425-bfc5-42eb-8dc4</comment></entryLink><entryLink id="7329-5a4d-921c-c1c2" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_db78-4d49-42ab-954a</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_f14d-9943-47b6-866c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a95-938f-4a07-9727</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_7775-78e1-44cc-87c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e3af-90aa-45c5-9667" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_b822-3417-4613-be37</comment></categoryLink>
+        <categoryLink id="0f57-eea8-407c-a44c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_25db-b03f-4881-b310</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink><entryLink id="42a7-c5ce-89f7-2336" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_3c03-a823-4466-9bd6</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8bbb-f95b-413f-b6f4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_41b0-6b0a-482a-919e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e1f7-3cc6-4794-8b6d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f12a-011b-4bb1-8468" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_05ce-cc31-40ad-9320</comment></categoryLink>
+        <categoryLink id="6013-c486-4b26-be65" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f13c-f8e1-4a50-bfe3</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink><entryLink id="384b-033e-4f9d-31b1" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry"><categoryLinks>
+        <categoryLink id="fde7-709b-4110-90a6" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_4c8d-96f6-48f9-9590</comment></categoryLink>
+        <categoryLink id="bc7b-cf85-4bdd-85f9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_049c-0fa5-4575-8fa8</comment></categoryLink>
+        <categoryLink id="5c54-8eb1-4a64-b11b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_7358-52d7-4aae-8e07</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="a965-337e-45bf-84d3" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup"><comment>    template_id_4784-b370-444b-93ae    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="b481-76ed-4ade-aa53" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup"><comment>    template_id_fe8f-c701-4ebd-ae76    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink><entryLink id="a3d1-8135-0daa-681c" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_54a4-6ec8-4c61-9c3e</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_f7fd-2d16-4603-a065</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8aa0-0f9d-47e7-a640" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_c0ac-4b8c-421c-a21b</comment></categoryLink>
+        <categoryLink id="40f2-3366-4a94-80c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8db9-079e-4482-b200</comment></categoryLink>
+        <categoryLink id="1c93-efb1-49e3-80a3" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_413c-9273-4308-b546</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="5831-d9ca-4513-a942" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup"><comment>    template_id_bbc4-33fc-4664-a18e    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="c7f9-09d1-4563-9e39" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup"><comment>    template_id_5c5d-d6ce-4ee4-9846    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink><entryLink id="792c-37c2-8548-693c" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry"><categoryLinks>
+        <categoryLink id="2da9-bd91-411f-8ef2" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_b084-df23-4f99-812f</comment></categoryLink>
+        <categoryLink id="4540-4f3c-4aa9-af32" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_84fc-9304-4e9e-ab78</comment></categoryLink>
+        <categoryLink id="6f64-e0b3-4faf-8c84" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d06a-7939-4691-9aed</comment></categoryLink>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="260b-3843-4056-ae30" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup"><comment>    template_id_831f-3373-456a-8fbc    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
+        <entryLink id="022b-58f0-461a-a5e5" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup"><comment>    template_id_741d-8c09-4211-ada6    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+      </entryLinks>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink><entryLink id="fa17-8a0d-0cef-8628" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry"><categoryLinks>
+        <categoryLink id="9773-b245-4fd8-8ffd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_ff9f-01cb-41b9-800e</comment></categoryLink>
+        <categoryLink id="f631-c801-47ef-a777" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_1315-6051-4a46-b070</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink><entryLink id="f0a5-8b7d-9e04-4da5" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4dce-8632-4f7c-813e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_8a71-3995-4155-ac33</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d206-f2ce-41b8-945a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan">
+                  <comment>    node_id_2e02-cf1c-4a71-861c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ec81-bd33-45a8-8550</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_3344-743c-45d3-b930</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e051-91a0-4796-ad9b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4272-9b9d-4c59-95f0</comment></categoryLink>
+        <categoryLink id="1d46-32bc-4a57-a73a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_d85b-1ae7-40d5-9341</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink><entryLink id="ddf1-7b2e-082b-d775" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4729-bc86-456b-b73d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_cf0f-e3f4-4fb4-989d</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1cc8-5611-4d9a-9218</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_2e32-ca02-48f0-a8dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c2a3-608a-4434-b984" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_0af1-d052-4bd7-aab6</comment></categoryLink>
+        <categoryLink id="f293-e427-4966-9a29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_45ce-e338-43c9-b63e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink><entryLink id="24e2-5293-cf94-a83c" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry"><categoryLinks>
+        <categoryLink id="ae87-9b89-4791-b23e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6140-2404-46f9-bd42</comment></categoryLink>
+        <categoryLink id="77ca-3e6c-499d-bedf" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_1c86-fad8-46ec-a0b0</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink><entryLink id="c204-13d1-4189-9724" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="19e0-02bc-48ce-9eca" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4e52-ad1b-48d4-8eed</comment></categoryLink>
+        <categoryLink id="3dc5-21e9-41c7-ac28" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"><comment>    template_id_6979-1ed3-4f1f-a025</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink><entryLink id="d1f7-b7cc-38ae-b34a" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1e60-42ba-4c8b-9077</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9860-f593-425e-b89b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_c842-10e8-4509-8eda</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ea52-ff41-40f6-8cf3</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_51e6-c5e1-4003-96bc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="064e-7dcb-41fd-8e37" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_4d7c-201f-4c99-b89a</comment></categoryLink>
+        <categoryLink id="796f-aabf-41e1-8718" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_10f9-4718-4e07-bb32</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink><entryLink id="944d-5882-4dfe-0bfa" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_773a-1ea4-41a0-b766</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_9d4d-6fb8-4131-a5a3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e3bc-02f8-4ece-a5ea</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c371-76d9-4a4d-bc00</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b4c6-d4ba-4b2e-9b99</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="02d9-9a8a-47fb-8ad2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6ea9-a7e5-437d-9e35</comment></categoryLink>
+        <categoryLink id="e2dc-2fcb-4f21-b6c7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_3cec-f053-42ab-a6eb</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink><entryLink id="d09c-0e11-efa3-c62c" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2bfa-b203-47e2-a828</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a39b-8a3c-49cf-bf62</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2a05-07b3-49c5-8145</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f730-87fb-44bd-b68e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_2d0e-6c49-4493-a022</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2e2-50c1-40c3-b4dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1514-0d23-4455-88ab" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_5ad5-8701-42cd-b2b6</comment></categoryLink>
+        <categoryLink id="5e71-7ba4-426d-ba0c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_20a4-4346-4a3b-a7d4</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink><entryLink id="1f97-bf58-5325-e7c8" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_22bd-baae-45f9-b366</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_52bd-55de-4d53-ba55</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_df1b-7476-4ab8-8d2f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_49fa-0dcf-4a61-a5b1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0ea-1443-4993-86e7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2a8-3fbe-448c-9902</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cff4-189a-4d4c-8d09" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3632-0b5d-4622-ae33</comment></categoryLink>
+        <categoryLink id="5652-2a65-4c4b-bc53" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_da44-7815-4fdd-981c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink><entryLink id="78c0-bd86-99b4-3d35" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af71-f3ff-49b1-83e9</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_1c9e-b3bf-4e88-a43f</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_6d0d-1b1d-4065-89cf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d0b7-8686-491e-9d33</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_7db8-0874-487a-be6f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1034-29a0-44b1-a85f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a94b-321d-4e2a-a00c" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_0c16-6841-42b2-b02d</comment></categoryLink>
+        <categoryLink id="f6d6-558f-4570-98b8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_602d-2d2d-4ff4-a82a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink><entryLink id="0605-ec8d-6663-886f" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3c84-6d74-4c42-b38d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_5b15-7aa4-4897-aaf1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_3326-31ed-4151-9b37</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6a0e-1b65-4057-ba5d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f8c7-abc9-45ec-955f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_2538-8dc5-446c-8344</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d85e-c762-435e-83d9" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_c1cf-cea4-4278-8f27</comment></categoryLink>
+        <categoryLink id="a5d5-a29e-4a2e-9b4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_5f51-2734-4a46-9f72</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink><entryLink id="1066-95b0-0f9d-0653" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d72c-519a-451f-81b6</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_3d16-444c-42c9-aad1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_f4b2-6371-494b-863a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_797f-a84b-42f6-8e66</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0d78-fe38-4829-9b12</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="53c5-68ca-4672-8134" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0397-c837-4fea-a527</comment></categoryLink>
+        <categoryLink id="9f31-b4db-4b7d-bc39" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_060b-bccb-4776-bd83</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink><entryLink id="97d7-de29-6a7f-1679" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6ecb-28e2-43ed-a6a0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_c067-1118-4d96-b28b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_250e-23c0-4e43-bf74</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1553-a6e6-4291-853f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_aab6-797b-427a-9fd8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9f20-7932-41d5-9ef4" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c77f-0819-473b-a8a2</comment></categoryLink>
+        <categoryLink id="54cb-af58-438d-9e32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_89fb-c924-4daf-923d</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink><entryLink id="0d49-ca54-940c-0756" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_005e-6607-4e2c-8dd2</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_7745-260c-4c36-b719</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_ba25-a4b2-4ba9-b023</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ddeb-f4c8-4091-9153</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4904-fd2f-429f-9cf7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_faea-b21b-43c5-b918</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3b5d-0be9-43ef-bada" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_b24f-3ae0-4cbb-b016</comment></categoryLink>
+        <categoryLink id="2b29-273c-4d80-bc7d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fd26-8e6b-4521-92b9</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink><entryLink id="3951-5694-c7f3-15cf" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_85c5-d4d9-4b23-9e4d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_80e8-d50b-4906-8153</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_b93b-d4f1-45eb-8a69</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e183-f183-4db7-83b5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0f39-204a-4217-b896</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_eee9-7bfd-4fea-a1bd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5561-53a8-47bc-bc14" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f81d-9435-4f11-99c1</comment></categoryLink>
+        <categoryLink id="b017-ce01-4afb-88da" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9568-6142-4fdd-be3a</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink><entryLink id="0a1c-5ad3-c7fc-494d" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ae19-30c0-43c5-920e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_6ebe-1bf3-4d78-9dd0</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1887-152d-48b7-b13f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_a7c4-ee6a-4f0b-8ab0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bd85-fa90-47ff-9f84</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_7bd6-9043-4d7e-ba37</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ee04-c72e-4166-9be5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_3610-c975-4d55-bdfe</comment></categoryLink>
+        <categoryLink id="5a31-125f-438c-b6a6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2fc2-f636-4c80-9608</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink><entryLink id="f6dd-6d5b-c299-0673" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_c28f-4109-44c4-ab64</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fdc1-a894-48bc-9e7c</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_4936-a68c-4524-9088</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb37-ac0c-49ae-9d6f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fb58-4d27-43f3-9937" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_3afe-cfc0-4da6-a985</comment></categoryLink>
+        <categoryLink id="508a-1b47-40e2-a1fa" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_04a8-6aae-45ae-bd4c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink><entryLink id="2f64-52bf-468a-22a5" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1ae7-c41b-4818-be71</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_08a5-b1bb-4ba1-ba42</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d677-b5ad-4838-8746</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_537f-bc1f-4aaa-b0dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="efab-89f2-4be7-b2af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bc67-ce1f-4004-aeb7</comment></categoryLink>
+        <categoryLink id="c6ae-4d7f-4210-86e9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_9a45-9699-4475-aeef</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink><entryLink id="aae0-3c7f-2d80-7468" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ae67-ef52-4cac-958c</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fc61-7306-4d99-acde</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1be0-67e7-45a1-bdbb</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_42a8-7fda-4e05-af0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3986-5cc4-40fb-a73f" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_565a-1592-491f-8b9b</comment></categoryLink>
+        <categoryLink id="5c43-7721-4b0c-a706" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_81d5-c14a-42ab-bdde</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink><entryLink id="c2c6-e375-9435-7000" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_edc4-4915-40ba-bbf0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_105f-ba26-4146-bc54</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7a2c-a76c-421c-a8a2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_05c9-0543-47ee-ba81</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e6ad-f0d7-4627-921b</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a041-b97b-4fd9-8f9b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c6a8-22a8-4d41-b969</comment></categoryLink>
+        <categoryLink id="3597-e0d5-48e5-b56d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_03ca-12cc-4e0a-b628</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink><entryLink id="ab94-44fe-ecc0-a5ad" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_99fc-5fe7-4b37-a62f</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_25f4-f6b8-4b44-8350</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_81f7-2311-4cce-95bc</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_09aa-af2a-4012-91d1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_00ae-fad3-4df6-9cb9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c6ce-dcc7-4555-9f3f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_f65b-8958-49b3-92a5</comment></categoryLink>
+        <categoryLink id="bcf0-2589-4b94-814b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0451-1929-4942-8c3f</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink><entryLink id="b5a1-3cbb-1d82-91a3" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1fb5-2375-4c22-b41e</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7d7c-255d-49b6-96b9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5321-254b-4890-9bf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ddf8-b8b7-4afb-b6dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ce7e-39fa-4be0-b7c8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_9441-d79b-4720-9667</comment></categoryLink>
+        <categoryLink id="9fc9-eb48-49a5-b33b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_7d7e-32d3-4692-b401</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink><entryLink id="fb95-27dc-5539-f106" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e76b-46ca-4ab8-a93d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8035-75b8-43bb-97c9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_71a4-31e7-4927-a0ab</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1e53-59c6-4738-91ad" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_a56d-347b-4b09-a918</comment></categoryLink>
+        <categoryLink id="001b-406e-4cdd-a6bb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_96e5-4531-4213-903e</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink><entryLink id="114f-1a49-372f-2fc0" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d8ee-81ed-45f9-8b79</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_8f4e-e8cb-4ac9-a415</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0a96-64aa-4b6e-8427" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_cefb-cfd7-4dc8-99c4</comment></categoryLink>
+        <categoryLink id="2282-7848-4b2e-be2d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a9fd-9d16-4a5e-855c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink><entryLink id="2354-d46f-49c8-4630" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d765-3bb2-4b48-bd12</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_0ca1-cfb4-4a56-ab3b</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="de33-0651-4f23-832e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_e6f7-a6ca-4825-bfc5</comment></categoryLink>
+        <categoryLink id="44c3-fe6e-43fe-9bf3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dbec-e027-4ec1-8514</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink><entryLink id="1a75-cc22-6e04-d9f3" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ada1-1e18-4cbc-9598</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b1d1-ac44-47dd-9159</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5d64-f00c-4464-891b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25f0-f825-4a83-8f0d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_64b1-9e36-44da-b36a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ae87-aa89-40f5-8cf0" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_d53e-113f-4a40-a3d5</comment></categoryLink>
+        <categoryLink id="7ab3-2f7d-44ca-a438" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1939-76b5-4279-9f8c</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink><entryLink id="1c75-2909-9649-b8c8" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f318-4b03-4767-8c7f</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b8ef-7245-4df8-a8c4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_6bce-ec44-48cb-873a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e878-d798-469d-b40e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_0678-4fdd-48e6-8f61</comment></categoryLink>
+        <categoryLink id="7eb7-4910-43d6-9f28" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_0d82-10a9-4de2-8ad7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink><entryLink id="c815-dbde-58b4-87cc" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d0c9-9a26-4324-b030</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4e9e-a61d-42f2-bacb</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ed9e-b634-4bec-9eb0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4614-ad0f-4fba-adaf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_8d08-24f6-41be-8931</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="70ed-b942-4b36-a8cc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_caf6-5548-4b89-8102</comment></categoryLink>
+        <categoryLink id="695a-81eb-4876-b102" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_63a3-be61-428d-ab29</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink><entryLink id="a0ad-db6b-ce33-f849" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1af8-4459-4717-8e3b</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_06b4-92b9-438c-b1a5</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6c8d-8b28-417b-9a7c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_715d-8186-4aa6-b40c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_390e-358c-4f8e-ade8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8b62-e13e-4011-a9c5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f4c0-4396-4f39-a34f</comment></categoryLink>
+        <categoryLink id="d19c-b799-4237-aab9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_1301-8415-490e-8f06</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink><entryLink id="8be5-dd6c-2276-908d" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7cf3-8a72-4f82-8cdc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_228c-5681-4ce8-b726</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_01bb-8abd-4253-9a4d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8312-1f0d-4b26-b881" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_2a08-4432-42ad-bfdb</comment></categoryLink>
+        <categoryLink id="6045-fbef-47f2-99dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_422e-0808-4897-8630</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink><entryLink id="6c53-3a25-88ea-4e3b" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="aac8-c00e-423d-a6a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_473b-e812-4158-9416</comment></categoryLink>
+        <categoryLink id="d963-7041-4f06-a6b6" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_00a2-63ff-4698-a35b</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink><entryLink id="8fca-6360-d5ba-c5a2" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry"><modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_8ed4-376d-4030-9439</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8a11-c2a0-4335-99ef</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_fa8e-1af7-4d41-ac8c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_94bd-c771-4a85-8581</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e385-24d3-45a7-be8b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_361e-fb90-4b0e-ac3d</comment></categoryLink>
+        <categoryLink id="b011-22cf-4d2d-afed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_d4ef-1074-45a9-959e</comment></categoryLink>
+        <categoryLink id="a50c-a2c5-47f8-978c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_febb-f536-4d25-a8ab</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink><entryLink id="88a1-d2dc-6a48-8aaa" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry"><modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_658f-b1ad-4347-a998</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_12bc-3db2-4d28-abce</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_9d83-7691-41d6-8dad</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_add7-ba48-46d4-8a02</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_1fb0-2421-40a4-9e49</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c34c-f279-4fbc-90ea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_7004-b00d-481f-b740</comment></categoryLink>
+        <categoryLink id="025e-e90d-4534-8352" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_4f88-2fc3-491c-bfb7</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink><entryLink id="d5bd-81d6-7a03-5796" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="58e5-3c23-2dda-0229" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
         <categoryLink id="ff26-ed07-184f-756c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="a2e7-8aba-5a78-727f" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
+    <entryLink id="a2e7-8aba-5a78-727f" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8396-e51c-4e2b-bada</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_13bb-9fb5-4580-92cf</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_bfb8-8125-4548-92f5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25e3-b8f5-4448-a7c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="1be8-a420-b14a-19a9" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="1f09-3b1e-1ee1-bf90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9040-9829-403a-90ec" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_f926-27fd-4a92-97a1</comment></categoryLink>
+        <categoryLink id="031e-6772-4981-814c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_82e3-36e1-4e85-8fcb</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
-    <entryLink id="66b8-529a-be23-5a19" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink><entryLink id="66b8-529a-be23-5a19" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"><categoryLinks>
+        <categoryLink id="2ff6-8c3b-4b32-909f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_aa93-057d-42f6-82d7</comment></categoryLink>
+        <categoryLink id="c8bd-7caf-41da-abc5" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_403c-4e9c-4af5-84ec</comment></categoryLink>
+      </categoryLinks>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink><entryLink id="2fa4-73e6-82b1-5754" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_23fa-06dd-49f9-a7db</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5b26-059e-40b3-9d93</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f7bf-3a1c-4103-aed8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="d227-914b-1dd2-e322" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="45b7-0d9a-26a4-b81f" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="1113-7c59-41fa-96c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_dd44-e0a8-42a8-bdcc</comment></categoryLink>
+        <categoryLink id="f92e-2ba6-4038-b567" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_c5b0-f9ae-468d-924a</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
-    <entryLink id="2fa4-73e6-82b1-5754" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7b5e-e260-f34d-7799" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="068e-a93b-4ea2-bb7b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-      </categoryLinks>
-    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink>
-    <entryLink id="319b-3912-a5ce-cece" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_3aed-0370-44b8-9b06</comment></entryLink><entryLink id="319b-3912-a5ce-cece" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="97a0-b618-c047-ccd8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="4a24-5771-62a2-b7e6" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+        <categoryLink id="6f14-114c-45d9-ab62" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_6577-e0fb-4fda-834e</comment></categoryLink>
+        <categoryLink id="2c10-c3f5-43bf-9cbc" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_5d59-09bf-4566-b7e1</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
-    <entryLink id="b2e6-42ba-afdd-367d" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="568a-3b75-3336-6ff3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="7de3-bfb1-bf9b-cf17" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink><entryLink id="b2e6-42ba-afdd-367d" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry"><categoryLinks>
+        <categoryLink id="efa5-dc24-419e-a745" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4207-8d8f-4b1a-836b</comment></categoryLink>
+        <categoryLink id="14a8-d8bb-4070-998b" name="Primarch's Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"><comment>    template_id_2b34-077f-4279-86fb</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
-    <entryLink id="6d4b-f6b9-af3b-46fb" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink><entryLink id="6d4b-f6b9-af3b-46fb" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b43b-547f-472e-9076</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8ff9-0498-4540-8552</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fbfe-931a-489b-a589</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f4c3-5aa6-4caa-abf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_17f8-f055-4c9c-b757</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="7234-ce4e-2bbe-e93b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
-        <categoryLink id="1b09-5f0e-ecb5-b773" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b26a-b5cf-4b64-960f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"><comment>    template_id_f1c8-27fd-4f98-8527</comment></categoryLink>
+        <categoryLink id="87eb-e154-400a-a5d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_2b20-1a8b-4753-b657</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
-    <entryLink id="551c-fb9b-4fe1-784c" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="a368-67bd-4471-6cb7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="e07c-8ff7-497d-511f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
-        <categoryLink id="0132-9e3a-aefe-795e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink><entryLink id="551c-fb9b-4fe1-784c" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry"><categoryLinks>
+        <categoryLink id="eb2c-a67b-46f2-9ef7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_fc9d-03d1-4bbd-a1c4</comment></categoryLink>
+        <categoryLink id="0aba-2252-4592-b75b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_f51c-73d7-4f29-be1c</comment></categoryLink>
+        <categoryLink id="2a1b-aea5-4446-999f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_257d-78c0-4bab-ba65</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="d168-545d-77b7-8bbf" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup" />
-        <entryLink id="82d5-3732-2887-dd73" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup">
+        <entryLink id="cdc9-353d-48ff-b767" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup"><comment>    template_id_ac26-33db-40a7-bdba    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="fe08-4c45-405a-9231" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_189b-db75-4db6-9fe9</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_cbdb-2500-4e13-876a</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_dc8e-2801-46d6-84f8    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
-    <entryLink id="9609-90ca-79c2-bae6" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink><entryLink id="9609-90ca-79c2-bae6" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry"><modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ad5d-3c79-4239-9116</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_60b1-049b-4a5f-85c2</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="99c6-145f-3c55-7f83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="bdd6-94f1-0b17-da0e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="63f8-7969-6ec3-f65e" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="38ca-fa0b-48d9-b5a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_bd6a-0cda-4e0f-80ae</comment></categoryLink>
+        <categoryLink id="13db-b61e-414f-a209" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_ae75-7cca-4701-9d56</comment></categoryLink>
+        <categoryLink id="895a-aae5-4d58-83b4" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_e517-62d4-48f7-8174</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="8ee3-1f14-b6ad-eba3" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup" />
-        <entryLink id="3957-b010-5ebc-759f" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup">
+        <entryLink id="4d37-e9fa-4504-b549" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup"><comment>    template_id_fafb-6414-474a-8a09    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="f5c6-c6e3-43c8-b8d5" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_1e43-c980-4508-8ec2</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_4140-36a7-4203-b5e9</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_a6a6-9bc7-4d4e-86a7    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
-    <entryLink id="e186-b7d7-08f5-3c17" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="56d2-4255-0fc9-09c8" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
-        <categoryLink id="2db5-ca5c-0af6-f099" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="50f6-8950-6c00-c97c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink><entryLink id="e186-b7d7-08f5-3c17" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry"><categoryLinks>
+        <categoryLink id="9bf7-2e99-4a83-80ac" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"><comment>    template_id_2599-24e3-44e5-9568</comment></categoryLink>
+        <categoryLink id="8074-4e41-4e24-a7aa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_285f-6e56-473b-b2fe</comment></categoryLink>
+        <categoryLink id="f86c-6273-462d-b41e" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"><comment>    template_id_685e-022f-4e2f-a568</comment></categoryLink>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="387a-ae79-d687-e5ce" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup" />
-        <entryLink id="1d9e-c70a-2281-4db9" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup">
+        <entryLink id="b140-7d42-4212-919a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup"><comment>    template_id_2a38-6544-4267-b584    template_targetId_7dee-602c-4b47-be09</comment></entryLink>
+        <entryLink id="3030-6e4d-4a07-98f0" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_8287-16ff-46ba-9838</comment>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_81c1-fca9-44dc-ba4c</comment>
+                </condition>
               </conditions>
             </modifier>
           </modifiers>
-        </entryLink>
+        <comment>    template_id_6e59-4592-47ef-b76d    template_targetId_be38-a066-4f8e-ae54</comment></entryLink>
       </entryLinks>
-    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
-    <entryLink id="0364-dbfe-ee3a-28f2" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink><entryLink id="0364-dbfe-ee3a-28f2" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_591d-d028-4663-918d</comment>
           <conditionGroups>
             <conditionGroup type="and">
+              <comment>    node_id_0482-c5f9-4c95-9597</comment>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_75a7-971d-4978-a83f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_a7d5-2bfe-4621-ac0c</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9f13-b460-4f27-b0cd</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_31fc-e265-45a7-bb5b</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4d81-bb58-c13c-7f3f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
-        <categoryLink id="ab85-59de-9a85-4d4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9b74-ac61-4a8f-ab2f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_67c2-df43-44fc-92d1</comment></categoryLink>
+        <categoryLink id="c532-e5cf-4b99-a2fa" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4136-bb4e-4dd4-99f9</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
-    <entryLink id="a7b6-424e-106d-0c35" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink><entryLink id="a7b6-424e-106d-0c35" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+          <comment>    node_id_13b3-ce1e-4f9d-8319</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d681-9d81-4abd-b11b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a57-e48b-4534-bca5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_1859-5641-4674-9097</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8ef7-4c9f-5abb-d31f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="62c5-1901-730f-1f10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7581-1223-4390-ab0a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_251a-df5b-4bfd-ad63</comment></categoryLink>
+        <categoryLink id="3c34-6bd0-45e4-a537" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_4644-98ab-4e3f-b1fd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
-    <entryLink id="19a7-0534-8cf1-b0b7" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink><entryLink id="19a7-0534-8cf1-b0b7" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+          <comment>    node_id_7583-6fa0-4089-a19e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_0e5c-99ab-41d3-a42e</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c296-e8e8-4a7a-989a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_8868-5bcb-4604-ba8e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5ef5-eba4-1722-94ca" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
-        <categoryLink id="0c24-30f6-e785-59de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9c6d-b7f1-4cc0-8f07" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"><comment>    template_id_a009-a597-4b51-b228</comment></categoryLink>
+        <categoryLink id="dfab-e40a-4de8-a9f6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_24f4-9145-4016-80d4</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
-    <entryLink id="67b7-112e-01ad-27a0" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink><entryLink id="67b7-112e-01ad-27a0" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
-          </conditions>
+          <comment>    node_id_e732-7499-47bf-9748</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_81a5-a959-46b7-baa4</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7ec3-447a-4644-b012</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_71e2-c430-4c99-a559</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_df7b-3fb9-4f65-9165</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6f98-dc70-2956-4b6e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
-        <categoryLink id="7dcb-8897-289a-6bb3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="30dd-2527-4805-b76a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_c165-3906-463a-9c73</comment></categoryLink>
+        <categoryLink id="eda4-c309-4a14-8316" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6d1-d14c-473f-be09</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
-    <entryLink id="7366-521a-bae5-0a02" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink><entryLink id="7366-521a-bae5-0a02" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_27a3-1e4c-4b76-a594</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_d59a-dcd0-44fd-b866</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_0c8b-2b92-49ed-98c7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_bafe-f799-41d9-ac85</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_6369-288c-4fec-a640</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_fe53-8858-41dc-8ec4</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ead3-18c3-4dcd-dd49" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="8c99-dc6a-f877-2a0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="9d8d-c264-13c1-42ad" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="6f4f-cf60-4e46-b48b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_3a22-caae-4eea-9bc5</comment></categoryLink>
+        <categoryLink id="bc6d-80ea-40a5-9fa1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_f759-f33e-4698-9f8a</comment></categoryLink>
+        <categoryLink id="6486-7c0a-44b5-95b6" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_c624-3ae0-46c0-9b06</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
-    <entryLink id="1d63-9ec6-1bc1-3085" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink><entryLink id="1d63-9ec6-1bc1-3085" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry"><modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_7fd1-8ce8-4d10-82e7</comment>
           <conditionGroups>
             <conditionGroup type="or">
+              <comment>    node_id_eaae-8c43-4d30-898c</comment>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_f67d-8cf3-424f-b491</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_b949-6414-4f3d-b268</comment>
+                </condition>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0774-a66d-297c-14f6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
-        <categoryLink id="756d-e6b6-75b3-9f19" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="ac5e-7b3b-d1d4-9c81" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+        <categoryLink id="a963-97b2-49a9-8b3d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_ac26-e639-4d53-9b8b</comment></categoryLink>
+        <categoryLink id="4d2a-3b50-4aed-9c13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_49af-0d08-4c7e-8ce6</comment></categoryLink>
+        <categoryLink id="155c-9384-4e4b-b1d9" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"><comment>    template_id_b606-de16-4659-95cd</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
-    <entryLink id="4784-cedb-8631-4001" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink><entryLink id="4784-cedb-8631-4001" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry"><modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b02f-e65f-4a88-a175</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b87b-bf35-4238-b7c6</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1aff-27af-435e-8102</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_fdf9-4906-4180-a39d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="412b-dd85-e27a-aa81" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="250b-6fa2-9cf3-0954" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="a757-4468-4174-8abf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_8378-ede4-476d-b657</comment></categoryLink>
+        <categoryLink id="64b6-041c-44a4-98dc" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"><comment>    template_id_d64f-ad19-426c-adf7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
-    <entryLink id="6158-e194-98e5-0806" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5816-e8b9-f2b8-c2d0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="69c9-4ef4-031e-0ffe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink><entryLink id="6158-e194-98e5-0806" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry"><categoryLinks>
+        <categoryLink id="b3c2-86f9-45eb-8aec" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_c6d4-581f-4746-bec3</comment></categoryLink>
+        <categoryLink id="2026-b0d4-4296-960b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"><comment>    template_id_2489-ee2a-45dd-b384</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
-    <entryLink id="1d84-d081-c72e-e242" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
-      <modifiers>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink><entryLink id="1d84-d081-c72e-e242" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry"><modifiers>
         <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af15-2c71-4f8b-833e</comment>
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_d95a-80b9-4463-af55</comment>
+            </condition>
           </conditions>
         </modifier>
       </modifiers>
-      <infoLinks>
-        <infoLink id="282a-cfa0-f347-c75b" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule" />
-      </infoLinks>
       <categoryLinks>
-        <categoryLink id="3329-4017-e23f-4891" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
-        <categoryLink id="2b21-d6e1-987f-fb24" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="ab84-c93c-49a2-8350" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"><comment>    template_id_b6b1-886e-4194-8bcd</comment></categoryLink>
+        <categoryLink id="a6b6-9d7f-4131-8556" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"><comment>    template_id_51b5-f9c1-4587-8fc7</comment></categoryLink>
       </categoryLinks>
-    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
-  </entryLinks>
-  <sharedSelectionEntries>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink><entryLink id="23b3-4f27-4a77-8097" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_a369-e639-4d89-8f78</comment></entryLink>
+    <entryLink id="a7a2-0823-4d75-a84c" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_59c9-be20-4f7c-b91d</comment></entryLink>
+    <entryLink id="d9a3-df03-4e5e-8a6f" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_ed2f-2214-418e-8562</comment></entryLink>
+    <entryLink id="55cc-ce10-4f3b-ae26" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
+    <entryLink id="6d3e-2088-4b8a-b7aa" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3531-57d1-4081-882d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_f233-2361-4177-8ba7</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b932-667a-4b43-8331</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
+    <entryLink id="ab59-0b5c-42ea-9f7f" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
+    <entryLink id="686f-1559-46a6-a577" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3129-6f59-4365-906b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="2bcb-0af1-4aea-9191" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
+    <entryLink id="9a7a-1e96-461d-aaab" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ede2-d453-4e34-8cda</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2907-3215-4b01-96ff</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_c90c-959f-40fb-a4cb</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ba2d-50ad-45f1-91c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="0e88-485e-43c2-8bef" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
+    <entryLink id="30f0-705f-4758-8d02" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_409c-0a5d-4ef8-a871</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7078-c1c7-4af2-b43d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_9a69-0fdc-4957-8982</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1a4c-69b5-4219-8502" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="fba0-3ea7-4eaf-b33a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
+    <entryLink id="959c-3702-4b38-97dd" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_6e3b-815f-42d7-a0d9</comment></entryLink>
+    <entryLink id="f7af-4a1e-4570-aad5" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false" />
+        <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_f22f-aa8d-45c5-b890</comment></entryLink>
+    <entryLink id="7d07-ea3b-41ff-8084" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+      </categoryLinks>
+    <comment>    template_id_fa70-d04e-4683-8eda</comment></entryLink>
+    <entryLink id="a1f8-13ce-4ce7-b1b1" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+      </categoryLinks>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
+  </entryLinks><sharedSelectionEntries>
     <selectionEntry id="7a04-bc44-70bb-cb98" name="Red Hand Destroyer Assault Squad" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="9f63-cb32-73a5-840e" name="Bearers of the Blood Hand" hidden="false">

--- a/2022 - LA - World Eaters.cat
+++ b/2022 - LA - World Eaters.cat
@@ -1,30 +1,29 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d901-0eca-48b5-304a" name="LA -  XII: World Eaters" revision="12" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="d901-0eca-48b5-304a" name="LA -  XII: World Eaters" revision="12" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="26">
   <entryLinks>
     <entryLink id="d647-fd99-73e0-bd57" name="Angron" hidden="false" collective="false" import="false" targetId="6352-8efa-0cc4-cfa7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="e3d0-6c05-8d56-6e01" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
-        <categoryLink id="b212-8e0c-46ce-f3b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e3d0-6c05-8d56-6e01" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true" />
+        <categoryLink id="b212-8e0c-46ce-f3b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
-    <entryLink id="eae7-92b5-7fb5-0667" name="Khârn the Bloody" hidden="false" collective="false" import="false" targetId="e726-7208-d919-a4a1" type="selectionEntry">
+    <entryLink id="eae7-92b5-7fb5-0667" name="Kh&#226;rn the Bloody" hidden="false" collective="false" import="false" targetId="e726-7208-d919-a4a1" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="9a45-dc53-86fd-a519" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="3cd1-2a33-5ca2-8154" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9a45-dc53-86fd-a519" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="3cd1-2a33-5ca2-8154" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="e38a-7bdf-7ddc-7084" name="Shabran Darr" hidden="true" collective="false" import="false" targetId="aa6d-c70a-199f-1db5" type="selectionEntry">
@@ -33,36 +32,36 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5380-a98e-902b-7621" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="7196-76e9-d9ce-2f13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="eaeb-08e5-5cda-7c6a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="5380-a98e-902b-7621" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="7196-76e9-d9ce-2f13" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="eaeb-08e5-5cda-7c6a" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="2d0a-125c-d539-b7cc" name="Red Hand Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="7a04-bc44-70bb-cb98" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d56-d960-0687-7fee" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="08cf-e4af-ba2a-6a96" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="abeb-1149-93ec-eb08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="08cf-e4af-ba2a-6a96" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="abeb-1149-93ec-eb08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="6fa2-aa20-9b69-1d6b" name="Rampager Squad" hidden="false" collective="false" import="false" targetId="2fb9-74a8-43b0-dd00" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8586-4da8-8d15-4d96" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="4ed9-df3c-d9cc-b1f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8586-4da8-8d15-4d96" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="4ed9-df3c-d9cc-b1f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="33ce-2039-527f-496b" name="Gahlan Surlak" hidden="true" collective="false" import="false" targetId="e812-10d1-b911-90c5" type="selectionEntry">
@@ -71,1023 +70,1023 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c631-e91c-7b35-038d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="8ba5-d6d8-3c2a-cf09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b9d3-c817-7e77-1c90" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="c631-e91c-7b35-038d" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="8ba5-d6d8-3c2a-cf09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b9d3-c817-7e77-1c90" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="85a9-21ca-dcf0-beb4" name="Red Butchers" hidden="false" collective="false" import="false" targetId="1987-2aa5-929b-979e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6809-da13-d863-b286" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="63b2-2890-7ed2-7b00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6809-da13-d863-b286" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="63b2-2890-7ed2-7b00" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="72f5-627b-f9c0-c6bf" name="  XII: World Eaters" hidden="false" collective="false" import="false" targetId="90ee-77dd-1b7f-ddfe" type="selectionEntry">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7455-be1c-d0be-c1cf" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5acc-e6b3-83a3-10c3" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7455-be1c-d0be-c1cf" type="min" />
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5acc-e6b3-83a3-10c3" type="max" />
       </constraints>
       <categoryLinks>
-        <categoryLink id="a155-7b9c-da9f-525b" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
+        <categoryLink id="a155-7b9c-da9f-525b" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true" />
       </categoryLinks>
     </entryLink>
     <entryLink id="a3bb-0abc-4d37-1e09" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="69cd-d34a-6980-b92d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="b59f-a5bb-fc27-6f74" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="69cd-d34a-6980-b92d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="b59f-a5bb-fc27-6f74" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2275-397b-407d-ae6b</comment></entryLink>
     <entryLink id="ea50-9e6b-0827-8392" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b686-7fdf-ec1f-956e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="7bdc-02ef-f4d8-d8b8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b686-7fdf-ec1f-956e" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="7bdc-02ef-f4d8-d8b8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_edf3-7f66-40be-9234</comment></entryLink>
     <entryLink id="7fb6-9ea7-83ab-efa1" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5117-96f2-2f9d-7427" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="90b9-5b4d-168c-059f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="5117-96f2-2f9d-7427" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="90b9-5b4d-168c-059f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e3b3-8b3e-44d9-94e1</comment></entryLink>
     <entryLink id="4445-7144-41dc-b8c6" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="00b1-fd9c-c21c-dc88" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="83d9-15d2-ab92-e520" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
-        <categoryLink id="dcad-743d-7ffc-e6f1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="00b1-fd9c-c21c-dc88" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="83d9-15d2-ab92-e520" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false" />
+        <categoryLink id="dcad-743d-7ffc-e6f1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_02ca-5079-4248-b353</comment></entryLink>
     <entryLink id="cb9e-4257-d7e5-23f2" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3cfd-be32-1879-77b2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="f12b-b3c2-781a-5805" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3cfd-be32-1879-77b2" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="f12b-b3c2-781a-5805" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b3aa-4fa3-4270-993b</comment></entryLink>
     <entryLink id="8eb6-4832-e4be-14ca" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f2a5-57f6-54b2-d012" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="2ac8-59f2-4876-fbac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f2a5-57f6-54b2-d012" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="2ac8-59f2-4876-fbac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_513d-c1d7-4928-95ec</comment></entryLink>
     <entryLink id="1528-2655-0329-c2df" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c697-ac01-974f-d163" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="2559-d869-f135-c64e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c697-ac01-974f-d163" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="2559-d869-f135-c64e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3b77-0148-4975-a6db</comment></entryLink>
     <entryLink id="15d3-53a0-372e-6a1c" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8027-3dbc-b54b-93b1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="cdc0-bf28-15b5-aa47" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8027-3dbc-b54b-93b1" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="cdc0-bf28-15b5-aa47" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_b99f-dff7-42f7-a135</comment></entryLink>
     <entryLink id="22ed-bf80-0f24-060e" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="943b-f22e-7486-e366" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="7ab8-5171-4b59-cccf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="943b-f22e-7486-e366" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="7ab8-5171-4b59-cccf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bfa2-4203-4ad3-b023</comment></entryLink>
     <entryLink id="7c3d-c611-42a7-6dbf" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7862-9fa1-f510-7267" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="e887-aae5-f55b-4a9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7862-9fa1-f510-7267" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="e887-aae5-f55b-4a9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3705-3a7a-4e90-92cd</comment></entryLink>
     <entryLink id="c4af-98b6-a14f-1afb" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="514d-df3d-f6f8-a6ba" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="fb98-343f-1289-c47e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="514d-df3d-f6f8-a6ba" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="fb98-343f-1289-c47e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_47ce-b432-4b4a-98da</comment></entryLink>
     <entryLink id="13da-0633-d7ed-4341" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c39f-d745-c6c6-b16e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="29ba-b9ae-d3b6-352b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="c39f-d745-c6c6-b16e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="29ba-b9ae-d3b6-352b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_d202-8e38-4b5e-96a8</comment></entryLink>
     <entryLink id="ee64-116b-826e-ef0e" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1d3a-0f50-83b4-6e54" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="07a3-482d-516b-2be1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1d3a-0f50-83b4-6e54" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="07a3-482d-516b-2be1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ef14-da3d-4b92-99ea</comment></entryLink>
     <entryLink id="f0ce-7db6-96e5-bac7" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="200a-9ca8-8e4a-5fc4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="af15-adc3-ed2c-5cb6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="200a-9ca8-8e4a-5fc4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="af15-adc3-ed2c-5cb6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7333-e181-4a55-8831</comment></entryLink>
     <entryLink id="8d00-818a-411f-bb94" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="86a1-96aa-bd3c-e50f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6e8e-a6d2-2b0a-b9ce" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="8ad0-d035-63bf-527a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="86a1-96aa-bd3c-e50f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6e8e-a6d2-2b0a-b9ce" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="8ad0-d035-63bf-527a" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_59ec-0ea0-4fcf-a75a</comment></entryLink>
     <entryLink id="92d0-ae38-6ae1-02df" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c094-c914-ef71-1891" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="b5c0-55d7-e2ea-b98a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c094-c914-ef71-1891" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="b5c0-55d7-e2ea-b98a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5ec5-8a6b-491f-a7f3</comment></entryLink>
     <entryLink id="17b5-4ae6-c333-9348" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d767-283f-08d5-889c" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="f8cd-d548-3ea0-19eb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d767-283f-08d5-889c" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="f8cd-d548-3ea0-19eb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c9f2-ee68-4c38-9314</comment></entryLink>
     <entryLink id="9978-135b-f50a-2126" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2465-7881-2bd9-3642" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="1fd0-9b05-a903-2341" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2465-7881-2bd9-3642" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="1fd0-9b05-a903-2341" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_aceb-c60a-415f-a342</comment></entryLink>
     <entryLink id="18fe-4c30-5218-5261" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fbed-9f8b-078f-bdb5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="52e0-e2ff-5775-07cb" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="fbed-9f8b-078f-bdb5" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="52e0-e2ff-5775-07cb" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9bcf-be6d-48ae-8638</comment></entryLink>
     <entryLink id="f17e-a880-1691-ab93" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3588-c002-d691-c403" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c799-41c1-a25b-a4d0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="3588-c002-d691-c403" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="c799-41c1-a25b-a4d0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2901-7b25-4b31-99a8</comment></entryLink>
     <entryLink id="3c94-7378-be96-61ab" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7e51-4152-a467-fecf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4794-1343-9e4b-fc1a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="7e51-4152-a467-fecf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4794-1343-9e4b-fc1a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5289-7ab5-4112-9854</comment></entryLink>
     <entryLink id="d714-b115-e4d2-d5fb" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a08e-eb29-5ada-b325" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="01b2-0923-b1db-6a48" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="a08e-eb29-5ada-b325" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="01b2-0923-b1db-6a48" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_79c8-6e0e-4175-9916</comment></entryLink>
     <entryLink id="ba49-9bef-dacf-bc65" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="46c8-5118-d4d7-4f93" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2806-6ea9-5f33-5cd3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="46c8-5118-d4d7-4f93" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2806-6ea9-5f33-5cd3" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_56c2-bbcb-4385-9b5a</comment></entryLink>
     <entryLink id="a5f0-a76a-0e95-27cf" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d722-74d2-0c64-ca9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cf52-8187-7800-27fe" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="d722-74d2-0c64-ca9c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cf52-8187-7800-27fe" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ec32-606f-4ca6-adac</comment></entryLink>
     <entryLink id="8b3b-fbf0-f2ac-01a9" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8723-ed96-8dcc-8165" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="cb81-812d-2c7c-2dd5" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="8723-ed96-8dcc-8165" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="cb81-812d-2c7c-2dd5" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_58fe-ef91-4e28-9109</comment></entryLink>
     <entryLink id="1ab4-66a8-0366-7069" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="93a1-4b84-ee73-f8ba" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="a205-053b-6086-3c22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="93a1-4b84-ee73-f8ba" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="a205-053b-6086-3c22" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_e44f-ea47-43a8-857f</comment></entryLink>
     <entryLink id="76df-2fab-57fd-3c6b" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="45ba-b099-01d8-66f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="eed4-8fa5-2f10-5415" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="45ba-b099-01d8-66f1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="eed4-8fa5-2f10-5415" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_73e7-101a-42d6-b1b2</comment></entryLink>
     <entryLink id="9ee4-95eb-fa45-1e3a" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d33f-1dd9-a196-ed64" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="7116-c17e-b7a0-c1ef" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d33f-1dd9-a196-ed64" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="7116-c17e-b7a0-c1ef" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_cb2e-1a1f-4bed-8fca</comment></entryLink>
     <entryLink id="9066-3ed5-196e-e303" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
       <modifiers>
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="db66-fe0b-23a3-15be" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="11e0-6037-2a25-b59f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="db66-fe0b-23a3-15be" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="11e0-6037-2a25-b59f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dbab-5cf8-42c8-9fdb</comment></entryLink>
     <entryLink id="4168-0cff-5897-4ef9" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7fda-3e55-a1cb-ae2c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="9933-e221-e720-bb95" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7fda-3e55-a1cb-ae2c" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="9933-e221-e720-bb95" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_522a-15ed-443b-a5f3</comment></entryLink>
     <entryLink id="dd2f-dd94-d07b-9168" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8009-cc0b-18e2-2fe2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4cd7-ef9f-2c8d-11d5" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="8009-cc0b-18e2-2fe2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4cd7-ef9f-2c8d-11d5" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_60e9-649a-41dc-8dd7</comment></entryLink>
     <entryLink id="7329-5a4d-921c-c1c2" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4589-77db-937c-daa0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="cee5-6147-325c-9993" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4589-77db-937c-daa0" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="cee5-6147-325c-9993" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6998-969d-4312-a9f2</comment></entryLink>
     <entryLink id="42a7-c5ce-89f7-2336" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c210-b2f4-1aeb-ca09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="91b4-475a-07ac-3879" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="c210-b2f4-1aeb-ca09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="91b4-475a-07ac-3879" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_abdb-0d0b-4557-996a</comment></entryLink>
     <entryLink id="384b-033e-4f9d-31b1" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b3fa-47fb-8dc4-4dda" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="d9d4-f5a4-7d12-61dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="6c24-6d75-811a-35c4" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="b3fa-47fb-8dc4-4dda" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="d9d4-f5a4-7d12-61dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="6c24-6d75-811a-35c4" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="7e41-eeb9-2cd9-7299" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup"/>
-        <entryLink id="95a7-2e60-d093-ed01" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup"/>
+        <entryLink id="7e41-eeb9-2cd9-7299" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup" />
+        <entryLink id="95a7-2e60-d093-ed01" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_e95d-4a2f-45c3-b44e</comment></entryLink>
     <entryLink id="a3d1-8135-0daa-681c" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f7e6-a58d-03a7-561d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="4846-af2d-dca7-20a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2601-43d3-d2b2-4ad7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="f7e6-a58d-03a7-561d" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="4846-af2d-dca7-20a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2601-43d3-d2b2-4ad7" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="136e-7ef0-c7e6-8596" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup"/>
-        <entryLink id="4119-40a8-f853-c537" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup"/>
+        <entryLink id="136e-7ef0-c7e6-8596" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup" />
+        <entryLink id="4119-40a8-f853-c537" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_ca44-db38-4377-b4ef</comment></entryLink>
     <entryLink id="792c-37c2-8548-693c" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f133-4181-01b0-2dba" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="7e56-a7e7-81d6-2564" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="08f0-ed00-c3f3-6804" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="f133-4181-01b0-2dba" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="7e56-a7e7-81d6-2564" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="08f0-ed00-c3f3-6804" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="e158-25a7-106c-2275" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup"/>
-        <entryLink id="1f22-039e-67ff-d438" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup"/>
+        <entryLink id="e158-25a7-106c-2275" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup" />
+        <entryLink id="1f22-039e-67ff-d438" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup" />
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_5798-3fc7-4d4c-ad41</comment></entryLink>
     <entryLink id="fa17-8a0d-0cef-8628" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="38e5-d9a0-d98d-476a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="8ce0-8334-fd87-7093" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="38e5-d9a0-d98d-476a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="8ce0-8334-fd87-7093" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4654-227a-4d95-8773</comment></entryLink>
     <entryLink id="f0a5-8b7d-9e04-4da5" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1c3c-74c9-a467-2fa2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="450d-2eb0-29bb-569c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1c3c-74c9-a467-2fa2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="450d-2eb0-29bb-569c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8579-90c4-43ba-a8b4</comment></entryLink>
     <entryLink id="ddf1-7b2e-082b-d775" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a532-a446-7136-3ebd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="ec1d-0fdf-bb03-e0dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a532-a446-7136-3ebd" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="ec1d-0fdf-bb03-e0dd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9eed-0620-42da-b8c4</comment></entryLink>
     <entryLink id="24e2-5293-cf94-a83c" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1399-ad92-ebaf-8da4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="af20-71d5-f3e4-db27" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="1399-ad92-ebaf-8da4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="af20-71d5-f3e4-db27" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1e13-9ff6-4335-8fbd</comment></entryLink>
     <entryLink id="c204-13d1-4189-9724" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7535-aed8-898c-8204" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="6e39-6251-3836-aa4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7535-aed8-898c-8204" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="6e39-6251-3836-aa4d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_92c7-96b3-4ff3-a262</comment></entryLink>
     <entryLink id="d1f7-b7cc-38ae-b34a" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1f66-aa58-e689-3240" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="909f-9f57-88f0-24a1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1f66-aa58-e689-3240" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="909f-9f57-88f0-24a1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_547d-bdfe-4930-9b58</comment></entryLink>
     <entryLink id="944d-5882-4dfe-0bfa" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="fc77-8d84-d247-3ff3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="dfb0-7d73-2d4b-61f9" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="fc77-8d84-d247-3ff3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="dfb0-7d73-2d4b-61f9" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_904a-21a0-43c7-a61c</comment></entryLink>
     <entryLink id="d09c-0e11-efa3-c62c" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="11e9-079d-a166-a603" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="0f33-287a-934e-2d4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="11e9-079d-a166-a603" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="0f33-287a-934e-2d4b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7649-50e6-43e1-a338</comment></entryLink>
     <entryLink id="1f97-bf58-5325-e7c8" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="1f8f-9637-18bb-84b3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="a051-c87b-3ceb-359c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1f8f-9637-18bb-84b3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="a051-c87b-3ceb-359c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_019f-e078-4a86-98bb</comment></entryLink>
     <entryLink id="78c0-bd86-99b4-3d35" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8dc6-172d-2f5d-6e2e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="37a3-1063-c0e7-15b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8dc6-172d-2f5d-6e2e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="37a3-1063-c0e7-15b4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0b55-7392-44c0-931c</comment></entryLink>
     <entryLink id="0605-ec8d-6663-886f" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ac65-732d-6f09-1134" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="4404-f0ac-038e-2e4a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ac65-732d-6f09-1134" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="4404-f0ac-038e-2e4a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c29e-d469-41e5-a72e</comment></entryLink>
     <entryLink id="1066-95b0-0f9d-0653" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="b776-a7a7-8b94-4301" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="21ba-0b57-1524-6fe2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b776-a7a7-8b94-4301" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="21ba-0b57-1524-6fe2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_98ee-9eac-46c6-8734</comment></entryLink>
     <entryLink id="97d7-de29-6a7f-1679" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8891-1509-ead6-744b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="bb9d-d126-8ca6-1474" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8891-1509-ead6-744b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="bb9d-d126-8ca6-1474" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fc74-1bab-45a7-a988</comment></entryLink>
     <entryLink id="0d49-ca54-940c-0756" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0987-83e4-d785-47c3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c230-5e6a-5266-4c5d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0987-83e4-d785-47c3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="c230-5e6a-5266-4c5d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a67-a1f3-4189-9e6e</comment></entryLink>
     <entryLink id="3951-5694-c7f3-15cf" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5c5a-ea18-1ae9-dcf3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="5642-51a6-3b4f-ffea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5c5a-ea18-1ae9-dcf3" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="5642-51a6-3b4f-ffea" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1585-c778-42d8-bd7e</comment></entryLink>
     <entryLink id="0a1c-5ad3-c7fc-494d" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="29d8-6c54-d110-d283" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="780e-8505-eb88-ff08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="29d8-6c54-d110-d283" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="780e-8505-eb88-ff08" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_30a0-f0af-4285-be06</comment></entryLink>
     <entryLink id="f6dd-6d5b-c299-0673" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ecbf-851b-6db6-8689" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7dda-a998-312b-0c4d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="ecbf-851b-6db6-8689" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7dda-a998-312b-0c4d" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_16af-605d-4499-bb17</comment></entryLink>
     <entryLink id="2f64-52bf-468a-22a5" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9291-3aac-d55b-0dae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4e0b-638d-e3f8-86d5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="9291-3aac-d55b-0dae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4e0b-638d-e3f8-86d5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_13de-750d-4f98-b462</comment></entryLink>
     <entryLink id="aae0-3c7f-2d80-7468" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ce31-3586-f2c9-3178" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="316f-98ee-d8d2-834d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ce31-3586-f2c9-3178" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="316f-98ee-d8d2-834d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c6c2-ec4b-4f2b-af9e</comment></entryLink>
     <entryLink id="c2c6-e375-9435-7000" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ca49-ab6d-6502-5714" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="2ef3-3d3e-4bac-cea8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ca49-ab6d-6502-5714" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="2ef3-3d3e-4bac-cea8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_ccdd-5be9-4975-b01d</comment></entryLink>
     <entryLink id="ab94-44fe-ecc0-a5ad" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="607b-9250-7230-0849" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="962a-3b0a-3838-4559" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="607b-9250-7230-0849" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="962a-3b0a-3838-4559" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a996-6d12-4d34-9e6a</comment></entryLink>
     <entryLink id="b5a1-3cbb-1d82-91a3" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9914-f6ab-61ec-5965" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7ca9-e2d8-10a0-862a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="9914-f6ab-61ec-5965" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7ca9-e2d8-10a0-862a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_eab9-0e2c-49b9-b8bf</comment></entryLink>
     <entryLink id="fb95-27dc-5539-f106" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e7bc-8e1a-ff75-556f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="f61c-8cba-7b30-c7f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e7bc-8e1a-ff75-556f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="f61c-8cba-7b30-c7f2" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_4a48-1563-4021-968f</comment></entryLink>
     <entryLink id="114f-1a49-372f-2fc0" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0d55-953c-1e62-3f90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2128-489a-8bb8-b2f7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="0d55-953c-1e62-3f90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2128-489a-8bb8-b2f7" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a948-21ae-4cfc-a7df</comment></entryLink>
     <entryLink id="2354-d46f-49c8-4630" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0345-9787-6c67-a8dd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="5196-536f-74ab-15a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0345-9787-6c67-a8dd" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="5196-536f-74ab-15a7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_889e-91aa-489a-b766</comment></entryLink>
     <entryLink id="1a75-cc22-6e04-d9f3" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9e7e-7589-e7ab-dfb8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="5e83-c9e9-095d-704e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9e7e-7589-e7ab-dfb8" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="5e83-c9e9-095d-704e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_bbe3-6b87-4619-80dd</comment></entryLink>
     <entryLink id="1c75-2909-9649-b8c8" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6984-e026-6945-1404" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f953-c46b-6a7c-e883" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6984-e026-6945-1404" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f953-c46b-6a7c-e883" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_3f8d-8859-4348-bf42</comment></entryLink>
     <entryLink id="c815-dbde-58b4-87cc" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ef6c-fbc2-9e91-32b4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="faaf-6c80-46a5-8abb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ef6c-fbc2-9e91-32b4" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="faaf-6c80-46a5-8abb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_87fa-f196-4c2e-9c3b</comment></entryLink>
     <entryLink id="a0ad-db6b-ce33-f849" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8527-a3ab-a2d2-6d13" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="c8df-a444-27c0-44d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8527-a3ab-a2d2-6d13" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="c8df-a444-27c0-44d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2708-1e9f-4820-9d53</comment></entryLink>
     <entryLink id="8be5-dd6c-2276-908d" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5e1f-4881-1e04-f96e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="6790-3a53-a02a-43c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5e1f-4881-1e04-f96e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="6790-3a53-a02a-43c0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_f8ba-83a9-4d1f-adf6</comment></entryLink>
     <entryLink id="6c53-3a25-88ea-4e3b" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="876c-84df-d9ff-e23f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="da9f-58a8-a3e5-c202" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="876c-84df-d9ff-e23f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="da9f-58a8-a3e5-c202" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_7a36-d995-434a-a787</comment></entryLink>
     <entryLink id="8fca-6360-d5ba-c5a2" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="3256-8276-77bb-1575" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="823b-d94a-5ab2-90a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="f907-d096-a1f6-b1db" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="3256-8276-77bb-1575" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="823b-d94a-5ab2-90a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="f907-d096-a1f6-b1db" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_8d6c-729f-4250-a5d4</comment></entryLink>
     <entryLink id="88a1-d2dc-6a48-8aaa" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d3ce-f8f2-9773-ced0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="5239-2986-33e4-6efb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="d3ce-f8f2-9773-ced0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="5239-2986-33e4-6efb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1408-38d9-406d-a090</comment></entryLink>
     <entryLink id="d5bd-81d6-7a03-5796" name="Deathstorm Drop Pod Squadron" hidden="false" collective="false" import="false" targetId="af13-fb4e-b792-61a3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="58e5-3c23-2dda-0229" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="ff26-ed07-184f-756c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="58e5-3c23-2dda-0229" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="ff26-ed07-184f-756c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
     </entryLink>
     <entryLink id="a2e7-8aba-5a78-727f" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1be8-a420-b14a-19a9" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="1f09-3b1e-1ee1-bf90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1be8-a420-b14a-19a9" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="1f09-3b1e-1ee1-bf90" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_fa0b-c14e-4b81-9dac</comment></entryLink>
     <entryLink id="66b8-529a-be23-5a19" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d227-914b-1dd2-e322" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="45b7-0d9a-26a4-b81f" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="d227-914b-1dd2-e322" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="45b7-0d9a-26a4-b81f" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_2029-1f36-432f-a6a1</comment></entryLink>
     <entryLink id="2fa4-73e6-82b1-5754" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7b5e-e260-f34d-7799" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="068e-a93b-4ea2-bb7b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="7b5e-e260-f34d-7799" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="068e-a93b-4ea2-bb7b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_a559-b494-4154-a88a</comment></entryLink>
     <entryLink id="319b-3912-a5ce-cece" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="97a0-b618-c047-ccd8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4a24-5771-62a2-b7e6" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="97a0-b618-c047-ccd8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="4a24-5771-62a2-b7e6" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_9e78-3e8a-477d-9920</comment></entryLink>
     <entryLink id="b2e6-42ba-afdd-367d" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="568a-3b75-3336-6ff3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="7de3-bfb1-bf9b-cf17" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+        <categoryLink id="568a-3b75-3336-6ff3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="7de3-bfb1-bf9b-cf17" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_23b2-54e0-4f09-95e5</comment></entryLink>
     <entryLink id="6d4b-f6b9-af3b-46fb" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7234-ce4e-2bbe-e93b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
-        <categoryLink id="1b09-5f0e-ecb5-b773" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7234-ce4e-2bbe-e93b" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true" />
+        <categoryLink id="1b09-5f0e-ecb5-b773" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_04f7-e2bb-4774-8d08</comment></entryLink>
     <entryLink id="551c-fb9b-4fe1-784c" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a368-67bd-4471-6cb7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="e07c-8ff7-497d-511f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
-        <categoryLink id="0132-9e3a-aefe-795e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="a368-67bd-4471-6cb7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="e07c-8ff7-497d-511f" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
+        <categoryLink id="0132-9e3a-aefe-795e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="d168-545d-77b7-8bbf" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup"/>
+        <entryLink id="d168-545d-77b7-8bbf" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup" />
         <entryLink id="82d5-3732-2887-dd73" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_6e9c-0842-4514-8ea6</comment></entryLink>
     <entryLink id="9609-90ca-79c2-bae6" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
       <modifiers>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="99c6-145f-3c55-7f83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="bdd6-94f1-0b17-da0e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="63f8-7969-6ec3-f65e" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="99c6-145f-3c55-7f83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="bdd6-94f1-0b17-da0e" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="63f8-7969-6ec3-f65e" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="8ee3-1f14-b6ad-eba3" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup"/>
+        <entryLink id="8ee3-1f14-b6ad-eba3" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup" />
         <entryLink id="3957-b010-5ebc-759f" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_11b1-c617-441a-9f1a</comment></entryLink>
     <entryLink id="e186-b7d7-08f5-3c17" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="56d2-4255-0fc9-09c8" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
-        <categoryLink id="2db5-ca5c-0af6-f099" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="50f6-8950-6c00-c97c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="56d2-4255-0fc9-09c8" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true" />
+        <categoryLink id="2db5-ca5c-0af6-f099" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="50f6-8950-6c00-c97c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false" />
       </categoryLinks>
       <entryLinks>
-        <entryLink id="387a-ae79-d687-e5ce" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup"/>
+        <entryLink id="387a-ae79-d687-e5ce" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="156e-4434-2c39-2fef" type="selectionEntryGroup" />
         <entryLink id="1d9e-c70a-2281-4db9" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
-    </entryLink>
+    <comment>    template_id_d712-0fd7-43d1-b880</comment></entryLink>
     <entryLink id="0364-dbfe-ee3a-28f2" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4d81-bb58-c13c-7f3f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-        <categoryLink id="ab85-59de-9a85-4d4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4d81-bb58-c13c-7f3f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
+        <categoryLink id="ab85-59de-9a85-4d4f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_0dcb-00a1-424c-a069</comment></entryLink>
     <entryLink id="a7b6-424e-106d-0c35" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="8ef7-4c9f-5abb-d31f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="62c5-1901-730f-1f10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8ef7-4c9f-5abb-d31f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="62c5-1901-730f-1f10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6bbc-f18a-422d-9e8d</comment></entryLink>
     <entryLink id="19a7-0534-8cf1-b0b7" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5ef5-eba4-1722-94ca" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
-        <categoryLink id="0c24-30f6-e785-59de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5ef5-eba4-1722-94ca" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true" />
+        <categoryLink id="0c24-30f6-e785-59de" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_1064-175d-4616-9c71</comment></entryLink>
     <entryLink id="67b7-112e-01ad-27a0" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="6f98-dc70-2956-4b6e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
-        <categoryLink id="7dcb-8897-289a-6bb3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6f98-dc70-2956-4b6e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
+        <categoryLink id="7dcb-8897-289a-6bb3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6e95-d5bf-451e-9b8a</comment></entryLink>
     <entryLink id="7366-521a-bae5-0a02" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="append" field="name" value="(Reserve Only)">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="ead3-18c3-4dcd-dd49" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="8c99-dc6a-f877-2a0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="9d8d-c264-13c1-42ad" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="ead3-18c3-4dcd-dd49" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="8c99-dc6a-f877-2a0b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="9d8d-c264-13c1-42ad" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_5c02-34db-4633-a4e9</comment></entryLink>
     <entryLink id="1d63-9ec6-1bc1-3085" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
       <modifiers>
         <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo" />
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0774-a66d-297c-14f6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
-        <categoryLink id="756d-e6b6-75b3-9f19" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ac5e-7b3b-d1d4-9c81" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+        <categoryLink id="0774-a66d-297c-14f6" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
+        <categoryLink id="756d-e6b6-75b3-9f19" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="ac5e-7b3b-d1d4-9c81" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_df5e-be36-49fa-b942</comment></entryLink>
     <entryLink id="4784-cedb-8631-4001" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="412b-dd85-e27a-aa81" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="250b-6fa2-9cf3-0954" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="412b-dd85-e27a-aa81" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="250b-6fa2-9cf3-0954" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_6093-2b4c-41b4-b6c4</comment></entryLink>
     <entryLink id="6158-e194-98e5-0806" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5816-e8b9-f2b8-c2d0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="69c9-4ef4-031e-0ffe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="5816-e8b9-f2b8-c2d0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="69c9-4ef4-031e-0ffe" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_c2bc-2985-468b-b512</comment></entryLink>
     <entryLink id="1d84-d081-c72e-e242" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <infoLinks>
-        <infoLink id="282a-cfa0-f347-c75b" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule"/>
+        <infoLink id="282a-cfa0-f347-c75b" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="3329-4017-e23f-4891" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="2b21-d6e1-987f-fb24" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="3329-4017-e23f-4891" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false" />
+        <categoryLink id="2b21-d6e1-987f-fb24" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true" />
       </categoryLinks>
-    </entryLink>
+    <comment>    template_id_dd8c-cf5d-4edb-a314</comment></entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="7a04-bc44-70bb-cb98" name="Red Hand Destroyer Assault Squad" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="9f63-cb32-73a5-840e" name="Bearers of the Blood Hand" hidden="false">
-          <description>A unit that contains at least one model with this special rule must declare a Charge if able when they begin the Assault phase within 12&quot; of an enemy unit. If there is more than one eligible target, the controlling player chooses the target of any Charges made. Note that this does not allow models with this special rule to Charge a different unit to one that they made a Shooting Attack against in the previous Shooting phase.</description>
+          <description>A unit that contains at least one model with this special rule must declare a Charge if able when they begin the Assault phase within 12" of an enemy unit. If there is more than one eligible target, the controlling player chooses the target of any Charges made. Note that this does not allow models with this special rule to Charge a different unit to one that they made a Shooting Attack against in the previous Shooting phase.</description>
         </rule>
         <rule id="2101-9f1b-9cb5-44b8" name="Ravaging Assault" hidden="false">
           <description>On a turn in which they have charged, a unit containing models with this special rule gains a bonus of +1 to the amount of Wounds inflicted when determining who has won a combat. Additionally, they gain a bonus of +1 to the result of any Sweeping Advance roll they make in a combat that they are on the winning side of. These bonuses do not stack with any other rules that increase the amount of Wounds inflicted when calculating who has won a combat and the result of a Sweeping Advance roll.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="0931-fd95-9df4-99fb" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule"/>
+        <infoLink id="0931-fd95-9df4-99fb" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule" />
         <infoLink id="7592-4cd4-fe09-bdb6" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Counter-Attack (1)"/>
+            <modifier type="set" field="name" value="Counter-Attack (1)" />
           </modifiers>
         </infoLink>
-        <infoLink id="11a4-5d44-61d3-2e00" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
-        <infoLink id="bbad-aacd-8169-a9b4" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
+        <infoLink id="11a4-5d44-61d3-2e00" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
+        <infoLink id="bbad-aacd-8169-a9b4" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="5c3d-505d-be3a-0021" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="ee5e-db50-34f8-2da8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="5c3d-505d-be3a-0021" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="ee5e-db50-34f8-2da8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="bb97-5922-24bd-d6ca" name="Blood Bonded" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="15c5-39eb-06a9-470b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="620c-bf02-acaa-a8bb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="15c5-39eb-06a9-470b" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="620c-bf02-acaa-a8bb" type="min" />
           </constraints>
           <profiles>
             <profile id="5a90-b91d-0082-022d" name="Blood Bonded" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="7a04-bc44-70bb-cb98" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf4c-40fc-04b7-80b7" type="equalTo"/>
+                    <condition field="selections" scope="7a04-bc44-70bb-cb98" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf4c-40fc-04b7-80b7" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1101,54 +1100,54 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="4669-76c5-d1bf-0aaf" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="4669-76c5-d1bf-0aaf" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="8446-e737-b3cc-945c" name="Melee Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0fb2-28ae-2339-eeb5">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3136-2368-a802-3f1a" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b89b-8b55-9c8d-1144" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3136-2368-a802-3f1a" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b89b-8b55-9c8d-1144" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="2eeb-6983-9aae-0536" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="266a-1f08-3374-ed6e" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="0fb2-28ae-2339-eeb5" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+                <entryLink id="0fb2-28ae-2339-eeb5" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry" />
                 <entryLink id="4470-5f34-e23c-38ef" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="82e6-1fd4-6634-b684" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="536f-1fd0-81a4-f484" name="Barb-Hook Lash" hidden="false" collective="false" import="true" targetId="e711-ab63-4899-8b00" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="24b5-c521-b05a-2311" name="Excoriator Chainaxe" hidden="false" collective="false" import="true" targetId="269e-ff0b-faec-d067" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="5404-b439-8e2a-41a6" name="Meteor Hammer" hidden="false" collective="false" import="true" targetId="314b-febc-93e8-a2e9" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="7bd3-eae3-1290-01f0" name="Two Falax Blades" hidden="false" collective="false" import="true" targetId="97ad-7991-5b27-c031" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1157,47 +1156,47 @@
               <entryLinks>
                 <entryLink id="f88e-9b06-a01a-b55e" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cefb-7d12-fde8-398b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cefb-7d12-fde8-398b" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="bc66-2dbe-fd7e-932d" name="Phosphex Bomb" hidden="false" collective="false" import="true" targetId="4188-13ff-cb03-109e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7129-55c2-f0e9-c348" type="max"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7129-55c2-f0e9-c348" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="bf4c-40fc-04b7-80b7" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8003-4827-a745-5ad7" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8003-4827-a745-5ad7" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="468d-c39d-1141-0bbc" name="2) Entire squad may take:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a02f-6bcf-770d-0608" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a02f-6bcf-770d-0608" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="617c-0441-90c4-78b2" name="Warhawk Jump Pack" hidden="false" collective="false" import="true" targetId="a298-8584-70ed-18ce" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="7a04-bc44-70bb-cb98" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="7a04-bc44-70bb-cb98" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
@@ -1206,19 +1205,19 @@
         </selectionEntryGroup>
         <selectionEntryGroup id="aacf-b00b-791b-3c61" name="1) Ravagers" hidden="false" collective="false" import="true" defaultSelectionEntryId="db36-9668-184b-5761">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e8b3-a255-1611-ce46" type="min"/>
-            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1834-2b9f-7d57-02a7" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e8b3-a255-1611-ce46" type="min" />
+            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1834-2b9f-7d57-02a7" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="db36-9668-184b-5761" name=" Ravager w/Chainsword" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="131d-51a5-0eca-3f86" type="max"/>
+                <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="131d-51a5-0eca-3f86" type="max" />
               </constraints>
               <profiles>
                 <profile id="7df3-621c-fc33-fb0a" name="Ravager" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1234,37 +1233,37 @@
               <entryLinks>
                 <entryLink id="5438-08f8-1748-8348" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="be5c-074c-c29a-c931" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="685c-67b7-e989-b04f" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="be5c-074c-c29a-c931" type="max" />
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="685c-67b7-e989-b04f" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="b46c-854c-2e85-35c3" name="Chainsword" hidden="false" collective="false" import="true" targetId="b5b7-b50a-ac86-9173" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="efd2-5a93-4e9d-7b26" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="1db9-da18-51c3-6e5d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="efd2-5a93-4e9d-7b26" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="1db9-da18-51c3-6e5d" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="34ff-115f-b2ad-9c40" name="Ravager w/ Heavy Weapon (1 in every 5)" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="44f2-da51-8db2-74e9" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="7a04-bc44-70bb-cb98" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="7a04-bc44-70bb-cb98" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="44f2-da51-8db2-74e9" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="44f2-da51-8db2-74e9" type="max" />
               </constraints>
               <profiles>
                 <profile id="fbfb-ca29-ccdf-d393" name="Ravager" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1280,24 +1279,24 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="4a44-8215-af96-28b5" name="Weapon Choice:" hidden="false" collective="false" import="true" defaultSelectionEntryId="95f3-0d0d-365d-0e22">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03aa-a933-2967-e94c" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8b1-90b1-6ff8-856c" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03aa-a933-2967-e94c" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8b1-90b1-6ff8-856c" type="min" />
                   </constraints>
                   <entryLinks>
                     <entryLink id="95f3-0d0d-365d-0e22" name="Missile Launcher (With suspensor web and rad missiles only)" hidden="false" collective="false" import="true" targetId="1e98-2cbd-1ddd-8111" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="7a04-bc44-70bb-cb98" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d9be-8c60-dd2a-66e4" type="max"/>
+                        <constraint field="selections" scope="7a04-bc44-70bb-cb98" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d9be-8c60-dd2a-66e4" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                       </costs>
                     </entryLink>
                     <entryLink id="d3d0-886e-f46b-962f" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="b6ac-3ba5-90ae-67f7" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="7a04-bc44-70bb-cb98" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bfaf-7eba-529a-0a15" type="max"/>
+                        <constraint field="selections" scope="7a04-bc44-70bb-cb98" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bfaf-7eba-529a-0a15" type="max" />
                       </constraints>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -1306,24 +1305,24 @@
               <entryLinks>
                 <entryLink id="38f2-5b23-d155-e450" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="2a43-95de-a19a-e6f8" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="3fda-700d-5413-fc96" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="2a43-95de-a19a-e6f8" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="3fda-700d-5413-fc96" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="b2c4-34be-a4a0-03ee" name=" Ravager w/Excoriator Chainaxe" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="566a-18c0-44ac-e368" type="max"/>
+                <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="566a-18c0-44ac-e368" type="max" />
               </constraints>
               <profiles>
                 <profile id="f15f-ef7a-8162-1e5d" name="Ravager" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1339,30 +1338,30 @@
               <entryLinks>
                 <entryLink id="606f-1319-a5be-834f" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="bc90-2b83-1106-265b" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="3072-2d57-a115-ca10" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="bc90-2b83-1106-265b" type="max" />
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="3072-2d57-a115-ca10" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="cdff-b752-154a-8cd2" name="Excoriator Chainaxe" hidden="false" collective="false" import="true" targetId="bcb2-fdee-b235-da0e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="ca3a-6522-9a7b-174c" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="c5de-f92f-f402-d782" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="ca3a-6522-9a7b-174c" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="c5de-f92f-f402-d782" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="5eb0-975c-8626-1f99" name=" Ravager w/Meteor Hammer" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="279d-8349-c84b-37b5" type="max"/>
+                <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="279d-8349-c84b-37b5" type="max" />
               </constraints>
               <profiles>
                 <profile id="812e-eb59-985a-b3ef" name="Ravager" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1378,30 +1377,30 @@
               <entryLinks>
                 <entryLink id="9ac7-5ca6-68c3-fe97" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="2154-b634-bf1d-142f" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="d75a-ff3e-5eae-c820" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="2154-b634-bf1d-142f" type="max" />
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="d75a-ff3e-5eae-c820" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="daee-c556-4fd2-f898" name="Meteor Hammer" hidden="false" collective="false" import="true" targetId="1994-6eda-5e87-3038" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="aaf0-6d11-032f-f865" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="66c0-3e97-53d0-f339" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="aaf0-6d11-032f-f865" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="66c0-3e97-53d0-f339" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="c247-33d8-5da1-c5fd" name=" Ravager w/Two Falax Blades" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18db-b5fd-d29d-bd9e" type="max"/>
+                <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18db-b5fd-d29d-bd9e" type="max" />
               </constraints>
               <profiles>
                 <profile id="c41e-9924-2d83-0983" name="Ravager" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1417,30 +1416,30 @@
               <entryLinks>
                 <entryLink id="a256-5ac0-26f0-5d52" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="7792-7b9b-20d2-414f" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="3ed8-eee4-5a9e-f39e" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="7792-7b9b-20d2-414f" type="max" />
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="3ed8-eee4-5a9e-f39e" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="37f7-4304-5f11-6296" name="Two Falax Blades" hidden="false" collective="false" import="true" targetId="6a9f-b0aa-e137-9d18" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="ddc1-2231-ad64-e2a7" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="f315-0a44-7e40-451f" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="ddc1-2231-ad64-e2a7" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="f315-0a44-7e40-451f" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="51a0-5dd3-f296-2d25" name=" Ravager w/Barb-Hook Lash" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afb5-0706-68da-fea0" type="max"/>
+                <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afb5-0706-68da-fea0" type="max" />
               </constraints>
               <profiles>
                 <profile id="8971-cb48-aeff-4329" name="Ravager" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1456,19 +1455,19 @@
               <entryLinks>
                 <entryLink id="5736-59c3-d82a-5ccc" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="1e09-34d3-afc9-1e63" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="7297-4b68-ae82-ae8d" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="1e09-34d3-afc9-1e63" type="max" />
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="7297-4b68-ae82-ae8d" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="d20c-605c-c08d-db1b" name="Barb-Hook Lash" hidden="false" collective="false" import="true" targetId="2403-fc44-ffd2-8fa6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="957e-1335-f037-290f" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="fe39-7836-d562-76ab" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="957e-1335-f037-290f" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="fe39-7836-d562-76ab" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1477,42 +1476,42 @@
       <entryLinks>
         <entryLink id="68fd-18dc-1674-8512" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9b1d-0746-583a-0714" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="87f5-d164-c760-292e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9b1d-0746-583a-0714" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="87f5-d164-c760-292e" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="4459-61dd-cd4f-d7af" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6a70-e3a7-b5c8-217f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="79ae-89ce-fb53-ef75" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6a70-e3a7-b5c8-217f" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="79ae-89ce-fb53-ef75" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="8044-5bef-ca82-39b8" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="53f5-fa74-6a7b-46b8" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="39b5-6d8d-114a-3198" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="53f5-fa74-6a7b-46b8" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="39b5-6d8d-114a-3198" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="9fe9-5bb6-e371-7580" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="931b-bee0-99c2-49f9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aecb-1415-e669-b521" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="931b-bee0-99c2-49f9" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aecb-1415-e669-b521" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="aa6d-c70a-199f-1db5" name="Shabran Darr" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c6f2-ce96-4619-a14e" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c6f2-ce96-4619-a14e" type="max" />
       </constraints>
       <profiles>
         <profile id="9db7-fcdf-9713-7a78" name="Shabran Darr" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1527,37 +1526,37 @@
       </profiles>
       <rules>
         <rule id="3c7e-33bc-d8bb-8933" name="Head-hunter" hidden="false">
-          <description>When fighting in a Challenge, Shabran Darr’s attacks gain the Breaching (4+) special rule.</description>
+          <description>When fighting in a Challenge, Shabran Darr&#8217;s attacks gain the Breaching (4+) special rule.</description>
         </rule>
       </rules>
       <infoLinks>
         <infoLink id="d873-cfba-0fb2-e014" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Feel No Pain (6+)"/>
+            <modifier type="set" field="name" value="Feel No Pain (6+)" />
           </modifiers>
         </infoLink>
         <infoLink id="2c42-92b6-e1a6-d7f7" name="Rage (X)" hidden="false" targetId="564d-3550-ae44-2f99" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Rage (2)"/>
+            <modifier type="set" field="name" value="Rage (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="d5d9-c74b-e8fc-6cf9" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule"/>
+        <infoLink id="d5d9-c74b-e8fc-6cf9" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule" />
         <infoLink id="c08a-678a-fcc7-f63e" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Breaching (4+)"/>
+            <modifier type="set" field="name" value="Breaching (4+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="82c7-7ee7-c815-1285" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="6018-e91b-ef03-2ee3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="66fc-9632-84b0-aa90" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="82c7-7ee7-c815-1285" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="6018-e91b-ef03-2ee3" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="66fc-9632-84b0-aa90" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="912e-502f-2838-ef01" name="The Liberator" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d84e-9f78-78db-211c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2538-a8a8-1d59-3d17" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d84e-9f78-78db-211c" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2538-a8a8-1d59-3d17" type="max" />
           </constraints>
           <profiles>
             <profile id="c29e-92ce-9449-c027" name="The Liberator" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -1572,112 +1571,112 @@
           <infoLinks>
             <infoLink id="17c5-d881-ceb6-e9aa" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Brutal (2)"/>
+                <modifier type="set" field="name" value="Brutal (2)" />
               </modifiers>
             </infoLink>
-            <infoLink id="dd33-b813-7d5e-1137" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+            <infoLink id="dd33-b813-7d5e-1137" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
             <infoLink id="c498-4b27-abbd-bfab" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Breaching (6+)"/>
+                <modifier type="set" field="name" value="Breaching (6+)" />
               </modifiers>
             </infoLink>
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="dd97-b103-abde-1913" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88f0-429e-48bb-b1c7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88f0-429e-48bb-b1c7" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="b6b8-8a95-a766-e26b" name="Bloody-handed" hidden="false" collective="false" import="true" targetId="2b87-826d-22a1-682c" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b64-ea15-b00a-e96d" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bbe-fe40-f8d6-3e1f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b64-ea15-b00a-e96d" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bbe-fe40-f8d6-3e1f" type="max" />
               </constraints>
             </entryLink>
           </entryLinks>
         </entryLink>
         <entryLink id="4432-dfb2-463d-1d8f" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="52f0-a4ee-b777-c68f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6541-a90f-36e0-8d52" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="52f0-a4ee-b777-c68f" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6541-a90f-36e0-8d52" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="a4dd-d2b6-af94-b00a" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="21c9-d4b3-cacc-dfff" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d52-0f75-ab9c-2ea1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="21c9-d4b3-cacc-dfff" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d52-0f75-ab9c-2ea1" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="5acd-c3a5-9855-5f1a" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6f0b-0740-81ff-9f3b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fce5-aff0-de84-4d6d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6f0b-0740-81ff-9f3b" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fce5-aff0-de84-4d6d" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="dfe2-59d3-1d3f-e804" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="41e9-d022-e54d-75ea" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8e29-909d-342e-e6ca" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="41e9-d022-e54d-75ea" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8e29-909d-342e-e6ca" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="ef5a-fb71-6724-1e36" name="Warhawk Jump Pack" hidden="false" collective="false" import="true" targetId="a298-8584-70ed-18ce" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c109-b308-920d-9cfc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c109-b308-920d-9cfc" type="max" />
           </constraints>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0" />
           </costs>
         </entryLink>
         <entryLink id="e86b-460d-bdbc-220f" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="05f8-0dd2-3cd1-c08a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="544c-eede-8cb1-4fe3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="05f8-0dd2-3cd1-c08a" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="544c-eede-8cb1-4fe3" type="min" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="140.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="140.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="1987-2aa5-929b-979e" name="Red Butchers" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="6fdb-6571-8b27-1cee" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule"/>
-        <infoLink id="b122-34c7-eea2-8d6f" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="6fdb-6571-8b27-1cee" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule" />
+        <infoLink id="b122-34c7-eea2-8d6f" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="5fad-5b89-77f2-111d" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Bulky (2)"/>
+            <modifier type="set" field="name" value="Bulky (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="33e4-8de2-cab5-2dd2" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
+        <infoLink id="33e4-8de2-cab5-2dd2" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule" />
         <infoLink id="7b7d-9e8e-7a7a-a6e4" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hatred (Everything)"/>
+            <modifier type="set" field="name" value="Hatred (Everything)" />
           </modifiers>
         </infoLink>
-        <infoLink id="9f9a-d927-04d9-579a" name="Ravening Madmen" hidden="false" targetId="1864-f270-d462-ecb5" type="rule"/>
+        <infoLink id="9f9a-d927-04d9-579a" name="Ravening Madmen" hidden="false" targetId="1864-f270-d462-ecb5" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="dac3-55aa-0d1b-36b7" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="cf1c-50e5-11f5-a5c0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="080b-8aab-b802-323a" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
-        <categoryLink id="4259-2c1a-9160-12f3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="dac3-55aa-0d1b-36b7" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
+        <categoryLink id="cf1c-50e5-11f5-a5c0" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="080b-8aab-b802-323a" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false" />
+        <categoryLink id="4259-2c1a-9160-12f3" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0ef2-9852-5b60-2ff2" name="Devoured" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2d98-3be4-b68a-cbdd" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="303d-3d45-514c-215b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2d98-3be4-b68a-cbdd" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="303d-3d45-514c-215b" type="max" />
           </constraints>
           <profiles>
             <profile id="3170-1ba8-7fc9-db8c" name="Devourer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1691,77 +1690,77 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="e96c-7be7-50c9-2e1d" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="e96c-7be7-50c9-2e1d" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="a999-8d13-e96f-b721" name="Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="83ef-25d3-f484-916e">
               <modifiers>
                 <modifier type="set" field="69cf-25b8-f7d8-a3fc" value="1.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c8b9-aa78-e740-0d6a" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c8b9-aa78-e740-0d6a" type="equalTo" />
                   </conditions>
                 </modifier>
                 <modifier type="set" field="ae57-1340-308e-6cb1" value="1.0">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c8b9-aa78-e740-0d6a" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c8b9-aa78-e740-0d6a" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="69cf-25b8-f7d8-a3fc" type="max"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ae57-1340-308e-6cb1" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="69cf-25b8-f7d8-a3fc" type="max" />
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ae57-1340-308e-6cb1" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="c8b9-aa78-e740-0d6a" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="45bc-a6fc-5bd1-e5b2" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="45bc-a6fc-5bd1-e5b2" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="157b-bd1d-6cfe-9e9d" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e7eb-010c-cabf-1292" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e7eb-010c-cabf-1292" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="d0d0-e4a8-a71c-85c4" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="d6df-6443-4d9b-c5ea" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5a26-74f6-c6d8-3fd5" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5a26-74f6-c6d8-3fd5" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="e4f7-c287-1006-8b5d" name="Minor Combi-Weapon" hidden="false" collective="false" import="true" targetId="605e-1b86-ca08-9226" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b6dc-8e1a-d429-ed13" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b6dc-8e1a-d429-ed13" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="3076-e86d-a998-4e3d" name="Magna Combi-Weapon" hidden="false" collective="false" import="true" targetId="e5b1-83e5-7272-a59e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="75a6-d67e-1798-f3f1" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="75a6-d67e-1798-f3f1" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="83ef-25d3-f484-916e" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="23c3-a17f-d0da-5eb6" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="23c3-a17f-d0da-5eb6" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="7feb-0034-4cc5-277d" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="441a-5f44-23d7-ea17" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="441a-5f44-23d7-ea17" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -1770,40 +1769,40 @@
           <entryLinks>
             <entryLink id="8243-f3a6-b4f2-3ecf" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3685-6db3-c35f-6cbb" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3685-6db3-c35f-6cbb" type="max" />
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
               </costs>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="5b3d-cf2e-8db7-3218" name="Dedicated Transport" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f07e-0132-bcfb-4b15" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f07e-0132-bcfb-4b15" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="febf-42b6-eb0a-67bb" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="1987-2aa5-929b-979e" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="selections" scope="1987-2aa5-929b-979e" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
                   </conditions>
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="dee6-894f-0cb5-e993" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry"/>
+            <entryLink id="dee6-894f-0cb5-e993" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="5028-ea9f-99c7-04e1" name=" Red Butchers" hidden="false" collective="false" import="true" defaultSelectionEntryId="7916-ca80-5a20-cfbb">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="03ea-a5bf-1718-a9dd" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1471-174f-67e0-4e39" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="03ea-a5bf-1718-a9dd" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1471-174f-67e0-4e39" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="8cd3-2909-c8c3-0cf1" name="Red Butcher (Pair of Lightning Claws)" hidden="false" collective="false" import="true" type="model">
@@ -1811,7 +1810,7 @@
                 <profile id="1066-ba44-5364-e924" name="Red Butcher" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1825,18 +1824,18 @@
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="3350-d90c-ee36-ecdb" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                <categoryLink id="3350-d90c-ee36-ecdb" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
               </categoryLinks>
               <entryLinks>
                 <entryLink id="0dba-da69-d791-9dfa" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="405f-030d-0343-ade8" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d67d-3abf-afe2-802e" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="695a-ed64-357b-075f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d67d-3abf-afe2-802e" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="695a-ed64-357b-075f" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="7916-ca80-5a20-cfbb" name="Red Butcher (Pair of Power Axes)" hidden="false" collective="false" import="true" type="model">
@@ -1844,7 +1843,7 @@
                 <profile id="9b79-c1e6-6215-4f8e" name="Red Butcher" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1858,21 +1857,21 @@
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="1a75-21e4-e926-1808" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                <categoryLink id="1a75-21e4-e926-1808" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
               </categoryLinks>
               <entryLinks>
                 <entryLink id="29a6-069f-4daa-a55a" name="Power Axe" hidden="false" collective="false" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="Pair of Power Axes"/>
+                    <modifier type="set" field="name" value="Pair of Power Axes" />
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e167-3d83-4b47-fde6" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="08f3-e679-00f6-1238" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e167-3d83-4b47-fde6" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="08f3-e679-00f6-1238" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="f307-35b7-3b94-91a6" name="Red Butcher (Power Axe &amp; Combi-Bolter)" hidden="false" collective="false" import="true" type="model">
@@ -1880,7 +1879,7 @@
                 <profile id="1d6a-79f0-23c6-9eb1" name="Red Butcher" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1894,24 +1893,24 @@
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="bdb6-5467-8aaf-75a8" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+                <categoryLink id="bdb6-5467-8aaf-75a8" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false" />
               </categoryLinks>
               <entryLinks>
                 <entryLink id="fa41-1e69-487d-b1ae" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="0f3d-c07c-7a7e-d534" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96f7-2590-4f56-50e4" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b5d-69c8-8788-4a97" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96f7-2590-4f56-50e4" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b5d-69c8-8788-4a97" type="min" />
                   </constraints>
                 </entryLink>
                 <entryLink id="e09b-7821-5e82-d08a" name="Power Axe" hidden="false" collective="false" import="true" targetId="ef98-66ac-fcaf-c15d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="df5f-673b-cbcb-96d4" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="642b-e188-bc88-c886" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="df5f-673b-cbcb-96d4" type="max" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="642b-e188-bc88-c886" type="min" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1920,55 +1919,55 @@
       <entryLinks>
         <entryLink id="4766-da73-f371-d1fb" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c4d8-28f5-ea60-a7f1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b496-d0f3-1cf8-92e7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c4d8-28f5-ea60-a7f1" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b496-d0f3-1cf8-92e7" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="2fb9-74a8-43b0-dd00" name="Rampager Squad" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="add" field="category" value="eee8-3c7c-2762-e33e">
           <conditions>
-            <condition field="selections" scope="2fb9-74a8-43b0-dd00" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a298-8584-70ed-18ce" type="equalTo"/>
+            <condition field="selections" scope="2fb9-74a8-43b0-dd00" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a298-8584-70ed-18ce" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
       <infoLinks>
-        <infoLink id="a803-4071-5d85-92c7" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule"/>
+        <infoLink id="a803-4071-5d85-92c7" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule" />
         <infoLink id="ed22-c7f9-5c36-1e71" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Furious Charge (1)"/>
+            <modifier type="set" field="name" value="Furious Charge (1)" />
           </modifiers>
         </infoLink>
-        <infoLink id="58cf-084a-5f23-934d" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule"/>
-        <infoLink id="f193-1b95-b0ab-0fc3" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="58cf-084a-5f23-934d" name="Chosen Warriors" hidden="false" targetId="13d1-9270-6539-08ed" type="rule" />
+        <infoLink id="f193-1b95-b0ab-0fc3" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="27fd-7bde-4c05-e9f2" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="56af-118e-8128-ae96" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="27fd-7bde-4c05-e9f2" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="56af-118e-8128-ae96" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="316d-d623-06cc-0a1b" name="Rampager Champion" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a2d-fec8-3968-a916" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7375-c8d9-b753-6e86" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a2d-fec8-3968-a916" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7375-c8d9-b753-6e86" type="max" />
           </constraints>
           <profiles>
             <profile id="1928-6800-d297-ac6a" name="Rampager Champion" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="2fb9-74a8-43b0-dd00" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                    <condition field="selections" scope="2fb9-74a8-43b0-dd00" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
-                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -1982,75 +1981,75 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="922f-b976-ade5-4768" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink id="922f-b976-ade5-4768" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false" />
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="0100-9dff-9956-9429" name="1) Melee Choice:" hidden="false" collective="false" import="true" defaultSelectionEntryId="40be-76c5-f7cd-772d">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="34c9-30ba-cc44-e98f" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e279-f52b-a0e9-9079" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="34c9-30ba-cc44-e98f" type="min" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e279-f52b-a0e9-9079" type="max" />
               </constraints>
               <entryLinks>
                 <entryLink id="1b70-90da-56b9-5240" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
                 <entryLink id="9b06-709d-d739-eeac" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="409e-5b77-9bdb-09ec" name="Barb-Hook Lash" hidden="false" collective="false" import="true" targetId="e711-ab63-4899-8b00" type="selectionEntry"/>
-                <entryLink id="21ce-f81b-b636-b034" name="Excoriator Chainaxe" hidden="false" collective="false" import="true" targetId="269e-ff0b-faec-d067" type="selectionEntry"/>
-                <entryLink id="a0f2-04fd-2f51-49ce" name="Falax Blade" hidden="false" collective="false" import="true" targetId="d5f4-6a95-b941-17e4" type="selectionEntry"/>
-                <entryLink id="5e39-b97c-dfe0-69db" name="Meteor Hammer" hidden="false" collective="false" import="true" targetId="314b-febc-93e8-a2e9" type="selectionEntry"/>
-                <entryLink id="40be-76c5-f7cd-772d" name="Two Falax Blades" hidden="false" collective="false" import="true" targetId="97ad-7991-5b27-c031" type="selectionEntry"/>
+                <entryLink id="409e-5b77-9bdb-09ec" name="Barb-Hook Lash" hidden="false" collective="false" import="true" targetId="e711-ab63-4899-8b00" type="selectionEntry" />
+                <entryLink id="21ce-f81b-b636-b034" name="Excoriator Chainaxe" hidden="false" collective="false" import="true" targetId="269e-ff0b-faec-d067" type="selectionEntry" />
+                <entryLink id="a0f2-04fd-2f51-49ce" name="Falax Blade" hidden="false" collective="false" import="true" targetId="d5f4-6a95-b941-17e4" type="selectionEntry" />
+                <entryLink id="5e39-b97c-dfe0-69db" name="Meteor Hammer" hidden="false" collective="false" import="true" targetId="314b-febc-93e8-a2e9" type="selectionEntry" />
+                <entryLink id="40be-76c5-f7cd-772d" name="Two Falax Blades" hidden="false" collective="false" import="true" targetId="97ad-7991-5b27-c031" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="5f98-40f7-e719-95ef" name="2) Pistol Choice:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2f66-52f0-45d7-d74b">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="e802-fed0-2c59-9f09" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d4d6-e6e0-11ca-4083" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="e802-fed0-2c59-9f09" type="max" />
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d4d6-e6e0-11ca-4083" type="min" />
               </constraints>
               <entryLinks>
                 <entryLink id="26cd-36f1-4b72-a412" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
-                <entryLink id="2f66-52f0-45d7-d74b" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+                <entryLink id="2f66-52f0-45d7-d74b" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry" />
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="b26c-0d71-8466-502e" name="3) Wargear" hidden="false" collective="false" import="true">
               <entryLinks>
                 <entryLink id="13d3-1e3d-adef-bbed" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0d25-33ca-5703-e0c1" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0d25-33ca-5703-e0c1" type="max" />
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0" />
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="e31f-8fdd-f192-5dbf" name="2) Entire squad may take:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c74-ca6a-0739-2603" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c74-ca6a-0739-2603" type="max" />
           </constraints>
           <entryLinks>
             <entryLink id="68d0-f122-d2af-4b5c" name="Warhawk Jump Pack" hidden="false" collective="false" import="true" targetId="a298-8584-70ed-18ce" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="10.0">
                   <repeats>
-                    <repeat field="selections" scope="2fb9-74a8-43b0-dd00" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="2fb9-74a8-43b0-dd00" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false" />
                   </repeats>
                 </modifier>
               </modifiers>
@@ -2063,24 +2062,24 @@
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="2fb9-74a8-43b0-dd00" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e31f-8fdd-f192-5dbf" type="equalTo"/>
+                    <condition field="selections" scope="2fb9-74a8-43b0-dd00" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan" />
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e31f-8fdd-f192-5dbf" type="equalTo" />
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e713-6979-a8e0-f56b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e713-6979-a8e0-f56b" type="max" />
           </constraints>
           <entryLinks>
-            <entryLink id="70fc-e554-c9a3-848e" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry"/>
+            <entryLink id="70fc-e554-c9a3-848e" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry" />
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="a420-a14f-f75c-6fa5" name="1) Rampagers" hidden="false" collective="false" import="true" defaultSelectionEntryId="95de-f8f7-2d72-a4cd">
           <constraints>
-            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="497d-3480-b894-5404" type="max"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2dbc-ce0a-1ea0-5e4b" type="min"/>
+            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="497d-3480-b894-5404" type="max" />
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2dbc-ce0a-1ea0-5e4b" type="min" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="6d3e-f01d-8d97-aa2b" name="Rampager w/Falax Blade" hidden="false" collective="false" import="true" type="model">
@@ -2088,7 +2087,7 @@
                 <profile id="ee6c-d04f-7553-d244" name="Rampager" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2104,19 +2103,19 @@
               <entryLinks>
                 <entryLink id="110a-8bb8-6266-199d" name="Falax Blade" hidden="false" collective="false" import="true" targetId="be1b-90ff-17f3-654e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3807-0d03-7ccf-ff18" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cca-6466-4926-c690" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3807-0d03-7ccf-ff18" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cca-6466-4926-c690" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="f146-e4cf-550c-7f17" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b653-54a1-531c-d02f" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81f1-223a-8960-314b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b653-54a1-531c-d02f" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81f1-223a-8960-314b" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="0b24-339a-5ddf-2a79" name="Rampager w/Barb-Hook Lash" hidden="false" collective="false" import="true" type="model">
@@ -2124,7 +2123,7 @@
                 <profile id="8956-2749-056d-0471" name="Rampager" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2140,19 +2139,19 @@
               <entryLinks>
                 <entryLink id="2204-bd46-f0f6-be88" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbed-a293-8ba9-fc23" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ea0-c414-54d0-8e7f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbed-a293-8ba9-fc23" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ea0-c414-54d0-8e7f" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="957d-4427-b784-60e5" name="Barb-Hook Lash" hidden="false" collective="false" import="true" targetId="2403-fc44-ffd2-8fa6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb32-f741-943d-59cb" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62d8-8129-203f-38a8" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb32-f741-943d-59cb" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62d8-8129-203f-38a8" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="3899-2854-4fd9-0cb2" name="Rampager w/Excoriator Chainaxe" hidden="false" collective="false" import="true" type="model">
@@ -2160,7 +2159,7 @@
                 <profile id="b7b4-1906-7c02-957c" name="Rampager" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2176,19 +2175,19 @@
               <entryLinks>
                 <entryLink id="71ee-2853-293a-10bc" name="Excoriator Chainaxe" hidden="false" collective="false" import="true" targetId="bcb2-fdee-b235-da0e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9913-20b1-46ec-c953" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf19-85a7-c86d-7310" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9913-20b1-46ec-c953" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf19-85a7-c86d-7310" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="dfbd-edba-4461-d716" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcb6-e42b-4aee-d660" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1783-754a-c21b-100e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcb6-e42b-4aee-d660" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1783-754a-c21b-100e" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="95de-f8f7-2d72-a4cd" name="Rampager w/Two Falax Blade" hidden="false" collective="false" import="true" type="model">
@@ -2196,7 +2195,7 @@
                 <profile id="6d34-d492-9160-1a86" name="Rampager" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2212,19 +2211,19 @@
               <entryLinks>
                 <entryLink id="b03d-8f46-ab41-b356" name="Two Falax Blades" hidden="false" collective="false" import="true" targetId="6a9f-b0aa-e137-9d18" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87f6-b150-2667-4e5b" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e00-ef14-1ad2-2550" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87f6-b150-2667-4e5b" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e00-ef14-1ad2-2550" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="bdd0-307e-e229-dab2" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba39-9d24-6bab-e5f2" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56b6-0bb4-3eae-8c48" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba39-9d24-6bab-e5f2" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56b6-0bb4-3eae-8c48" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="0a53-f8b4-252e-5c23" name="Rampager w/Meteor Hammer" hidden="false" collective="false" import="true" type="model">
@@ -2232,7 +2231,7 @@
                 <profile id="94f8-1ea3-03ed-90e7" name="Rampager" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry</characteristic>
-                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2248,19 +2247,19 @@
               <entryLinks>
                 <entryLink id="8964-162d-f51e-8d62" name="Meteor Hammer" hidden="false" collective="false" import="true" targetId="1994-6eda-5e87-3038" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9785-4c5a-8bb1-749b" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3ef-1046-ce91-4c6e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9785-4c5a-8bb1-749b" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3ef-1046-ce91-4c6e" type="max" />
                   </constraints>
                 </entryLink>
                 <entryLink id="2c30-c323-02e6-636d" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="52fe-46cd-520d-9df3" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="def1-0089-b513-854e" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69e7-3845-bff3-9ef0" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="def1-0089-b513-854e" type="min" />
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69e7-3845-bff3-9ef0" type="max" />
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2269,49 +2268,49 @@
       <entryLinks>
         <entryLink id="5bae-f41c-c11b-b7d0" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c4a1-9d96-9002-5faa" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f720-d522-a2f2-e427" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c4a1-9d96-9002-5faa" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f720-d522-a2f2-e427" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="c40c-a575-0232-c960" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9708-82bc-2360-048c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8cdb-4c4b-6eca-5631" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9708-82bc-2360-048c" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8cdb-4c4b-6eca-5631" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="cf65-742e-98df-72c9" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b300-1de0-b37c-a2f0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f36d-48aa-1d54-0e9e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b300-1de0-b37c-a2f0" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f36d-48aa-1d54-0e9e" type="max" />
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="47.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="47.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="1e98-2cbd-1ddd-8111" name="Missile Launcher (With suspensor web and rad missiles only)" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="9a37-a49c-1e9e-cf92" name="Rad Missile (Missile Launcher)" hidden="false" targetId="ec3c-78ff-bbfa-66d7" type="profile"/>
-        <infoLink id="4b3e-d2e9-736b-bab3" name="Suspensor Web" hidden="false" targetId="457c-1f2c-ca90-1bf3" type="profile"/>
-        <infoLink id="22e2-87d1-e26a-b13a" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
-        <infoLink id="5990-b2b6-93bf-d63d" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
-        <infoLink id="35d6-7dc1-0c12-3140" name="Rad-Phage" hidden="false" targetId="8189-e963-d2e5-5d3d" type="rule"/>
+        <infoLink id="9a37-a49c-1e9e-cf92" name="Rad Missile (Missile Launcher)" hidden="false" targetId="ec3c-78ff-bbfa-66d7" type="profile" />
+        <infoLink id="4b3e-d2e9-736b-bab3" name="Suspensor Web" hidden="false" targetId="457c-1f2c-ca90-1bf3" type="profile" />
+        <infoLink id="22e2-87d1-e26a-b13a" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule" />
+        <infoLink id="5990-b2b6-93bf-d63d" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule" />
+        <infoLink id="35d6-7dc1-0c12-3140" name="Rad-Phage" hidden="false" targetId="8189-e963-d2e5-5d3d" type="rule" />
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="6352-8efa-0cc4-cfa7" name="Angron" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="426b-a3da-a898-7dd8" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="426b-a3da-a898-7dd8" type="max" />
       </constraints>
       <profiles>
         <profile id="90ce-d522-db2a-f9d2" name="Angron" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Primarch (Unique)
 </characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">8</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
@@ -2326,36 +2325,36 @@
       </profiles>
       <rules>
         <rule id="9566-305a-70c3-4a11" name="Red Sands" hidden="false">
-          <description>In any given turn Angron may make as many Challenges as there are enemy models with the Character sub-type or Primarch Unit Type locked in combat with him, up to his current number of Attacks. Pull out all the challengers and fight them in an order decided by Angron’s controlling player during the Challenge part of the Fight sub-phase, save that any enemy model with the Primarch Unit Type must be fought first. Angron must divide his attacks between them and must devote at least one attack to each Challenge he fights in. All models challenged by Angron, and Angron himself, count as being in a Challenge and follow all the rules for Challenges and any models that are not removed as Casualties remain in a Challange with Angron until either all the Challengers are removed as Casualties, angron is removed as a Casualty or the challenge is ended by the effect of another rule.</description>
+          <description>In any given turn Angron may make as many Challenges as there are enemy models with the Character sub-type or Primarch Unit Type locked in combat with him, up to his current number of Attacks. Pull out all the challengers and fight them in an order decided by Angron&#8217;s controlling player during the Challenge part of the Fight sub-phase, save that any enemy model with the Primarch Unit Type must be fought first. Angron must divide his attacks between them and must devote at least one attack to each Challenge he fights in. All models challenged by Angron, and Angron himself, count as being in a Challenge and follow all the rules for Challenges and any models that are not removed as Casualties remain in a Challange with Angron until either all the Challengers are removed as Casualties, angron is removed as a Casualty or the challenge is ended by the effect of another rule.</description>
         </rule>
       </rules>
       <infoLinks>
         <infoLink id="035d-fd72-9b02-c6c2" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Hatred (Everything)"/>
+            <modifier type="set" field="name" value="Hatred (Everything)" />
           </modifiers>
         </infoLink>
         <infoLink id="1a31-6274-99fa-3537" name="Rampage (X)" hidden="false" targetId="3efb-2a2c-2d0b-92fc" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Rampage (2)"/>
+            <modifier type="set" field="name" value="Rampage (2)" />
           </modifiers>
         </infoLink>
         <infoLink id="5f31-0079-6d3b-1f48" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Furious Charge (2)"/>
+            <modifier type="set" field="name" value="Furious Charge (2)" />
           </modifiers>
         </infoLink>
-        <infoLink id="ff06-648d-8872-53e5" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule"/>
+        <infoLink id="ff06-648d-8872-53e5" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8d69-ffc8-873e-2e42" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="b990-1902-a070-c6d2" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="8d69-ffc8-873e-2e42" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="b990-1902-a070-c6d2" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="646c-85f5-7755-cc45" name="Gorefather &amp; Gorechild" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2dc-1913-0c32-55bd" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f374-0816-750d-5bbc" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2dc-1913-0c32-55bd" type="min" />
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f374-0816-750d-5bbc" type="max" />
           </constraints>
           <profiles>
             <profile id="0335-d920-125b-6ad6" name="Gorefather" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2369,20 +2368,20 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="e452-39d6-aaed-2104" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
-            <infoLink id="cb97-4052-b83d-2419" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule"/>
-            <infoLink id="e04b-4f1c-c89d-673d" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule"/>
-            <infoLink id="792f-3ef6-f56b-309d" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
-            <infoLink id="870a-18f2-4427-1fbf" name="Gorechild" hidden="false" targetId="7415-f2c4-4eb5-609d" type="profile"/>
+            <infoLink id="e452-39d6-aaed-2104" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule" />
+            <infoLink id="cb97-4052-b83d-2419" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule" />
+            <infoLink id="e04b-4f1c-c89d-673d" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule" />
+            <infoLink id="792f-3ef6-f56b-309d" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
+            <infoLink id="870a-18f2-4427-1fbf" name="Gorechild" hidden="false" targetId="7415-f2c4-4eb5-609d" type="profile" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="ab32-693e-692d-01a6" name="The Armour of Mars" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="060f-7af5-5c71-4f7e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83ce-05dd-fa46-a043" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="060f-7af5-5c71-4f7e" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83ce-05dd-fa46-a043" type="max" />
           </constraints>
           <profiles>
             <profile id="53fa-9bfa-1db1-4ac6" name="The Armour of Mars" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
@@ -2392,34 +2391,34 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
-        <selectionEntry id="0ff7-853b-3e0a-b501" name="The Butcher&apos;s Nails" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="0ff7-853b-3e0a-b501" name="The Butcher's Nails" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4cf-7689-402e-ed1d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a4b-669d-6350-d109" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4cf-7689-402e-ed1d" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a4b-669d-6350-d109" type="max" />
           </constraints>
           <profiles>
-            <profile id="7c75-992c-a3f7-382c" name="The Butcher&apos;s Nails" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+            <profile id="7c75-992c-a3f7-382c" name="The Butcher's Nails" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
               <characteristics>
-                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">At the start of each of the controlling player’s turns after the first Angron gains +1 to his Attack characteristic for the rest of the game, to a maximum of 10 attacks at the start of the controlling player’s fifth turn (if the game lasts that long). If Angron is in Reserves at the start of the Controlling player’s turn then this rule has no effect and his Attacks does not increase that turn. Additionally, any To Hit rolls made in any Assuault Phase targeting a unit that includes Angron, always counts the majority Weapon Skill of the Unit as 3, regardless of the Actual Weapon Skill of the models in that Unit.</characteristic>
+                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">At the start of each of the controlling player&#8217;s turns after the first Angron gains +1 to his Attack characteristic for the rest of the game, to a maximum of 10 attacks at the start of the controlling player&#8217;s fifth turn (if the game lasts that long). If Angron is in Reserves at the start of the Controlling player&#8217;s turn then this rule has no effect and his Attacks does not increase that turn. Additionally, any To Hit rolls made in any Assuault Phase targeting a unit that includes Angron, always counts the majority Weapon Skill of the Unit as 3, regardless of the Actual Weapon Skill of the models in that Unit.</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
         <selectionEntry id="c182-2fb7-ac08-d951" name="The Spite Furnace" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d1a-39a1-1e6a-69fd" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="470a-6288-5663-2da6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d1a-39a1-1e6a-69fd" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="470a-6288-5663-2da6" type="max" />
           </constraints>
           <profiles>
             <profile id="6f30-3978-48bf-a804" name="The Spite Furnace" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">12"</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 2, Gets Hot, Master-crafted</characteristic>
@@ -2427,31 +2426,31 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="2ed6-4c76-34e6-c6b8" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
-            <infoLink id="a933-5da8-00db-d1a6" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="2ed6-4c76-34e6-c6b8" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule" />
+            <infoLink id="a933-5da8-00db-d1a6" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="5586-2100-1adc-0f7e" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed74-c61f-582f-ea3a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d661-1191-b0eb-af8b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed74-c61f-582f-ea3a" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d661-1191-b0eb-af8b" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="4c86-a564-be6a-cfca" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6c6-fb30-3bd4-d52c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b1d-53c0-5030-a0f7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6c6-fb30-3bd4-d52c" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b1d-53c0-5030-a0f7" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="111a-d22d-5d94-cf6f" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d26a-1c99-542d-49d3" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f904-f520-1a5c-fccb" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d26a-1c99-542d-49d3" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f904-f520-1a5c-fccb" type="max" />
           </constraints>
           <profiles>
             <profile id="3550-2afc-df78-f164" name="Sire of the World Eaters" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
@@ -2463,18 +2462,18 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="450.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="450.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="e812-10d1-b911-90c5" name="Gahlan Surlak" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0606-8335-857a-a6d4" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0606-8335-857a-a6d4" type="max" />
       </constraints>
       <profiles>
         <profile id="2038-4e8b-96cf-a832" name="Gahlan Surlak" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName=" Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7"</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">6</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
@@ -2488,20 +2487,20 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="ee89-f02b-d346-ce36" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
-        <infoLink id="7cba-d485-b59f-7d53" name="Sacred Trust" hidden="false" targetId="7cdc-4095-eb1e-2b07" type="rule"/>
-        <infoLink id="b04b-077c-a729-1a77" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule"/>
+        <infoLink id="ee89-f02b-d346-ce36" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule" />
+        <infoLink id="7cba-d485-b59f-7d53" name="Sacred Trust" hidden="false" targetId="7cdc-4095-eb1e-2b07" type="rule" />
+        <infoLink id="b04b-077c-a729-1a77" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule" />
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9218-c0cc-8dc7-a683" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="6456-b9f2-a391-2c29" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
-        <categoryLink id="58d8-8eda-8902-2a74" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
+        <categoryLink id="9218-c0cc-8dc7-a683" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="6456-b9f2-a391-2c29" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
+        <categoryLink id="58d8-8eda-8902-2a74" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="01fb-10e7-0c43-2b0d" name="Fleshripper" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b1d4-abbf-887d-3203" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f0a5-c964-8c0f-6220" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b1d4-abbf-887d-3203" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f0a5-c964-8c0f-6220" type="max" />
           </constraints>
           <profiles>
             <profile id="ae8d-1bfb-5b82-ac04" name="Fleshripper" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -2514,123 +2513,123 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="805a-6a56-7a8f-0d04" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
-            <infoLink id="6d29-a0bf-de5d-d168" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+            <infoLink id="805a-6a56-7a8f-0d04" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
+            <infoLink id="6d29-a0bf-de5d-d168" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="4710-caf4-17f8-c984" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d01-78c7-f812-22cd" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="55c9-0666-174b-a5c7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d01-78c7-f812-22cd" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="55c9-0666-174b-a5c7" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="4c3a-97a1-6c87-d4e3" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b787-78c2-4b7e-b006" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d0c5-ebf4-0b12-69e7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b787-78c2-4b7e-b006" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d0c5-ebf4-0b12-69e7" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="ebd1-0638-5328-f136" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ee92-2e57-f713-ec3a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2a12-9203-fa6f-5c3b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ee92-2e57-f713-ec3a" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2a12-9203-fa6f-5c3b" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="1d77-ace8-3c97-1351" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b7a4-f1d8-8140-1493" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="51b3-22fb-7d14-c97a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b7a4-f1d8-8140-1493" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="51b3-22fb-7d14-c97a" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="5e6a-b9eb-f20c-307c" name="Narthecium" hidden="false" collective="false" import="true" targetId="dd7a-d404-a96c-1251" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="320f-6fa4-22a9-1e20" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1e2e-f4cd-3b90-c3fd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="320f-6fa4-22a9-1e20" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1e2e-f4cd-3b90-c3fd" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="b6f2-e8f1-3280-ad9d" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8732-39b1-ce70-936c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d604-1d05-893c-ecc6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8732-39b1-ce70-936c" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d604-1d05-893c-ecc6" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="c8b0-9adb-1595-4541" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe1d-0d84-0681-93b1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe1d-0d84-0681-93b1" type="max" />
           </constraints>
           <profiles>
             <profile id="622f-954e-3ea4-4c59" name="Abhorrent Augmentations" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If Gahlan Surlak is chosen as the army&apos;s Warlord, before any models are deployed the controlling player may choose up to a total of three Legion Tactical Squads and Legion Despoiler Squads from the same Detachment as Gahlan Surlak to have Abhorrent Augmentations. These units gain Bitter Duty special rules along with +1 to their Strength characteristic, but suffer -1 to their BS and lose the Heart of the Legion special rule and Line Unit Sub-Type. In addition, an army whose Warlord is Gahlan Surlak may make an additional Reaction in the opposing player’s Movement phase, as long as Gahlan Surlak has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If Gahlan Surlak is chosen as the army's Warlord, before any models are deployed the controlling player may choose up to a total of three Legion Tactical Squads and Legion Despoiler Squads from the same Detachment as Gahlan Surlak to have Abhorrent Augmentations. These units gain Bitter Duty special rules along with +1 to their Strength characteristic, but suffer -1 to their BS and lose the Heart of the Legion special rule and Line Unit Sub-Type. In addition, an army whose Warlord is Gahlan Surlak may make an additional Reaction in the opposing player&#8217;s Movement phase, as long as Gahlan Surlak has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
-        <entryLink id="0faf-54f0-ef15-986d" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup"/>
+        <entryLink id="0faf-54f0-ef15-986d" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup" />
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="150.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="150.0" />
       </costs>
     </selectionEntry>
-    <selectionEntry id="e726-7208-d919-a4a1" name="Khârn the Bloody" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="e726-7208-d919-a4a1" name="Kh&#226;rn the Bloody" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="40b6-ae71-99d5-3c02" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="40b6-ae71-99d5-3c02" type="max" />
       </constraints>
       <infoLinks>
-        <infoLink id="9edd-a134-ccb1-feba" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="9edd-a134-ccb1-feba" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule" />
         <infoLink id="de94-db6a-cb28-80c9" name="Rampage (X)" hidden="false" targetId="3efb-2a2c-2d0b-92fc" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Rampage (3)"/>
+            <modifier type="set" field="name" value="Rampage (3)" />
           </modifiers>
         </infoLink>
-        <infoLink id="ab4c-6d4b-f51c-1257" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule"/>
+        <infoLink id="ab4c-6d4b-f51c-1257" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule" />
         <infoLink id="9048-193b-4a96-f1af" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Precision Strikes (4+)"/>
+            <modifier type="set" field="name" value="Precision Strikes (4+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="6d76-7591-3f6a-4f2c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="2e2e-a670-504f-7861" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-        <categoryLink id="a72b-1dd1-a0d9-f099" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+        <categoryLink id="6d76-7591-3f6a-4f2c" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false" />
+        <categoryLink id="2e2e-a670-504f-7861" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false" />
+        <categoryLink id="a72b-1dd1-a0d9-f099" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false" />
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="3017-90ed-f8d5-20fb" name="Melee Weapon" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="67fc-b661-70ee-62f5" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cf81-7952-3c0d-f99f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="67fc-b661-70ee-62f5" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cf81-7952-3c0d-f99f" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="f63d-f84b-420d-4d58" name="Gorechild" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6352-8efa-0cc4-cfa7" type="atLeast"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6352-8efa-0cc4-cfa7" type="atLeast" />
                   </conditions>
                 </modifier>
               </modifiers>
               <profiles>
                 <profile id="ab03-9670-6518-3de5" name="Gorechild" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
                   <characteristics>
-                    <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Gorechild may only be taken if Angron is not part of the same army as Khârn the Bloody.</characteristic>
+                    <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Gorechild may only be taken if Angron is not part of the same army as Kh&#226;rn the Bloody.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="ecd1-bb5d-5e20-bc30" name="Gorechild" hidden="false" targetId="7415-f2c4-4eb5-609d" type="profile"/>
-                <infoLink id="5eb5-a47a-7cf0-6f37" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule"/>
-                <infoLink id="f153-b623-095b-aa97" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
-                <infoLink id="2e6f-f224-5bfe-4e62" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
-                <infoLink id="3177-efb2-9a48-47ba" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule"/>
+                <infoLink id="ecd1-bb5d-5e20-bc30" name="Gorechild" hidden="false" targetId="7415-f2c4-4eb5-609d" type="profile" />
+                <infoLink id="5eb5-a47a-7cf0-6f37" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule" />
+                <infoLink id="f153-b623-095b-aa97" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
+                <infoLink id="2e6f-f224-5bfe-4e62" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule" />
+                <infoLink id="3177-efb2-9a48-47ba" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule" />
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="e3aa-ea54-3583-2d52" name="The Cutter" hidden="false" collective="false" import="true" type="upgrade">
@@ -2645,20 +2644,20 @@
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="eb7d-9328-3e43-4ff5" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+                <infoLink id="eb7d-9328-3e43-4ff5" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
                 <infoLink id="4f84-144d-ca2d-5738" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Rending (4+)"/>
+                    <modifier type="set" field="name" value="Rending (4+)" />
                   </modifiers>
                 </infoLink>
                 <infoLink id="1c34-4786-9d5a-5e80" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Murderous Strike (6+)"/>
+                    <modifier type="set" field="name" value="Murderous Strike (6+)" />
                   </modifiers>
                 </infoLink>
               </infoLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2667,56 +2666,56 @@
       <entryLinks>
         <entryLink id="7171-eac4-1e36-32e1" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2a6e-ab8b-1051-3885" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fa1f-c410-cd00-e1aa" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2a6e-ab8b-1051-3885" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fa1f-c410-cd00-e1aa" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="3dbc-bf9c-ede2-2da6" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7b3c-dd7f-ae97-7672" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4524-00f2-7d09-bdc6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7b3c-dd7f-ae97-7672" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4524-00f2-7d09-bdc6" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="d05f-21df-4130-8b44" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a40b-b9cc-e83e-880e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6aac-9847-aa5a-b384" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a40b-b9cc-e83e-880e" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6aac-9847-aa5a-b384" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="906b-febd-6eff-fd2b" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="46b1-6b69-21dd-830e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0353-59af-da12-be87" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="46b1-6b69-21dd-830e" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0353-59af-da12-be87" type="max" />
           </constraints>
         </entryLink>
         <entryLink id="2cc3-aaad-6ede-b5a8" name="Iron Halo" hidden="false" collective="false" import="true" targetId="b081-bf3c-f43d-4bd5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6d0f-ce97-a10e-5177" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f039-059c-edf6-535d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6d0f-ce97-a10e-5177" type="min" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f039-059c-edf6-535d" type="max" />
           </constraints>
         </entryLink>
-        <entryLink id="7685-b8f0-a22b-f29a" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup"/>
+        <entryLink id="7685-b8f0-a22b-f29a" name="Retinue" hidden="false" collective="false" import="true" targetId="a01f-cd9e-bd21-853e" type="selectionEntryGroup" />
         <entryLink id="be42-8973-ed4c-e798" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9a4-fc7e-c758-e2da" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3146-d7d5-09f2-0222" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9a4-fc7e-c758-e2da" type="max" />
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3146-d7d5-09f2-0222" type="min" />
           </constraints>
         </entryLink>
         <entryLink id="02e0-26ed-7614-7cd6" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9fc-64f4-a000-4250" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9fc-64f4-a000-4250" type="max" />
           </constraints>
           <profiles>
             <profile id="1e27-6b41-31a4-bea5" name="Savage Assault" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">No enemy unit may declare a Reaction against a Charge made by a unit that includes Khârn the Bloody, unless the unit targeted by that Charge includes a model with the Primarch Unit Type. In addition, an army with Khârn the Bloody as its Warlord may make an additional Advance Reaction during the opposing player&apos;s Movement phase as long as Khârn the Bloody has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">No enemy unit may declare a Reaction against a Charge made by a unit that includes Kh&#226;rn the Bloody, unless the unit targeted by that Charge includes a model with the Primarch Unit Type. In addition, an army with Kh&#226;rn the Bloody as its Warlord may make an additional Advance Reaction during the opposing player's Movement phase as long as Kh&#226;rn the Bloody has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="2403-fc44-ffd2-8fa6" name="Barb-Hook Lash" hidden="false" collective="true" import="true" type="upgrade">
@@ -2731,21 +2730,21 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="f816-cc15-752e-3da8" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
+        <infoLink id="f816-cc15-752e-3da8" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule" />
         <infoLink id="1870-e3bd-55a1-54e1" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Rending (5+)"/>
+            <modifier type="set" field="name" value="Rending (5+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="a723-8a89-da38-4fff" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+        <infoLink id="a723-8a89-da38-4fff" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
         <infoLink id="8e2c-4a12-5eed-0ef7" name="Reach (X)" hidden="false" targetId="19bf-62a2-5737-890b" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Reach (1)"/>
+            <modifier type="set" field="name" value="Reach (1)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="bcb2-fdee-b235-da0e" name="Excoriator Chainaxe" hidden="false" collective="true" import="true" type="upgrade">
@@ -2761,24 +2760,24 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="7694-aadf-edbe-50fb" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
-        <infoLink id="af09-9662-d768-7d0a" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+        <infoLink id="7694-aadf-edbe-50fb" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
+        <infoLink id="af09-9662-d768-7d0a" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule" />
         <infoLink id="7706-b422-4032-846a" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Murderous Strike (5+)"/>
+            <modifier type="set" field="name" value="Murderous Strike (5+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="ab30-d5f6-691b-69b1" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+        <infoLink id="ab30-d5f6-691b-69b1" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule" />
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="be1b-90ff-17f3-654e" name="Falax Blade" hidden="false" collective="true" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="equalTo" />
           </conditions>
         </modifier>
       </modifiers>
@@ -2788,26 +2787,26 @@
             <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+1</characteristic>
             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Specialist Weapon, Rending (4+), Duellist’s Edge (1)
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Specialist Weapon, Rending (4+), Duellist&#8217;s Edge (1)
 </characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="2eab-2308-37e0-d852" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
+        <infoLink id="2eab-2308-37e0-d852" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule" />
         <infoLink id="4040-0283-7e47-6c4f" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value=" Rending (4+)"/>
+            <modifier type="set" field="name" value=" Rending (4+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="04c9-581e-3373-7f5f" name="Duellist’s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule">
+        <infoLink id="04c9-581e-3373-7f5f" name="Duellist&#8217;s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Duellist’s Edge (1)"/>
+            <modifier type="set" field="name" value="Duellist&#8217;s Edge (1)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="6a9f-b0aa-e137-9d18" name="Two Falax Blades" hidden="false" collective="true" import="true" type="upgrade">
@@ -2817,26 +2816,26 @@
             <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+1</characteristic>
             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Specialist Weapon, Rending (4+), Duellist’s Edge (1)
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Specialist Weapon, Rending (4+), Duellist&#8217;s Edge (1)
 </characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="2424-a2b2-2ba1-724e" name="Duellist’s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule">
+        <infoLink id="2424-a2b2-2ba1-724e" name="Duellist&#8217;s Edge (X)" hidden="false" targetId="7bf3-86ce-04c2-e6ba" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Duellist’s Edge (1)"/>
+            <modifier type="set" field="name" value="Duellist&#8217;s Edge (1)" />
           </modifiers>
         </infoLink>
         <infoLink id="8e46-ce07-cd43-f701" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value=" Rending (4+)"/>
+            <modifier type="set" field="name" value=" Rending (4+)" />
           </modifiers>
         </infoLink>
-        <infoLink id="83a1-32ee-6973-0390" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
+        <infoLink id="83a1-32ee-6973-0390" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule" />
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
     <selectionEntry id="1994-6eda-5e87-3038" name="Meteor Hammer" hidden="false" collective="true" import="true" type="upgrade">
@@ -2851,20 +2850,20 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="88a9-458a-3628-ec19" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule"/>
+        <infoLink id="88a9-458a-3628-ec19" name="Two-handed" hidden="false" targetId="4c23-e863-a569-7617" type="rule" />
         <infoLink id="e61f-c8df-322b-8c3e" name="Reach (X)" hidden="false" targetId="19bf-62a2-5737-890b" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Reach (1)"/>
+            <modifier type="set" field="name" value="Reach (1)" />
           </modifiers>
         </infoLink>
         <infoLink id="3fd6-d839-77c0-012d" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Breaching (5+)"/>
+            <modifier type="set" field="name" value="Breaching (5+)" />
           </modifiers>
         </infoLink>
       </infoLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -2873,111 +2872,111 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo" />
           </conditions>
         </modifier>
         <modifier type="set" field="e2c2-b728-eefc-694f" value="1.0">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan" />
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="afb6-6008-7317-e1f8" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2c2-b728-eefc-694f" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="afb6-6008-7317-e1f8" type="max" />
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2c2-b728-eefc-694f" type="min" />
       </constraints>
       <selectionEntryGroups>
         <selectionEntryGroup id="eca2-cd74-4ad6-297e" name=" XII: World Eaters" publicationId="09c5-eeae-f398-b653" page="216" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d30-6c73-d302-3253" type="max"/>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="743c-5f76-fe51-5e36" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d30-6c73-d302-3253" type="max" />
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="743c-5f76-fe51-5e36" type="max" />
           </constraints>
           <selectionEntries>
             <selectionEntry id="ff97-2439-4914-ea90" name="Blood Hunger (Traitor only)" publicationId="09c5-eeae-f398-b653" page="216" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo" />
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e3ad-4392-d004-a82d" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="57c1-bab0-1c1f-242b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e3ad-4392-d004-a82d" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="57c1-bab0-1c1f-242b" type="max" />
               </constraints>
               <profiles>
                 <profile id="7bda-048c-3bd9-3b74" name="Blood Hunger" publicationId="09c5-eeae-f398-b653" page="216" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait gains a bonus Wound whenever a melee attack it has made causes an enemy model to be removed as a casualty (this may raise the model’s Wounds score above its starting value, but no higher than 6 Wounds). In addition, a Warlord with this Trait, and any unit it has joined, must declare a Charge in any of the Controlling player’s Assault phases where there is an enemy unit within 12&quot; and line of sight of the Warlord or its unit, and must always target the closest enemy unit if possible. Furthermore, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty. </characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">A Warlord with this Trait gains a bonus Wound whenever a melee attack it has made causes an enemy model to be removed as a casualty (this may raise the model&#8217;s Wounds score above its starting value, but no higher than 6 Wounds). In addition, a Warlord with this Trait, and any unit it has joined, must declare a Charge in any of the Controlling player&#8217;s Assault phases where there is an enemy unit within 12" and line of sight of the Warlord or its unit, and must always target the closest enemy unit if possible. Furthermore, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Movement phase as long as the Warlord has not been removed as a casualty. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
             <selectionEntry id="95a5-4e72-9737-42c9" name="Cloaked in Blood" publicationId="09c5-eeae-f398-b653" page="216" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5216-d61f-06bf-6ec3" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f24a-d075-eb8e-6081" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5216-d61f-06bf-6ec3" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f24a-d075-eb8e-6081" type="max" />
               </constraints>
               <profiles>
                 <profile id="4b9c-e04b-b323-9a90" name="Cloaked in Blood" publicationId="09c5-eeae-f398-b653" page="216" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any model that does not have the Legiones Astartes (World Eaters) special rule must reduce its Leadership by -2 while locked in combat with this Warlord or any unit that includes this Warlord. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty. </characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any model that does not have the Legiones Astartes (World Eaters) special rule must reduce its Leadership by -2 while locked in combat with this Warlord or any unit that includes this Warlord. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Movement phase as long as the Warlord has not been removed as a casualty. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
-            <selectionEntry id="60d9-e526-126c-a6de" name="The Butcher’s Claws" publicationId="09c5-eeae-f398-b653" page="216" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="60d9-e526-126c-a6de" name="The Butcher&#8217;s Claws" publicationId="09c5-eeae-f398-b653" page="216" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9da3-446e-bae7-37b0" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3173-3c5d-a12b-f3c6" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9da3-446e-bae7-37b0" type="max" />
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3173-3c5d-a12b-f3c6" type="max" />
               </constraints>
               <profiles>
-                <profile id="fd74-fa1c-877b-a681" name="The Butcher’s Claws" publicationId="09c5-eeae-f398-b653" page="216" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                <profile id="fd74-fa1c-877b-a681" name="The Butcher&#8217;s Claws" publicationId="09c5-eeae-f398-b653" page="216" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When a Warlord with this Trait, and all models with the Legiones Astartes (World Eaters) special rule in a unit that it has joined, gain a bonus attack from the Violence Incarnate clause of the Legiones Astartes (World Eaters) special rule they also gain +1 Strength for the remainder of that turn. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Assault phase as long as the Warlord has not been removed as a casualty. </characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When a Warlord with this Trait, and all models with the Legiones Astartes (World Eaters) special rule in a unit that it has joined, gain a bonus attack from the Violence Incarnate clause of the Legiones Astartes (World Eaters) special rule they also gain +1 Strength for the remainder of that turn. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player&#8217;s Assault phase as long as the Warlord has not been removed as a casualty. </characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0" />
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="0ceb-a305-b862-dd39" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+        <entryLink id="0ceb-a305-b862-dd39" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup" />
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="a01f-cd9e-bd21-853e" name="Retinue" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="099f-d31e-9178-0276" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="099f-d31e-9178-0276" type="max" />
       </constraints>
       <entryLinks>
         <entryLink id="5b6e-89e7-3b28-f664" name="Command Squad, Cataphractii" hidden="false" collective="false" import="true" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
           <modifiers>
             <modifier type="append" field="name" value="(Reserve Only)">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo" />
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="2b36-986b-95a5-212d" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
-        <entryLink id="6f6c-6a79-ac41-8a7d" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="2b36-986b-95a5-212d" name="Tartaros Command Squad (Placeholder Points)" hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry" />
+        <entryLink id="6f6c-6a79-ac41-8a7d" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry" />
       </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
@@ -2993,6 +2992,6 @@
     </profile>
   </sharedProfiles>
   <catalogueLinks>
-    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true" />
   </catalogueLinks>
 </catalogue>

--- a/2022 - LA Template.cattemplate
+++ b/2022 - LA Template.cattemplate
@@ -1,0 +1,2177 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="a5f8-9711-42a9-84e3" name="LA - Template" revision="1" battleScribeVersion="2.03" authorName="BSCopy Script" authorContact="" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="29" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <readme>This is a template (made originally from the blood angels cat) used to copy rites of war to all 18 legions.</readme>
+  <entryLinks>
+    <entryLink id="5798-3fc7-4d4c-ad41" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="b084-df23-4f99-812f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="84fc-9304-4e9e-ab78" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="d06a-7939-4691-9aed" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="831f-3373-456a-8fbc" name="Retinue" hidden="false" collective="false" import="true" targetId="be38-a066-4f8e-ae54" type="selectionEntryGroup"/>
+        <entryLink id="741d-8c09-4211-ada6" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7dee-602c-4b47-be09" type="selectionEntryGroup"/>
+      </entryLinks>
+    </entryLink>
+    <entryLink id="c2bc-2985-468b-b512" name="Apothecarion Detachment" hidden="false" collective="false" import="false" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="c6d4-581f-4746-bec3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2489-ee2a-45dd-b384" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="6093-2b4c-41b4-b6c4" name="Arquitor Squadron " hidden="false" collective="false" import="false" targetId="9e46-a480-c382-c49c" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b02f-e65f-4a88-a175</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b87b-bf35-4238-b7c6</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1aff-27af-435e-8102</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_fdf9-4906-4180-a39d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8378-ede4-476d-b657" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d64f-ad19-426c-adf7" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="df5e-be36-49fa-b942" name="Assault Squad" hidden="false" collective="false" import="false" targetId="a8e9-70e1-b8bc-8ee2" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_7fd1-8ce8-4d10-82e7</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_eaae-8c43-4d30-898c</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_f67d-8cf3-424f-b491</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_b949-6414-4f3d-b268</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ac26-e639-4d53-9b8b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="49af-0d08-4c7e-8ce6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b606-de16-4659-95cd" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="5c02-34db-4633-a4e9" name="Breacher Squad" hidden="false" collective="false" import="false" targetId="ad97-c090-fa67-696f" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_27a3-1e4c-4b76-a594</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_d59a-dcd0-44fd-b866</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_0c8b-2b92-49ed-98c7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_bafe-f799-41d9-ac85</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_6369-288c-4fec-a640</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_fe53-8858-41dc-8ec4</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3a22-caae-4eea-9bc5" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="f759-f33e-4698-9f8a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c624-3ae0-46c0-9b06" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="d712-0fd7-43d1-b880" name="Centurion" hidden="false" collective="false" import="false" targetId="25a2-7a52-632a-6b2c" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="2599-24e3-44e5-9568" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="285f-6e56-473b-b2fe" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="685e-022f-4e2f-a568" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="2a38-6544-4267-b584" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7dee-602c-4b47-be09" type="selectionEntryGroup"/>
+        <entryLink id="6e59-4592-47ef-b76d" name="Retinue" hidden="false" collective="false" import="true" targetId="be38-a066-4f8e-ae54" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_8287-16ff-46ba-9838</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_81c1-fca9-44dc-ba4c</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+    </entryLink>
+    <entryLink id="11b1-c617-441a-9f1a" name="Centurion, Cataphractii " hidden="false" collective="false" import="false" targetId="3766-ea98-0aa7-62d0" type="selectionEntry">
+      <modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ad5d-3c79-4239-9116</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_60b1-049b-4a5f-85c2</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="bd6a-0cda-4e0f-80ae" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ae75-7cca-4701-9d56" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="e517-62d4-48f7-8174" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="fafb-6414-474a-8a09" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7dee-602c-4b47-be09" type="selectionEntryGroup"/>
+        <entryLink id="a6a6-9bc7-4d4e-86a7" name="Retinue" hidden="false" collective="false" import="true" targetId="be38-a066-4f8e-ae54" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_1e43-c980-4508-8ec2</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_4140-36a7-4203-b5e9</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+    </entryLink>
+    <entryLink id="6e9c-0842-4514-8ea6" name="Centurion, Tartaros " hidden="false" collective="false" import="false" targetId="f806-8a4e-d0d6-beaa" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="fc9d-03d1-4bbd-a1c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f51c-73d7-4f29-be1c" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="257d-78c0-4bab-ba65" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="ac26-33db-40a7-bdba" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7dee-602c-4b47-be09" type="selectionEntryGroup"/>
+        <entryLink id="dc8e-2801-46d6-84f8" name="Retinue" hidden="false" collective="false" import="true" targetId="be38-a066-4f8e-ae54" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <comment>    node_id_189b-db75-4db6-9fe9</comment>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="lessThan">
+                  <comment>    node_id_cbdb-2500-4e13-876a</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+    </entryLink>
+    <entryLink id="04f7-e2bb-4774-8d08" name="Cerberus Squadron" hidden="false" collective="false" import="false" targetId="137a-e079-34cd-8161" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b43b-547f-472e-9076</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8ff9-0498-4540-8552</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fbfe-931a-489b-a589</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f4c3-5aa6-4caa-abf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_17f8-f055-4c9c-b757</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f1c8-27fd-4f98-8527" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="2b20-1a8b-4753-b657" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="3aed-0370-44b8-9b06" name="Contemptor Dreadnought Talon" hidden="false" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_23fa-06dd-49f9-a7db</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5b26-059e-40b3-9d93</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f7bf-3a1c-4103-aed8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dd44-e0a8-42a8-bdcc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="c5b0-f9ae-468d-924a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="fa0b-c14e-4b81-9dac" name="Damocles Command Rhino" hidden="false" collective="false" import="false" targetId="e337-8239-5e92-7f5f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8396-e51c-4e2b-bada</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_13bb-9fb5-4580-92cf</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_bfb8-8125-4548-92f5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25e3-b8f5-4448-a7c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f926-27fd-4a92-97a1" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="82e3-36e1-4e85-8fcb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1408-38d9-406d-a090" name="Deredeo Dreadnought Talon" hidden="false" collective="false" import="false" targetId="bfdf-831f-2171-c1e7" type="selectionEntry">
+      <modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_658f-b1ad-4347-a998</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_12bc-3db2-4d28-abce</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_9d83-7691-41d6-8dad</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_add7-ba48-46d4-8a02</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_1fb0-2421-40a4-9e49</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7004-b00d-481f-b740" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="4f88-2fc3-491c-bfb7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="8d6c-729f-4250-a5d4" name="Despoiler Squad" hidden="false" collective="false" import="false" targetId="4357-930e-165a-a6e3" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_8ed4-376d-4030-9439</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8a11-c2a0-4335-99ef</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_fa8e-1af7-4d41-ac8c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_94bd-c771-4a85-8581</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="361e-fb90-4b0e-ac3d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="d4ef-1074-45a9-959e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="febb-f536-4d25-a8ab" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="7a36-d995-434a-a787" name="Destroyer Assault Squad" hidden="false" collective="false" import="false" targetId="d30b-59bb-8ae0-36d1" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="473b-e812-4158-9416" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="00a2-63ff-4698-a35b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="f8ba-83a9-4d1f-adf6" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="false" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7cf3-8a72-4f82-8cdc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_228c-5681-4ce8-b726</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_01bb-8abd-4253-9a4d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2a08-4432-42ad-bfdb" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="422e-0808-4897-8630" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="2708-1e9f-4820-9d53" name="Falchion" hidden="false" collective="false" import="false" targetId="1fe8-7386-9509-d2d8" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1af8-4459-4717-8e3b</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_06b4-92b9-438c-b1a5</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6c8d-8b28-417b-9a7c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_715d-8186-4aa6-b40c</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_390e-358c-4f8e-ade8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f4c0-4396-4f39-a34f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="1301-8415-490e-8f06" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="87fa-f196-4c2e-9c3b" name="Fellblade" hidden="false" collective="false" import="false" targetId="9c3c-f15a-9a1f-c0d0" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d0c9-9a26-4324-b030</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4e9e-a61d-42f2-bacb</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ed9e-b634-4bec-9eb0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4614-ad0f-4fba-adaf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_8d08-24f6-41be-8931</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="caf6-5548-4b89-8102" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="63a3-be61-428d-ab29" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="3f8d-8859-4348-bf42" name="Fire Raptor Gunship" hidden="false" collective="false" import="false" targetId="f6e1-24e2-fbdb-c5ef" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f318-4b03-4767-8c7f</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b8ef-7245-4df8-a8c4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_6bce-ec44-48cb-873a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0678-4fdd-48e6-8f61" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0d82-10a9-4de2-8ad7" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="bbe3-6b87-4619-80dd" name="Glaive" hidden="false" collective="false" import="false" targetId="04e0-f69f-f759-b0b3" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ada1-1e18-4cbc-9598</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_b1d1-ac44-47dd-9159</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5d64-f00c-4464-891b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_25f0-f825-4a83-8f0d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_64b1-9e36-44da-b36a</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d53e-113f-4a40-a3d5" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="1939-76b5-4279-9f8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="889e-91aa-489a-b766" name="Heavy Support Squad" hidden="false" collective="false" import="false" targetId="bac9-5389-e2e7-0b1f" type="selectionEntry">
+      <modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d765-3bb2-4b48-bd12</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_0ca1-cfb4-4a56-ab3b</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e6f7-a6ca-4825-bfc5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="dbec-e027-4ec1-8514" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="a948-21ae-4cfc-a7df" name="Javelin Squadron" hidden="false" collective="false" import="false" targetId="deea-102f-8fbe-e2e5" type="selectionEntry">
+      <modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_d8ee-81ed-45f9-8b79</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_8f4e-e8cb-4ac9-a415</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="cefb-cfd7-4dc8-99c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a9fd-9d16-4a5e-855c" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="4a48-1563-4021-968f" name="Kharybdis Assault Claw" hidden="false" collective="false" import="false" targetId="f64a-90b7-19c8-182a" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e76b-46ca-4ab8-a93d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8035-75b8-43bb-97c9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_71a4-31e7-4927-a0ab</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a56d-347b-4b09-a918" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="96e5-4531-4213-903e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="eab9-0e2c-49b9-b8bf" name="Kratos Squadron" hidden="false" collective="false" import="false" targetId="5900-37fc-9339-c1b7" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1fb5-2375-4c22-b41e</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7d7c-255d-49b6-96b9</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5321-254b-4890-9bf2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ddf8-b8b7-4afb-b6dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9441-d79b-4720-9667" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7d7e-32d3-4692-b401" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="c6c2-ec4b-4f2b-af9e" name="Land Raider Proteus Carrier Squadron" hidden="false" collective="false" import="false" targetId="b6cd-dd1a-6b2c-41d6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_ae67-ef52-4cac-958c</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fc61-7306-4d99-acde</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1be0-67e7-45a1-bdbb</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_42a8-7fda-4e05-af0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="565a-1592-491f-8b9b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="81d5-c14a-42ab-bdde" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="13de-750d-4f98-b462" name="Land Raider Proteus Explorator" hidden="false" collective="false" import="false" targetId="59a6-1cd2-185d-bf57" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1ae7-c41b-4818-be71</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_08a5-b1bb-4ba1-ba42</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d677-b5ad-4838-8746</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_537f-bc1f-4aaa-b0dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="bc67-ce1f-4004-aeb7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9a45-9699-4475-aeef" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="16af-605d-4499-bb17" name="Land Raider Spartan" hidden="false" collective="false" import="false" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_c28f-4109-44c4-ab64</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fdc1-a894-48bc-9e7c</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_4936-a68c-4524-9088</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb37-ac0c-49ae-9d6f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3afe-cfc0-4da6-a985" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="04a8-6aae-45ae-bd4c" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="904a-21a0-43c7-a61c" name="Leviathan Dreadnought Talon" hidden="false" collective="false" import="false" targetId="c2a7-9e2c-fc65-1b78" type="selectionEntry">
+      <modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_773a-1ea4-41a0-b766</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_9d4d-6fb8-4131-a5a3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_e3bc-02f8-4ece-a5ea</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c371-76d9-4a4d-bc00</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b4c6-d4ba-4b2e-9b99</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6ea9-a7e5-437d-9e35" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3cec-f053-42ab-a6eb" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="547d-bdfe-4930-9b58" name="Mastodon" hidden="false" collective="false" import="false" targetId="7f24-2b72-9128-5330" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1e60-42ba-4c8b-9077</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9860-f593-425e-b89b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_c842-10e8-4509-8eda</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_ea52-ff41-40f6-8cf3</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_51e6-c5e1-4003-96bc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4d7c-201f-4c99-b89a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="10f9-4718-4e07-bb32" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1e13-9ff6-4335-8fbd" name="Mortalis Destroyer Squad" hidden="false" collective="false" import="false" targetId="dbd4-930e-e003-9449" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="6140-2404-46f9-bd42" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1c86-fad8-46ec-a0b0" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="a369-e639-4d89-8f78" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_0a59-9f36-424f-ab2b</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_24c1-b2de-4c70-b5a2</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1bf6-db3e-464f-b2d3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_dd50-50c1-4b42-a47d</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_db4d-af6c-4204-8e6e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dc16-16d0-4890-a8e8" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="4b1e-3f1f-49cb-8343" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="4654-227a-4d95-8773" name="Outrider Squadron" hidden="false" collective="false" import="false" targetId="70eb-e4da-8b3f-f065" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="ff9f-01cb-41b9-800e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1315-6051-4a46-b070" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ca44-db38-4377-b4ef" name="Praetor, Cataphractii" hidden="false" collective="false" import="false" targetId="1b79-1951-5a63-4b9e" type="selectionEntry">
+      <modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_54a4-6ec8-4c61-9c3e</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_f7fd-2d16-4603-a065</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0ac-4b8c-421c-a21b" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="8db9-079e-4482-b200" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="413c-9273-4308-b546" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="bbc4-33fc-4664-a18e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7dee-602c-4b47-be09" type="selectionEntryGroup"/>
+        <entryLink id="5c5d-d6ce-4ee4-9846" name="Retinue" hidden="false" collective="false" import="true" targetId="be38-a066-4f8e-ae54" type="selectionEntryGroup"/>
+      </entryLinks>
+    </entryLink>
+    <entryLink id="e95d-4a2f-45c3-b44e" name="Praetor, Tartaros" hidden="false" collective="false" import="false" targetId="3760-204e-444c-1044" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="4c8d-96f6-48f9-9590" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="049c-0fa5-4575-8fa8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7358-52d7-4aae-8e07" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="4784-b370-444b-93ae" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="7dee-602c-4b47-be09" type="selectionEntryGroup"/>
+        <entryLink id="fe8f-c701-4ebd-ae76" name="Retinue" hidden="false" collective="false" import="true" targetId="be38-a066-4f8e-ae54" type="selectionEntryGroup"/>
+      </entryLinks>
+    </entryLink>
+    <entryLink id="59c9-be20-4f7c-b91d" name="Predator Squadron " hidden="true" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7f87-6d3e-4738-b3ee</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_cd74-309d-4d08-825e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="32cb-7077-4d54-9f38" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2c35-def7-4c44-9b02" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="0c9a-d272-491c-a4a0" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="7425-bfc5-42eb-8dc4" name="Proteus Land Speeder Squadron" hidden="false" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="75a7-dc06-445b-b2dc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e21a-c03b-4885-ac46" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="522a-15ed-443b-a5f3" name="Rapier Battery" hidden="false" collective="false" import="false" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
+      <modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9a08-5fe6-4010-bbc3</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_72cf-cfce-4e02-b379</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f55b-7555-444b-beee" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="3386-c9ad-4d74-9474" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="dbab-5cf8-42c8-9fdb" name="Reconnaissance Squad" hidden="false" collective="false" import="false" targetId="6db7-6e88-877e-35ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_a0f6-9606-4b75-a2f8</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_94b3-1331-474b-885b</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="79fa-3370-4ae0-9e12" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="bb53-4e65-4fb6-9dd7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="cb2e-1a1f-4bed-8fca" name="Sabre Strike Squadron" hidden="false" collective="false" import="false" targetId="133b-e657-437e-f298" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_f8cc-833a-4ac1-bf89</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+              <comment>    node_id_5988-c012-4dad-9a66</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8d82-3279-4481-84bb" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="e25c-925e-4b96-8bb3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="73e7-101a-42d6-b1b2" name="Scorpius Squadon" hidden="false" collective="false" import="false" targetId="47d9-c0d0-12aa-9690" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6b73-b21c-4e2b-9d14</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_a7fe-cc62-4a6f-a781</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_5be1-1937-4964-a455</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_da1d-b2bc-4117-82a4</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7010-be56-4709-b058" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7379-a740-47ba-a054" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="e44f-ea47-43a8-857f" name="Scout Squad" hidden="false" collective="false" import="false" targetId="9b10-b657-a65a-9d60" type="selectionEntry">
+      <modifiers>
+        <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_dd34-83cf-47d7-b557</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_be88-afef-49b3-bd1e</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="944f-7420-4982-8ea9" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="ea80-0efe-457d-a450" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="58fe-ef91-4e28-9109" name="Seeker Squad" hidden="false" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="9a36-f261-43cc-9bd1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a648-8396-442a-af59" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ec32-606f-4ca6-adac" name="Sicaran Arcus Squadron" hidden="false" collective="false" import="false" targetId="3b14-e731-0d0f-bfe7" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_cb81-0303-4b88-ae53</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_9648-31e3-43aa-8cf3</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_0507-da81-4023-bfcf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0e84-54ff-488d-b066</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c6ff-0977-4c92-bb28" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f555-7d39-458f-84c9" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="56c2-bbcb-4385-9b5a" name="Sicaran Omega Squadron" hidden="false" collective="false" import="false" targetId="c88b-fe44-34a3-97e1" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_8203-5b00-497b-b939</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_40ee-3e71-4978-b1e4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f6a8-f660-46dc-b3c5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_d988-3af6-48bf-b0a8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="39e5-eda5-45d1-a643" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6416-21bb-4df4-9de8" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="79c8-6e0e-4175-9916" name="Sicaran Punisher Squadron" hidden="false" collective="false" import="false" targetId="13d9-b56a-6194-d521" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_b03e-5d91-4be3-8adc</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_0443-29c0-46e9-ad1d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f2c9-7356-4c27-a22f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0e9-4a9e-4b2b-a9d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5528-2dac-4be5-900c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="dc8f-d888-4585-991d" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="7f16-dadb-4bbc-bad7" name="Sicaran Squadron" hidden="false" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_1d3c-8e17-489f-9002</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_5725-8bee-4bcc-878d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_be47-0d6f-49f2-9f4b</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_863c-f3a4-4802-b80c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="899e-b052-4d5b-8c18" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f5e9-cff6-41d2-a016" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="2901-7b25-4b31-99a8" name="Sicaran Venator Squadron" hidden="false" collective="false" import="false" targetId="1345-e0db-2fcb-dcc8" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_72da-1513-4e02-b595</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7a48-a3b0-4a26-849b</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e232-25f3-4cb7-8ab2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_9aa4-5660-4697-8ab2</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="09cd-2176-40af-bba6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="05e6-7c63-4a35-9ba0" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="e940-cd57-49e9-a428" name="Sky-Hunter Squadron" hidden="false" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="0dfa-4004-4751-8022" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a669-0f5d-4fd3-811b" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="aceb-c60a-415f-a342" name="Sokar Stormbird" hidden="false" collective="false" import="false" targetId="f403-630f-71ae-5a7d" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_09b5-4e3b-4c84-a574</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_32e5-ebba-41fb-9ff2</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_838e-0ccf-4d3a-aabd</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_dfef-0ec2-49fb-a534</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4f60-472b-45a9-ab9e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="e2e3-af36-45a6-a955" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="c9f2-ee68-4c38-9314" name="Spatha Attack Bike Squadron" hidden="true" collective="false" import="false" targetId="4d72-1cc1-8bee-aa88" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_936f-1ef7-472e-840e</comment>
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+              <comment>    node_id_d73d-d52e-4c75-8ac0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7a55-ecb4-4e5d-b955" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="f28c-710e-4ff8-9810" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="5ec5-8a6b-491f-a7f3" name="Storm Eagle Gunship" hidden="false" collective="false" import="false" targetId="8aa5-ff31-7de7-19d4" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_a743-0cc2-45ae-a7eb</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2721-e88d-41f7-bedc</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_e10f-1390-4b33-8fcc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="2008-f1c4-4285-a14f" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="e88b-a95a-4647-af3b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="59ec-0ea0-4fcf-a75a" name="Tactical Squad" hidden="false" collective="false" import="false" targetId="aa72-63e4-bc60-4611" type="selectionEntry">
+      <modifiers>
+        <modifier type="remove" field="category" value="8f42-a824-fb5f-8fea">
+          <comment>    node_id_25d8-330b-4574-b515</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7836-6878-47a8-8827</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_5ea9-46dd-4a11-9410</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_ab5d-961b-4924-a705</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9189-836c-475d-a52e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="e1fa-b7d8-47b0-a88a" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="a137-e3c0-4d63-a48c" name="Compulsory Troops:" hidden="false" targetId="8f42-a824-fb5f-8fea" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="7333-e181-4a55-8831" name="Tactical Support Squad" hidden="false" collective="false" import="false" targetId="50ed-5869-643d-1ac5" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="b1d5-fd75-4f17-bbf4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f221-bf81-4045-849b" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="d202-8e38-4b5e-96a8" name="Techmarine Covenant" hidden="false" collective="false" import="false" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="51af-a137-4a1c-97a4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="ec1f-c326-40a8-9d1f" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ec78-3ba9-438b-a7e8" name="Terminator Cataphractii Squad" hidden="false" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
+      <modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_c111-feb0-4012-98cd</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_63d7-8427-431d-9ae6</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e707-fde1-457f-91c4" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="ec67-8573-4460-89db" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="0848-4e03-417a-b224" name="Terminator Tartaros Squad" hidden="false" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="ac1c-b3bf-4011-918a" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="589c-1d0e-4b7d-be6b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="3b77-0148-4975-a6db" name="Thunderhawk Gunship" hidden="false" collective="false" import="false" targetId="8754-3a4f-213b-bdc0" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_6087-a5e5-4d3c-9ebd</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_c7e1-5f42-4528-bf07</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1950-08dc-4544-ab01</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_daf3-31ed-42c0-85dc</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7d4f-547c-43ed-a520" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="f04e-04e8-4891-9b1f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="b3aa-4fa3-4270-993b" name="Typhon Squadron" hidden="false" collective="false" import="false" targetId="d06a-3087-af13-ca95" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_d512-fd07-4a29-863a</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_55c6-a35f-485a-9f0d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d89e-cf1f-4ceb-b3de</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e2c9-0d01-403c-900e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_a7b8-c835-4cb2-b3d5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e22a-c5f8-4825-a45f" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="03fc-6a7f-45a5-bcb8" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="9d03-74fb-4e04-91f4" name="Veteran Squad" hidden="false" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="0aff-4f6e-4b03-a23c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="7d5a-62e7-43ee-b79b" name="Compulsory Elite:" hidden="false" targetId="bb1f-ae32-b587-c3e1" primary="false"/>
+        <categoryLink id="4986-9157-49f2-b670" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="e3b3-8b3e-44d9-94e1" name="Vindicator Squadron" hidden="false" collective="false" import="false" targetId="9245-0776-6747-adb8" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_319e-90d4-44a3-8e83</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_28db-d943-4099-9abd</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1a45-a592-49df-9465</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bb31-d0b2-4677-928e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1b86-0977-4a8b-adac" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="b449-403a-4e42-9239" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="2275-397b-407d-ae6b" name="Xiphon Interceptor" hidden="false" collective="false" import="false" targetId="596b-5478-e079-59ab" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_fbfa-8d78-4d6d-8a05</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_21f2-0916-46bf-b75a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_4fbd-633b-4dd6-9fdd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4f71-446f-4cff-afda" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="3f44-8647-43a4-ac22" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="23b2-54e0-4f09-95e5" name="Command Squad" hidden="false" collective="false" import="false" targetId="0aca-632d-1642-8af9" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="4207-8d8f-4b1a-836b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="2b34-077f-4279-86fb" name="Primarch&apos;s Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1064-175d-4616-9c71" name="Avenger Strike Fighter" hidden="true" collective="false" import="false" targetId="b25c-e85c-1c29-9e05" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_7583-6fa0-4089-a19e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_0e5c-99ab-41d3-a42e</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c296-e8e8-4a7a-989a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_8868-5bcb-4604-ba8e</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a009-a597-4b51-b228" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="24f4-9145-4016-80d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="6e95-d5bf-451e-9b8a" name="Legion Basilisk Squadron" hidden="true" collective="false" import="false" targetId="8b8a-e685-5b8b-c08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_e732-7499-47bf-9748</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_81a5-a959-46b7-baa4</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7ec3-447a-4644-b012</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_71e2-c430-4c99-a559</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_df7b-3fb9-4f65-9165</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c165-3906-463a-9c73" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="b6d1-d14c-473f-be09" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="6bbc-f18a-422d-9e8d" name="Caestus Assault Ram" hidden="true" collective="false" import="false" targetId="67b6-3d17-3b16-a94d" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_13b3-ce1e-4f9d-8319</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d681-9d81-4abd-b11b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a57-e48b-4534-bca5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_1859-5641-4674-9097</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="251a-df5b-4bfd-ad63" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="4644-98ab-4e3f-b1fd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="0dcb-00a1-424c-a069" name="Castra Ferrum Dreadnought Talon" hidden="true" collective="false" import="false" targetId="daf7-b23b-5474-5836" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_591d-d028-4663-918d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_0482-c5f9-4c95-9597</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_75a7-971d-4978-a83f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_a7d5-2bfe-4621-ac0c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_9f13-b460-4f27-b0cd</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_31fc-e265-45a7-bb5b</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="67c2-df43-44fc-92d1" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="4136-bb4e-4dd4-99f9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="a996-6d12-4d34-9e6a" name="Land Raider Achilles Squadron" hidden="true" collective="false" import="false" targetId="4996-8971-603f-e2a2" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_99fc-5fe7-4b37-a62f</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_25f4-f6b8-4b44-8350</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_81f7-2311-4cce-95bc</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_09aa-af2a-4012-91d1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_00ae-fad3-4df6-9cb9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f65b-8958-49b3-92a5" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="0451-1929-4942-8c3f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ccdd-5be9-4975-b01d" name="Land Raider Phobos Squadron" hidden="true" collective="false" import="false" targetId="681a-7426-96af-caac" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_edc4-4915-40ba-bbf0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_105f-ba26-4146-bc54</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7a2c-a76c-421c-a8a2</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_05c9-0543-47ee-ba81</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e6ad-f0d7-4627-921b</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c6a8-22a8-4d41-b969" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="03ca-12cc-4e0a-b628" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="30a0-f0af-4285-be06" name="Legion Baneblade" hidden="true" collective="false" import="false" targetId="ee5c-0952-bf95-6333" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ae19-30c0-43c5-920e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_6ebe-1bf3-4d78-9dd0</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1887-152d-48b7-b13f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_a7c4-ee6a-4f0b-8ab0</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_bd85-fa90-47ff-9f84</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_7bd6-9043-4d7e-ba37</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3610-c975-4d55-bdfe" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="2fc2-f636-4c80-9608" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1585-c778-42d8-bd7e" name="Legion Banehammer" hidden="true" collective="false" import="false" targetId="1240-c71c-3a60-cf20" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_85c5-d4d9-4b23-9e4d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_80e8-d50b-4906-8153</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_b93b-d4f1-45eb-8a69</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_e183-f183-4db7-83b5</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0f39-204a-4217-b896</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_eee9-7bfd-4fea-a1bd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f81d-9435-4f11-99c1" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="9568-6142-4fdd-be3a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="4a67-a1f3-4189-9e6e" name="Legion Macharius Heavy Tank Squadron" hidden="true" collective="false" import="false" targetId="36ed-ca59-0d95-d85c" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_005e-6607-4e2c-8dd2</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_7745-260c-4c36-b719</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_ba25-a4b2-4ba9-b023</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_ddeb-f4c8-4091-9153</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_4904-fd2f-429f-9cf7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_faea-b21b-43c5-b918</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b24f-3ae0-4cbb-b016" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="fd26-8e6b-4521-92b9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="fc74-1bab-45a7-a988" name="Legion Malcador Assault Tank Squadron" hidden="true" collective="false" import="false" targetId="528b-183f-5e27-8b0c" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6ecb-28e2-43ed-a6a0</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_c067-1118-4d96-b28b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_250e-23c0-4e43-bf74</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_1553-a6e6-4291-853f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_aab6-797b-427a-9fd8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c77f-0819-473b-a8a2" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="89fb-c924-4daf-923d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="98ee-9eac-46c6-8734" name="Legion Minotaur Battery" hidden="true" collective="false" import="false" targetId="6bf4-d9b2-127c-d477" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d72c-519a-451f-81b6</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_3d16-444c-42c9-aad1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_f4b2-6371-494b-863a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_797f-a84b-42f6-8e66</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_0d78-fe38-4829-9b12</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0397-c837-4fea-a527" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="060b-bccb-4776-bd83" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="c29e-d469-41e5-a72e" name="Legion Shadowsword" hidden="true" collective="false" import="false" targetId="8a75-acc6-6fd6-90b8" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3c84-6d74-4c42-b38d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_5b15-7aa4-4897-aaf1</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_3326-31ed-4151-9b37</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_6a0e-1b65-4057-ba5d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_f8c7-abc9-45ec-955f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_2538-8dc5-446c-8344</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c1cf-cea4-4278-8f27" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="5f51-2734-4a46-9f72" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="0b55-7392-44c0-931c" name="Legion Stormblade" hidden="true" collective="false" import="false" targetId="4ac0-4b85-58da-0907" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af71-f3ff-49b1-83e9</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_1c9e-b3bf-4e88-a43f</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_6d0d-1b1d-4065-89cf</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_d0b7-8686-491e-9d33</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_7db8-0874-487a-be6f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_1034-29a0-44b1-a85f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0c16-6841-42b2-b02d" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="602d-2d2d-4ff4-a82a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="019f-e078-4a86-98bb" name="Legion Stormlord" hidden="true" collective="false" import="false" targetId="0887-0f66-2c7e-a5ba" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_22bd-baae-45f9-b366</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_52bd-55de-4d53-ba55</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_df1b-7476-4ab8-8d2f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_49fa-0dcf-4a61-a5b1</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b0ea-1443-4993-86e7</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2a8-3fbe-448c-9902</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3632-0b5d-4622-ae33" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="da44-7815-4fdd-981c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="7649-50e6-43e1-a338" name="Legion Stormsword" hidden="true" collective="false" import="false" targetId="8e67-8f84-730c-2778" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2bfa-b203-47e2-a828</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a39b-8a3c-49cf-bf62</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2a05-07b3-49c5-8145</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_f730-87fb-44bd-b68e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_2d0e-6c49-4493-a022</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+                  <comment>    node_id_d2e2-50c1-40c3-b4dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5ad5-8701-42cd-b2b6" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="20a4-4346-4a3b-a7d4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="92c7-96b3-4ff3-a262" name="Legion Medusa Squadron" hidden="true" collective="false" import="false" targetId="24c8-5f6a-d48a-27b7" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1909-0076-43fa-8ba1</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_a18c-c199-4de0-a83c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_7678-a2e4-474c-9072</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_9823-4e72-4d96-83fe</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_759e-04a6-4fbe-9c44</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4e52-ad1b-48d4-8eed" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="6979-1ed3-4f1f-a025" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="9eed-0620-42da-b8c4" name="Nathaniel Garro" hidden="true" collective="false" import="false" targetId="0583-258d-f0a0-2170" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4729-bc86-456b-b73d</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_cf0f-e3f4-4fb4-989d</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1cc8-5611-4d9a-9218</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_2e32-ca02-48f0-a8dd</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0af1-d052-4bd7-aab6" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="45ce-e338-43c9-b63e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="6998-969d-4312-a9f2" name="Legion Primaris-Lightning Strike Fighter" hidden="true" collective="false" import="false" targetId="5fdc-bbd1-5610-2a50" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_db78-4d49-42ab-954a</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_f14d-9943-47b6-866c</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_8a95-938f-4a07-9727</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_7775-78e1-44cc-87c8</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b822-3417-4613-be37" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="25db-b03f-4881-b310" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ef14-da3d-4b92-99ea" name="Tarantula Sentry Gun Battery" hidden="true" collective="false" import="false" targetId="124f-0ced-9231-bba4" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_b743-7a00-43e4-beb8</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_d12f-2c98-4e62-a716</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d4d7-ba67-47aa-962f</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+                  <comment>    node_id_1637-edee-457a-bb0d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f203-bc26-421f-b79e" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="a53e-59d9-4ac2-a21f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="3705-3a7a-4e90-92cd" name="Terminator Indomitus Squad" hidden="true" collective="false" import="false" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3348-16e4-4a9a-a549</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_bea4-c4a8-4843-b9fe</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_2970-17ff-4be1-91e5</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_503a-46e7-40e7-bd07</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_4555-15e1-43ff-80a0</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fce3-801c-49c8-85d4" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="0c2d-2349-44b6-9831" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="b99f-dff7-42f7-a135" name="Legion Thunderbolt Fighter" hidden="true" collective="false" import="false" targetId="5d24-1e9a-ad9d-95ca" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_2f46-a0b6-48a5-a0ee</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_636f-0f8a-43f1-910b</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_c883-39c8-4a74-aeaa</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_0796-e467-4438-89b3</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5a04-9847-4c91-a49a" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+        <categoryLink id="b4b4-daeb-483c-a306" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="513d-c1d7-4928-95ec" name="Tylos Rubio" hidden="true" collective="false" import="false" targetId="56bf-2c6d-a0fa-a145" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_dfdc-f6f6-49d2-a7b3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_354c-c71f-472f-b268</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_1127-c974-4663-874d</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="greaterThan">
+                  <comment>    node_id_0843-bef2-4767-8307</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="28e0-91e7-4ada-9fac" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="4448-a712-4dd7-bf6d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="edf3-7f66-40be-9234" name="Whirlwind" hidden="true" collective="false" import="false" targetId="3118-4a9b-afa4-1a73" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafa-470f-4c2c-8be3</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_e2ba-a855-4de2-9f46</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_0171-b30d-44ee-9389</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_fdfb-119b-4774-934a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_3891-9a00-4f8f-b95f</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="e5df-17d4-4521-9d5b" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+        <categoryLink id="0ecd-4873-4d3a-b28b" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="dd8c-cf5d-4edb-a314" name="Seeker Squad" hidden="true" collective="false" import="false" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_af15-2c71-4f8b-833e</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_d95a-80b9-4463-af55</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b6b1-886e-4194-8bcd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="51b5-f9c1-4587-8fc7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="9e78-3e8a-477d-9920" name="Command Squad, Cataphractii" hidden="false" collective="false" import="false" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
+      <modifiers>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_421a-b0ab-45e5-b4a7</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_26f8-b35f-4d47-bcf3</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6577-e0fb-4fda-834e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5d59-09bf-4566-b7e1" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="2029-1f36-432f-a6a1" name="Command Squad, Tartaros " hidden="false" collective="false" import="false" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="aa93-057d-42f6-82d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="403c-4e9c-4af5-84ec" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ed2f-2214-418e-8562" name="Master of Armour" hidden="true" collective="false" import="false" targetId="0e4e-1b9a-6b38-e575" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_1a71-d890-4fd5-bfbf</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_e6aa-89f5-49ee-badf</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5b41-a9f0-4801-9dff" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="d64e-e976-4668-bb95" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+        <categoryLink id="17a6-f363-4094-9a7c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="abdb-0d0b-4557-996a" name="Predator Squadron " hidden="false" collective="false" import="false" targetId="45fd-df3e-9bc4-60b6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_3c03-a823-4466-9bd6</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_8bbb-f95b-413f-b6f4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed1f-9473-df70-4544" type="equalTo">
+                  <comment>    node_id_41b0-6b0a-482a-919e</comment>
+                </condition>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_e1f7-3cc6-4794-8b6d</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="05ce-cc31-40ad-9320" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f13c-f8e1-4a50-bfe3" name="Heavy Support:" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="5289-7ab5-4112-9854" name="Sicaran Squadron" hidden="true" collective="false" import="false" targetId="706a-9532-f06d-00ed" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_6baf-f376-469e-a51b</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb7-6c5c-76ce-5b77" type="equalTo">
+              <comment>    node_id_7657-ee27-4ab0-a7af</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fe4f-c8f2-470f-901c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="f3f0-973b-4a45-ac41" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="9bcf-be6d-48ae-8638" name="Sky-Hunter Squadron" hidden="true" collective="false" import="false" targetId="6263-c696-2f2e-c105" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_3531-57d1-4081-882d</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_f233-2361-4177-8ba7</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_b932-667a-4b43-8331</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="63ff-0a92-42ab-ae8c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="204c-7b0f-4fb9-b1b3" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="85e6-cb31-427c-a040" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="60e9-649a-41dc-8dd7" name="Proteus Land Speeder Squadron" hidden="true" collective="false" import="false" targetId="a736-43ca-ed95-a08f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_48bd-f09b-458d-a0aa</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_fea7-9057-491f-a41a</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c36-fde3-14ed-4db4" type="equalTo">
+                  <comment>    node_id_8dc2-2717-40ff-b152</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="68dd-fc0f-4fde-8adc" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="74ca-dd4f-46be-8be7" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="8579-90c4-43ba-a8b4" name="Nullificator Squad" hidden="true" collective="false" import="false" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_4dce-8632-4f7c-813e</comment>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <comment>    node_id_8a71-3995-4155-ac33</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d344-d97b-4687-8a62" type="greaterThan">
+                  <comment>    node_id_d206-f2ce-41b8-945a</comment>
+                </condition>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="greaterThan">
+                  <comment>    node_id_2e02-cf1c-4a71-861c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="append" field="name" value="(Reserve Only)">
+          <comment>    node_id_ec81-bd33-45a8-8550</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+              <comment>    node_id_3344-743c-45d3-b930</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4272-9b9d-4c59-95f0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="d85b-1ae7-40d5-9341" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="47ce-b432-4b4a-98da" name="Terminator Cataphractii Squad" hidden="true" collective="false" import="false" targetId="d91a-a3c7-d7be-4293" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_eafb-5453-4dd9-8623</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_41ad-3585-4031-9b76</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_a02c-8632-499f-827c</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="3129-6f59-4365-906b" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="2bcb-0af1-4aea-9191" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="02ca-5079-4248-b353" name="Veteran Squad" hidden="true" collective="false" import="false" targetId="a423-7dd8-3f1b-3e28" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_ede2-d453-4e34-8cda</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_2907-3215-4b01-96ff</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_c90c-959f-40fb-a4cb</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="ba2d-50ad-45f1-91c9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="0e88-485e-43c2-8bef" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="bfa2-4203-4ad3-b023" name="Terminator Tartaros Squad" hidden="true" collective="false" import="false" targetId="1a8e-0ded-a4dc-2b4e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_409c-0a5d-4ef8-a871</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_7078-c1c7-4af2-b43d</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ca1-b02c-e2c7-5f09" type="equalTo">
+                  <comment>    node_id_9a69-0fdc-4957-8982</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1a4c-69b5-4219-8502" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="fba0-3ea7-4eaf-b33a" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="6e3b-815f-42d7-a0d9" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_9bdf-c865-4c4f-9115</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_51a8-a846-4090-a37f</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_955c-196e-4d75-9f91</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0d5b-be56-47af-a22e" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="2e59-1043-4719-96c4" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="52fa-8c3c-49d4-a321" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="f22f-aa8d-45c5-b890" name="Termite Assault Drill" hidden="true" collective="false" import="false" targetId="cb30-307a-f0d7-3b13" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_d88d-69db-477d-ad46</comment>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <comment>    node_id_4d65-b98e-4a78-9dc4</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a621-2c8c-3df0-89d3" type="equalTo">
+                  <comment>    node_id_b5a1-a9eb-45d5-ada9</comment>
+                </condition>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1fef-4409-4fab-93fc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="ca2d-245e-48b4-a1cf" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="6692-6e39-44f0-ad8e" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="fa70-d04e-4683-8eda" name="Venerable Ancient Contemptor Dreadnought" hidden="true" collective="false" import="false" targetId="dad1-0807-e254-d498" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_173d-02e3-4974-a502</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_9286-579f-4e52-8a67</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="9261-acb5-4230-8d89" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1a5d-cbc8-418f-91a3" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="c0cb-406f-4b46-9d8d" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="a559-b494-4154-a88a" name="Contemptor Dreadnought Talon" hidden="true" collective="false" import="false" targetId="d664-5692-cd41-f9be" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <comment>    node_id_642c-0100-4ef3-abd5</comment>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5b7-3410-a8e5-95a6" type="equalTo">
+              <comment>    node_id_3e51-8f78-4faa-9519</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c0b2-dd90-46c1-a2a9" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="9a94-76fb-4a89-ad5d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="be38-a066-4f8e-ae54" name="Retinue" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="90e8-296e-44d1-8c57" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="c2e6-af68-4845-9567" name="Command Squad, Tartaros " hidden="false" collective="false" import="true" targetId="58d0-a0fd-d20b-cb1b" type="selectionEntry"/>
+        <entryLink id="31b9-9494-4fe5-a2c6" name="Command Squad" hidden="false" collective="false" import="true" targetId="0aca-632d-1642-8af9" type="selectionEntry"/>
+        <entryLink id="fcda-7dec-45a7-a11c" name="Command Squad, Cataphractii" hidden="false" collective="false" import="true" targetId="1b17-dcd6-0153-3efe" type="selectionEntry">
+          <modifiers>
+            <modifier type="append" field="name" value="(Reserve Only)">
+              <comment>    node_id_972d-5235-4c49-8eeb</comment>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbde-0e4f-0b5a-43d2" type="equalTo">
+                  <comment>    node_id_15da-7bd1-4ceb-b8f0</comment>
+                </condition>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="7dee-602c-4b47-be09" name="Warlord Traits" hidden="false" collective="false" import="true">
+      <modifiers>
+        <modifier type="set" field="b923-c7ac-4895-985a" value="1.0">
+          <comment>    node_id_4bd4-0d97-400e-9a80</comment>
+          <conditions>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0176-56a3-d590-b103" type="greaterThan">
+              <comment>    node_id_e8ea-30f1-4403-b8b1</comment>
+            </condition>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <comment>    node_id_7bac-2c77-47f2-ad72</comment>
+          <conditions>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0176-56a3-d590-b103" type="equalTo">
+              <comment>    node_id_0ce1-be1e-4445-94fe</comment>
+            </condition>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f06d-b982-486e-90fc" type="max"/>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b923-c7ac-4895-985a" type="min"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="e570-95bd-4802-ab86" name="    Generic Warlord Traits" hidden="false" collective="false" import="true" targetId="c064-819f-d9ef-1775" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <catalogueLinks>
+    <catalogueLink id="1f71-db51-401f-b023" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
+  </catalogueLinks>
+</catalogue>

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1829,9 +1829,9 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <profile id="82d4-f8af-c0fd-0c55" name="Escaton Power Claw " hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">2x</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">x2</characteristic>
             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Shred, Murderous Strike (6+), Unwiedly, Specialist Weapon</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Shred, Murderous Strike (6+), Unwieldy, Specialist Weapon</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -4601,8 +4601,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <profiles>
         <profile id="3290-c851-e9ac-a8d2" name="Trophies of Judgement" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
           <characteristics>
-            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Confers the Fear (1) special rule to models with Trophies Of Judgement.
-</characteristic>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Confers the Fear (1) special rule.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -6265,7 +6264,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       <profiles>
         <profile id="6f43-10f9-5c6a-6db6" name="Preysight" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
           <characteristics>
-            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">All models in a unit with a Preysight upgrade gain the Night Vision special rule</characteristic>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Confers the Night Vision special rule.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -7858,6 +7857,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <condition field="selections" scope="d664-5692-cd41-f9be" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5ac-3da6-a69b-f6b8" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="6399-5c65-7833-1025">
+          <conditions>
+            <condition field="selections" scope="d664-5692-cd41-f9be" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5ac-3da6-a69b-f6b8" type="greaterThan"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink id="6cb7-533a-0bf3-29b0" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
@@ -7901,6 +7905,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                       </conditionGroups>
                     </conditionGroup>
                   </conditionGroups>
+                </modifier>
+                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Dreadnought (Line)">
+                  <conditions>
+                    <condition field="selections" scope="d664-5692-cd41-f9be" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5ac-3da6-a69b-f6b8" type="greaterThan"/>
+                  </conditions>
                 </modifier>
               </modifiers>
               <characteristics>
@@ -8224,7 +8233,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="d5ac-3da6-a69b-f6b8" name="Fuiry of the Ancients Compulsory Troops" hidden="true" collective="false" import="true" type="upgrade">
+        <selectionEntry id="d5ac-3da6-a69b-f6b8" name="Fury of the Ancients Compulsory Troops" hidden="true" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditionGroups>
@@ -8576,67 +8585,72 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="03be-5d55-d05a-771d" name="Praetor" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="name" value="Warsmith">
-          <conditions>
-            <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb35-21a5-c296-ddd9" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="add" field="category" value="9231-183c-b97b-63f9">
-          <conditions>
-            <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ef-e7a2-a480-3f5a" type="atLeast"/>
-          </conditions>
-        </modifier>
-        <modifier type="add" field="category" value="eee8-3c7c-2762-e33e">
-          <conditions>
-            <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e42-9815-97e4-3386" type="atLeast"/>
-          </conditions>
-        </modifier>
-        <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
-          <conditionGroups>
-            <conditionGroup type="and">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>Add Category (X)</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="eee8-3c7c-2762-e33e">
               <conditions>
-                <condition field="selections" scope="03be-5d55-d05a-771d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e254-77a1-6dae-14a0" type="equalTo"/>
-                <condition field="selections" scope="03be-5d55-d05a-771d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3952-66ed-93ea-27ee" type="equalTo"/>
-                <condition field="selections" scope="03be-5d55-d05a-771d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4108-5f37-0b50-b419" type="equalTo"/>
+                <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e42-9815-97e4-3386" type="atLeast"/>
               </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="add" field="category" value="6d79-a3e4-381f-7b0f">
-          <conditionGroups>
-            <conditionGroup type="or">
+            </modifier>
+            <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e254-77a1-6dae-14a0" type="equalTo"/>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3952-66ed-93ea-27ee" type="equalTo"/>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4108-5f37-0b50-b419" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="6d79-a3e4-381f-7b0f">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3952-66ed-93ea-27ee" type="atLeast"/>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4108-5f37-0b50-b419" type="atLeast"/>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e254-77a1-6dae-14a0" type="atLeast"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="9231-183c-b97b-63f9">
               <conditions>
-                <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3952-66ed-93ea-27ee" type="atLeast"/>
-                <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4108-5f37-0b50-b419" type="atLeast"/>
-                <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e254-77a1-6dae-14a0" type="atLeast"/>
+                <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ef-e7a2-a480-3f5a" type="atLeast"/>
               </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <categoryLinks>
         <categoryLink id="555c-4c0c-29a0-082a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d862-5767-da41-cff0" name="Legion Praetor" hidden="false" collective="false" import="true" type="model">
-          <modifiers>
-            <modifier type="set" field="name" value="Warsmith">
-              <conditions>
-                <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb35-21a5-c296-ddd9" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Iron-Father">
-              <conditions>
-                <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4655-4447-299c-8fe2" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Jarl">
-              <conditions>
-                <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4606-34cf-86b7-fb89" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
+          <modifierGroups>
+            <modifierGroup>
+              <comment>Set Name to (X)</comment>
+              <modifiers>
+                <modifier type="set" field="name" value="Jarl">
+                  <conditions>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4606-34cf-86b7-fb89" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Iron-Father">
+                  <conditions>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4655-4447-299c-8fe2" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Warsmith">
+                  <conditions>
+                    <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb35-21a5-c296-ddd9" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </modifierGroup>
+          </modifierGroups>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e1a-a8bc-1c40-3dca" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b3c-ec8d-3ad5-bcff" type="max"/>
@@ -8794,14 +8808,6 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="55ea-02c7-7bc5-acea" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3602-3853-9629-1967" type="max"/>
-                  </constraints>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
-                  </costs>
-                </entryLink>
                 <entryLink id="a5ef-e7a2-a480-3f5a" name="Boarding Shield" hidden="false" collective="false" import="true" targetId="0c0f-f751-cc4e-4951" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e31-567f-8c8f-4fe4" type="max"/>
@@ -8930,6 +8936,22 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="c0ee-9167-b5ce-e7aa" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3b2-04a6-3d5e-8572" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="41de-ea40-b8d8-2fc8" name="Escaton Power Claw" hidden="false" collective="false" import="true" targetId="3504-bed7-057b-603b" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e59e-44b9-3698-4f5a" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="fb94-51ab-dd77-b7a1" name="3) May take:" hidden="false" collective="false" import="true">
@@ -9023,6 +9045,22 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                             <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="08e4-5e02-da82-f296" type="equalTo"/>
                             <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="atLeast"/>
                             <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a723-2b6f-6e58-8b71" name="Corvid Pattern Jump Pack" hidden="false" collective="false" import="true" targetId="874d-6440-0698-f6e7" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="d862-5767-da41-cff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
@@ -9245,6 +9283,45 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </constraints>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1ec9-0ed9-5e31-f31a" name="Cyber-Familiar" hidden="true" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a715-9965-801c-280f" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ae43-8dcc-33cb-caf1" name="Cameleoline" hidden="false" collective="false" import="true" targetId="9a64-04fb-d978-67f0" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dd4-f72c-534f-1acf" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f791-1cce-5ede-359f" name="Trophies of Judgement" hidden="false" collective="false" import="true" targetId="bde7-7c77-5973-cd52" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32d0-00e7-3d4a-962b" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="cba3-4afd-c837-d6fc" name="Lords of Murder" hidden="false" collective="false" import="true" targetId="2b85-7073-16f5-0ea2" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8eb1-a810-6b38-9964" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -9575,6 +9652,37 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="c84b-6568-1636-1dd8" name="Cyber-Familiar" hidden="true" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5357-aed2-c810-b2e5" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3989-23f6-0990-014d" name="Trophies of Judgement" hidden="false" collective="false" import="true" targetId="bde7-7c77-5973-cd52" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3396-0731-ba2b-6edf" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1389-f4a7-ebdc-e4cf" name="Lords of Murder" hidden="false" collective="false" import="true" targetId="2b85-7073-16f5-0ea2" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="efae-3c89-40c2-55c3" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="5ac7-91ec-6c49-64cc" name="1) Armour Choice" hidden="false" collective="false" import="true" defaultSelectionEntryId="65ca-51eb-5464-7a87">
@@ -9867,6 +9975,37 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="36e7-19ca-4841-c542" name="Cyber-Familiar" hidden="true" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1389-1252-7eec-2817" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1766-2e59-1a6f-24ac" name="Trophies of Judgement" hidden="false" collective="false" import="true" targetId="bde7-7c77-5973-cd52" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87a3-83c8-6fe9-3789" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4818-ed8b-b6ea-b510" name="Lords of Murder" hidden="false" collective="false" import="true" targetId="2b85-7073-16f5-0ea2" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5a6e-d1a1-a632-cdc0" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -9913,179 +10052,189 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </costs>
     </selectionEntry>
     <selectionEntry id="25a2-7a52-632a-6b2c" name="Centurion" hidden="false" collective="false" import="true" type="model">
-      <modifiers>
-        <modifier type="add" field="category" value="eee8-3c7c-2762-e33e">
-          <conditions>
-            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a3f-5c9e-f4d6-c92d" type="atLeast"/>
-          </conditions>
-        </modifier>
-        <modifier type="add" field="category" value="6d79-a3e4-381f-7b0f">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a8ac-7465-70fb-70fb" type="atLeast"/>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f152-51f5-b509-2d9c" type="atLeast"/>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9924-004c-e683-877b" type="atLeast"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f152-51f5-b509-2d9c" type="equalTo"/>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9924-004c-e683-877b" type="equalTo"/>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a8ac-7465-70fb-70fb" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="add" field="category" value="9231-183c-b97b-63f9">
-          <conditions>
-            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5670-f70b-eda6-0cfa" type="atLeast"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <selectionEntries>
-        <selectionEntry id="c681-938e-6d11-cd43" name="Legion Centurion" publicationId="a716-c1c4-7b26-8424" page="22" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>Add Category (X)</comment>
           <modifiers>
-            <modifier type="set" field="name" value="Forge Lord">
+            <modifier type="add" field="category" value="9231-183c-b97b-63f9">
               <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62c8-8f27-9673-8450" type="equalTo"/>
+                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5670-f70b-eda6-0cfa" type="atLeast"/>
               </conditions>
             </modifier>
-            <modifier type="set" field="name" value="Champion">
+            <modifier type="add" field="category" value="6d79-a3e4-381f-7b0f">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a8ac-7465-70fb-70fb" type="atLeast"/>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f152-51f5-b509-2d9c" type="atLeast"/>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9924-004c-e683-877b" type="atLeast"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="eee8-3c7c-2762-e33e">
               <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="05a2-a69e-0c9e-1544" type="equalTo"/>
+                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a3f-5c9e-f4d6-c92d" type="atLeast"/>
               </conditions>
             </modifier>
-            <modifier type="set" field="name" value="Vigilator">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27e9-630d-4cf4-6d68" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Pathfinder">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a28d-408e-c833-9055" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Librarian">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8846-2f93-a2be-18dc" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Master of Signals">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35ac-992e-97a7-1612" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Esoterist">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d332-0e64-7ecf-6c35" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Castellan">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7962-e835-2ae5-c6f1" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Praevian ">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c8b-1020-32f3-3b2a" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Mortificator">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="368d-0cdc-5ce6-eb38" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Chaplain">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4831-6948-851c-3925" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Herald">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b6d0-40f1-d82f-c01e" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Delegatus">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Siege Breaker">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9335-7da8-087e-30de" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Primus Medicae">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7df3-04e8-c056-47cb" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Armistos">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="31f5-cbc4-58e0-ed6e" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Moritat">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="384d-df82-14cb-f918" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Paladin of Hekatonystika">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6f69-f2bd-fe7e-12c4" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Warmonger">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d6cc-2e7f-16e3-e66c" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Stormseer">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b6c-5897-3790-2940" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Saboteur">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c2a0-636c-9918-f851" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Dark Emissary">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ac-ebaf-8c66-3c1d" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Pack Thegn">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aab9-d1c0-a5cb-9788" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Speaker of the Dead">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e9ab-2cc5-4507-eded" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Phoenix Warden">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5aff-6654-f53b-c5ac" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Caster of Runes">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b625-1cef-3057-156c" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Diabolist">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4e1a-275e-e691-5b92" type="equalTo"/>
-              </conditions>
+            <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f152-51f5-b509-2d9c" type="equalTo"/>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9924-004c-e683-877b" type="equalTo"/>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a8ac-7465-70fb-70fb" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
+        </modifierGroup>
+      </modifierGroups>
+      <selectionEntries>
+        <selectionEntry id="c681-938e-6d11-cd43" name="Legion Centurion" publicationId="a716-c1c4-7b26-8424" page="22" hidden="false" collective="false" import="true" type="model">
+          <modifierGroups>
+            <modifierGroup>
+              <comment>Set Name to (X)</comment>
+              <modifiers>
+                <modifier type="set" field="name" value="Warmonger">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d6cc-2e7f-16e3-e66c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Delegatus">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Armistos">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="31f5-cbc4-58e0-ed6e" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Pathfinder">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a28d-408e-c833-9055" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Librarian">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8846-2f93-a2be-18dc" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Stormseer">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b6c-5897-3790-2940" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Dark Emissary">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ac-ebaf-8c66-3c1d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Forge Lord">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62c8-8f27-9673-8450" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Champion">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="05a2-a69e-0c9e-1544" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Herald">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b6d0-40f1-d82f-c01e" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Speaker of the Dead">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e9ab-2cc5-4507-eded" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Siege Breaker">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9335-7da8-087e-30de" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Saboteur">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c2a0-636c-9918-f851" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Primus Medicae">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7df3-04e8-c056-47cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Vigilator">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27e9-630d-4cf4-6d68" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Caster of Runes">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b625-1cef-3057-156c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Esoterist">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d332-0e64-7ecf-6c35" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Pack Thegn">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aab9-d1c0-a5cb-9788" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Praevian ">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c8b-1020-32f3-3b2a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Chaplain">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4831-6948-851c-3925" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Diabolist">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4e1a-275e-e691-5b92" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Castellan">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7962-e835-2ae5-c6f1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Master of Signals">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35ac-992e-97a7-1612" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Phoenix Warden">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5aff-6654-f53b-c5ac" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Paladin of Hekatonystika">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6f69-f2bd-fe7e-12c4" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Moritat">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="384d-df82-14cb-f918" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Mortificator">
+                  <conditions>
+                    <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="368d-0cdc-5ce6-eb38" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </modifierGroup>
+          </modifierGroups>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66bd-5b8f-c477-e633" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fa1-692e-d639-4769" type="max"/>
@@ -10584,6 +10733,14 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="02e2-8413-2644-edf9" name="Escaton Power Claw" hidden="false" collective="false" import="true" targetId="3504-bed7-057b-603b" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6ce-a301-a574-a84e" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="525d-defc-1b29-0886" name="2) May take one:" hidden="false" collective="false" import="true">
@@ -10796,6 +10953,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                       </conditionGroups>
                     </modifier>
                   </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a783-0565-2f6e-6c3e" name="Corvid Pattern Jump Pack" hidden="false" collective="false" import="true" targetId="874d-6440-0698-f6e7" type="selectionEntry">
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
                   </costs>
@@ -11072,6 +11234,57 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </constraints>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="2fb2-c857-5766-aad8" name="Cyber-Familiar" hidden="true" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d4e8-d65d-250c-58cd" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="01f2-5fd2-66eb-d36b" name="Cameleoline" hidden="false" collective="false" import="true" targetId="9a64-04fb-d978-67f0" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="368d-0cdc-5ce6-eb38" type="greaterThan"/>
+                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3c8b-1020-32f3-3b2a" type="greaterThan"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8397-a103-2b95-b7a6" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="c87f-77b6-ab3d-faa3" name="Trophies of Judgement" hidden="false" collective="false" import="true" targetId="bde7-7c77-5973-cd52" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d08-3b95-16e8-6ed1" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f9c6-16c2-1834-d2e5" name="Lords of Murder" hidden="false" collective="false" import="true" targetId="2b85-7073-16f5-0ea2" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3783-de0e-c4fd-2413" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -16138,63 +16351,68 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="da79-9588-cc7f-e02f" name="Legion Cataphractii Centurion" hidden="false" collective="false" import="true" type="model">
-          <modifiers>
-            <modifier type="set" field="name" value="Delegatus">
-              <conditions>
-                <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Chaplain">
-              <conditions>
-                <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4831-6948-851c-3925" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Esoterist">
-              <conditions>
-                <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d332-0e64-7ecf-6c35" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Primus Medicae">
-              <conditions>
-                <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7df3-04e8-c056-47cb" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Librarian">
-              <conditions>
-                <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8846-2f93-a2be-18dc" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Forge Lord">
-              <conditions>
-                <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62c8-8f27-9673-8450" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Siege Breaker">
-              <conditions>
-                <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9335-7da8-087e-30de" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Mortificator">
-              <conditions>
-                <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="368d-0cdc-5ce6-eb38" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Primus Nullificator">
-              <conditions>
-                <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Champion">
-              <conditions>
-                <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="05a2-a69e-0c9e-1544" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Herald">
-              <conditions>
-                <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b6d0-40f1-d82f-c01e" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
+          <modifierGroups>
+            <modifierGroup>
+              <comment>Set Name to (X)</comment>
+              <modifiers>
+                <modifier type="set" field="name" value="Forge Lord">
+                  <conditions>
+                    <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62c8-8f27-9673-8450" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Siege Breaker">
+                  <conditions>
+                    <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9335-7da8-087e-30de" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Primus Nullificator">
+                  <conditions>
+                    <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71e-10a6-216f-d796" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Delegatus">
+                  <conditions>
+                    <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Herald">
+                  <conditions>
+                    <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b6d0-40f1-d82f-c01e" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Chaplain">
+                  <conditions>
+                    <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4831-6948-851c-3925" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Esoterist">
+                  <conditions>
+                    <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d332-0e64-7ecf-6c35" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Primus Medicae">
+                  <conditions>
+                    <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7df3-04e8-c056-47cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Mortificator">
+                  <conditions>
+                    <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="368d-0cdc-5ce6-eb38" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Librarian">
+                  <conditions>
+                    <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8846-2f93-a2be-18dc" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Champion">
+                  <conditions>
+                    <condition field="selections" scope="3766-ea98-0aa7-62d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="05a2-a69e-0c9e-1544" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </modifierGroup>
+          </modifierGroups>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c118-13df-a496-1a6b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4459-694b-245b-b190" type="min"/>
@@ -16462,6 +16680,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="f8e6-bf04-0df7-2c2f" name="Escaton Power Claw" hidden="false" collective="false" import="true" targetId="3504-bed7-057b-603b" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="a1d0-2a7a-e2c0-8764" name="4) May take:" hidden="false" collective="false" import="true">
@@ -16597,6 +16820,37 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </constraints>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4d3c-3404-f8c3-7546" name="Cyber-Familiar" hidden="true" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a23c-837c-ad54-192a" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ebfa-fec9-1ae8-ef0b" name="Trophies of Judgement" hidden="false" collective="false" import="true" targetId="bde7-7c77-5973-cd52" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c977-e3c8-b3ae-4109" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="097e-401c-88bf-77f8" name="Lords of Murder" hidden="false" collective="false" import="true" targetId="2b85-7073-16f5-0ea2" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6264-2e48-388b-43d1" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -20060,63 +20314,68 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="69fc-a6ab-d7a8-0e83" name="Legion Tartaros Centurion" hidden="false" collective="false" import="true" type="model">
-          <modifiers>
-            <modifier type="set" field="name" value="Delegatus">
-              <conditions>
-                <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Chaplain">
-              <conditions>
-                <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4831-6948-851c-3925" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Esoterist">
-              <conditions>
-                <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d332-0e64-7ecf-6c35" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Primus Medicae">
-              <conditions>
-                <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7df3-04e8-c056-47cb" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Librarian">
-              <conditions>
-                <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8846-2f93-a2be-18dc" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Forge Lord">
-              <conditions>
-                <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62c8-8f27-9673-8450" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Siege Breaker">
-              <conditions>
-                <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9335-7da8-087e-30de" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Mortificator">
-              <conditions>
-                <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="368d-0cdc-5ce6-eb38" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Phoenix Warden">
-              <conditions>
-                <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5aff-6654-f53b-c5ac" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Champion">
-              <conditions>
-                <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="05a2-a69e-0c9e-1544" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Herald">
-              <conditions>
-                <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b6d0-40f1-d82f-c01e" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
+          <modifierGroups>
+            <modifierGroup>
+              <comment>Set Name to (X)</comment>
+              <modifiers>
+                <modifier type="set" field="name" value="Esoterist">
+                  <conditions>
+                    <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d332-0e64-7ecf-6c35" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Herald">
+                  <conditions>
+                    <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b6d0-40f1-d82f-c01e" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Phoenix Warden">
+                  <conditions>
+                    <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5aff-6654-f53b-c5ac" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Forge Lord">
+                  <conditions>
+                    <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62c8-8f27-9673-8450" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Delegatus">
+                  <conditions>
+                    <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35d4-0dcd-f7d2-a6da" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Champion">
+                  <conditions>
+                    <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="05a2-a69e-0c9e-1544" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Chaplain">
+                  <conditions>
+                    <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4831-6948-851c-3925" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Primus Medicae">
+                  <conditions>
+                    <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7df3-04e8-c056-47cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Librarian">
+                  <conditions>
+                    <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8846-2f93-a2be-18dc" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Siege Breaker">
+                  <conditions>
+                    <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9335-7da8-087e-30de" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Mortificator">
+                  <conditions>
+                    <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="368d-0cdc-5ce6-eb38" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </modifierGroup>
+          </modifierGroups>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bf28-2763-0f5c-cd19" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2fa0-1f29-a152-226b" type="min"/>
@@ -20371,24 +20630,10 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="306f-6e75-d6c8-ab29" name="Force Weapon" hidden="true" collective="false" import="true" targetId="a9c2-6881-3391-9622" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="69fc-a6ab-d7a8-0e83" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8846-2f93-a2be-18dc" type="equalTo"/>
-                            <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b625-1cef-3057-156c" type="equalTo"/>
-                            <condition field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b6c-5897-3790-2940" type="equalTo"/>
-                            <condition field="selections" scope="69fc-a6ab-d7a8-0e83" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d332-0e64-7ecf-6c35" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="f806-8a4e-d0d6-beaa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6698-83e1-b5c0-012c" type="max"/>
-                  </constraints>
+                <entryLink id="742f-9750-b3eb-5a6a" name="Escaton Power Claw" hidden="false" collective="false" import="true" targetId="3504-bed7-057b-603b" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
@@ -20525,6 +20770,37 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
                   </constraints>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1a97-7752-cfc5-6969" name="Cyber-Familiar" hidden="true" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6eba-1361-3770-d301" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="c4a7-cf67-9be0-a002" name="Trophies of Judgement" hidden="false" collective="false" import="true" targetId="bde7-7c77-5973-cd52" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06ed-0883-0f29-355f" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="545b-4274-4809-7d7d" name="Lords of Murder" hidden="false" collective="false" import="true" targetId="2b85-7073-16f5-0ea2" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ac7c-65a4-618b-7114" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -42114,6 +42390,44 @@ Invulnerable saves granted by a combat shield or boarding shield do not stack wi
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="205.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="9a64-04fb-d978-67f0" name="Cameleoline" hidden="true" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fc8-d770-7563-510a" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="b72c-52d2-1355-b4e1" name="Cameleoline" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Confers the Shrouded (6+) special rule, or improves an existing version of the Shrouded (X) special rule by one step (from 5+ to 4+, for example).</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+    </selectionEntry>
+    <selectionEntry id="2b85-7073-16f5-0ea2" name="Lords of Murder" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b28b-71f7-e4f4-8f9c" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab19-3453-807e-0a29" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="8af4-84a0-d4f4-eac1" name="Bloody Murder" hidden="false" typeId="b46c-270c-d29e-f0ff" typeName="Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0982-427b-1d4a-d07c">When a unit composed entirely of models with this special rule declares a Charge targeting a unit that is Pinned or Falling Back, the Charge roll gains an additional +1 modifier, and if the Charge is successful then all models in the Charging unit gain +1 Attack for the duration of the turn in which that Charge is made.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="61a2-7005-1e6c-c08e" name="Hexagrammaton Choice:" hidden="true" collective="false" import="true">
@@ -44014,6 +44328,23 @@ Hit rolls for each attack, for a total of 24 To Hit rolls over the full 6 attack
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
           </costs>
         </entryLink>
+        <entryLink id="20af-b7ba-f1ee-7d0a" name="Escaton Power Claw" hidden="true" collective="false" import="true" targetId="3504-bed7-057b-603b" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b28b-71f7-e4f4-8f9c" type="equalTo"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4f07-3d45-4f28-a0c6" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+          </costs>
+        </entryLink>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="bb49-6a88-7ffa-6aa7" name="Terminator Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="c0a9-4f05-4261-68ad">
@@ -44312,7 +44643,7 @@ Hit rolls for each attack, for a total of 24 To Hit rolls over the full 6 attack
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="b1c4-f1e2-2f66-6d38" name="(Pack Thegn) Grant Consul the Skirmish Sub-type" hidden="true" collective="false" import="true" type="upgrade">
+        <selectionEntry id="b1c4-f1e2-2f66-6d38" name="(Pack Thegn) Grant unit the Skirmish Sub-type" hidden="true" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ Great, thank you! Please [Report a bug][bug report] - you can also suggest enhan
 
 ## Standards
 
+### .cattemplate? and what are all the template_id_ comments?
+A .cattemplate file is a .cat file, renamed to .cattemplate, used by [BSCOPY][https://github.com/nstephenh/BSCopy]
+
+We can use bscopy to keep all 18 legions up to date with generic units and rites of war.
+It builds a "map" of source to target ids in comments. If you copy a node with a comment that has an ID in it,
+please delete the comment. 
+
+If you want to add something generic to all 18 legions, rename the .cattemplate to .cat, edit it to add the new unit, 
+rename the file back to .cat, and then run BSCopy's copy_changes_from_template or ask @NStephenH#0001 in discord.
+
 ### For 2.0
 
 In general, we remove the "Legion" prefix from units.


### PR DESCRIPTION
This branch copies Blood Angels to LA Template.cattemplate,
and then those changes to all the individual legions using https://github.com/nstephenh/BSCopy

See readme.md for how BSCopy works.

This isn't all the ROW but it's all of them that we have so far.

Note:
The BSCopy output does mess up white space a bit. If it would help I can just save each file in battlescribe to return the whitespace to normal.